### PR TITLE
cogni-trends: add eval specs for the three new skills

### DIFF
--- a/cogni-trends/skills/trend-booklet/evals/evals.json
+++ b/cogni-trends/skills/trend-booklet/evals/evals.json
@@ -1,0 +1,101 @@
+{
+  "skill_name": "trend-booklet",
+  "evals": [
+    {
+      "id": 1,
+      "name": "eval-happy-path-de",
+      "prompt": "Erzeuge das Trend-Booklet für unser Fertigungsprojekt — die Trend-Recherche ist abgeschlossen.",
+      "expected_output": "A German-language tips-trend-booklet.md grouped by dimension/subcategory/horizon plus a tips-trend-booklet-index.json listing all 60 candidates, with tips-project.json marked complete and the build-booklet-index.sh gate passing.",
+      "files": [],
+      "expectations": [
+        "tips-trend-booklet.md exists at the project root",
+        "tips-trend-booklet-index.json exists and is valid JSON",
+        "tips-trend-booklet-index.json lists exactly 60 candidate entries",
+        "Booklet contains 4 H2 dimension sections in T -> I -> P -> S order: Externe Effekte, Digitale Wertetreiber, Neue Horizonte, Digitales Fundament",
+        "Within each dimension, candidates are grouped first by subcategory and then by horizon bucket (ACT / PLAN / OBSERVE)",
+        "Each candidate entry includes Summary, Key citations, Supports investment themes and Keywords blocks",
+        "Every theme back-reference in the booklet resolves to an existing theme_id in tips-value-model.json (round-trip check passes)",
+        "Orphan candidates (no theme back-reference) render in a per-dimension or end-of-document appendix",
+        "build-booklet-index.sh exits 0 and prints a JSON object with success: true",
+        "tips-project.json is updated with trend_booklet_complete: true",
+        "tips-project.json records booklet_density (e.g. 'standard', 'compact', 'rich')",
+        "Booklet prose is written in German throughout"
+      ]
+    },
+    {
+      "id": 2,
+      "name": "eval-happy-path-en",
+      "prompt": "Build the trend booklet — trend-research is already complete.",
+      "expected_output": "An English-language tips-trend-booklet.md and tips-trend-booklet-index.json covering all 60 candidates with English dimension and horizon labels, with project metadata marked complete.",
+      "files": [],
+      "expectations": [
+        "tips-trend-booklet.md exists at the project root",
+        "tips-trend-booklet-index.json exists and is valid JSON with 60 candidate entries",
+        "Booklet contains 4 H2 dimension sections in T -> I -> P -> S order using English labels: Forces, Impact, Horizons, Foundations",
+        "Horizon buckets within each subcategory use English labels: Act, Plan, Observe",
+        "Each candidate entry includes Summary, Key citations, Supports investment themes and Keywords blocks (English headings)",
+        "Every theme back-reference resolves to a theme_id present in tips-value-model.json",
+        "Orphan candidates render in a per-dimension or end-of-document appendix",
+        "build-booklet-index.sh exits 0 with a success: true JSON payload",
+        "tips-project.json is updated with trend_booklet_complete: true and booklet_density set",
+        "Booklet prose is written in English throughout"
+      ]
+    },
+    {
+      "id": 3,
+      "name": "eval-density-compact",
+      "prompt": "Erzeuge das Trend-Booklet in der kompakten Variante.",
+      "expected_output": "A compact-density tips-trend-booklet.md with shorter per-entry summaries and at most two citations per entry, plus the matching index file and a project flag recording the density tier chosen.",
+      "files": [],
+      "expectations": [
+        "tips-trend-booklet.md exists and renders all 60 candidates",
+        "tips-trend-booklet-index.json exists and is valid JSON with 60 entries",
+        "Each candidate's Summary block is approximately 80 words (within +/- 25%)",
+        "Each candidate entry has at most 2 entries in its Key citations block",
+        "tips-project.json contains booklet_density: 'compact'",
+        "Booklet still contains 4 H2 dimension sections in T -> I -> P -> S order",
+        "Subcategory -> horizon grouping (ACT/PLAN/OBSERVE) is preserved",
+        "build-booklet-index.sh exits 0",
+        "Theme back-references still round-trip through tips-value-model.json",
+        "Total booklet word count is meaningfully smaller than a standard-density build (the file is shorter than a standard-density booklet for the same project)"
+      ]
+    },
+    {
+      "id": 4,
+      "name": "eval-zero-act-dimension",
+      "prompt": "Erzeuge das Booklet — eine Dimension hat in dieser Runde keine ACT-Kandidaten.",
+      "expected_output": "A booklet that renders the affected dimension with an empty Act bucket plus an explanatory note, while Plan and Observe buckets and the other three dimensions render normally.",
+      "files": [],
+      "expectations": [
+        "tips-trend-booklet.md is produced successfully (skill does not halt)",
+        "The dimension with zero ACT candidates contains an ACT bucket header followed by a note such as 'no Act-horizon candidates this round' (or equivalent localised wording)",
+        "That dimension's PLAN bucket renders its candidates normally",
+        "That dimension's OBSERVE bucket renders its candidates normally",
+        "The other three dimensions render full ACT/PLAN/OBSERVE buckets as usual",
+        "tips-trend-booklet-index.json still lists 60 candidate entries (no candidates dropped)",
+        "build-booklet-index.sh exits 0 with success: true",
+        "Theme back-references still round-trip through tips-value-model.json",
+        "tips-project.json is updated with trend_booklet_complete: true"
+      ]
+    },
+    {
+      "id": 5,
+      "name": "eval-fewer-than-60-candidates",
+      "prompt": "Build the booklet for the legacy energy project — note it only has 47 trend-scout candidates.",
+      "expected_output": "A WARN about the pre-60-quota project, followed by a successful booklet that renders all 47 available candidates, with the index and project metadata reflecting the actual count.",
+      "files": [],
+      "expectations": [
+        "Skill emits a WARN message stating that trend-scout-output.json.tips_candidates.total is below the current 60-candidate quota",
+        "Skill proceeds to produce tips-trend-booklet.md after the WARN",
+        "tips-trend-booklet.md renders all 47 candidates",
+        "tips-trend-booklet-index.json is valid JSON and lists exactly 47 entries",
+        "Booklet still contains 4 H2 dimension sections in T -> I -> P -> S order (even if some buckets are sparse)",
+        "Sparse or empty dimension/horizon buckets render with an explanatory note rather than missing headers",
+        "Orphan candidates (no theme back-reference) appear in a per-dimension or end-of-document appendix",
+        "Theme back-references still round-trip through tips-value-model.json",
+        "build-booklet-index.sh exits 0 with success: true",
+        "tips-project.json is updated with trend_booklet_complete: true and records the actual candidate count (47) somewhere in the booklet metadata or project flags"
+      ]
+    }
+  ]
+}

