### PR TITLE
cogni-help: add canonical 'Related workflows' to guide plugin-catalog

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -127,7 +127,7 @@
     {
       "name": "cogni-help",
       "source": "./cogni-help",
-      "version": "0.1.5",
+      "version": "0.1.7",
       "maturity": "preview",
       "description": "Central help hub for the insight-wave ecosystem. Interactive courses (12-course curriculum), plugin discovery, cross-plugin workflow guides, troubleshooting, quick-reference cheatsheets, and GitHub issue filing.",
       "keywords": [

--- a/cogni-help/.claude-plugin/plugin.json
+++ b/cogni-help/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-help",
-  "version": "0.1.5",
+  "version": "0.1.7",
   "description": "Central help hub for the insight-wave ecosystem. Interactive courses (12-course curriculum), plugin discovery, cross-plugin workflow guides, troubleshooting, quick-reference cheatsheets, and GitHub issue filing.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-help/skills/guide/references/plugin-catalog.md
+++ b/cogni-help/skills/guide/references/plugin-catalog.md
@@ -35,6 +35,8 @@ to verify research output before publishing.
 
 **Works with**: cogni-research (verifies research claims), cogni-narrative (checks narrative accuracy)
 
+**Related workflows**: research-to-report
+
 ---
 
 ## cogni-consulting
@@ -50,6 +52,8 @@ Lean Canvas authoring and refinement via the business-model-hypothesis vision cl
 orchestration that calls the right plugins at the right time.
 
 **Requires**: Most other plugins (it orchestrates them)
+
+**Related workflows**: consulting-engagement, portfolio-to-pitch
 
 ---
 
@@ -83,6 +87,8 @@ perspective simulation, or needs readability scoring.
 
 **Works with**: cogni-narrative (narrative → polish), cogni-sales (pitch polish)
 
+**Related workflows**: content-pipeline, portfolio-to-pitch
+
 ---
 
 ## cogni-help (this plugin)
@@ -110,6 +116,8 @@ propositions. Supports 16 content formats. Bilingual DE/EN.
 
 **Requires**: cogni-trends (themes), cogni-portfolio (propositions)
 
+**Related workflows**: trends-to-solutions, content-pipeline
+
 ---
 
 ## cogni-narrative
@@ -123,6 +131,8 @@ TIPS-native trend panorama. Executive synthesis and citation bridging.
 into a compelling executive narrative or story.
 
 **Feeds into**: cogni-visual (narrative → slides), cogni-copywriting (narrative → polish)
+
+**Related workflows**: research-to-report, portfolio-to-pitch, content-pipeline
 
 ---
 
@@ -139,6 +149,8 @@ size the opportunity, or analyze competitors.
 **Requires**: cogni-consulting (optional, for Lean Canvas hypothesis input)
 **Feeds into**: cogni-marketing (propositions → content), cogni-sales (propositions → pitch)
 
+**Related workflows**: trends-to-solutions, portfolio-to-pitch, portfolio-to-website
+
 ---
 
 ## cogni-research
@@ -152,6 +164,8 @@ with parallel web research, claims-verified review loops. Three depth levels.
 deep-dive analyses with verified claims and citations.
 
 **Works with**: cogni-claims (verification), cogni-narrative (report → story)
+
+**Related workflows**: research-to-report
 
 ---
 
@@ -167,6 +181,8 @@ market segment, built on portfolio data with optional trend enrichment.
 
 **Requires**: cogni-portfolio (propositions), optionally cogni-trends (strategic trends)
 
+**Related workflows**: portfolio-to-pitch
+
 ---
 
 ## cogni-trends
@@ -180,6 +196,8 @@ market segment, built on portfolio data with optional trend enrichment.
 produce trend reports for strategic decision-making. DACH-focused. Bilingual EN/DE.
 
 **Feeds into**: cogni-portfolio (trends → investment themes), cogni-marketing (themes → content)
+
+**Related workflows**: trends-to-solutions
 
 ---
 
@@ -195,6 +213,8 @@ Excalidraw, Pencil MCP, and PPTX rendering.
 
 **Requires**: Content from cogni-narrative or cogni-copywriting as input
 
+**Related workflows**: research-to-report, portfolio-to-pitch, content-pipeline, install-to-infographic
+
 ---
 
 ## cogni-workspace
@@ -208,3 +228,5 @@ theme management, plugin discovery, and workspace health diagnostics.
 themes, or diagnose workspace configuration issues.
 
 **Foundation for**: All other plugins (provides shared env vars and settings)
+
+**Related workflows**: portfolio-to-website, install-to-infographic


### PR DESCRIPTION
Closes #151. Child of #152 (workflow-tour epic), depends on merged #146/#147 (workflow renames).

## Summary
- Add a `**Related workflows**:` line to each applicable plugin section in `cogni-help/skills/guide/references/plugin-catalog.md`, using only the 7 canonical workflow IDs (`research-to-report`, `trends-to-solutions`, `portfolio-to-pitch`, `portfolio-to-website`, `consulting-engagement`, `content-pipeline`, `install-to-infographic`).
- 11 plugin sections updated (cogni-claims, cogni-consulting, cogni-copywriting, cogni-marketing, cogni-narrative, cogni-portfolio, cogni-research, cogni-sales, cogni-trends, cogni-visual, cogni-workspace). cogni-docs and cogni-help (this plugin) intentionally have no Related-workflows line — neither has a clean canonical workflow.
- Bumps cogni-help 0.1.5 → 0.1.7 in `plugin.json` and `marketplace.json`.

## Scope decisions
- **Why 0.1.7 not 0.1.6**: PR #164 (issue #150) is the sibling phase-1 child and bumps to 0.1.6 first. This PR jumps to 0.1.7 to avoid a merge collision on the version line. Diff against current main is 0.1.5 → 0.1.7; after #164 merges, this branch rebases cleanly to 0.1.6 → 0.1.7.
- **No edits to cheatsheet or teach**: Recon confirmed `cheatsheet/SKILL.md` generates per-plugin cards from runtime plugin metadata (no static workflow ID list), and `teach/references/courses/0*.md` recap sections reference workflows generically (no stale IDs found via grep). Editing them would be churn, not fix.
- **Migration ledger preserved**: `canonical-workflows.md` lines 59/60/62 still reference old IDs (`research-to-slides`, `trend-to-marketing`, `new-engagement`) as part of the migration audit trail. Acceptance criteria explicitly allow this.

## Test plan
- [ ] `grep -rE 'research-to-slides|trend-to-marketing|new-engagement' cogni-help/` returns hits ONLY in `cogni-help/skills/workflow/references/canonical-workflows.md`.
- [ ] `grep -E '^\*\*Related workflows' cogni-help/skills/guide/references/plugin-catalog.md` lists 11 lines, each using only canonical IDs.
- [ ] Every workflow ID referenced has a matching file in `cogni-help/skills/workflow/references/workflows/` (no typos).
- [ ] `jq -r .version cogni-help/.claude-plugin/plugin.json` → `0.1.7`.
- [ ] cogni-help marketplace.json entry version → `0.1.7`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
