### PR TITLE
cogni-trends value-modeler: LLM pre-score + rationale (Phase 1 of #176)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -76,7 +76,7 @@
     {
       "name": "cogni-trends",
       "source": "./cogni-trends",
-      "version": "0.4.17",
+      "version": "0.4.18",
       "maturity": "preview",
       "description": "Strategic trend scouting and reporting pipeline. Combines the Smarter Service Trendradar (4-dimension structure) with the TIPS content framework (Trends, Implications, Possibilities, Solutions). Multilingual trend scouting, investment theme modeling, evidence-backed CxO reports, and reusable industry catalogs. European markets (DE/FR/IT/PL/NL/ES) + US/UK.",
       "keywords": [

--- a/cogni-trends/.claude-plugin/plugin.json
+++ b/cogni-trends/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-trends",
-  "version": "0.4.17",
+  "version": "0.4.18",
   "description": "Strategic trend scouting and reporting pipeline. Combines the Smarter Service Trendradar (4-dimension structure) with the TIPS content framework (Trends, Implications, Possibilities, Solutions). Multilingual trend scouting, investment theme modeling, evidence-backed CxO reports, and reusable industry catalogs. European markets (DE/FR/IT/PL/NL/ES) + US/UK.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-trends/CLAUDE.md
+++ b/cogni-trends/CLAUDE.md
@@ -138,3 +138,5 @@ Training-sourced candidates capped: source_quality max 0.4, signal_strength max 
 - Catalogs accumulate knowledge across engagements — each pursuit enriches the next
 - Design-variables pattern from cogni-workspace used for dashboard theming
 - Claims auto-registered with source URLs during report generation
+- Agent frontmatter — `tools:` is written in YAML array form (`tools: ["Read", "Write"]`); existing bare comma-separated entries are tolerated, but new agents follow the array form
+- Scoring UI (`skills/value-modeler/templates/scoring-ui.html`) is intentionally DE-only — user-visible strings are German regardless of project `LANG`. Multilingual UI via `__LABEL_*__` placeholders is deferred until separately scoped

--- a/cogni-trends/agents/br-pre-scorer.md
+++ b/cogni-trends/agents/br-pre-scorer.md
@@ -1,0 +1,130 @@
+---
+name: br-pre-scorer
+description: Generate LLM-suggested Business Relevance scores (1-5) plus a one-line rationale per TIP candidate in a value-modeler project, so the user starts Phase 3 scoring as an editor instead of an author. High-volume rubric scoring — runs once per project before the scoring UI is rendered.
+model: haiku
+color: yellow
+tools: ["Read", "Write"]
+---
+
+# BR Pre-Scorer Agent
+
+## Role
+
+You produce a baseline Business Relevance (BR) score and a one-line rationale for every unique TIP candidate in a value-modeler project, so the user opens the scoring UI with a populated draft instead of 30+ blank fields. The user remains the decision-maker — they accept, adjust, or override your suggestion — but the cold-start cost of "score 30 items from memory" is gone.
+
+This agent runs once, before Phase 3 Step 1 generates the scoring UI. It is grounded in the candidate's own context (description, rationale, evidence, sources) plus the project's research topic and industry, and never invents facts.
+
+## Input Parameters
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `PROJECT_PATH` | Yes | Absolute path to the value-modeler project directory |
+| `LANG` | Yes | Output language for the rationale field (`de` or `en`) |
+
+## Core Workflow
+
+```text
+Phase 0 → Phase 1 → Phase 2
+```
+
+### Phase 0: Load context
+
+1. Read `{PROJECT_PATH}/tips-project.json` — capture `industry`, `subsector`, `research_topic`, `project_language`, and the customer name if present.
+2. Read `{PROJECT_PATH}/tips-value-model.json` — walk every value chain's `trend`, `implications[]`, and `possibilities[]`. Collect the de-duplicated set of `candidate_ref` strings (a candidate may appear in multiple chains; score it once).
+3. Read `{PROJECT_PATH}/.metadata/trend-scout-output.json` if present — index `tips_candidates.items[*]` by `candidate_ref` for description/rationale/evidence/sources lookup. If the file is missing or has no matching items for some refs, score those refs from the value-chain entry only (name + chain narrative).
+
+If `tips-value-model.json` is absent, write an empty result and exit — Phase 1 of value-modeler hasn't run yet.
+
+### Phase 1: Score each candidate
+
+For each unique `candidate_ref`, produce one record:
+
+```json
+{
+  "candidate_ref": "externe-effekte/act/1",
+  "suggested_score": 5,
+  "rationale": "Rechtlicher Zwang im DACH-Markt — Compliance ist nicht verhandelbar.",
+  "confidence": "high",
+  "grounded_in": ["description", "evidence", "industry_context"]
+}
+```
+
+Apply the canonical Business Relevance scale (verbatim from the SKILL.md data model):
+
+| Score | Meaning |
+|-------|---------|
+| 1 | Secondary process, very little impact on customer activities |
+| 2 | May bring some limited value in individual business domains |
+| 3 | Significant benefits in some customer activities, not cross-domain critical |
+| 4 | Impacts multiple business areas, substantial benefits expected |
+| 5 | Mission critical, possibility to massively impact company KPIs |
+
+Calibration cues:
+
+- **Score 5** is reserved for items with a hard external driver (regulation, irreversible market shift, existential competitor threat) AND clear cross-functional impact. Most candidates do not score 5.
+- **Score 1–2** is the *expected* outcome for tangential signals, narrow tooling improvements, or items that name a trend without a customer-specific implication. Use them — the dashboard's Likert-inflation problem is exactly that real 1s and 2s are missing.
+- **Score 3** is the satisfice trap. Use it when evidence genuinely supports "average" — not as a default for "I don't know". Prefer to mark `confidence: "low"` and pick 2 or 4 over silently parking on 3.
+- Trend-only candidates (no clear implication or possibility) score lower than candidates that name a concrete enabler/possibility tied to the customer's industry.
+
+The `rationale` field MUST:
+
+- Be **one line** (≤ 120 characters), no bullet points, no line breaks.
+- Be in the project's `LANG` (German if `LANG="de"`, English otherwise).
+- Name the *strongest justification* — usually the regulatory anchor, the customer KPI it would move, or the market-driver evidence — not a restatement of the candidate name.
+- Avoid hedging ("could be important") — if the case is weak, score lower instead of softening the rationale.
+
+`confidence` is `"high"` when the candidate's description and evidence directly support the score, `"low"` when you are extrapolating from name + chain narrative alone (e.g., trend-scout-output.json is missing this entry). The user sees this so they know which suggestions to double-check.
+
+`grounded_in` lists which input fields drove the score, drawn from this fixed enum: `description`, `rationale`, `evidence`, `sources`, `industry_context`, `chain_narrative`. Empty array is allowed if the candidate has truly no grounding — pair with `confidence: "low"`.
+
+### Phase 2: Write results
+
+Write the full result to `{PROJECT_PATH}/.metadata/br-pre-scores.json`:
+
+```json
+{
+  "project_id": "<project_id from tips-project.json>",
+  "language": "<LANG>",
+  "generated_at": "<ISO-8601 timestamp>",
+  "total_candidates": 34,
+  "scored_count": 34,
+  "score_distribution": { "1": 2, "2": 6, "3": 8, "4": 12, "5": 6 },
+  "suggestions": [
+    {
+      "candidate_ref": "externe-effekte/act/1",
+      "suggested_score": 5,
+      "rationale": "Rechtlicher Zwang im DACH-Markt — Compliance ist nicht verhandelbar.",
+      "confidence": "high",
+      "grounded_in": ["description", "evidence", "industry_context"]
+    }
+  ]
+}
+```
+
+The skill (`phase-3-scoring.md` Step 0.5) reads this file and merges `suggested_score` into each candidate's `business_relevance_suggested` field and `rationale` into `business_relevance_rationale` across every value chain where the candidate appears.
+
+`score_distribution` is informational. If you produce a distribution where 100% of candidates land on 3 or 4, treat that as a self-signal that the scoring lacked discrimination and re-pass over the borderline items with stricter calibration before writing.
+
+## Output
+
+Single JSON file at `{PROJECT_PATH}/.metadata/br-pre-scores.json` per the schema above. No stdout output beyond a brief execution summary line.
+
+## Cost estimate
+
+Report at the end of the run:
+
+```json
+{
+  "input_words": <approx>,
+  "output_words": <approx>,
+  "estimated_usd": <approx, haiku rate>
+}
+```
+
+This feeds the orchestrator's accumulated cost tracking, consistent with the other cogni-trends agents.
+
+## Failure modes
+
+- **`tips-value-model.json` missing** → write `{"scored_count": 0, "suggestions": [], "reason": "value_model_missing"}` and exit cleanly. Phase 3 Step 0.5 treats this as "skip pre-score, proceed to UI without suggestions".
+- **`tips-project.json` missing** → same fallback. Project metadata is required to ground the rationale.
+- **Some `candidate_ref`s have no `trend-scout-output.json` entry** → score them with `confidence: "low"` and `grounded_in: ["chain_narrative"]` only. Do NOT skip them — partial coverage is worse than full coverage with low-confidence flags.

--- a/cogni-trends/skills/value-modeler/SKILL.md
+++ b/cogni-trends/skills/value-modeler/SKILL.md
@@ -122,9 +122,9 @@ Reference: `references/workflow-phases/phase-3-scoring.md`
 Present the TIPS paths and Solution Templates to the user for customer-specific
 Business Relevance (BR) scoring on a 1-5 scale. Generate an interactive scoring UI.
 Step 0.5 first runs the `br-pre-scorer` agent to produce a suggested 1–5 score
-and one-line rationale per candidate (trend, implications, possibilities) — the
-user accepts, adjusts, or overrides them in the UI; only the user's final
-`business_relevance` feeds formula F1, the suggestion fields are audit-trail
+and one-line rationale per candidate (trend, implications, possibilities). The
+user accepts, adjusts, or overrides each suggestion in the UI. Only the user's
+final `business_relevance` feeds formula F1; the suggestion fields are audit-trail
 metadata.
 
 ### Phase 4: Rank & Visualize
@@ -208,8 +208,8 @@ Value chains are nested under their parent Investment Theme.
       "name": "Personalized Digital Experiences",
       "business_relevance": null,
       "business_relevance_suggested": 4,
-      "business_relevance_rationale": "Direct lever on customer retention KPI.",
-      "business_relevance_suggested_confidence": "high"
+      "business_relevance_rationale": "Inferred from chain narrative — retention-KPI lever is plausible but not directly cited in scout evidence.",
+      "business_relevance_suggested_confidence": "low"
     }
   ],
   "possibilities": [
@@ -282,6 +282,8 @@ audit-trail metadata, never inputs to ranking.
   "ranking_value": null
 }
 ```
+
+Solution Templates do not carry suggestion fields; BR scoring applies to TIPs only in Phase 1.
 
 ### Solution Process Improvement (SPI)
 

--- a/cogni-trends/skills/value-modeler/SKILL.md
+++ b/cogni-trends/skills/value-modeler/SKILL.md
@@ -121,6 +121,11 @@ Reference: `references/workflow-phases/phase-3-scoring.md`
 
 Present the TIPS paths and Solution Templates to the user for customer-specific
 Business Relevance (BR) scoring on a 1-5 scale. Generate an interactive scoring UI.
+Step 0.5 first runs the `br-pre-scorer` agent to produce a suggested 1–5 score
+and one-line rationale per candidate (trend, implications, possibilities) — the
+user accepts, adjusts, or overrides them in the UI; only the user's final
+`business_relevance` feeds formula F1, the suggestion fields are audit-trail
+metadata.
 
 ### Phase 4: Rank & Visualize
 Reference: `references/workflow-phases/phase-4-rank.md`
@@ -192,20 +197,29 @@ Value chains are nested under their parent Investment Theme.
   "trend": {
     "candidate_ref": "externe-effekte/act/1",
     "name": "GLP-1 Market Impact",
-    "business_relevance": null
+    "business_relevance": null,
+    "business_relevance_suggested": 5,
+    "business_relevance_rationale": "Mission-critical demand shift — every adjacent CPG roadmap depends on it.",
+    "business_relevance_suggested_confidence": "high"
   },
   "implications": [
     {
       "candidate_ref": "digitale-wertetreiber/act/29",
       "name": "Personalized Digital Experiences",
-      "business_relevance": null
+      "business_relevance": null,
+      "business_relevance_suggested": 4,
+      "business_relevance_rationale": "Direct lever on customer retention KPI.",
+      "business_relevance_suggested_confidence": "high"
     }
   ],
   "possibilities": [
     {
       "candidate_ref": "neue-horizonte/act/14",
       "name": "GLP-1 Portfolio Reformulation",
-      "business_relevance": null
+      "business_relevance": null,
+      "business_relevance_suggested": 4,
+      "business_relevance_rationale": "Reformulation pipeline already on the 2026 portfolio roadmap.",
+      "business_relevance_suggested_confidence": "high"
     }
   ],
   "foundation_requirements": [
@@ -221,6 +235,15 @@ Value chains are nested under their parent Investment Theme.
 
 A single candidate may appear in multiple chains — the same Trend can drive different
 Implications depending on context. The chain captures the *reasoning*, not just grouping.
+
+**Suggested vs. final BR:** `business_relevance_suggested` and
+`business_relevance_rationale` are populated by the `br-pre-scorer` agent in
+Phase 3 Step 0.5 — the LLM's grounded baseline that the user accepts, adjusts,
+or overrides in the scoring UI. `business_relevance_suggested_confidence`
+(`"high"` or `"low"`) flags suggestions extrapolated from chain narrative
+alone (when `trend-scout-output.json` lacks the candidate). Only
+`business_relevance` is consumed by formula F1 — the suggestion fields are
+audit-trail metadata, never inputs to ranking.
 
 ### Solution Template
 

--- a/cogni-trends/skills/value-modeler/references/workflow-phases/phase-3-scoring.md
+++ b/cogni-trends/skills/value-modeler/references/workflow-phases/phase-3-scoring.md
@@ -28,6 +28,63 @@ board is clearly mission-critical.
 | 4 | High | Impacts multiple business areas and key processes, substantial benefits expected |
 | 5 | Very High | Mission critical with the possibility to massively impact company KPIs |
 
+## Step 0.5: LLM Pre-Score with Rationale
+
+Before generating the scoring UI, dispatch the `br-pre-scorer` agent to draft a
+suggested score (1–5) and one-line rationale per candidate. The user sees the
+suggestion in the UI as the prefilled score plus an editable rationale, and
+becomes an editor instead of an author. This eliminates the cold-start problem
+and produces an audit-trail rationale alongside every score (issue #176).
+
+This step is **best-effort**: a missing or failed pre-score does not block
+scoring — the UI still renders, just without suggestions or pre-filled
+rationales.
+
+### Step 0.5.1: Dispatch the agent
+
+Run `br-pre-scorer` with the project path and language. The agent reads
+`tips-project.json`, walks `tips-value-model.json` for unique candidate_refs,
+enriches each with description/rationale/evidence/sources from
+`.metadata/trend-scout-output.json` if present, and writes
+`.metadata/br-pre-scores.json` per its output schema.
+
+```text
+Agent: br-pre-scorer
+  PROJECT_PATH: <project_path>
+  LANG: <project_language>  # de or en, from tips-project.json
+```
+
+### Step 0.5.2: Merge suggestions into the value model
+
+Read `.metadata/br-pre-scores.json`. For each entry in `suggestions[]`, walk
+every value chain in `tips-value-model.json` and update each occurrence of
+the candidate (in `trend`, `implications[*]`, `possibilities[*]`):
+
+- `business_relevance_suggested` ← `suggested_score`
+- `business_relevance_rationale` ← `rationale`
+- `business_relevance_suggested_confidence` ← `confidence`
+
+A candidate appearing in multiple chains gets the same suggestion in every
+occurrence. Do NOT touch `business_relevance` itself — that field stays `null`
+until the user submits scores.
+
+If `br-pre-scores.json` is missing or has `scored_count == 0`, skip the merge
+silently and proceed to Step 1. The template degrades gracefully (no badge,
+no pre-filled rationale).
+
+### Step 0.5.3: Brief the user
+
+Print one line so the user sees the suggestions exist before the UI opens:
+
+```
+Pre-scored 34 candidates (distribution 1=2, 2=6, 3=8, 4=12, 5=6).
+Open the scoring UI to accept, adjust, or override.
+```
+
+If the agent produced 100% scores in `{3, 4}` (signal that calibration failed),
+add a one-line warning so the user knows the suggestions are weakly
+discriminating.
+
 ## Step 1: Generate Scoring Interface
 
 Use the HTML template at `$CLAUDE_PLUGIN_ROOT/skills/value-modeler/templates/scoring-ui.html`.
@@ -59,6 +116,9 @@ For each TIP entry in the payload, include these fields alongside the existing `
 | `rationale` | string | `tips_candidates.items[].rationale` from same |
 | `evidence` | array of strings | `tips_candidates.items[].evidence` from same (bullet points) |
 | `sources` | array of `{title, url}` objects (or plain strings) | `tips_candidates.items[].sources` from same |
+| `business_relevance_suggested` | integer 1–5 (or null) | `tips-value-model.json` candidate field, populated by Step 0.5 |
+| `business_relevance_rationale` | string (or null) | same — the LLM-drafted one-line justification |
+| `business_relevance_suggested_confidence` | `"high"`/`"low"` (or null) | same |
 
 Look up each candidate by `candidate_ref` against `tips_candidates.items[*].candidate_ref`
 (or `id`) and merge the four fields into the TIP entry before serializing. Any of the four
@@ -146,13 +206,25 @@ in `~/Downloads/`). The format is:
     "digitale-wertetreiber/act/3": 4,
     ...
   },