--- a/cogni-trends/skills/trend-research/evals/evals.json
+++ b/cogni-trends/skills/trend-research/evals/evals.json
@@ -1,0 +1,106 @@
+{
+  "skill_name": "trend-research",
+  "evals": [
+    {
+      "id": 1,
+      "name": "eval-happy-path-de",
+      "prompt": "Führe die Trend-Recherche für mein Fertigungsprojekt durch — trend-scout und value-modeler sind bereits abgeschlossen.",
+      "expected_output": "Per-dimension enriched-trends, claims and section files plus optional deep-research artefacts, all summarised in .metadata/trend-research-output.json for a German manufacturing project that already has 60 agreed trend-scout candidates and at least one value-modeler investment theme.",
+      "files": [],
+      "expectations": [
+        ".metadata/trend-research-output.json exists and is valid JSON",
+        "trend-research-output.json contains all manifest keys: schema_version, completed_at, language, market_region, dimensions_enriched, value_model_hash_at_research, candidates_hash_at_research, files",
+        "trend-research-output.json.dimensions_enriched is an array of length 4 covering externe-effekte, digitale-wertetreiber, neue-horizonte and digitales-fundament",
+        "trend-research-output.json.language is 'de' and market_region is 'de', 'dach' or another German-speaking market",
+        ".logs/enriched-trends-{dimension}.json exists for all 4 TIPS dimensions and each parses as valid JSON",
+        ".logs/claims-{dimension}.json exists for all 4 dimensions and each parses as valid JSON",
+        ".logs/section-{dimension}.md exists for all 4 dimensions (consumed later by verify-trend-report's revisor)",
+        "3-5 .logs/deep-research-*.json files exist when the user opted into Phase 0.5",
+        "trend-research-output.json.value_model_hash_at_research matches the SHA of the current tips-value-model.json",
+        "trend-research-output.json.candidates_hash_at_research matches the SHA of the current trend-scout-output.json",
+        "trend-research-output.json.files maps every produced artefact to a relative path that resolves on disk",
+        "validate-enriched-trends.sh exits with status 0 against the produced enriched-trends-*.json files",
+        "Each enriched-trends-{dimension}.json preserves all 15 trend-scout candidates for that dimension (no candidates dropped)",
+        "Section markdown files are written in German prose matching the workspace language"
+      ]
+    },
+    {
+      "id": 2,
+      "name": "eval-happy-path-en",
+      "prompt": "Run the trend-research phase for my digital-health project — trend-scout and value-modeler are both complete.",
+      "expected_output": "Enriched-trend, claims and section artefacts for all four TIPS dimensions plus a trend-research-output.json manifest, written in English for a US/UK digital-health project with completed trend-scout (60 candidates) and value-modeler outputs.",
+      "files": [],
+      "expectations": [
+        ".metadata/trend-research-output.json exists and is valid JSON",
+        "trend-research-output.json.language is 'en' and market_region is 'us', 'uk' or another English-speaking market",
+        "trend-research-output.json.dimensions_enriched has length 4 and covers all TIPS dimensions",
+        ".logs/enriched-trends-{dimension}.json exists and is valid JSON for all 4 dimensions",
+        ".logs/claims-{dimension}.json exists and is valid JSON for all 4 dimensions",
+        ".logs/section-{dimension}.md exists for all 4 dimensions and is written in English",
+        "Optional deep-research-*.json files exist when the user opted into Phase 0.5; otherwise the manifest's deep_research_trends array is empty",
+        "trend-research-output.json.value_model_hash_at_research and candidates_hash_at_research match the current value-model and scout output hashes",
+        "validate-enriched-trends.sh exits with status 0 against the produced files",
+        "All 60 trend-scout candidates appear across the 4 enriched-trends files (15 per dimension)",
+        "Web-research citations in claims files use English-language sources predominantly",
+        "trend-research-output.json.files paths all resolve to existing files on disk"
+      ]
+    },
+    {
+      "id": 3,
+      "name": "eval-skip-deep-research",
+      "prompt": "Starte trend-research, aber überspringe bitte die Deep-Research-Phase.",
+      "expected_output": "Full enriched-trends, claims and section artefacts plus a trend-research-output.json manifest, but with no deep-research log files produced because the user declined Phase 0.5.",
+      "files": [],
+      "expectations": [
+        ".metadata/trend-research-output.json exists and is valid JSON",
+        "No files matching .logs/deep-research-*.json exist in the project",
+        "trend-research-output.json.deep_research_trends is an empty array",
+        "trend-research-output.json.files map contains no key whose path starts with '.logs/deep-research-'",
+        ".logs/enriched-trends-{dimension}.json is present and valid JSON for all 4 dimensions",
+        ".logs/claims-{dimension}.json is present and valid JSON for all 4 dimensions",
+        ".logs/section-{dimension}.md is present for all 4 dimensions",
+        "trend-research-output.json.dimensions_enriched has length 4",
+        "validate-enriched-trends.sh exits with status 0",
+        "trend-research-output.json.completed_at is an ISO-8601 timestamp"
+      ]
+    },
+    {
+      "id": 4,
+      "name": "eval-missing-value-model",
+      "prompt": "/trend-research",
+      "expected_output": "The skill HALTs immediately with a clear error explaining that value-modeler must run first; no manifest or enriched-trends artefacts are produced.",
+      "files": [],
+      "expectations": [
+        "Skill output contains a HALT or hard-stop message naming value-modeler / tips-value-model.json as the missing prerequisite",
+        ".metadata/trend-research-output.json does NOT exist after the failed run",
+        "No new files matching .logs/enriched-trends-*.json are produced",
+        "No new files matching .logs/claims-*.json are produced",
+        "No new files matching .logs/section-*.md are produced",
+        "No .logs/deep-research-*.json files are produced",
+        "tips-project.json is not mutated by the failed run (modification timestamp unchanged)",
+        "Error message points the user to run /value-modeler before retrying",
+        "Skill exits without invoking any web-search tool calls"
+      ]
+    },
+    {
+      "id": 5,
+      "name": "eval-mixed-language",
+      "prompt": "Bitte führe die Trend-Recherche durch, aber gib die Ergebnisse auf Englisch aus — das Projekt selbst ist auf Deutsch.",
+      "expected_output": "German-language AskUserQuestion prompts during interaction, but enriched-trends, claims and section artefacts written in English with manifest.language='en', and web research that mixes German and English source queries.",
+      "files": [],
+      "expectations": [
+        "AskUserQuestion prompts shown to the user during the run are in German (INTERACTION_LANGUAGE = workspace language)",
+        ".metadata/trend-research-output.json exists and is valid JSON",
+        "trend-research-output.json.language is 'en'",
+        ".logs/section-{dimension}.md files for all 4 dimensions are written in English prose",
+        ".logs/enriched-trends-{dimension}.json narrative fields (descriptions, rationale) are in English",
+        ".logs/claims-{dimension}.json claim text is in English",
+        "Web-research log entries include at least one German-language query AND at least one English-language query",
+        "trend-research-output.json.value_model_hash_at_research and candidates_hash_at_research match the German project's existing value-model and scout outputs",
+        "All 4 dimensions appear in trend-research-output.json.dimensions_enriched",
+        "validate-enriched-trends.sh exits with status 0",
+        "tips-project.json language field remains 'de' (workspace language unchanged)"
+      ]
+    }
+  ]
+}

