### PR TITLE
cogni-trends: expandable TIP details in value-modeler scoring UI

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -76,7 +76,7 @@
     {
       "name": "cogni-trends",
       "source": "./cogni-trends",
-      "version": "0.4.16",
+      "version": "0.4.17",
       "maturity": "preview",
       "description": "Strategic trend scouting and reporting pipeline. Combines the Smarter Service Trendradar (4-dimension structure) with the TIPS content framework (Trends, Implications, Possibilities, Solutions). Multilingual trend scouting, investment theme modeling, evidence-backed CxO reports, and reusable industry catalogs. European markets (DE/FR/IT/PL/NL/ES) + US/UK.",
       "keywords": [

--- a/cogni-trends/.claude-plugin/plugin.json
+++ b/cogni-trends/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-trends",
-  "version": "0.4.16",
+  "version": "0.4.17",
   "description": "Strategic trend scouting and reporting pipeline. Combines the Smarter Service Trendradar (4-dimension structure) with the TIPS content framework (Trends, Implications, Possibilities, Solutions). Multilingual trend scouting, investment theme modeling, evidence-backed CxO reports, and reusable industry catalogs. European markets (DE/FR/IT/PL/NL/ES) + US/UK.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-trends/skills/value-modeler/references/workflow-phases/phase-3-scoring.md
+++ b/cogni-trends/skills/value-modeler/references/workflow-phases/phase-3-scoring.md
@@ -42,10 +42,37 @@ Use the HTML template at `$CLAUDE_PLUGIN_ROOT/skills/value-modeler/templates/sco
 3. Write to `value-modeler-scoring.html` in the project directory
 4. Open it: `open value-modeler-scoring.html`
 
+### TIP candidate enrichment in the payload
+
+When you build the TIP entries inside `value_chains[].trend`, `value_chains[].implications[]`,
+and `value_chains[].possibilities[]`, carry the full candidate context — not just the short
+name. The template renders an expandable `<details>` block per TIP that shows description,
+rationale, evidence, and sources so the user can score 30+ candidates without keeping
+`trend-candidates.md` open in a second window (issue #175).
+
+For each TIP entry in the payload, include these fields alongside the existing `name`,
+`candidate_ref`, `score`, and horizon fields:
+
+| Field | Type | Source |
+|-------|------|--------|
+| `description` | string | `tips_candidates.items[].description` from `.metadata/trend-scout-output.json` |
+| `rationale` | string | `tips_candidates.items[].rationale` from same |
+| `evidence` | array of strings | `tips_candidates.items[].evidence` from same (bullet points) |
+| `sources` | array of `{title, url}` objects (or plain strings) | `tips_candidates.items[].sources` from same |
+
+Look up each candidate by `candidate_ref` against `tips_candidates.items[*].candidate_ref`
+(or `id`) and merge the four fields into the TIP entry before serializing. Any of the four
+may be empty or omitted on the source candidate — the template degrades gracefully and
+omits the corresponding section, so do not synthesize placeholder content. If
+`trend-scout-output.json` is missing entirely (legacy projects), serialize the payload
+without these fields and the template will simply skip the details block on each row.
+
 The template renders Strategic Themes as sections, with value chains as cards beneath each
 theme. Each card has 1-5 button scoring per TIP candidate. Candidates appearing in multiple
 chains are synced — the user scores once, it propagates. A progress bar shows scoring
-coverage per theme and overall. "Export" downloads `br-scores.json`.
+coverage per theme and overall. Each TIP row carries an inline expandable "Details" section
+(native HTML5 `<details>`/`<summary>`, no JS) that reveals description, rationale, evidence,
+and sources when clicked. "Export" downloads `br-scores.json`.
 
 The user may show this to stakeholders — it's designed to be professional and self-contained.
 The theme-level grouping makes it practical even for non-technical stakeholders to work

--- a/cogni-trends/skills/value-modeler/templates/scoring-ui.html
+++ b/cogni-trends/skills/value-modeler/templates/scoring-ui.html
@@ -47,8 +47,8 @@
   .chain-narrative { color: var(--muted); font-size: 0.875rem; margin-bottom: 1rem;
     font-style: italic; }
 
-  .tip-row { display: flex; align-items: center; gap: 1rem; padding: 0.75rem 0;
-    border-top: 1px solid var(--border); }
+  .tip-row { padding: 0.75rem 0; border-top: 1px solid var(--border); }
+  .tip-row-main { display: flex; align-items: center; gap: 1rem; }
   .tip-role { width: 24px; height: 24px; border-radius: 50%; display: flex;
     align-items: center; justify-content: center; font-weight: 700; font-size: 0.75rem;
     flex-shrink: 0; }
@@ -70,6 +70,30 @@
   .br-btn.s3.selected { background: var(--mid); border-color: var(--mid); color: #000; }
   .br-btn.s4.selected { background: #84cc16; border-color: #84cc16; color: #000; }
   .br-btn.s5.selected { background: var(--high); border-color: var(--high); color: #000; }
+
+  .tip-details { margin-top: 0.6rem; margin-left: 40px; font-size: 0.85rem;
+    color: var(--muted); }
+  .tip-details summary { cursor: pointer; padding: 0.25rem 0.5rem; border-radius: 4px;
+    user-select: none; list-style: none; display: inline-flex; align-items: center;
+    gap: 0.4rem; }
+  .tip-details summary::-webkit-details-marker { display: none; }
+  .tip-details summary::before { content: '\25B8'; font-size: 0.7rem; color: var(--muted);
+    transition: transform 0.15s; display: inline-block; }
+  .tip-details[open] summary::before { transform: rotate(90deg); }
+  .tip-details summary:hover { color: var(--accent); }
+  .tip-details-body { margin-top: 0.5rem; padding: 0.75rem 1rem;
+    border-left: 2px solid var(--border); background: rgba(255,255,255,0.02);
+    border-radius: 0 4px 4px 0; color: var(--text); }
+  .tip-details-body p { margin-bottom: 0.6rem; line-height: 1.5; }
+  .tip-details-body h4 { font-size: 0.7rem; text-transform: uppercase;
+    letter-spacing: 0.05em; color: var(--muted); margin-top: 0.6rem;
+    margin-bottom: 0.3rem; font-weight: 600; }
+  .tip-details-body h4:first-child { margin-top: 0; }
+  .tip-details-body ul { padding-left: 1.25rem; margin-bottom: 0.5rem; }
+  .tip-details-body ul li { margin-bottom: 0.25rem; line-height: 1.45; }
+  .tip-details-body a { color: var(--accent); text-decoration: none;
+    word-break: break-word; }
+  .tip-details-body a:hover { text-decoration: underline; }
 
   .legend { display: flex; gap: 1rem; flex-wrap: wrap; margin-bottom: 2rem;
     font-size: 0.8rem; color: var(--muted); }
@@ -134,6 +158,43 @@ if (!MODEL_DATA.investment_themes && !MODEL_DATA.themes && (MODEL_DATA.value_cha
   });
 }
 
+function esc(s) {
+  if (s == null) return '';
+  return String(s)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function renderTipDetails(tip) {
+  const description = tip.description;
+  const rationale = tip.rationale;
+  const evidence = Array.isArray(tip.evidence) ? tip.evidence.filter(Boolean) : [];
+  const sources = Array.isArray(tip.sources) ? tip.sources.filter(Boolean) : [];
+  if (!description && !rationale && !evidence.length && !sources.length) return '';
+  const parts = [];
+  if (description) parts.push(`<h4>Beschreibung</h4><p>${esc(description)}</p>`);
+  if (rationale)   parts.push(`<h4>Begr&uuml;ndung</h4><p>${esc(rationale)}</p>`);
+  if (evidence.length) {
+    const items = evidence.map(e => `<li>${esc(e)}</li>`).join('');
+    parts.push(`<h4>Evidenz</h4><ul>${items}</ul>`);
+  }
+  if (sources.length) {
+    const items = sources.map(src => {
+      if (typeof src === 'string') return `<li>${esc(src)}</li>`;
+      const title = esc(src.title || src.url || '');
+      const url = src.url ? esc(src.url) : null;
+      return url
+        ? `<li><a href="${url}" target="_blank" rel="noopener">${title}</a></li>`
+        : `<li>${title}</li>`;
+    }).join('');
+    parts.push(`<h4>Quellen</h4><ul>${items}</ul>`);
+  }
+  return `<details class="tip-details"><summary>Details</summary><div class="tip-details-body">${parts.join('')}</div></details>`;
+}
+
 function init() {
   const container = document.getElementById('themes');
   const seen = new Set();
@@ -191,17 +252,20 @@ function init() {
         row.dataset.themeId = itId;
         const roleClass = tip.role === 'T' ? 'role-t' : tip.role === 'I' ? 'role-i' : 'role-p';
         row.innerHTML = `
-          <div class="tip-role ${roleClass}">${tip.role}</div>
-          <div class="tip-info">
-            <div class="tip-name">${tip.name}</div>
-            <div class="tip-meta">${ref}</div>
+          <div class="tip-row-main">
+            <div class="tip-role ${roleClass}">${tip.role}</div>
+            <div class="tip-info">
+              <div class="tip-name">${esc(tip.name)}</div>
+              <div class="tip-meta">${esc(ref)}</div>
+            </div>
+            <div class="br-buttons">
+              ${[1,2,3,4,5].map(n =>
+                `<button class="br-btn s${n}" data-ref="${esc(ref)}" data-score="${n}" data-theme="${itId}"
+                  onclick="setScore('${esc(ref)}', ${n}, '${itId}')">${n}</button>`
+              ).join('')}
+            </div>
           </div>
-          <div class="br-buttons">
-            ${[1,2,3,4,5].map(n =>
-              `<button class="br-btn s${n}" data-ref="${ref}" data-score="${n}" data-theme="${itId}"
-                onclick="setScore('${ref}', ${n}, '${itId}')">${n}</button>`
-            ).join('')}
-          </div>
+          ${renderTipDetails(tip)}
         `;
         card.appendChild(row);
 


### PR DESCRIPTION
Closes #175.

## Summary
- Add native HTML5 `<details>`/`<summary>` block to each `tip-row` in `value-modeler/templates/scoring-ui.html` so users can expand a TIP to read its full description, rationale, evidence bullets, and source list inline while scoring.
- Extend the `__MODEL_DATA_PLACEHOLDER__` contract in `phase-3-scoring.md` Step 1 to merge `description`, `rationale`, `evidence`, and `sources` from `.metadata/trend-scout-output.json` (`tips_candidates.items[*]`) into each TIP entry alongside the existing `name` / `candidate_ref` / `score` / horizon fields.
- Add light CSS for the new `.tip-details` block (subtle border, muted text, source-list bullets) consistent with the existing dark-surface theme. Restructure `.tip-row` to a vertical layout (existing flex-row content wrapped in `.tip-row-main`) so the expandable section sits beneath the score buttons rather than colliding with them.
- Bump `cogni-trends` from 0.4.16 to 0.4.17 in both `plugin.json` and `marketplace.json` (per repo convention for skill changes).

## Scope decisions
- **In:** Template change + workflow-phase reference change + version bump. Reporter's option 1 (`<details>`/`<summary>` per tip-row) is the lowest-risk and most accessible variant — no JS framework dependency, zero impact on existing scoring/sync/export logic, which all key off `candidate_ref` and remain untouched.
- **Out:** Hover-tooltips (option 2) and per-chain collapsible panels (option 3) are explicitly deferred — option 1 covers the workflow-break problem on its own, and adding multiple presentation modes here would muddy the review.
- **Out:** No script edits — the value-modeler skill has no `scripts/` directory; placeholder substitution is procedural text in the workflow-phase reference. The fix is a docs change, not code.
- **Out:** SKILL.md is unchanged — Step 1 detail lives in `references/workflow-phases/phase-3-scoring.md` already and the SKILL itself only points at it.

## Implementation notes
- Added a small `esc()` helper for HTML-escaping fields that previously came pre-trusted from `MODEL_DATA` — the new fields (`description`, `rationale`, `evidence`, `sources`) carry user-/web-sourced text that should be escaped on render. Applied the same escape to the existing `name` / `candidate_ref` interpolations for consistency.
- `renderTipDetails(tip)` returns an empty string when all four fields are absent or empty, so legacy projects (no `trend-scout-output.json`) generate the same UI as before — the expandable section is opt-in per row.
- Sources accept either `{title, url}` objects (preferred) or plain strings — both render as bullet items, only the object form gets a clickable link.

## Test plan
- [ ] Open `value-modeler-scoring.html` generated against a representative project payload (with `description`/`rationale`/`evidence`/`sources` populated on each TIP) — confirm each `tip-row` shows a clickable caret/summary; click expands to a panel with all four sections rendered.
- [ ] Confirm collapsed/expanded state does not interfere with the 1-5 scoring buttons (no overlap, click targets remain hittable).
- [ ] Run a fresh value-modeler Phase 3 generation on an existing TIPS project — verify the generated `value-modeler-scoring.html` includes the populated detail blocks and that `br-scores.json` export remains schema-identical to before.
- [ ] Confirm a TIP missing one of the optional fields (e.g. no `sources`) renders gracefully (omit the section, do not show an empty bullet list).
- [ ] Render a legacy payload without the four new fields — confirm the details block is suppressed entirely (no empty caret rows).
- [ ] Cross-check `marketplace.json` `cogni-trends` entry now reads version 0.4.17 alongside `plugin.json`.