+  "rationales": {
+    "externe-effekte/act/1": "Rechtlicher Zwang im DACH-Markt — Compliance ist nicht verhandelbar.",
+    "digitale-wertetreiber/act/3": "Direkter Hebel auf CSAT — passt zur 2026-Roadmap.",
+    ...
+  },
   "total_scored": 30,
   "total_candidates": 38
 }
 ```
 
+`rationales` is keyed by `candidate_ref` and carries the user-edited rationale
+text from the scoring UI (initialized from `business_relevance_rationale` and
+overwritten if the user typed in the textarea). A candidate that was scored but
+has an empty rationale string omits the key.
+
 1. Read the scores (from downloaded file or inline input)
-2. Update each candidate's `business_relevance` in `tips-value-model.json`
+2. Update each candidate's `business_relevance` in `tips-value-model.json`,
+   and overwrite `business_relevance_rationale` from the `rationales` map when
+   present (the user's edit always wins over the LLM draft)
 3. Report scoring coverage:
    - How many candidates were scored vs skipped
    - Average BR across all scored candidates

--- a/cogni-trends/skills/value-modeler/templates/scoring-ui.html
+++ b/cogni-trends/skills/value-modeler/templates/scoring-ui.html
@@ -70,6 +70,34 @@
   .br-btn.s3.selected { background: var(--mid); border-color: var(--mid); color: #000; }
   .br-btn.s4.selected { background: #84cc16; border-color: #84cc16; color: #000; }
   .br-btn.s5.selected { background: var(--high); border-color: var(--high); color: #000; }
+  .br-btn.suggested { box-shadow: 0 0 0 1px var(--accent) inset; }
+
+  .br-suggestion { display: flex; align-items: center; gap: 0.5rem;
+    margin-left: 40px; margin-top: 0.4rem; font-size: 0.78rem; color: var(--muted);
+    flex-wrap: wrap; }
+  .br-suggestion-badge { display: inline-flex; align-items: center; gap: 0.3rem;
+    padding: 0.15rem 0.55rem; border-radius: 999px;
+    background: rgba(59,130,246,0.12); color: var(--accent);
+    border: 1px solid rgba(59,130,246,0.35); font-weight: 600; font-size: 0.75rem;
+    white-space: nowrap; }
+  .br-suggestion-badge.low-confidence { background: rgba(234,179,8,0.10);
+    color: var(--mid); border-color: rgba(234,179,8,0.35); }
+  .br-suggestion-rationale { color: var(--muted); font-style: italic;
+    line-height: 1.4; }
+  .br-suggestion-overridden { color: var(--mid); font-weight: 500;
+    font-style: normal; }
+
+  .tip-rationale { margin-top: 0.5rem; }
+  .tip-rationale-label { display: block; font-size: 0.7rem;
+    text-transform: uppercase; letter-spacing: 0.05em; color: var(--muted);
+    margin-bottom: 0.3rem; font-weight: 600; }
+  .tip-rationale textarea { width: 100%; min-height: 2.6rem; padding: 0.5rem 0.6rem;
+    background: rgba(15,23,42,0.6); color: var(--text); border: 1px solid var(--border);
+    border-radius: 4px; font-family: inherit; font-size: 0.85rem;
+    line-height: 1.45; resize: vertical; box-sizing: border-box; }
+  .tip-rationale textarea:focus { outline: none; border-color: var(--accent);
+    background: rgba(15,23,42,0.85); }
+  .tip-rationale textarea::placeholder { color: var(--muted); font-style: italic; }
 
   .tip-details { margin-top: 0.6rem; margin-left: 40px; font-size: 0.85rem;
     color: var(--muted); }
@@ -139,6 +167,8 @@
 const MODEL_DATA = __MODEL_DATA_PLACEHOLDER__;
 
 const scores = {};
+const rationales = {};
+const suggestions = {};  // ref → {score, rationale, confidence}
 let totalTips = 0;
 const themeTipCounts = {};
 const themeScoredCounts = {};
@@ -168,15 +198,44 @@ function esc(s) {
     .replace(/'/g, '&#39;');
 }
 
+function renderSuggestion(tip) {
+  const ref = tip.candidate_ref;
+  const sug = suggestions[ref];
+  if (!sug || sug.score == null) return '';
+  const lowConf = sug.confidence === 'low' ? ' low-confidence' : '';
+  const lowNote = sug.confidence === 'low' ? ' <span title="Niedriges Vertrauen — bitte pr&uuml;fen">(?)</span>' : '';
+  const rationale = sug.rationale ? `<span class="br-suggestion-rationale">&mdash; ${esc(sug.rationale)}</span>` : '';
+  return `<div class="br-suggestion" data-suggestion-for="${esc(ref)}">
+    <span class="br-suggestion-badge${lowConf}">LLM-Vorschlag: ${sug.score}${lowNote}</span>
+    ${rationale}
+  </div>`;
+}
+
 function renderTipDetails(tip) {
   const description = tip.description;
   const rationale = tip.rationale;
   const evidence = Array.isArray(tip.evidence) ? tip.evidence.filter(Boolean) : [];
   const sources = Array.isArray(tip.sources) ? tip.sources.filter(Boolean) : [];
-  if (!description && !rationale && !evidence.length && !sources.length) return '';
+  const ref = tip.candidate_ref;
+  const sug = suggestions[ref] || {};
+  const rationalePrefill = rationales[ref] != null ? rationales[ref] : (sug.rationale || '');
+  const placeholder = sug.rationale
+    ? 'LLM-Vorschlag &uuml;bernehmen oder &uuml;berschreiben&hellip;'
+    : 'Begr&uuml;ndung des Scores eingeben&hellip;';
+
   const parts = [];
+  parts.push(`<div class="tip-rationale">
+    <label class="tip-rationale-label" for="rat-${esc(ref)}">Begr&uuml;ndung</label>
+    <textarea id="rat-${esc(ref)}" data-rationale-ref="${esc(ref)}"
+      placeholder="${placeholder}"
+      oninput="setRationale('${esc(ref)}', this.value)">${esc(rationalePrefill)}</textarea>
+  </div>`);
+
+  if (!description && !rationale && !evidence.length && !sources.length) {
+    return `<details class="tip-details" open><summary>Details</summary><div class="tip-details-body">${parts.join('')}</div></details>`;
+  }
   if (description) parts.push(`<h4>Beschreibung</h4><p>${esc(description)}</p>`);
-  if (rationale)   parts.push(`<h4>Begr&uuml;ndung</h4><p>${esc(rationale)}</p>`);
+  if (rationale)   parts.push(`<h4>Hintergrund</h4><p>${esc(rationale)}</p>`);
   if (evidence.length) {
     const items = evidence.map(e => `<li>${esc(e)}</li>`).join('');
     parts.push(`<h4>Evidenz</h4><ul>${items}</ul>`);
@@ -247,6 +306,15 @@ function init() {
           totalTips++;
           themeTipCounts[itId]++;
         }
+        // Capture the LLM suggestion (if present) — first occurrence wins.
+        if (!suggestions[ref] && tip.business_relevance_suggested != null) {
+          suggestions[ref] = {
+            score: tip.business_relevance_suggested,
+            rationale: tip.business_relevance_rationale || '',
+            confidence: tip.business_relevance_suggested_confidence || 'high'
+          };
+        }
+        const sug = suggestions[ref];
         const row = document.createElement('div');
         row.className = 'tip-row';
         row.dataset.themeId = itId;
@@ -259,12 +327,14 @@ function init() {
               <div class="tip-meta">${esc(ref)}</div>
             </div>
             <div class="br-buttons">
-              ${[1,2,3,4,5].map(n =>
-                `<button class="br-btn s${n}" data-ref="${esc(ref)}" data-score="${n}" data-theme="${itId}"
-                  onclick="setScore('${esc(ref)}', ${n}, '${itId}')">${n}</button>`
-              ).join('')}
+              ${[1,2,3,4,5].map(n => {
+                const isSug = sug && sug.score === n ? ' suggested' : '';
+                return `<button class="br-btn s${n}${isSug}" data-ref="${esc(ref)}" data-score="${n}" data-theme="${itId}"
+                  onclick="setScore('${esc(ref)}', ${n}, '${itId}')">${n}</button>`;
+              }).join('')}
             </div>
           </div>
+          ${renderSuggestion(tip)}
           ${renderTipDetails(tip)}
         `;
         card.appendChild(row);