--- a/cogni-trends/skills/trend-synthesis/evals/evals.json
+++ b/cogni-trends/skills/trend-synthesis/evals/evals.json
@@ -1,0 +1,99 @@
+{
+  "skill_name": "trend-synthesis",
+  "evals": [
+    {
+      "id": 1,
+      "name": "eval-happy-path-de",
+      "prompt": "Erstelle aus den vorhandenen Recherche-Artefakten den finalen TIPS-Trendreport für unser Fertigungsprojekt.",
+      "expected_output": "A canonical TIPS-skeleton trend report (tips-trend-report.md) plus tips-trend-report-claims.json for a German project whose trend-research phase completed successfully, with the trend-scout manifest updated to record completion.",
+      "files": [],
+      "expectations": [
+        "tips-trend-report.md exists at the project root",
+        "tips-trend-report.md begins with a valid YAML frontmatter block",
+        "YAML frontmatter contains report_mode: smarter-service-themed and language: de",
+        "YAML frontmatter does NOT contain an arc_id field",
+        "Report has exactly 4 H2 dimension headers in T -> I -> P -> S order: Externe Effekte, Digitale Wertetreiber, Neue Horizonte, Digitales Fundament",
+        "Each dimension contains H3 theme-cases that align with the entries in report-theme-anchors.json",
+        "Each theme-case includes Stake / Move / Cost-of-Inaction beats but no visible 'Stake:' / 'Move:' / 'Cost of Inaction:' headers in the rendered prose",
+        "A closing 'Capability Imperative' synthesis section is present after the four dimension sections",
+        "A claims registry table is present and includes a 'dimension' column",
+        "tips-trend-report-claims.json exists and is valid JSON",
+        "trend-scout-output.json is updated with trend_report_complete: true and trend_report_mode: 'smarter-service-themed'",
+        "Report prose is written in German throughout"
+      ]
+    },
+    {
+      "id": 2,
+      "name": "eval-happy-path-en",
+      "prompt": "Generate the TIPS trend report from our completed trend-research artefacts.",
+      "expected_output": "An English-language tips-trend-report.md following the canonical TIPS skeleton plus a tips-trend-report-claims.json registry, with trend-scout-output.json marked complete.",
+      "files": [],
+      "expectations": [
+        "tips-trend-report.md exists with valid YAML frontmatter",
+        "YAML frontmatter contains report_mode: smarter-service-themed and language: en",
+        "YAML frontmatter does NOT contain an arc_id field",
+        "Report has exactly 4 H2 dimension headers in T -> I -> P -> S order using English labels: Forces, Impact, Horizons, Foundations",
+        "Each dimension has H3 theme-case sections matching report-theme-anchors.json",
+        "Each theme-case weaves Stake / Move / Cost-of-Inaction beats into prose without visible beat headers",
+        "A closing 'Capability Imperative' synthesis section is present",
+        "Claims registry table is present and contains a 'dimension' column",
+        "tips-trend-report-claims.json exists and is valid JSON",
+        "trend-scout-output.json is updated with trend_report_complete: true and trend_report_mode: 'smarter-service-themed'",
+        "Report prose is written in English throughout"
+      ]
+    },
+    {
+      "id": 3,
+      "name": "eval-missing-manifest",
+      "prompt": "/trend-synthesis",
+      "expected_output": "The skill HALTs because no trend-research-output.json manifest exists; no report or claims file is created.",
+      "files": [],
+      "expectations": [
+        "Skill output contains a HALT message instructing the user to 'Run /trend-research first' (or equivalent prerequisite-missing wording)",
+        ".metadata/trend-research-output.json does not exist before or after the run",
+        "tips-trend-report.md is NOT created by the failed run",
+        "tips-trend-report-claims.json is NOT created by the failed run",
+        "trend-scout-output.json is not mutated (no trend_report_complete flag added)",
+        "tips-project.json is not mutated by the failed run",
+        "Skill exits before invoking any subagents or writing tools"
+      ]
+    },
+    {
+      "id": 4,
+      "name": "eval-legacy-arc-cleanup",
+      "prompt": "Bitte erstelle den Trendreport neu — die alte Version war noch arc-basiert.",
+      "expected_output": "A freshly regenerated tips-trend-report.md built from the canonical TIPS skeleton, with all legacy arc-based artefacts and metadata fields cleaned up before regeneration.",
+      "files": [],
+      "expectations": [
+        "Phase 0 logs include a message such as 'legacy report_arc_id ignored — using canonical TIPS skeleton'",
+        "The previous tips-trend-report.md is overwritten (not appended to) — file modification timestamp updates and file size reflects a fresh build",
+        "tips-project.json no longer contains a report_arc_id field after the run",
+        "tips-trend-report.md YAML frontmatter does not contain a trend_report_arc_id key (or any arc_id key)",
+        "The literal substring 'arc' (case-insensitive, as a standalone word) does not appear anywhere in the produced tips-trend-report.md",
+        "Report has exactly 4 H2 dimension headers in T -> I -> P -> S order",
+        "Each dimension has H3 theme-cases matching report-theme-anchors.json",
+        "Closing 'Capability Imperative' synthesis section is present",
+        "tips-trend-report-claims.json is regenerated and is valid JSON",
+        "trend-scout-output.json.trend_report_mode is 'smarter-service-themed'"
+      ]
+    },
+    {
+      "id": 5,
+      "name": "eval-stale-research",
+      "prompt": "Erstelle den Trendreport. (Hinweis: value-modeler wurde nach trend-research erneut ausgeführt.)",
+      "expected_output": "A WARNing about the stale research manifest, an opportunity to halt or proceed, and — if proceeded — a report whose theme back-references reflect only the older value-model snapshot, with the hash mismatch logged.",
+      "files": [],
+      "expectations": [
+        "Skill emits a WARN message stating that .metadata/trend-research-output.json.value_model_hash_at_research does not match the current tips-value-model.json hash",
+        "WARN message offers the user a choice to re-run /trend-research or to proceed with stale data",
+        "If the user proceeds, the produced tips-trend-report.md theme back-references only reference theme_ids present in the value-model snapshot at research time (not new themes added afterwards)",
+        "Hash mismatch is recorded in the run logs (e.g. .logs/trend-synthesis.log or equivalent)",
+        "tips-trend-report.md is still produced when the user proceeds",
+        "tips-trend-report-claims.json is produced and valid JSON when the user proceeds",
+        "YAML frontmatter records the stale-research condition (e.g. a stale_research_warning or research_value_model_hash_at_synthesis field, or a notes field flagging the mismatch)",
+        "trend-scout-output.json.trend_report_complete is set to true only if the user proceeds",
+        "If the user halts, no tips-trend-report.md is written and no flags are flipped on trend-scout-output.json"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Follow-up to PR #192. The cogni-trends refactor in #192 split the monolithic `trend-report` skill into three focused skills (`trend-research`, `trend-synthesis`, `trend-booklet`) and deleted the old `trend-report/evals/evals.json`. This PR replaces that deleted eval spec with one descriptive eval-spec file per new skill, mirroring the existing `trend-scout/evals/evals.json` pattern (plain-text assertions, no `type` field, no executable runner).

Each file lives at `cogni-trends/skills/{skill}/evals/evals.json` and contains 5 test cases covering happy paths in German and English, one mixed-language case, one edge case, and one error/halt case.

### `trend-research`
Specs the Phase-0..N enrichment workflow: per-dimension `enriched-trends-*.json`, `claims-*.json`, `section-*.md` files plus the `trend-research-output.json` manifest with hash pinning to value-model and trend-scout outputs. Covers happy paths (DE/EN), opt-out of deep-research, halt when value-modeler hasn't run, and the mixed-language interaction case.

### `trend-synthesis`
Specs the canonical TIPS-skeleton report build: `tips-trend-report.md` with 4 H2 dimensions in T->I->P->S order, theme-cases with hidden Stake/Move/Cost-of-Inaction beats, the closing Capability Imperative section, and `tips-trend-report-claims.json`. Covers happy paths (DE/EN), missing-manifest halt, legacy `report_arc_id` cleanup, and the stale-research hash-mismatch path.

### `trend-booklet`
Specs the long-form companion: `tips-trend-booklet.md` grouped by dimension -> subcategory -> horizon plus `tips-trend-booklet-index.json` covering all 60 candidates, with theme back-refs round-tripping through `tips-value-model.json`. Covers happy paths (DE/EN), compact density tier, an empty-ACT-bucket dimension, and the legacy <60-candidate fallback.

## Test plan

- [ ] Confirm each new `evals.json` is valid JSON and follows the `trend-scout` schema (skill_name + evals[] with id/name/prompt/expected_output/files/expectations)
- [ ] Spot-check the assertions reference real artefact filenames used by the corresponding skill (`.metadata/trend-research-output.json`, `tips-trend-report.md`, `tips-trend-booklet-index.json`, etc.)
- [ ] Manually verify one happy-path eval per skill against a fixture project once the new skills land

Parent refactor: #192

https://claude.ai/code/session_01RxaPP4tpJAHx4svfVf8rkz

---
_Generated by [Claude Code](https://claude.ai/code/session_01RxaPP4tpJAHx4svfVf8rkz)_