### PR TITLE
cogni-wiki 0.0.19: wiki-refresh stale-page loop (Punkt 3)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -254,7 +254,7 @@
     {
       "name": "cogni-wiki",
       "source": "./cogni-wiki",
-      "version": "0.0.18",
+      "version": "0.0.19",
       "maturity": "incubating",
       "description": "A better RAG for personal and small-team knowledge work. Claude maintains a persistent, interlinked markdown wiki that compiles sources once at ingest — no embeddings, no vector store, no re-discovery per query. Answers come from the wiki (not memory), contradictions are surfaced at ingest (not missed at retrieval), and knowledge compounds instead of starting from zero. Based on Andrej Karpathy's LLM Wiki pattern.",
       "keywords": [

--- a/cogni-wiki/.claude-plugin/plugin.json
+++ b/cogni-wiki/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-wiki",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "description": "A better RAG for personal and small-team knowledge work. Claude maintains a persistent, interlinked markdown wiki that compiles sources once at ingest — no embeddings, no vector store, no re-discovery per query. Answers come from the wiki (not memory), contradictions are surfaced at ingest (not missed at retrieval), and knowledge compounds instead of starting from zero. Based on Andrej Karpathy's LLM Wiki pattern.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-wiki/CLAUDE.md
+++ b/cogni-wiki/CLAUDE.md
@@ -7,7 +7,7 @@ Compile-time knowledge engine for personal and small-team knowledge work — a b
 ```
 agents/                         1 agent (fan-out worker)
   ingest-worker.md                Per-source subagent for wiki-ingest batch mode (Steps 1–8)
-skills/                         8 wiki skills
+skills/                         9 wiki skills
   wiki-setup/                     Bootstrap a new wiki at a user-chosen root
     references/
       SCHEMA.md.template          Copied into the wiki at setup time
@@ -39,6 +39,9 @@ skills/                         8 wiki skills
     scripts/
       render_dashboard.py         Reads wiki/ → writes wiki-dashboard.html (stdlib only)
   wiki-from-research/             Cold-start: chains research-setup → research-report → wiki-setup → wiki-ingest --discover research:<slug>. Mode A (--topic) or Mode B (--research-slug).
+  wiki-refresh/                   Stale-page refresh loop. Pull-mode: matches lint-flagged stale pages to sub-questions of an existing cogni-research project (Jaccard token overlap), then dispatches wiki-update per match. Sequential, batch-confirmed.
+    scripts/
+      refresh_planner.py            Reads stale wiki pages + research entities; emits per-page match plan as JSON
 
 references/
   karpathy-pattern.md             Shared Karpathy-pattern reference, cited by all skills
@@ -48,11 +51,11 @@ references/
 
 | Type | Count | Items |
 |------|-------|-------|
-| Skills | 8 | wiki-setup, wiki-ingest, wiki-query, wiki-lint, wiki-update, wiki-resume, wiki-dashboard, wiki-from-research |
+| Skills | 9 | wiki-setup, wiki-ingest, wiki-query, wiki-lint, wiki-update, wiki-resume, wiki-dashboard, wiki-from-research, wiki-refresh |
 | Agents | 1 | ingest-worker (per-source fan-out worker for wiki-ingest batch mode; not directly dispatchable) |
 | Commands | 0 | — (skills serve as slash commands per plugin-dev guidance) |
 | Hooks | 0 | — (all bookkeeping lives inside skills) |
-| Scripts | 6 | backlink_audit.py, wiki_index_update.py, batch_builder.py, lint_wiki.py, wiki_status.sh, render_dashboard.py |
+| Scripts | 7 | backlink_audit.py, wiki_index_update.py, batch_builder.py, lint_wiki.py, wiki_status.sh, render_dashboard.py, refresh_planner.py |
 
 ## Wiki Data Layout (outside the plugin)
 
@@ -129,6 +132,7 @@ insight-wave already uses Claude Code's auto-memory system at `~/.claude/project
 
 - **cogni-research → cogni-wiki** (v0.0.17, sub-question-centric — Option B). `wiki-ingest --discover research:<project-slug>` enumerates one batch entry per sub-question of a completed cogni-research project, materialises per-sub-question synthesis files under `<wiki-root>/raw/research-<slug>/sq-NN-<short>.md`, and feeds them through the standard batch-mode pipeline (Steps 1–8 per source). The synthesis bundles findings (from contexts), verified claims (filtered to `verification_status: verified`), and source URLs. Materialisation is the one deviation from the discovery-is-read-only rule and is unavoidable: cogni-research spreads each sub-question's evidence across four entity types, and the per-source ingest-worker reads one file. Materialisation is deterministic and idempotent. See `skills/wiki-ingest/references/batch-mode.md` §"Discovery → research" for the full contract. The reverse path (`wiki-researcher` agent reading a wiki as a RAG source for a research project) is owned by cogni-research and pre-dates this integration.
 - **wiki-from-research cold-start** (v0.0.18). The `wiki-from-research` skill chains `cogni-research:research-setup` → `cogni-research:research-report` (auto-chained internally) → `cogni-wiki:wiki-setup` → `cogni-wiki:wiki-ingest --discover research:<slug>` in one dispatch. Mode A starts from a free-text `--topic`; Mode B starts from an existing `--research-slug`. The skill is a pure orchestrator — it writes nothing directly; every artefact comes from its sub-skills' contracts. Pre-flight is fail-fast: wiki-target collisions are detected before any cogni-research dispatch (so an unusable target never burns research budget). Mode B verifies `output/report.md` exists, refuses `report_source ∈ {wiki, hybrid}` projects (circular-evidence risk), and nudges the user to run `verify-report` first if zero claims are verified.
+- **wiki-refresh stale-page loop** (v0.0.19, pull-mode only). The `wiki-refresh` skill closes the *update* loop — stale wiki pages get fresh evidence from a completed cogni-research project. Calls `lint_wiki.py` directly to enumerate `stale_page` (>365d) and `stale_draft` (>180d) findings, runs `refresh_planner.py` to match each stale page to the highest-scoring sub-question via Jaccard token overlap on `(title + tags + type)` vs `(query + parent_topic)`, prints a batch plan for one user confirmation, then materialises one synthesis file per match under `<wiki-root>/raw/refresh-<research-slug>-<YYYY-MM-DD>/<page-slug>.md` and dispatches `wiki-update` sequentially per page. Default match threshold `0.30`, tunable via `--match-threshold` or interactively via the `refine` action in the plan-review prompt. Push-mode auto-research per stale page is deferred (cost-prohibitive at scale). The entity-loading helpers in `refresh_planner.py` mirror those in `batch_builder.py` — known tech debt, parallel to the `_wiki_lock` duplication noted in §"Concurrency Invariant".
 
 ## Future Integration Points
 

--- a/cogni-wiki/skills/wiki-refresh/SKILL.md
+++ b/cogni-wiki/skills/wiki-refresh/SKILL.md
@@ -1,0 +1,235 @@
+---
+name: wiki-refresh
+description: "Refresh stale wiki pages with fresh evidence from a completed cogni-research project. Runs wiki-lint internally, matches stale pages to sub-questions via deterministic token overlap (Jaccard), prints a batch plan for one user confirmation, then dispatches wiki-update per matched page with the synthesised refresh content as the new source. Trigger when the user says 'refresh stale pages from research <slug>', 'wiki-refresh against project X', 'update aging pages with the new agent-economy research', 'pull recent findings into stale pages', or 'my wiki is getting stale, use the latest research to refresh it'. Pull-mode only — does not auto-launch new research."
+allowed-tools: Read, Bash, Glob, AskUserQuestion, Skill
+---
+
+# Wiki Refresh
+
+Close the *update* loop in the cogni-research → cogni-wiki integration. Wiki pages age (`wiki-lint` flags `stale_page` >365d, `stale_draft` >180d), but lint alone doesn't bring fresh evidence. This skill matches stale pages to sub-questions of a completed cogni-research project, materialises one synthesis file per matched pair, and pipes each through `wiki-update` to apply the diff against the existing page.
+
+This is a **pull-mode** primitive — the user provides the fresh research project; this skill never spins up new research. (Push-mode auto-research per stale page is deferred — it would cost ~$0.50/page and surprises a wiki owner with a research bill.)
+
+The skill is a pure orchestrator. It calls `lint_wiki.py` directly for staleness data (cheaper than dispatching `wiki-lint`, which would write a noise line to `wiki/log.md`), runs `refresh_planner.py` for the match plan, materialises per-page refresh files under `<wiki-root>/raw/refresh-<research-slug>-<YYYY-MM-DD>/`, and then dispatches `wiki-update` sequentially per matched page. Every wiki write goes through existing locked code paths.
+
+Read `${CLAUDE_PLUGIN_ROOT}/references/karpathy-pattern.md` once before proceeding to re-anchor on the three-layer model (raw / wiki / schema) — refresh content lands in `raw/`, not directly in `wiki/pages/`.
+
+## When to run
+
+- User asks to refresh stale pages from a specific completed cogni-research project
+- User wants to pull fresh evidence into an aging wiki without re-running research from scratch
+- After a periodic deep-research run on a known domain, to fan the new findings into existing wiki pages
+
+## Never run when
+
+- The user has no existing cogni-research project to pull from — that's `wiki-from-research`'s territory (Mode A)
+- The wiki has zero stale pages and the user did not pass `--pages` — there's nothing to refresh
+- The cogni-research project's `report_source` is `wiki` or `hybrid` — circular evidence (deferred per `wiki-from-research`'s same rule)
+
+## Parameters
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `--from-research <slug>` | Yes | Slug of an existing `cogni-research-<slug>/` project. Auto-located at `<workspace>/cogni-research-<slug>/` or `<wiki-root>/cogni-research-<slug>/`. |
+| `--research-root <path>` | No | Override auto-locate. |
+| `--match-threshold <float>` | No | Jaccard cutoff for accepting a match. Default `0.30`. Range `[0.0, 1.0]`. |
+| `--days <N>` | No | Override staleness threshold (collapses lint's `STALE_PAGE_DAYS=365` and `STALE_DRAFT_DAYS=180` to a single `N`). Mutually exclusive with `--pages`. |
+| `--pages <slug,slug>` | No | Explicit page list, bypassing the lint-based stale filter. Implies the user is targeting specific pages. Mutually exclusive with `--days`. |
+| `--limit <N>` | No | Cap matches at N after ranking by score (highest first). Excess pages are reported as unmatched. |
+| `--force` | No | With `--pages`: include sub-threshold matches (the best available sub-question is taken regardless of score). No effect on lint-driven runs — we never auto-refresh below threshold. |
+| `--related-sweep <yes\|no>` | No | Pass-through to `wiki-update`. Default `no` (related-sweep multiplies work and the user only batch-confirms the top-level plan). |
+| `--dry-run` | No | Print the resolved plan and stop. No materialisation, no `wiki-update` dispatch. |
+| `--wiki-root <path>` | No | Override auto-detected wiki root. |
+
+## Workflow
+
+### 0. Pre-flight (always; fail-fast)
+
+1. Resolve `wiki_root` (walk up for `.cogni-wiki/config.json`).
+2. Resolve `project = cogni-research-<slug>` via the same logic as `batch_builder.py::_locate_research_project`.
+3. Verify `<project>/project-config.json` exists. Verify `<project>/output/report.md` exists. Verify at least one `<project>/00-sub-questions/data/sq-*.md` exists. Any missing → abort with the verbatim missing-path.
+4. Read `<project>/project-config.json`. If `report_source ∈ {wiki, hybrid}`: abort with "circular-evidence projects can't refresh a wiki — same rule as wiki-from-research".
+5. **Project-staleness warning (not abort).** If the project's youngest source file (under `<project>/02-sources/data/`) has a `fetched_at` older than 180 days, emit one paragraph: "this research project is itself >180 days old; the refresh may not actually bring newer evidence than the existing pages." Continue anyway.
+6. Compute `today = YYYY-MM-DD` for the per-day refresh subdir name.
+
+### 1. Lint for staleness (skipped if `--pages` is set)
+
+Direct script call:
+
+```bash
+python3 ${CLAUDE_PLUGIN_ROOT}/skills/wiki-lint/scripts/lint_wiki.py --wiki-root <wiki_root>
+```
+
+Parse stdout JSON. From `data.warnings[]`, collect entries where `class == "stale_page"` or `class == "stale_draft"`. Extract the `page` field of each as the slug list.
+
+If `--days N` was set, post-filter the lint output: walk pages in `<wiki_root>/wiki/pages/`, parse frontmatter, keep only those whose `(today - updated).days > N`.
+
+If the resolved stale list is empty, emit "wiki is up to date — no stale pages to refresh" and exit 0.
+
+### 2. Compute match plan
+
+Dispatch the helper:
+
+```bash
+python3 ${CLAUDE_PLUGIN_ROOT}/skills/wiki-refresh/scripts/refresh_planner.py \
+  --wiki-root <wiki_root> \
+  --research-slug <slug> \
+  [--research-root <path>] \
+  [--threshold 0.3] \
+  [--days N | --pages slug,slug] \
+  [--limit N] \
+  [--force]
+```
+
+The script returns `{"success": true, "data": {"matches": [...], "unmatched_pages": [...], "stats": {...}}}`. On `success: false`, surface the error verbatim and stop.
+
+### 3. Print plan, batch-confirm
+
+Render plan as a table the user can review:
+
+```
+Refresh plan (research: <slug>, <date>):
+  <K> of <stale_total> stale pages matched, <below_threshold> below threshold
+
+  page                       age   →  sub-question                                      score
+  ai-safety-evals            412d  →  sq-03 What evaluation methods…                    0.42
+  llm-jailbreaks             198d  →  sq-07 How do current jailbreak techniques…        0.38
+
+Unmatched (<count>): legacy-rag-notes (best 0.12), …
+```
+
+Truncate sub-question queries to ~50 chars in the table; the full query lives in the JSON for any user that wants to inspect it.
+
+If `--dry-run` was set, stop here. Exit 0.
+
+Otherwise, AskUserQuestion with three options:
+
+| Label | Action |
+|---|---|
+| `proceed` | Run Steps 4–6 against the current plan |
+| `refine` | Re-prompt for `--match-threshold` (free text), loop back to Step 2 |
+| `abort` | Exit 0, no writes |
+
+Default surfaced: `proceed` if `data.stats.matched > 0`, otherwise `refine`.
+
+### 4. Materialise per-page refresh markdown
+
+For each entry in `data.matches[]`:
+
+1. Compute output path:
+   ```
+   <wiki_root>/raw/refresh-<research-slug>-<today>/<page-slug>.md
+   ```
+   Date in path → reruns same day overwrite deterministically; reruns different days preserve audit trail.
+2. Compose the body. Use the same context/source/claim aggregation as `batch_builder.py` (Step 5 of `wiki-ingest --discover research:`), restricted to the matched sub-question:
+   ```markdown
+   # <Page Title> — refresh from research <slug> (<date>)
+
+   *Sub-question SQ-<NN> ("<query>") matched <score:.2f> against this page (`reasons: <reasons>`). Findings below are from the research project and may refine, contradict, or supplement the current page.*
+
+   ## Findings
+
+   <context bodies for the matched sub-question>
+
+   ## Verified claims
+
+   - <statement> ([source](<url>)) — verified <date>
+
+   ## New sources
+
+   - [<title>](<url>) — <publisher>          # only sources NOT already in the page's `sources:` frontmatter
+   ```
+   If the "new sources" set-difference is empty, label the section `## Sources (already in page)` instead — `wiki-update`'s LLM may still cross-check claims against them.
+
+   **Verified-claim filter**: `verification_status == "verified"` AND the claim's `source_ref` overlaps with the matched sub-question's contexts' source set. Same structural join as PR #197.
+
+3. Write atomically: write to `<path>.tmp`, then `os.replace(<path>.tmp, <path>)`.
+
+The skill does **not** pre-bake a diff. `wiki-update`'s LLM-driven Step 3 (diff-before-write) computes the diff from the existing page + the new source.
+
+### 5. Dispatch wiki-update sequentially
+
+For each entry in `data.matches[]`, in score-desc order (already provided by the planner):
+
+```
+Skill("cogni-wiki:wiki-update",
+      args="--page <page-slug> --reason new-source --source raw/refresh-<slug>-<today>/<page-slug>.md --related-sweep <no|yes>")
+```
+
+**Sequential, not parallel.** `wiki-update` mutates `wiki/index.md` (and, with `--related-sweep yes`, potentially many other pages). The advisory lock at `<wiki-root>/.cogni-wiki/.lock` keeps writes safe, but parallel dispatch buys nothing because each call already serialises on the lock; sequential keeps the orchestration trivial and the failure surface single-threaded.
+
+If a `wiki-update` dispatch fails for a specific page (e.g. the page was deleted between Step 1 and now, or the page is locked by an unrelated worker), capture the error in a `failures: [{page: <slug>, error: <message>}]` list and continue with the rest of the batch. Per-page failures never halt the run.
+
+### 6. Final summary
+
+Plain prose, ≤8 lines:
+
+- Research source slug + date used
+- `N` pages refreshed successfully (slug list)
+- `K` failures (slug + error per failure)
+- `M` pages unmatched / below threshold (slug list)
+- Path to the per-day refresh subdir under `raw/` (kept for audit; user may `git rm -rf` if undesired)
+- Suggested next: `wiki-lint` (catches contradictions surfaced by the refreshes), `wiki-query` to spot-check that a refreshed page reflects the new findings.
+
+## Match algorithm
+
+The planner uses **Jaccard on token sets**:
+
+- Page side: tokens from `title + " " + " ".join(tags) + " " + type`.
+- Sub-question side: tokens from `query + " " + parent_topic`.
+- `score = |A ∩ B| / |A ∪ B|`.
+
+Tokenizer (in `refresh_planner.py`):
+1. Lowercase, replace any non-`[a-z0-9]` run with space, split on whitespace.
+2. Drop tokens with `len < 3`.
+3. Drop ~30 stopwords (`a, an, the, of, in, on, for, with, and, or, …`).
+4. Mini suffix-strip: `ies → y`, then trailing `ing | ed | es | s` → empty.
+5. Set up the deduped result.
+
+**Asymmetric-overlap rejected**: with short titles (1–2 tokens), one matching term gives score 1.0, which over-matches.
+**Weighted Jaccard rejected**: a wiki's tag corpus is too small to estimate IDF reliably.
+
+Tie-breakers (highest-scoring sub-question wins per page):
+- Higher score wins
+- On tie: lower `section_index` wins
+- On tie: lexicographic sub-question id wins
+
+Threshold default `0.30` is empirically reasonable but tunable. The user can `refine` the threshold in Step 3, or pass `--match-threshold` upfront.
+
+## Edge cases
+
+- **Project too old.** Step 0 (5) emits a one-paragraph warning and continues.
+- **Zero stale pages.** Step 1 exits clean with `nothing to do`.
+- **Zero matches above threshold.** Step 3 surfaces `0 of N matched`; the `refine` option re-prompts. The default surfaced flips to `refine`.
+- **Page newer than project report.** The page's `updated:` may be more recent than the project's `output/report.md` if the user hand-edited the page between research runs. Refresh proceeds regardless — the refresh's value is the *evidence axis*, not just recency.
+- **Re-run same day.** The per-day subdir overwrites deterministically; the planner's match output is byte-identical for the same inputs (deterministic tokenizer + sorted reasons).
+- **`wiki-update` per-page failure.** Captured in `failures[]`; the batch continues. The user sees per-failure detail in Step 6.
+- **`--pages` with an unknown slug.** The planner emits `stale_pages_total: 0` (the slug isn't in the wiki at all). Step 1 surfaces it; the SKILL warns and excludes it from the batch.
+- **Sub-question with zero contexts.** The planner still scores it normally (the query+parent_topic tokens still match). The materialised file has an empty `## Findings` section; `wiki-update`'s LLM detects the lack of new evidence and likely retires the refresh — acceptable.
+
+## Out of scope
+
+- **Push-mode auto-research** per stale page. Cost-prohibitive at scale; user explicitly chose pull-only.
+- **LLM-judged matching.** Token overlap is debuggable, deterministic, and good enough for v1. LLM matching is a future option if false-positive rates prove unacceptable.
+- **Per-page interactive confirmation.** Batch-confirm only — the user reviews the whole plan once.
+- **URL-drift detection** on page sources. `wiki-lint` doesn't do this today; this skill doesn't either. A `wiki-claims-resweep` skill (Punkt 4) is the right place.
+- **Refresh of non-stale pages.** Override via `--pages` only.
+- **Wiki/hybrid-mode research projects** as the source. Same circular-evidence concern as `wiki-from-research`.
+- **Refactor of `batch_builder.py`** to share entity-loading helpers. The duplication is acknowledged tech debt — both consumers target the same cogni-research entity contract; a schema change touches both anyway. Refactor is non-urgent (parallel to the `_wiki_lock` situation noted in `cogni-wiki/CLAUDE.md`).
+
+## Output
+
+The skill produces:
+- A populated `<wiki-root>/raw/refresh-<research-slug>-<today>/` subdir with one synthesis file per matched page (audit trail; idempotent same-day, preserved across days)
+- Updated wiki pages — bumped `updated:`, expanded `sources:`, body diffed by `wiki-update`'s LLM
+- Append-only `wiki/log.md` with one `update` line per refreshed page (written by `wiki-update`)
+
+No file is created outside `<wiki-root>/`.
+
+## References
+
+- `${CLAUDE_PLUGIN_ROOT}/references/karpathy-pattern.md` — the three-layer model
+- `${CLAUDE_PLUGIN_ROOT}/skills/wiki-lint/scripts/lint_wiki.py` — direct invocation in Step 1; `STALE_*_DAYS` constants
+- `${CLAUDE_PLUGIN_ROOT}/skills/wiki-update/SKILL.md` — Step 5 dispatch contract (`--page`, `--reason new-source`, `--source`, `--related-sweep`)
+- `${CLAUDE_PLUGIN_ROOT}/skills/wiki-ingest/scripts/batch_builder.py` — entity-loading pattern (`_locate_research_project`, `_load_sub_questions`, `_index_research_entities`, `_render_synthesis`); `refresh_planner.py` mirrors these helpers
+- `${CLAUDE_PLUGIN_ROOT}/skills/wiki-refresh/scripts/refresh_planner.py` — match-plan generator

--- a/cogni-wiki/skills/wiki-refresh/scripts/refresh_planner.py
+++ b/cogni-wiki/skills/wiki-refresh/scripts/refresh_planner.py
@@ -1,0 +1,491 @@
+#!/usr/bin/env python3
+"""
+refresh_planner.py — match stale wiki pages to cogni-research sub-questions
+and emit a refresh plan on stdout. The wiki-refresh skill consumes this
+plan: it materialises one refresh markdown per matched (page, sub-question)
+pair and dispatches wiki-update to apply each.
+
+Boundary: this script does NOT write to the wiki. It only reads and emits
+JSON. Materialisation lives in the SKILL.md (Step 5), which keeps the
+script idempotent and dry-run-safe.
+
+Match algorithm: Jaccard on token sets, page-side = title + tags + type,
+sub-question-side = query + parent_topic. Stopword-filtered, lightly
+suffix-stripped. Symmetric and deterministic. Threshold default 0.30.
+
+Stdlib-only, Python 3.8+. Output contract:
+
+    {
+      "success": true,
+      "data": {
+        "matches": [
+          {
+            "page": "<slug>",
+            "page_title": "...",
+            "page_age_days": <int>,
+            "page_type": "<type>",
+            "page_tags": [...],
+            "sub_question": "<sq-id>",
+            "sub_question_query": "...",
+            "sub_question_section_index": <int>,
+            "score": <float>,
+            "reasons": ["tag overlap: [...]", "title term: '<t>'", ...]
+          }
+        ],
+        "unmatched_pages": ["<slug>", ...],
+        "stats": {
+          "stale_pages_total": <int>,
+          "matched": <int>,
+          "below_threshold": <int>,
+          "sub_questions_total": <int>
+        }
+      },
+      "error": ""
+    }
+
+    On failure: {"success": false, "data": {}, "error": "..."} with exit 1.
+
+Note on duplication: lines 100–230 (frontmatter parser, wikilink stripper,
+entity loaders) mirror equivalent helpers in
+`cogni-wiki/skills/wiki-ingest/scripts/batch_builder.py`. The duplication
+is acknowledged tech debt — both targets share the same cogni-research
+entity contract (`schemas/{sub-question,context,source,report-claim}.schema.json`),
+and a schema change would touch both consumers anyway. Refactor is non-urgent
+(parallel to the `_wiki_lock` situation described in cogni-wiki/CLAUDE.md).
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+
+# Staleness thresholds — must match cogni-wiki/skills/wiki-lint/scripts/lint_wiki.py
+STALE_DRAFT_DAYS = 180
+STALE_PAGE_DAYS = 365
+
+DEFAULT_THRESHOLD = 0.30
+
+FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.DOTALL)
+SLUG_CLEAN_RE = re.compile(r"[^a-z0-9]+")
+TOKEN_SPLIT_RE = re.compile(r"[^a-z0-9]+")
+
+STOPWORDS = frozenset({
+    "a", "an", "the", "of", "in", "on", "for", "with", "and", "or", "to", "is", "are", "was", "were",
+    "be", "been", "being", "have", "has", "had", "do", "does", "did", "will", "would", "should", "can",
+    "could", "may", "might", "must", "what", "how", "why", "when", "where", "which", "who", "whom",
+    "this", "that", "these", "those", "it", "its", "their", "they", "them", "we", "us", "our",
+    "vs", "into", "from", "about", "as", "by", "if", "any", "all", "some", "more", "most",
+})
+
+
+def fail(msg: str) -> None:
+    print(json.dumps({"success": False, "data": {}, "error": msg}))
+    sys.exit(1)
+
+
+def ok(data: dict) -> None:
+    print(json.dumps({"success": True, "data": data, "error": ""}))
+    sys.exit(0)
+
+
+# ---------------------------------------------------------------------------
+# Frontmatter / wikilink helpers (mirror batch_builder.py)
+# ---------------------------------------------------------------------------
+
+
+def parse_frontmatter(text: str) -> dict:
+    m = FRONTMATTER_RE.match(text)
+    if not m:
+        return {}
+    out: dict = {}
+    current_key = None
+    for line in m.group(1).splitlines():
+        if not line.strip() or line.lstrip().startswith("#"):
+            continue
+        if line.startswith("  - ") and current_key:
+            out.setdefault(current_key, []).append(line[4:].strip())
+            continue
+        if ":" in line:
+            k, _, v = line.partition(":")
+            k = k.strip()
+            v = v.strip()
+            current_key = k
+            if v.startswith("[") and v.endswith("]"):
+                inside = v[1:-1].strip()
+                out[k] = [x.strip() for x in inside.split(",") if x.strip()] if inside else []
+            elif v:
+                out[k] = v
+            else:
+                out[k] = []
+    return out
+
+
+def _unquote(s: str) -> str:
+    s = s.strip()
+    if len(s) >= 2 and s[0] == s[-1] and s[0] in ('"', "'"):
+        return s[1:-1]
+    return s
+
+
+def _strip_wikilink(ref: str) -> str:
+    inner = _unquote(ref)
+    if inner.startswith("[[") and inner.endswith("]]"):
+        inner = inner[2:-2]
+    return inner.rsplit("/", 1)[-1]
+
+
+def parse_date(s: str):
+    try:
+        return dt.datetime.strptime(s.strip(), "%Y-%m-%d").date()
+    except (ValueError, AttributeError):
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Wiki side: stale page enumeration
+# ---------------------------------------------------------------------------
+
+
+def find_wiki_root(start: Path) -> Path:
+    current = start.resolve()
+    while True:
+        if (current / ".cogni-wiki" / "config.json").is_file():
+            return current
+        if current.parent == current:
+            fail(f"not inside a cogni-wiki (no .cogni-wiki/config.json at or above {start})")
+        current = current.parent
+
+
+def load_wiki_pages(wiki_root: Path) -> list[dict]:
+    """Return all wiki pages with parsed frontmatter and computed age."""
+    pages_dir = wiki_root / "wiki" / "pages"
+    if not pages_dir.is_dir():
+        return []
+    today = dt.date.today()
+    pages: list[dict] = []
+    for path in sorted(pages_dir.iterdir()):
+        if not (path.is_file() and path.suffix == ".md"):
+            continue
+        if path.name.startswith("lint-"):
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        fm = parse_frontmatter(text)
+        slug = path.stem
+        title = _unquote(fm.get("title", "")) or slug
+        page_type = _unquote(fm.get("type", "")) or "summary"
+        tags = fm.get("tags", []) if isinstance(fm.get("tags"), list) else []
+        tags = [_unquote(t) for t in tags if isinstance(t, str)]
+        sources = fm.get("sources", []) if isinstance(fm.get("sources"), list) else []
+        sources = [_unquote(s) for s in sources if isinstance(s, str)]
+        status = _unquote(fm.get("status", "")).lower()
+        updated_str = _unquote(fm.get("updated", ""))
+        updated = parse_date(updated_str)
+        age_days = (today - updated).days if updated else None
+        pages.append({
+            "slug": slug,
+            "title": title,
+            "type": page_type,
+            "tags": tags,
+            "sources": sources,
+            "status": status,
+            "updated": updated_str,
+            "age_days": age_days,
+            "path": path,
+        })
+    return pages
+
+
+def filter_stale(pages: list[dict], days_override: int | None) -> list[dict]:
+    """Apply lint's staleness rule (or --days override) to the page list."""
+    out = []
+    for p in pages:
+        age = p.get("age_days")
+        if age is None:
+            # No valid `updated:` — lint flags as a frontmatter warning, not stale.
+            # Skip here; stale-by-age is the only signal this script consumes.
+            continue
+        if days_override is not None:
+            if age > days_override:
+                out.append(p)
+        else:
+            if p["status"] == "draft" and age > STALE_DRAFT_DAYS:
+                out.append(p)
+            elif age > STALE_PAGE_DAYS:
+                out.append(p)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Research side: entity loaders (mirrors batch_builder.py)
+# ---------------------------------------------------------------------------
+
+
+def locate_research_project(slug_or_path: str, wiki_root: Path, override: str | None) -> Path:
+    if override:
+        project = Path(override).resolve()
+        if not project.is_dir():
+            fail(f"--research-root not a directory: {project}")
+        return project
+    if "/" in slug_or_path or slug_or_path.startswith("."):
+        candidate = Path(slug_or_path).resolve()
+        if candidate.is_dir():
+            return candidate
+        fail(f"--research path not found: {candidate}")
+    candidates = [
+        wiki_root.parent / f"cogni-research-{slug_or_path}",
+        wiki_root / f"cogni-research-{slug_or_path}",
+    ]
+    for c in candidates:
+        if c.is_dir():
+            return c.resolve()
+    fail(
+        "cogni-research project not found. Tried: "
+        + ", ".join(str(c) for c in candidates)
+        + ". Pass --research-root to override."
+    )
+    return Path()  # unreachable
+
+
+def load_sub_questions(project: Path) -> list[dict]:
+    sq_dir = project / "00-sub-questions" / "data"
+    if not sq_dir.is_dir():
+        fail(f"sub-questions dir missing: {sq_dir}")
+    items: list[dict] = []
+    for path in sorted(sq_dir.glob("sq-*.md")):
+        text = path.read_text(encoding="utf-8")
+        fm = parse_frontmatter(text)
+        if not fm.get("query"):
+            continue
+        try:
+            section_index = int(fm.get("section_index", 0))
+        except (TypeError, ValueError):
+            section_index = 0
+        items.append({
+            "id": _unquote(fm.get("dc:identifier") or path.stem),
+            "query": _unquote(fm["query"]),
+            "parent_topic": _unquote(fm.get("parent_topic", "")),
+            "section_index": section_index,
+            "status": _unquote(fm.get("status", "")),
+        })
+    items.sort(key=lambda x: (x["section_index"], x["id"]))
+    return items
+
+
+# ---------------------------------------------------------------------------
+# Tokenizer
+# ---------------------------------------------------------------------------
+
+
+def _stem(token: str) -> str:
+    """Mini suffix-stripper. Order matters: longest suffix first."""
+    if len(token) < 4:
+        return token
+    if token.endswith("ies") and len(token) > 4:
+        return token[:-3] + "y"
+    for suffix in ("ing", "ed", "es", "s"):
+        if token.endswith(suffix) and len(token) - len(suffix) >= 3:
+            return token[: -len(suffix)]
+    return token
+
+
+def tokenize(*parts: str) -> set:
+    text = " ".join(p for p in parts if p)
+    text = text.lower()
+    raw_tokens = TOKEN_SPLIT_RE.split(text)
+    out: set = set()
+    for t in raw_tokens:
+        if len(t) < 3:
+            continue
+        if t in STOPWORDS:
+            continue
+        out.add(_stem(t))
+    return out
+
+
+def jaccard(a: set, b: set) -> float:
+    if not a and not b:
+        return 0.0
+    union = a | b
+    if not union:
+        return 0.0
+    return len(a & b) / len(union)
+
+
+def explain_match(page: dict, sq: dict, page_tokens: set, sq_tokens: set) -> list[str]:
+    """Up to 3 human-readable reasons. Debuggability, not behavioural.
+
+    Deterministic — sorted token iteration so reruns produce identical reasons.
+    """
+    reasons: list[str] = []
+    page_tag_tokens = tokenize(" ".join(page["tags"]))
+    overlap_tags = sorted(t for t in page_tag_tokens if t in sq_tokens)
+    if overlap_tags:
+        reasons.append(f"tag overlap: {overlap_tags[:3]}")
+    title_tokens = tokenize(page["title"])
+    title_hits = sorted(t for t in title_tokens if t in sq_tokens)
+    if title_hits:
+        reasons.append(f"title term: '{title_hits[0]}'")
+    type_token = tokenize(page["type"])
+    if type_token and any(t in sq_tokens for t in type_token):
+        reasons.append("type match")
+    return reasons[:3]
+
+
+# ---------------------------------------------------------------------------
+# Match planner
+# ---------------------------------------------------------------------------
+
+
+def build_plan(
+    stale_pages: list[dict],
+    sub_questions: list[dict],
+    threshold: float,
+    force: bool,
+    limit: int | None,
+) -> dict:
+    matches: list[dict] = []
+    unmatched: list[str] = []
+    below_threshold = 0
+
+    sq_token_cache: dict = {}
+    for sq in sub_questions:
+        sq_token_cache[sq["id"]] = tokenize(sq["query"], sq["parent_topic"])
+
+    for page in stale_pages:
+        page_tokens = tokenize(page["title"], " ".join(page["tags"]), page["type"])
+        best: dict | None = None
+        for sq in sub_questions:
+            score = jaccard(page_tokens, sq_token_cache[sq["id"]])
+            if best is None or (score, -sq["section_index"], sq["id"]) > (
+                best["score"], -best["sub_question_section_index"], best["sub_question"]
+            ):
+                # Tie-break: higher score wins; on tie, lower section_index wins;
+                # on tie, lex sub-question id wins. We invert section_index so
+                # max-tuple compare picks the lower one.
+                best = {
+                    "score": score,
+                    "sub_question": sq["id"],
+                    "sub_question_query": sq["query"],
+                    "sub_question_section_index": sq["section_index"],
+                    "_sq_obj": sq,
+                    "_page_tokens": page_tokens,
+                }
+        if best is None:
+            unmatched.append(page["slug"])
+            continue
+        if best["score"] < threshold and not force:
+            below_threshold += 1
+            unmatched.append(page["slug"])
+            continue
+        reasons = explain_match(page, best["_sq_obj"], best["_page_tokens"], sq_token_cache[best["sub_question"]])
+        matches.append({
+            "page": page["slug"],
+            "page_title": page["title"],
+            "page_age_days": page["age_days"],
+            "page_type": page["type"],
+            "page_tags": page["tags"],
+            "sub_question": best["sub_question"],
+            "sub_question_query": best["sub_question_query"],
+            "sub_question_section_index": best["sub_question_section_index"],
+            "score": round(best["score"], 4),
+            "reasons": reasons,
+        })
+
+    # Sort matches by score desc for plan readability and --limit.
+    matches.sort(key=lambda m: (-m["score"], m["sub_question_section_index"], m["page"]))
+
+    if limit is not None and limit >= 0:
+        if len(matches) > limit:
+            dropped = matches[limit:]
+            matches = matches[:limit]
+            for m in dropped:
+                unmatched.append(m["page"])
+
+    return {
+        "matches": matches,
+        "unmatched_pages": sorted(set(unmatched)),
+        "stats": {
+            "stale_pages_total": len(stale_pages),
+            "matched": len(matches),
+            "below_threshold": below_threshold,
+            "sub_questions_total": len(sub_questions),
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Match stale wiki pages to cogni-research sub-questions; emit refresh plan as JSON.",
+    )
+    parser.add_argument("--research-slug", required=True, help="cogni-research project slug or path.")
+    parser.add_argument("--research-root", help="Override auto-located project root.")
+    parser.add_argument("--wiki-root", help="Override auto-detected wiki root.")
+    parser.add_argument("--threshold", type=float, default=DEFAULT_THRESHOLD,
+                        help=f"Jaccard threshold for matching (default {DEFAULT_THRESHOLD}).")
+    parser.add_argument("--days", type=int, default=None,
+                        help="Override staleness threshold (collapses STALE_PAGE_DAYS+STALE_DRAFT_DAYS to N).")
+    parser.add_argument("--pages", help="Comma-separated page slug list; bypasses staleness filter.")
+    parser.add_argument("--limit", type=int, default=None, help="Cap matches at N after ranking.")
+    parser.add_argument("--force", action="store_true",
+                        help="With --pages: include sub-threshold matches.")
+    args = parser.parse_args()
+
+    if args.pages and args.days is not None:
+        fail("--pages and --days are mutually exclusive")
+    if args.threshold < 0.0 or args.threshold > 1.0:
+        fail(f"--threshold must be in [0.0, 1.0], got {args.threshold}")
+
+    return args
+
+
+def main() -> None:
+    args = parse_args()
+
+    wiki_root = Path(args.wiki_root).resolve() if args.wiki_root else find_wiki_root(Path.cwd())
+    if not (wiki_root / ".cogni-wiki" / "config.json").is_file():
+        fail(f"not a cogni-wiki: {wiki_root}/.cogni-wiki/config.json not found")
+
+    project = locate_research_project(args.research_slug, wiki_root, args.research_root)
+    if not (project / "project-config.json").is_file():
+        fail(f"not a cogni-research project (missing project-config.json): {project}")
+
+    sub_questions = load_sub_questions(project)
+    if not sub_questions:
+        ok({
+            "matches": [],
+            "unmatched_pages": [],
+            "stats": {"stale_pages_total": 0, "matched": 0, "below_threshold": 0, "sub_questions_total": 0},
+        })
+
+    all_pages = load_wiki_pages(wiki_root)
+    if args.pages:
+        wanted = {s.strip() for s in args.pages.split(",") if s.strip()}
+        stale_pages = [p for p in all_pages if p["slug"] in wanted]
+        # Note: we do NOT filter by age here — explicit --pages bypasses staleness.
+        missing = wanted - {p["slug"] for p in stale_pages}
+        # Missing slugs are not fatal; they're surfaced via the SKILL's pre-flight,
+        # not here. The planner just doesn't include them.
+        del missing
+    else:
+        stale_pages = filter_stale(all_pages, args.days)
+
+    plan = build_plan(stale_pages, sub_questions, args.threshold, args.force, args.limit)
+    ok(plan)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Schließt den **Update-Loop** in der cogni-research → cogni-wiki Integration. Stale Wiki-Pages bekommen frische Evidenz aus einem bereits abgeschlossenen Research-Projekt, appliziert per `wiki-update` mit Diff-Gate. **Punkt 3** der fünf Integrations-Ideen (Punkt 1 = #197, Punkt 2 = #198).

```
wiki-refresh --from-research <slug>                    # batch-confirmed refresh
wiki-refresh --from-research <slug> --dry-run          # preview plan
wiki-refresh --from-research <slug> --match-threshold 0.20    # looser matching
wiki-refresh --from-research <slug> --pages a,b --force       # specific pages, ignore threshold
```

## Architecture

Pure Orchestrator. Keine neuen Lock-protected Files; Concurrency-Invariant in `cogni-wiki/CLAUDE.md` bleibt unverändert.

```
0. Pre-flight (research project sane, refuses wiki/hybrid mode)
1. lint_wiki.py direct call → stale_page (>365d) + stale_draft (>180d) slugs
2. refresh_planner.py → Jaccard match (page title+tags+type vs sub-question query+parent_topic)
3. Batch-confirm plan (proceed | abort | refine threshold)
4. Per match: materialize raw/refresh-<slug>-<date>/<page>.md
5. Per match: sequential Skill("cogni-wiki:wiki-update", --reason new-source --source <path>)
6. Final summary (refreshed/failures/unmatched)
```

## Design choices (user-confirmed)

| Decision | Choice | Rationale |
|---|---|---|
| Evidence Source | **Pull-only** (`--from-research <slug>`) | Push (auto-research per stale page) ~$0.50/page × N — surprise budget burner. Punkt 4 territory if needed. |
| Match Algorithm | **Jaccard mit Light-Stemming** (stdlib, deterministisch) | Asymmetric over-matches short titles (1-word → 1.0 Score). Weighted-Jaccard braucht IDF-Stats die ein Wiki nicht hat. LLM-Matching teuer + nicht-deterministisch. |
| Diff-Gate | **Batch-Confirm** (1 prompt für N Pages) | Per-Page-Confirm nicht skalierbar. Per-Page-Visibility-only (kein Confirm) übergeht den User bei großen Refreshes. |

## Files

| File | Type | Purpose |
|---|---|---|
| `cogni-wiki/skills/wiki-refresh/SKILL.md` | New (235 Zeilen, 2K Wörter) | Orchestration |
| `cogni-wiki/skills/wiki-refresh/scripts/refresh_planner.py` | New (~440 Zeilen, stdlib) | Match-Plan-Generator |
| `cogni-wiki/.claude-plugin/plugin.json` | Modified | 0.0.18 → 0.0.19 |
| `.claude-plugin/marketplace.json` | Modified | mirror auf 0.0.19 |
| `cogni-wiki/CLAUDE.md` | Modified | Plugin Architecture (Skills 8→9, Scripts 6→7), Cross-Plugin Integration entry |

## Match Algorithm Details

**Tokenizer** (~25 stdlib Zeilen):
- Lowercase, non-`[a-z0-9]` Runs → Space, split
- Drop `len < 3` Tokens
- ~30 Stopwords (`a, an, the, of, in, on, …`)
- Mini Suffix-Strip: `ies → y`, dann trailing `ing | ed | es | s`

**Score**: `|A ∩ B| / |A ∪ B|`. Threshold default `0.30`.

**Tie-break**: höherer Score → niedrigerer `section_index` → lex sub-question id.

**Reasons-Feld** für Debuggability: deterministisch sortiert, up to 3 von `tag overlap: [...]`, `title term: '<t>'`, `type match`.

## Test surface (synthetic, $0)

Smoke-Test gegen 3-Page-Stale-Wiki + 3-Sub-Question-Research-Projekt:

- [x] **Default 0.30**: 1 Match (`ai-safety-evals` → `sq-evals`, score 0.33), 1 below threshold (`legacy-rag-notes`), 1 fresh (excluded)
- [x] **Threshold 0.95**: 0 Matches, clean exit
- [x] **`--pages --force`** auf fresh Page: dispatched trotz Score 0.0
- [x] **`--days 30` Override**: alle 3 Pages stale by Age
- [x] **Mutex `--pages` + `--days`**: validation error
- [x] **Threshold out of range**: validation error
- [x] **Determinism**: re-runs produzieren byte-identische JSON
- [x] **Missing project-config.json**: clean error
- [x] **Non-existent --pages slug**: empty result, kein crash
- [ ] **End-to-end mit echtem wiki-update**: deferred — wiki-update-LLM-Diff fires erst zur Runtime

## Out of scope (explizit für v1)

- Push-mode auto-research per stale Page
- LLM-judged Matching
- Per-Page-Interactive-Confirm
- URL-Drift-Detection (Punkt 4 territory)
- Refresh non-stale Pages außer via `--pages --force`
- Wiki/hybrid-mode Research-Projects als Source
- Refactor von `batch_builder.py` (Entity-Loader-Duplizierung dokumentiert als known tech debt, parallel zur `_wiki_lock`-Duplizierung)

## Follow-ups (eigene PRs)

- Punkt 4 — Claims re-verify sweep (`wiki-lint`-Erweiterung gegen cogni-claims)
- Punkt 5 — Reverse Bridge in `wiki-query` ("Vertiefen"-Verb)

---
_Generated by [Claude Code](https://claude.ai/code/session_014mYCZWmymzbinGxm3pE9aL)_