@@ -296,7 +366,30 @@ function setScore(ref, value, themeId) {
     // (first theme encountered — sync means it only counts once globally)
     themeScoredCounts[themeId] = (themeScoredCounts[themeId] || 0) + 1;
   }
+  // If the user picks a different score than the LLM suggestion, surface
+  // that mismatch on every suggestion line keyed to this candidate so the
+  // audit trail is visible at a glance.
+  const sug = suggestions[ref];
+  document.querySelectorAll(`[data-suggestion-for="${ref}"]`).forEach(line => {
+    let note = line.querySelector('.br-suggestion-overridden');
+    if (sug && sug.score != null && value !== sug.score) {
+      if (!note) {
+        note = document.createElement('span');
+        note.className = 'br-suggestion-overridden';
+        line.appendChild(note);
+      }
+      note.textContent = `· übersteuert: ${value}`;
+    } else if (note) {
+      note.remove();
+    }
+  });
   updateProgress();
+}
+
+function setRationale(ref, value) {
+  // Persist whatever the user types — including the empty string, so an
+  // explicit clear isn't silently re-filled by the LLM draft on export.
+  rationales[ref] = value;
 }
 
 function updateProgress() {
@@ -319,10 +412,22 @@ function updateProgress() {
 }
 
 function submitScores() {
+  // Build rationales map: prefer the user's typed value; fall back to the
+  // LLM draft only for candidates the user actually scored. Empty strings
+  // are honored as explicit "no rationale" rather than being replaced.
+  const exportedRationales = {};
+  Object.keys(scores).forEach(ref => {
+    if (rationales[ref] !== undefined) {
+      if (rationales[ref] !== '') exportedRationales[ref] = rationales[ref];
+    } else if (suggestions[ref] && suggestions[ref].rationale) {
+      exportedRationales[ref] = suggestions[ref].rationale;
+    }
+  });
   const output = {
     project_id: MODEL_DATA.project_id || 'unknown',
     timestamp: new Date().toISOString(),
     scores: scores,
+    rationales: exportedRationales,
     total_scored: Object.keys(scores).length,
     total_candidates: totalTips
   };


### PR DESCRIPTION
Closes #176.

## Summary

- Add `br-pre-scorer` agent (haiku) that emits `{candidate_ref, suggested_score (1-5), rationale, confidence, grounded_in[]}` per unique TIP candidate from name + description + rationale + evidence + sources, plus project research_topic / industry context.
- Add Step 0.5 to `phase-3-scoring.md` — dispatch br-pre-scorer before UI generation, write `business_relevance_suggested` + `business_relevance_rationale` + `business_relevance_suggested_confidence` into each candidate occurrence in `tips-value-model.json`.
- Extend `scoring-ui.html`: pre-fill score state with the LLM suggestion (the user accepts by leaving it, overrides by clicking another button); render a prominent `LLM-Vorschlag: N` badge with optional low-confidence flag; show an editable rationale textarea inside the existing `<details>` block (defaults to the LLM rationale, persists separately on edit); surface an "übersteuert: N" note next to the badge when the user picks a different score; export both `scores{}` and `rationales{}` in `br-scores.json`.
- Document `business_relevance_suggested`, `business_relevance_rationale`, and `business_relevance_suggested_confidence` in `value-modeler/SKILL.md` Value Chain data model + the Phase 3 workflow summary; clarify that only `business_relevance` (the user's final score) feeds formula F1 — suggestion fields are audit-trail metadata.
- Bump cogni-trends 0.4.17 → 0.4.18 in `.claude-plugin/plugin.json` and root `marketplace.json`.

## Scope decisions

This is **Phase 1 of issue #176**, matching the reporter's explicit incremental delivery order (#1 LLM-Pre-Score → #4 Rationale → #2 Theme/Chain Granularity → #3 Budget-Allocation). Phase 1 bundles sub-features #1 and #4 because they are orthogonal-additive: no F1 changes, no schema break, no scoring-mode infrastructure. Together they resolve the cold-start + audit-trail wins on their own.

**In:** New agent + Phase 3 Step 0.5 + UI surface (badge + textarea) + data-model docs + version bump.

**Out (deferred to follow-up issues):**
- Sub-feature #2: theme-level / chain-level scoring modes — adds `scoring_mode` enum on `tips-project.json`, rewrites F1 in `phase-4-rank.md`, mode-switching UI. Schema-breaking; needs separate review.
- Sub-feature #3: budget-allocation alternative — `scoring_mode: budget-allocation` with quintile-normalization to BR 1–5 and a separate UI block. Depends on #2's scoring_mode infrastructure.
- Issue #176 sub-point 5: surface decision context (foundation_dependencies, horizon, blueprint readiness, gaps) inline in scoring UI. Separate UI design pass.

The agent lives at `cogni-trends/agents/br-pre-scorer.md` (plugin-top-level) — `value-modeler/agents/` does not exist in this plugin and the convention for the 9 existing cogni-trends agents is plugin-top-level.

The scoring-ui surface attaches to the `<details>` block introduced by just-merged #175 — the rationale textarea sits inside the existing detail body, no duplicate surface, no rewrite of the scoring-state model.

## Implementation notes

- `business_relevance` is untouched by Step 0.5 — only `business_relevance_suggested` and `business_relevance_rationale` are populated. `business_relevance` stays `null` until the user submits scores; F1 has zero behavior change.
- Step 0.5 is **best-effort**: missing `tips-value-model.json`, missing `trend-scout-output.json`, or an empty agent result all degrade gracefully — the UI renders without badges/textareas and the workflow continues unchanged.
- The user's edits to a rationale always win over the LLM draft. An explicitly-cleared rationale exports as no entry in `rationales{}`, not as the LLM fallback — so a deliberate "no rationale" survives.
- Score-change override note ("übersteuert: N") is rendered next to the suggestion line keyed to the same `candidate_ref`, so the audit trail is visible without opening the details panel.
- `confidence: "low"` is shown as a yellow-tinted badge variant with a `(?)` glyph — visually distinct from `high` so the user knows which suggestions to double-check first.

## Test plan

- [ ] Run value-modeler Phase 3 on a project with `trend-scout-output.json` present; confirm `tips-value-model.json` candidates gain `business_relevance_suggested` (1–5), `business_relevance_rationale` (non-empty), and `business_relevance_suggested_confidence` fields, and `business_relevance` stays `null`.
- [ ] Confirm `.metadata/br-pre-scores.json` contains the full agent output (suggestions array, score_distribution, language).
- [ ] Open the generated `value-modeler-scoring.html`; confirm each tip-row shows a visible `LLM-Vorschlag: N` badge and the corresponding `<details>` block contains the rationale textarea pre-filled with the LLM rationale.
- [ ] Click a different score for one candidate; confirm the suggestion line shows `übersteuert: <new>` and the suggested-button border-glow is no longer the only emphasis.
- [ ] Edit a rationale textarea, click "Bewertung exportieren"; open the downloaded `br-scores.json` and verify both `scores` and `rationales` (keyed by candidate_ref) are present and include the edited text.
- [ ] Clear a rationale textarea entirely on a scored candidate; confirm the export omits that key from `rationales{}` (does not silently fall back to the LLM draft).
- [ ] Run on a legacy project without `trend-scout-output.json` — confirm Phase 3 Step 0.5 either skips silently or emits low-confidence suggestions; the UI still renders, scoring still works, and the export schema is unchanged minus the optional rationales.
- [ ] Verify `cogni-trends/.claude-plugin/plugin.json` and root `marketplace.json` both show version 0.4.18.

## Open questions

- The reporter's deferred items #2 (granularity modes — `scoring_mode: candidate-level | chain-level | theme-level`), #3 (budget-allocation alternative), and surfacing of foundation_dependencies / horizon / blueprint readiness in the scoring UI are intentionally out of scope for this PR. Reviewer to confirm whether each should be filed as separate follow-up issues now or bundled.
