### PR TITLE
cogni-knowledge 0.0.1: wiki-first research that compounds (Phase 1 MVP)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,8 +5,8 @@
     "email": "stephan@cogni-work.ai"
   },
   "metadata": {
-    "description": "Insight-wave is a 14-plugin ecosystem for Claude Code that turns consulting, research, portfolio, and communication workflows into AI-assisted, bilingual (EN/DE) pipelines — trend scouting, portfolio messaging, narrative transformation, visual deliverables, sales enablement, claim verification, knowledge management, and end-to-end consulting orchestration.",
-    "version": "1.0.1"
+    "description": "Insight-wave is a 15-plugin ecosystem for Claude Code that turns consulting, research, portfolio, and communication workflows into AI-assisted, bilingual (EN/DE) pipelines — trend scouting, portfolio messaging, narrative transformation, visual deliverables, sales enablement, claim verification, knowledge management, wiki-first research, and end-to-end consulting orchestration.",
+    "version": "1.0.2"
   },
   "plugins": [
     {
@@ -272,6 +272,24 @@
         "backlinks",
         "agent",
         "queue"
+      ]
+    },
+    {
+      "name": "cogni-knowledge",
+      "source": "./cogni-knowledge",
+      "version": "0.0.1",
+      "maturity": "incubating",
+      "description": "Wiki-first research that compounds. Binds a cogni-research project to a cogni-wiki knowledge base so every research run deposits into the same persistent, queryable, interlinked markdown wiki — and so future runs read what previous runs filed instead of starting from zero. Thin orchestrator over cogni-research and cogni-wiki; no forked agents, no duplicated scripts. The differentiator vs. one-shot deep-research tools (OpenAI Deep Research, Perplexity Spaces, GPT Researcher) is the binding: knowledge accumulates across projects instead of dying in chat history.",
+      "keywords": [
+        "knowledge-base",
+        "wiki-first",
+        "compound-knowledge",
+        "research-orchestrator",
+        "binding",
+        "karpathy",
+        "deep-research",
+        "knowledge-graph",
+        "incubating"
       ]
     }
   ]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # insight-wave
 
-13-plugin monorepo for consulting, sales, and marketing on Claude Code. AGPL-3.0. All plugins follow the Claude Code plugin standard.
+15-plugin monorepo for consulting, sales, and marketing on Claude Code. AGPL-3.0. All plugins follow the Claude Code plugin standard.
 
 ## Repo Structure
 

--- a/cogni-knowledge/.claude-plugin/plugin.json
+++ b/cogni-knowledge/.claude-plugin/plugin.json
@@ -1,0 +1,21 @@
+{
+  "name": "cogni-knowledge",
+  "version": "0.0.1",
+  "description": "Wiki-first research that compounds. Binds a cogni-research project to a cogni-wiki knowledge base so every research run deposits into the same persistent, queryable, interlinked markdown wiki — and so future runs read what previous runs filed instead of starting from zero. Thin orchestrator over cogni-research and cogni-wiki; no forked agents, no duplicated scripts. The differentiator vs. one-shot deep-research tools (OpenAI Deep Research, Perplexity Spaces, GPT Researcher) is the binding: knowledge accumulates across projects instead of dying in chat history.",
+  "author": {
+    "name": "Stephan de Haas",
+    "email": "stephan@cogni-work.ai"
+  },
+  "license": "AGPL-3.0-only",
+  "keywords": [
+    "knowledge-base",
+    "wiki-first",
+    "compound-knowledge",
+    "research-orchestrator",
+    "binding",
+    "karpathy",
+    "deep-research",
+    "knowledge-graph",
+    "incubating"
+  ]
+}

--- a/cogni-knowledge/CHANGELOG.md
+++ b/cogni-knowledge/CHANGELOG.md
@@ -1,0 +1,22 @@
+# cogni-knowledge changelog
+
+## 0.0.1 — 2026-05-19
+
+Initial Incubating release. Phase 1 of the wiki-first research epic.
+
+### Added
+
+- Plugin scaffold (`.claude-plugin/plugin.json`, README, CLAUDE.md).
+- `binding.json` data model (`.cogni-knowledge/binding.json`, schema v0.0.1).
+- Skill `knowledge-setup` — bootstrap a knowledge base (wiki + binding).
+- Skill `knowledge-research` — research a topic INTO the bound wiki via `cogni-wiki:wiki-from-research` (Mode A), then stamp lineage and record the project.
+- Skill `knowledge-resume` — status + delegate to `cogni-wiki:wiki-resume`.
+- Script `knowledge-binding.py` — stdlib CLI for `--init`, `--append-project`, `--read`.
+- Script `lineage-stamp.py` — stdlib CLI that stamps `derived_from_research: <slug>` into deposited wiki page frontmatter.
+- References: `differentiation-thesis.md`, `delegation-contract.md`, `absorption-roadmap.md`.
+
+### Out of scope (deferred to later phases)
+
+- `knowledge-report` (Phase 2) — wiki-roundtrip composition with cycle-guard.
+- `knowledge-query`, `knowledge-dashboard`, `knowledge-refresh` (Phase 3).
+- Internal alpha (Phase 4), graduation to Preview (Phase 5), cogni-research absorption (Phase 6).

--- a/cogni-knowledge/CLAUDE.md
+++ b/cogni-knowledge/CLAUDE.md
@@ -36,7 +36,7 @@ They live as siblings. The wiki is the substrate; the binding records which rese
 | `knowledge-binding.py` | `--init` / `--append-project` / `--read` against `.cogni-knowledge/binding.json` | No (stdlib only) |
 | `lineage-stamp.py` | Stamps `derived_from_research: <slug>` into the YAML frontmatter of deposited wiki pages | No (stdlib only) |
 
-All scripts return `{"success": bool, "data": {...}, "error": "..."}` per the insight-wave convention (`/home/user/insight-wave/CLAUDE.md` §"Script Output Format"). Stdlib only — no pip dependencies.
+All scripts return `{"success": bool, "data": {...}, "error": "..."}` per the insight-wave convention (`../CLAUDE.md` §"Script Output Format"). Stdlib only — no pip dependencies.
 
 ## Data model — `binding.json`
 
@@ -88,11 +88,11 @@ Only the frontmatter changes — page bodies are never touched.
 
 ## Conventions
 
-- Skill names: `knowledge-*` (generic skill names like `setup`, `research`, `resume` MUST be prefixed per `/home/user/insight-wave/CLAUDE.md` §"Contributing").
+- Skill names: `knowledge-*` (generic skill names like `setup`, `research`, `resume` MUST be prefixed per `../CLAUDE.md` §"Contributing").
 - Skill frontmatter: `name`, `description`, `allowed-tools` — same shape as cogni-wiki/cogni-research skills.
 - Script CLI: `python3 scripts/<name>.py --action ...`, JSON envelope output.
 - Path conventions: knowledge bases default to `<cwd>/<knowledge-slug>/` (matching `cogni-wiki/{slug}/`).
-- Versioning: bump patch on any skill/script change; mirror in `marketplace.json` (`/home/user/insight-wave/CLAUDE.md` §"Version Management").
+- Versioning: bump patch on any skill/script change; mirror in `marketplace.json` (`../CLAUDE.md` §"Version Management").
 
 ## Future phases
 

--- a/cogni-knowledge/CLAUDE.md
+++ b/cogni-knowledge/CLAUDE.md
@@ -45,7 +45,6 @@ All scripts return `{"success": bool, "data": {...}, "error": "..."}` per the in
   "knowledge_slug": "<kebab-case>",
   "knowledge_title": "<human readable>",
   "wiki_path": "<absolute path to wiki root>",
-  "wiki_slug": "<wiki slug from wiki-setup>",
   "research_projects": [
     {
       "slug": "<research-project-slug>",

--- a/cogni-knowledge/CLAUDE.md
+++ b/cogni-knowledge/CLAUDE.md
@@ -1,0 +1,102 @@
+# cogni-knowledge — developer guide
+
+Wiki-first research orchestrator. Binds a `cogni-wiki` knowledge base to N `cogni-research` projects so the work compounds across runs instead of dying in chat history. Every primitive delegates upward — there are no forked agents, no duplicated scripts, no agent definitions in this plugin.
+
+## Architecture
+
+```
+.cogni-knowledge/binding.json   ← the only new state cogni-knowledge owns
+       │
+       ▼
+knowledge-* skills (orchestrators)
+       │
+       ▼
+cogni-wiki / cogni-research (delegate targets)
+```
+
+A "knowledge base" is one directory that contains both:
+
+- `.cogni-wiki/config.json` — the wiki manifest (owned by `cogni-wiki`)
+- `.cogni-knowledge/binding.json` — the binding manifest (owned by this plugin)
+
+They live as siblings. The wiki is the substrate; the binding records which research projects have contributed.
+
+## Skills (Phase 1)
+
+| Skill | Role |
+|---|---|
+| `knowledge-setup` | Bootstrap a knowledge base. Dispatches `cogni-wiki:wiki-setup` if no wiki exists, then writes `binding.json`. |
+| `knowledge-research` | Research a topic INTO the bound wiki. Dispatches `cogni-wiki:wiki-from-research --topic ...` (Mode A), then stamps lineage and appends to the binding. |
+| `knowledge-resume` | Status. Reads `binding.json` and delegates to `cogni-wiki:wiki-resume` (which itself runs `wiki-health`). |
+
+## Scripts
+
+| Script | Purpose | LLM? |
+|---|---|---|
+| `knowledge-binding.py` | `--init` / `--append-project` / `--read` against `.cogni-knowledge/binding.json` | No (stdlib only) |
+| `lineage-stamp.py` | Stamps `derived_from_research: <slug>` into the YAML frontmatter of deposited wiki pages | No (stdlib only) |
+
+All scripts return `{"success": bool, "data": {...}, "error": "..."}` per the insight-wave convention (`/home/user/insight-wave/CLAUDE.md` §"Script Output Format"). Stdlib only — no pip dependencies.
+
+## Data model — `binding.json`
+
+```json
+{
+  "knowledge_slug": "<kebab-case>",
+  "knowledge_title": "<human readable>",
+  "wiki_path": "<absolute path to wiki root>",
+  "wiki_slug": "<wiki slug from wiki-setup>",
+  "research_projects": [
+    {
+      "slug": "<research-project-slug>",
+      "deposited_at": "<YYYY-MM-DD>",
+      "report_path": "<absolute path to output/report.md>",
+      "report_source": "web | local | wiki | hybrid"
+    }
+  ],
+  "topic_lineage": {
+    "covered_themes": [],
+    "open_themes": []
+  },
+  "created": "<YYYY-MM-DD>",
+  "schema_version": "0.0.1"
+}
+```
+
+The file is small (< 4 KiB even at 20+ deposited projects). It is *not* a database — it is a narrative manifest that records what the user has chosen to bind together. Search across the wiki itself for content; consult the binding only for "what projects fed this base".
+
+## Delegation contract
+
+The hard rule: **no logic that already exists upstream**. If you find yourself writing code that duplicates a `cogni-wiki` script or a `cogni-research` agent, stop and re-delegate. The full mapping lives in `references/delegation-contract.md`.
+
+A few specifics:
+
+- `knowledge-setup` does NOT re-implement `wiki-setup`. It only handles the `binding.json` half.
+- `knowledge-research` does NOT call `cogni-research:research-setup` directly — that already happens transitively inside `cogni-wiki:wiki-from-research`. Going one level lower would re-implement the same orchestration.
+- `knowledge-resume` does NOT compute wiki health. `wiki-resume` already calls `wiki-health` automatically as of cogni-wiki v0.0.27.
+
+## Lineage stamping
+
+`cogni-wiki:wiki-ingest --discover research:<slug>` deposits per-sub-question pages and creates the directory `<wiki-root>/raw/research-<slug>/`. The directory itself records the lineage implicitly (which raw files seeded which page), but Phase 2's cycle-guard needs a queryable `derived_from_research: <slug>` field in the page YAML frontmatter to detect circular evidence without a filesystem walk. `lineage-stamp.py` adds that field, idempotently.
+
+The script:
+
+1. Globs `<wiki-root>/wiki/**/*.md`.
+2. For each page, reads the YAML `sources:` field. If any `sources[]` entry path contains `raw/research-<slug>/`, the page is derived from that research project.
+3. If the page already has `derived_from_research: <slug>`, skip (idempotent). Otherwise, insert the field into the frontmatter.
+
+Only the frontmatter changes — page bodies are never touched.
+
+## Conventions
+
+- Skill names: `knowledge-*` (generic skill names like `setup`, `research`, `resume` MUST be prefixed per `/home/user/insight-wave/CLAUDE.md` §"Contributing").
+- Skill frontmatter: `name`, `description`, `allowed-tools` — same shape as cogni-wiki/cogni-research skills.
+- Script CLI: `python3 scripts/<name>.py --action ...`, JSON envelope output.
+- Path conventions: knowledge bases default to `<cwd>/<knowledge-slug>/` (matching `cogni-wiki/{slug}/`).
+- Versioning: bump patch on any skill/script change; mirror in `marketplace.json` (`/home/user/insight-wave/CLAUDE.md` §"Version Management").
+
+## Future phases
+
+Phase 2 lights up `knowledge-report` (wiki-roundtrip composition with cycle-guard). Phase 3 lights up `knowledge-query`, `knowledge-dashboard`, `knowledge-refresh`. Phase 4 is the internal alpha. Phase 5 graduates to v0.1.0 (Preview). Phase 6 absorbs `cogni-research`. See `references/absorption-roadmap.md`.
+
+Do not implement Phase 2+ work in Phase 1 commits. The MVP is intentionally small.

--- a/cogni-knowledge/LICENSE
+++ b/cogni-knowledge/LICENSE
@@ -1,0 +1,661 @@
+                    GNU AFFERO GENERAL PUBLIC LICENSE
+                       Version 3, 19 November 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU Affero General Public License is a free, copyleft license for
+software and other kinds of works, specifically designed to ensure
+cooperation with the community in the case of network server software.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+our General Public Licenses are intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  Developers that use our General Public Licenses protect your rights
+with two steps: (1) assert copyright on the software, and (2) offer
+you this License which gives you legal permission to copy, distribute
+and/or modify the software.
+
+  A secondary benefit of defending all users' freedom is that
+improvements made in alternate versions of the program, if they
+receive widespread use, become available for other developers to
+incorporate.  Many developers of free software are heartened and
+encouraged by the resulting cooperation.  However, in the case of
+software used on network servers, this result may fail to come about.
+The GNU General Public License permits making a modified version and
+letting the public access it on a server without ever releasing its
+source code to the public.
+
+  The GNU Affero General Public License is designed specifically to
+ensure that, in such cases, the modified source code becomes available
+to the community.  It requires the operator of a network server to
+provide the source code of the modified version running there to the
+users of that server.  Therefore, public use of a modified version, on
+a publicly accessible server, gives the public access to the source
+code of the modified version.
+
+  An older license, called the Affero General Public License and
+published by Affero, was designed to accomplish similar goals.  This is
+a different license, not a version of the Affero GPL, but Affero has
+released a new version of the Affero GPL which permits relicensing under
+this license.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU Affero General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Remote Network Interaction; Use with the GNU General Public License.
+
+  Notwithstanding any other provision of this License, if you modify the
+Program, your modified version must prominently offer all users
+interacting with it remotely through a computer network (if your version
+supports such interaction) an opportunity to receive the Corresponding
+Source of your version by providing access to the Corresponding Source
+from a network server at no charge, through some standard or customary
+means of facilitating copying of software.  This Corresponding Source
+shall include the Corresponding Source for any work covered by version 3
+of the GNU General Public License that is incorporated pursuant to the
+following paragraph.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the work with which it is combined will remain governed by version
+3 of the GNU General Public License.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU Affero General Public License from time to time.  Such new versions
+will be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU Affero General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU Affero General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU Affero General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If your software can interact with users remotely through a computer
+network, you should also make sure that it provides a way for users to
+get its source.  For example, if your program is a web application, its
+interface could display a "Source" link that leads users to an archive
+of the code.  There are many ways you could offer source, and different
+solutions will be better for different programs; see section 13 for the
+specific requirements.
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU AGPL, see
+<https://www.gnu.org/licenses/>.

--- a/cogni-knowledge/README.md
+++ b/cogni-knowledge/README.md
@@ -60,7 +60,7 @@ The second `knowledge-research` reads the wiki that the first deposited — that
 One new artifact: `<knowledge-base>/.cogni-knowledge/binding.json`, sibling to the wiki's `.cogni-wiki/config.json`. It records:
 
 - `knowledge_slug`, `knowledge_title`
-- `wiki_path`, `wiki_slug` (the bound wiki)
+- `wiki_path` — absolute path to the bound cogni-wiki (the wiki's own slug is read live from `<wiki_path>/.cogni-wiki/config.json` so it cannot drift)
 - `research_projects[]` — one entry per deposited run: `slug`, `deposited_at`, `report_path`, `report_source`
 - `topic_lineage` — `covered_themes[]` and `open_themes[]` (populated as the base grows)
 

--- a/cogni-knowledge/README.md
+++ b/cogni-knowledge/README.md
@@ -1,0 +1,117 @@
+# cogni-knowledge
+
+> **Incubating** (v0.0.x) — skills, data formats, and workflows may change at any time.
+
+**Wiki-first research that compounds.** Every shipped deep-research tool today produces a document and loses the underlying knowledge to chat history. cogni-knowledge inverts that posture: a research run *binds* to a named knowledge base, deposits its findings into a persistent cogni-wiki, and the next run reads from the same wiki before going to the web. Knowledge gets denser with every project — instead of starting from zero each time.
+
+This plugin is a thin orchestrator. It does not fork cogni-research or cogni-wiki. Every primitive delegates upward to those plugins; the only new state cogni-knowledge owns is a `binding.json` that records "this wiki is the knowledge base for topic area X, and these research projects have contributed to it."
+
+## Why this exists
+
+| Problem | One-shot research tools | cogni-knowledge |
+|---|---|---|
+| Where do findings go after the report ships? | Lost to chat history | Filed in a persistent wiki |
+| Second research run on a related topic | Starts from zero | Reads the wiki first |
+| Cross-project synthesis | Manual; copy-paste between sessions | Automatic — wiki accumulates and interlinks |
+| Provenance of a stale fact | Forgotten by next session | `derived_from_research: <slug>` traces every page back to the run that filed it |
+| Refresh stale claims | Manual re-research | `knowledge-refresh` (push: re-research stale topics; pull: re-deposit from a new project) |
+
+## What it is
+
+**IS:** A binding orchestrator that turns `cogni-research + cogni-wiki` into a wiki-first research workflow. A knowledge base = one cogni-wiki + a `binding.json` manifest. Every `knowledge-research` run deposits into that wiki and is recorded in the binding; every `knowledge-report` (Phase 2) reads from it.
+
+**DOES** (Phase 1, the MVP): three skills — `knowledge-setup`, `knowledge-research`, `knowledge-resume` — and two scripts (`knowledge-binding.py`, `lineage-stamp.py`).
+
+**MEANS for you:** the work compounds. Run research on EU AI Act Article 6 today; tomorrow's run on foundation-model obligations reads what you already filed. The wiki becomes the single source of truth for your topic area, queryable forever via `cogni-wiki:wiki-query` or future `knowledge-query`. No vector store, no embeddings — just markdown that compounds.
+
+## What it does
+
+| Skill | Purpose | Delegates to |
+|---|---|---|
+| `knowledge-setup` | Bootstrap a knowledge base (wiki + binding manifest) | `cogni-wiki:wiki-setup` |
+| `knowledge-research` | Research a topic INTO the bound wiki and record the project | `cogni-wiki:wiki-from-research` (Mode A) |
+| `knowledge-resume` | Status: deposited projects, wiki health, suggested next action | `cogni-wiki:wiki-resume` |
+
+Phase 2+ skills (`knowledge-report`, `knowledge-query`, `knowledge-dashboard`, `knowledge-refresh`) follow once Phase 1 proves out the accumulation thesis. See `references/absorption-roadmap.md` for the full epic plan.
+
+## Installation
+
+Install via the insight-wave marketplace:
+
+```
+/plugin install cogni-knowledge@insight-wave
+```
+
+Requires both `cogni-wiki` and `cogni-research` installed (they are the delegate targets).
+
+## Quick start
+
+```
+/cogni-knowledge:knowledge-setup --knowledge-slug eu-ai-act --knowledge-title "EU AI Act knowledge base"
+/cogni-knowledge:knowledge-research --knowledge-slug eu-ai-act --topic "EU AI Act Article 6 high-risk systems"
+/cogni-knowledge:knowledge-research --knowledge-slug eu-ai-act --topic "EU AI Act foundation model obligations"
+/cogni-knowledge:knowledge-resume --knowledge-slug eu-ai-act
+```
+
+The second `knowledge-research` reads the wiki that the first deposited — that is the compounding loop.
+
+## Data model
+
+One new artifact: `<knowledge-base>/.cogni-knowledge/binding.json`, sibling to the wiki's `.cogni-wiki/config.json`. It records:
+
+- `knowledge_slug`, `knowledge_title`
+- `wiki_path`, `wiki_slug` (the bound wiki)
+- `research_projects[]` — one entry per deposited run: `slug`, `deposited_at`, `report_path`, `report_source`
+- `topic_lineage` — `covered_themes[]` and `open_themes[]` (populated as the base grows)
+
+All other state lives upstream: wiki pages in `cogni-wiki`, research artifacts in `cogni-research-<slug>/`. cogni-knowledge owns nothing else.
+
+## How it works
+
+```
+knowledge-setup
+  → cogni-wiki:wiki-setup (creates the wiki)
+  → knowledge-binding.py --init (writes binding.json)
+
+knowledge-research --knowledge-slug X --topic T
+  → cogni-wiki:wiki-from-research --topic T --wiki-root <bound>
+       → cogni-research:research-setup → research-report  (produces report.md)
+       → cogni-wiki:wiki-setup (skipped if wiki exists)
+       → cogni-wiki:wiki-ingest --discover research:<slug>  (deposits per-sub-question pages)
+  → lineage-stamp.py  (stamps derived_from_research: <slug> into deposited pages)
+  → knowledge-binding.py --append-project  (records the project in binding.json)
+```
+
+The deposited pages are now part of the wiki and visible to the next `knowledge-research` run via the upstream `wiki-researcher` agent when `report_source=wiki` is selected (Phase 2 lights this up automatically).
+
+## Components
+
+- 3 skills (`knowledge-setup`, `knowledge-research`, `knowledge-resume`)
+- 2 scripts (`knowledge-binding.py`, `lineage-stamp.py`)
+- 3 references (`differentiation-thesis.md`, `delegation-contract.md`, `absorption-roadmap.md`)
+
+## Architecture
+
+cogni-knowledge sits **between the user and `cogni-research`+`cogni-wiki`**. Direct user → `cogni-research` and direct user → `cogni-wiki` paths remain unchanged. The plugin's only value-add is the binding (`binding.json`), lineage stamping, and one-prompt workflow choreography.
+
+```
+user ──> cogni-knowledge ──> cogni-wiki:wiki-from-research ──> cogni-research:research-setup → research-report
+                                                          └──> cogni-wiki:wiki-ingest
+```
+
+## Dependencies
+
+- `cogni-wiki` ≥ 0.0.39
+- `cogni-research` ≥ 0.8.3
+
+## Custom development
+
+Adding a skill: every skill delegates. If you find yourself writing a new agent or duplicating cogni-wiki/cogni-research logic, the right answer is almost always to push the change upstream and re-delegate. See `references/delegation-contract.md` for the contract.
+
+## License
+
+AGPL-3.0-only. See [LICENSE](LICENSE).
+
+---
+
+Built by [Cogni Work](https://cogni-work.ai). Part of [insight-wave](../README.md).

--- a/cogni-knowledge/references/absorption-roadmap.md
+++ b/cogni-knowledge/references/absorption-roadmap.md
@@ -1,0 +1,96 @@
+# Absorption roadmap
+
+cogni-knowledge is structured around a committed endgame: if the alpha proves positive, `cogni-research` is absorbed into this plugin. The phases below trace the path from "Phase 1 MVP scaffold" to "cogni-research archived, cogni-knowledge v1.0".
+
+Reading order: this file, then `differentiation-thesis.md`, then `delegation-contract.md`.
+
+## Phases
+
+### Phase 1 — MVP: binding + accumulating research (v0.0.1 → v0.0.5) — **THIS PHASE**
+
+**Status.** Shipped at v0.0.1.
+
+**Deliverables.**
+- Plugin scaffold (`.claude-plugin/plugin.json`, `README.md`, `CLAUDE.md`, `CHANGELOG.md`).
+- `binding.json` data model.
+- Skills: `knowledge-setup`, `knowledge-research`, `knowledge-resume`.
+- Scripts: `knowledge-binding.py`, `lineage-stamp.py`.
+- Marketplace registration in `/insight-wave/.claude-plugin/marketplace.json`.
+
+**Out of scope.** Wiki-roundtrip composition, cycle-guard, push-refresh, dashboard, query convenience.
+
+### Phase 2 — Wiki-roundtrip reports (v0.0.6 → v0.0.10)
+
+**Goal.** Reports get composed by reading the deposited wiki pages, not transient research contexts.
+
+**Deliverables.**
+- `scripts/cycle-guard.py` — detects circular wiki↔research evidence chains by walking the `derived_from_research:` lineage stamps.
+- Modification to `cogni-wiki/skills/wiki-from-research/SKILL.md`: lift the hard abort on `report_source ∈ {wiki, hybrid}`, gated behind `--allow-wiki-source --cycle-guard-cleared` opt-in flags. Default behavior unchanged for direct users.
+- `skills/knowledge-report/SKILL.md` — dispatches `cogni-research:research-setup` with `report_source=wiki, wiki_paths=[<bound>]`, runs `research-report`, then re-deposits via `wiki-from-research` Mode B with the cycle-guard cleared flag.
+
+### Phase 3 — Query, dashboard, push-refresh (v0.0.11 → v0.0.15)
+
+**Goal.** Make the accumulated knowledge legible and self-healing.
+
+**Deliverables.**
+- `knowledge-query` — binding-aware wrapper of `cogni-wiki:wiki-query`.
+- `knowledge-dashboard` — composes `cogni-wiki:wiki-dashboard` with a binding overlay (deposited projects, claim verification heatmap).
+- `knowledge-refresh` — push-mode (re-research stale topics) and pull-mode (delegate to `cogni-wiki:wiki-refresh`).
+
+### Phase 4 — Internal alpha (v0.0.16 → v0.0.20)
+
+**Goal.** Test on one real knowledge area for ≥ 3 research projects. Decide go/no-go on absorption.
+
+**Activities.**
+- Run ≥ 3 `knowledge-research` invocations on a real topic (EU AI Act suggested).
+- Run ≥ 1 `knowledge-report` against the populated base (Phase 2 round-trip).
+- Compare against equivalent standalone `cogni-research` runs on:
+  - Time-to-second-research.
+  - Cross-project information density (`[[wikilinks]]` between projects).
+  - Claims duplication.
+  - User-perceived value (subjective).
+- Document findings in `references/alpha-findings.md`.
+
+**Go/no-go gate.**
+- Positive → commit to Phase 5 + Phase 6.
+- Negative → freeze cogni-knowledge as an experimental path; do not migrate cogni-research consumers.
+
+### Phase 5 — Hardening + 0.1.x graduation (v0.1.0)
+
+**Goal.** Cross the Incubating → Preview maturity boundary.
+
+**Deliverables.**
+- Comprehensive `README.md` and `CLAUDE.md`.
+- `cogni-docs:doc-audit` clean.
+- Update `/insight-wave/CLAUDE.md` data-flow diagram.
+- New entry in `/insight-wave/docs/workflows/` for the wiki-first research cycle.
+- Flip README maturity callout to Preview.
+- Validate skill names with `cogni-workspace/scripts/check-skill-names.sh`.
+
+### Phase 6 — Absorption migration (cogni-knowledge v1.0.0; cogni-research → archived)
+
+**Goal.** Execute the committed endgame.
+
+**Deliverables.**
+1. **Move cogni-research internals into cogni-knowledge.**
+   - Agents: `cogni-research/agents/{section-researcher, deep-researcher, local-researcher, wiki-researcher, writer, reviewer, revisor, claim-extractor, source-curator}.md` → `cogni-knowledge/agents/`.
+   - Skills: `cogni-research/skills/{research-setup, research-report, research-resume, verify-report, audit-arcs}` core logic absorbed into cogni-knowledge equivalents.
+   - Scripts: `cogni-research/scripts/*` → `cogni-knowledge/scripts/`.
+   - Schemas: `cogni-research/schemas/*` → `cogni-knowledge/schemas/`.
+2. **Migrate downstream callers.**
+   - `cogni-trends`: cut over `trend-research` from cogni-research to cogni-knowledge (with a default knowledge base per trend domain).
+   - `cogni-narrative`: arc-driven research integration cut over.
+   - `cogni-portfolio`: verify (mostly uses `WebSearch` directly per existing audit).
+   - `cogni-wiki:wiki-from-research`: leave it dispatching `cogni-research:research-setup` for back-compat during the deprecation window; rotate to cogni-knowledge in a follow-up.
+3. **Deprecate cogni-research.** 2-version sunset; final state has `"archived": true` in `cogni-research/.claude-plugin/plugin.json` and mirror in marketplace.json.
+4. **Top-level docs.** Update `/insight-wave/CLAUDE.md` data-flow diagram.
+
+**Out of scope for the entire epic.** Absorbing cogni-wiki itself — it is a general-purpose Karpathy-pattern knowledge engine usable standalone (interview notes, PDFs, raw drops). Keep separate.
+
+## Open questions for the absorption phase
+
+These are recorded so they do not block Phase 1 → Phase 5 work; revisit when Phase 6 is approved.
+
+- **Rename at v1.0?** Does `cogni-knowledge` keep its name once it owns the full research surface, or does it rename to something cleaner? Defer the decision to Phase 5 — the marketing answer depends on what positioning the alpha findings support.
+- **Backwards-compat alias.** Should we ship a `cogni-research:` alias inside cogni-knowledge during the sunset window, or just rely on downstream consumers cutting over? Defer to Phase 6 planning.
+- **Multi-wiki knowledge bases.** Today's binding records exactly one `wiki_path`. A future extension could allow `wiki_paths[]` for federated bases. Defer until a user explicitly asks for it — premature now.

--- a/cogni-knowledge/references/delegation-contract.md
+++ b/cogni-knowledge/references/delegation-contract.md
@@ -59,3 +59,7 @@ When Phase 6 absorbs cogni-research, these agents move into `cogni-knowledge/age
 ## What about Phase 2's `--allow-wiki-source` flag on `wiki-from-research`?
 
 Phase 2 modifies `cogni-wiki:wiki-from-research` to lift its current abort on `report_source ∈ {wiki, hybrid}` projects, gated behind a new `--allow-wiki-source --cycle-guard-cleared` opt-in. This is the right pattern: the cycle-guard logic lives in cogni-knowledge (it is cogni-knowledge-specific — there is no general-purpose meaning to "research lineage" in `cogni-wiki`), but the deposit pathway lives in `cogni-wiki`. We add an opt-in flag instead of forking the deposit pathway.
+
+## Wiring `report_source` into `binding.json` (Phase 2 guardrail)
+
+`knowledge-research` (Phase 1) hard-codes `--report-source web` when calling `knowledge-binding.py append-project`. That is correct *only* because `cogni-wiki:wiki-from-research` Mode A refuses `report_source ∈ {wiki, hybrid}` projects today (see its Step 0(3)). Phase 2 lifts that abort, and the new `knowledge-report` skill MUST read the actual `report_source` from `<project>/.metadata/project-config.json` and pass it through — `web` for the initial run, `wiki` once `knowledge-report` lights up, `hybrid` if a user opts in. Forgetting this wiring would silently mis-label every Phase 2 deposit as `web` and break the cycle-guard's lineage reasoning. The field MUST be sourced live from the research project, never assumed.

--- a/cogni-knowledge/references/delegation-contract.md
+++ b/cogni-knowledge/references/delegation-contract.md
@@ -1,0 +1,61 @@
+# Delegation contract
+
+cogni-knowledge is a **thin orchestrator**. Every primitive delegates to `cogni-wiki` or `cogni-research`. This document is the precise contract: what cogni-knowledge owns vs. what it delegates.
+
+## The hard rule
+
+If a behavior already exists in `cogni-wiki` or `cogni-research`, cogni-knowledge MUST delegate to it. Re-implementing upstream behavior in this plugin is a design error, not a shortcut. The reasons:
+
+1. **Bugfix locality.** A bug in wiki bootstrapping should be fixed in one place (`cogni-wiki:wiki-setup`), not in N orchestrators that each forked the logic.
+2. **Future absorption.** Phase 6 absorbs `cogni-research` into this plugin. Until then, the absorption boundary is clean only if we never duplicate.
+3. **Version skew.** `cogni-wiki` and `cogni-research` are released independently. Forked logic drifts; delegated logic tracks the upstream automatically.
+
+## What cogni-knowledge owns
+
+- **`binding.json`.** The single new artifact. Records knowledge_slug, wiki path, deposited research_projects[]. Read/written by `scripts/knowledge-binding.py`.
+- **Lineage stamping.** `scripts/lineage-stamp.py` adds `derived_from_research: <slug>` to YAML frontmatter on deposited wiki pages. Phase 2's cycle-guard depends on this; we cannot push it upstream because the field is cogni-knowledge-specific (`cogni-wiki` is general-purpose and has no concept of research lineage).
+- **Skill choreography.** The order and conditional logic of dispatching upstream skills. This is real value — the user gets one-prompt workflows in exchange for the loss of fine-grained control.
+- **Opinionated defaults.** `--research-overrides report_type=detailed` if the caller did not pass any; `--skip-prefill-prompt` on `wiki-setup` so the seeding does not duplicate `knowledge-research`'s own deposit-driven seeding.
+
+## What cogni-knowledge delegates
+
+| Behavior | Delegate target |
+|---|---|
+| Bootstrap a wiki (create directory layout, write `.cogni-wiki/config.json`, seed SCHEMA.md/index.md/log.md/overview.md) | `cogni-wiki:wiki-setup` |
+| Cold-start a wiki from a research topic | `cogni-wiki:wiki-from-research` (Mode A) |
+| Deposit an already-completed research project into a wiki | `cogni-wiki:wiki-from-research` (Mode B) |
+| Configure a research project (interactive menu, market/language/tone/citations/source mode) | `cogni-research:research-setup` (transitively, via `wiki-from-research`) |
+| Run the research pipeline (sub-questions, parallel researchers, writer, reviewer, claims) | `cogni-research:research-report` (transitively) |
+| Write per-sub-question wiki pages | `cogni-wiki:wiki-ingest --discover research:<slug>` (transitively) |
+| Read from a wiki during research (Phase 2+) | `cogni-research`'s `wiki-researcher` agent, via `report_source=wiki` in `cogni-research:research-setup` |
+| Compute wiki health (broken links, missing frontmatter, entries_count drift) | `cogni-wiki:wiki-health` |
+| Show wiki status | `cogni-wiki:wiki-resume` (which itself runs `wiki-health`) |
+| Query the wiki (Phase 3) | `cogni-wiki:wiki-query` |
+| Lint the wiki for staleness (Phase 3) | `cogni-wiki:wiki-lint` |
+| Render the wiki dashboard (Phase 3) | `cogni-wiki:wiki-dashboard` |
+| Refresh stale pages from a research project (Phase 3 pull-mode) | `cogni-wiki:wiki-refresh` |
+
+## What about `agents/`?
+
+cogni-knowledge has no `agents/` directory by design. All agent dispatch goes to upstream agents:
+
+- `cogni-research/agents/section-researcher.md` (web research per sub-question)
+- `cogni-research/agents/deep-researcher.md` (recursive web research for deep mode)
+- `cogni-research/agents/local-researcher.md` (local-document research)
+- `cogni-research/agents/wiki-researcher.md` (wiki-as-source research — load-bearing for Phase 2)
+- `cogni-research/agents/writer.md`, `reviewer.md`, `revisor.md` (composition)
+- `cogni-research/agents/claim-extractor.md`, `source-curator.md` (provenance)
+
+When Phase 6 absorbs cogni-research, these agents move into `cogni-knowledge/agents/`. Until then, leaving them upstream means we benefit from any cogni-research patch immediately.
+
+## How to add a new cogni-knowledge skill
+
+1. Identify the user-facing job to be done.
+2. Map the job to upstream primitives (cogni-wiki and/or cogni-research). If the mapping requires logic that does not exist upstream, push that logic upstream first — do not implement it in cogni-knowledge.
+3. The new skill's body is: (a) read `binding.json`, (b) dispatch upstream skill(s), (c) update `binding.json` if state changed, (d) compose a summary.
+4. If the skill needs new state, it goes in `binding.json` — never in a parallel manifest.
+5. Scripts (`knowledge-*.py`) stay stdlib-only. Anything that needs a library belongs upstream.
+
+## What about Phase 2's `--allow-wiki-source` flag on `wiki-from-research`?
+
+Phase 2 modifies `cogni-wiki:wiki-from-research` to lift its current abort on `report_source ∈ {wiki, hybrid}` projects, gated behind a new `--allow-wiki-source --cycle-guard-cleared` opt-in. This is the right pattern: the cycle-guard logic lives in cogni-knowledge (it is cogni-knowledge-specific — there is no general-purpose meaning to "research lineage" in `cogni-wiki`), but the deposit pathway lives in `cogni-wiki`. We add an opt-in flag instead of forking the deposit pathway.

--- a/cogni-knowledge/references/differentiation-thesis.md
+++ b/cogni-knowledge/references/differentiation-thesis.md
@@ -1,0 +1,59 @@
+# Differentiation thesis
+
+Every shipped deep-research tool today produces a document and loses the underlying knowledge to chat history.
+
+- OpenAI Deep Research → a report, then nothing.
+- Perplexity Spaces → a thread, then nothing persistent that the next thread reads.
+- GPT Researcher → a report file, no cross-project compounding.
+- Anthropic's research feature → conversational; the next session starts fresh.
+
+The reason this happens is structural: the LLM's knowledge of "what I just researched" lives in the conversation context, and the conversation context dies when the session ends. The artifacts shipped to the user (the report) are *outputs*, not *substrate* — they are not designed to be read back into a future research run, and the tools do not provide an automatic pathway for that to happen.
+
+**cogni-knowledge inverts the posture.** A research run is not a one-shot output — it is a *contribution* to a persistent, queryable knowledge base. The base is a `cogni-wiki`: interlinked markdown, compiled once at ingest, with explicit `[[wikilinks]]` and YAML frontmatter that traces every page to a source. The next research run reads the base before going to the web.
+
+## Why a wiki, not a vector store
+
+A vector store would let the same compounding happen in principle, but in practice it loses three properties that matter for serious research:
+
+1. **Cross-references are explicit, not statistical.** `[[wikilinks]]` say "page A is genuinely about page B"; cosine similarity can only say "page A's embedding is close to B's embedding" — a weaker, frequently-wrong signal that misses both real connections (different wording) and pretends connections that aren't there (similar wording, different meaning).
+2. **Contradictions surface at ingest.** When `wiki-ingest` writes page B and page A already says something incompatible, the conflict is visible at file-write time. A vector store stores both and lets the retrieval layer hope for the best.
+3. **Debugging is reading.** When a query produces a wrong answer, the user reads markdown files to figure out why. With a vector store, the user has to reverse-engineer chunk retrieval scores.
+
+See `cogni-wiki/README.md` §"Why this exists" for the longer form.
+
+## Why this plugin exists separately from cogni-wiki
+
+cogni-wiki is a **general-purpose** knowledge engine. It ingests anything: PDFs, interview notes, meeting transcripts, papers, web pages. The Karpathy pattern is domain-neutral.
+
+cogni-knowledge is **opinionated about wiki-first research**. Specifically:
+
+- It assumes there is a *bound* knowledge base — one wiki per topic area, recorded in a `binding.json` manifest.
+- It assumes every research run on that area deposits into that wiki.
+- It records each deposit's lineage so future runs can avoid circular evidence (Phase 2 cycle-guard).
+- It does NOT support web-only one-shot mode — those users belong in `cogni-research` directly.
+
+The opinionation is the value. cogni-wiki can ingest research, but it does not enforce "every research run goes here." cogni-knowledge does.
+
+## The compounding loop
+
+```
+Run 1: research topic A          → wiki has pages P1..P5
+Run 2: research adjacent topic B → wiki-researcher reads P1..P5 from the bound wiki
+                                  → finds gaps → fetches new sources only for the gaps
+                                  → deposits new pages P6..P9, some [[wikilinking]] back to P1..P5
+Run 3: research deeper subtopic  → reads P1..P9 → minimal new web work
+                                  → deposits P10..P12, dense with cross-references
+```
+
+The wiki gets denser. The cost per research run trends down. The cross-project synthesis is visible in the markdown itself — no special query needed.
+
+## What success looks like
+
+In Phase 4 (alpha), we will measure:
+
+- **Time-to-second-research.** Should drop as the wiki primes the second run.
+- **Information density.** Count `[[wikilinks]]` between pages from different research projects (proxy for compounding).
+- **Claims duplication.** Compare claim count vs. unique-source count. `wiki-ingest` dedupes claims at deposit.
+- **User-perceived value.** Would the user pick `cogni-knowledge` over standalone `cogni-research`?
+
+A positive alpha is what triggers Phase 6 (absorbing `cogni-research`). A negative alpha freezes `cogni-knowledge` as an experimental path and we do not migrate.

--- a/cogni-knowledge/scripts/knowledge-binding.py
+++ b/cogni-knowledge/scripts/knowledge-binding.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""
+knowledge-binding.py — read/write .cogni-knowledge/binding.json
+
+Three actions:
+  --init           create a new binding manifest
+  --append-project record a deposited cogni-research project
+  --read           emit the current binding manifest as JSON
+
+All output uses the insight-wave script envelope:
+  {"success": bool, "data": {...}, "error": "..."}
+
+Stdlib only. No pip dependencies.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import json
+import os
+import sys
+from pathlib import Path
+
+SCHEMA_VERSION = "0.0.1"
+BINDING_DIRNAME = ".cogni-knowledge"
+BINDING_FILENAME = "binding.json"
+VALID_REPORT_SOURCES = {"web", "local", "wiki", "hybrid"}
+
+
+def _emit(success: bool, data: dict | None = None, error: str = "") -> int:
+    payload = {"success": success, "data": data or {}, "error": error}
+    print(json.dumps(payload, indent=2, ensure_ascii=False))
+    return 0 if success else 1
+
+
+def _binding_path(knowledge_root: Path) -> Path:
+    return knowledge_root / BINDING_DIRNAME / BINDING_FILENAME
+
+
+def _today() -> str:
+    return _dt.date.today().isoformat()
+
+
+def _read_binding(knowledge_root: Path) -> dict:
+    bp = _binding_path(knowledge_root)
+    if not bp.is_file():
+        raise FileNotFoundError(f"binding not found at {bp}")
+    with bp.open("r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def _write_binding(knowledge_root: Path, payload: dict) -> Path:
+    bp = _binding_path(knowledge_root)
+    bp.parent.mkdir(parents=True, exist_ok=True)
+    tmp = bp.with_suffix(".json.tmp")
+    with tmp.open("w", encoding="utf-8") as fh:
+        json.dump(payload, fh, indent=2, ensure_ascii=False)
+        fh.write("\n")
+    os.replace(tmp, bp)
+    return bp
+
+
+def cmd_init(args: argparse.Namespace) -> int:
+    knowledge_root = Path(args.knowledge_root).resolve()
+    wiki_path = Path(args.wiki_path).resolve()
+
+    if not knowledge_root.is_dir():
+        return _emit(False, error=f"knowledge_root does not exist: {knowledge_root}")
+    if not wiki_path.is_dir():
+        return _emit(False, error=f"wiki_path does not exist: {wiki_path}")
+
+    bp = _binding_path(knowledge_root)
+    if bp.is_file():
+        existing = json.loads(bp.read_text(encoding="utf-8"))
+        return _emit(
+            False,
+            data={"existing": existing, "path": str(bp)},
+            error="binding already exists at the target; refusing to overwrite",
+        )
+
+    wiki_config = wiki_path / ".cogni-wiki" / "config.json"
+    if not wiki_config.is_file():
+        return _emit(
+            False,
+            error=(
+                f"wiki_path is not a cogni-wiki (missing {wiki_config}). "
+                "Run cogni-wiki:wiki-setup first or fix the path."
+            ),
+        )
+    try:
+        wiki_slug = json.loads(wiki_config.read_text(encoding="utf-8")).get("slug", "")
+    except json.JSONDecodeError:
+        wiki_slug = ""
+
+    payload = {
+        "knowledge_slug": args.knowledge_slug,
+        "knowledge_title": args.knowledge_title,
+        "wiki_path": str(wiki_path),
+        "wiki_slug": wiki_slug,
+        "research_projects": [],
+        "topic_lineage": {"covered_themes": [], "open_themes": []},
+        "created": _today(),
+        "schema_version": SCHEMA_VERSION,
+    }
+    written = _write_binding(knowledge_root, payload)
+    return _emit(True, data={"path": str(written), "binding": payload})
+
+
+def cmd_append_project(args: argparse.Namespace) -> int:
+    knowledge_root = Path(args.knowledge_root).resolve()
+
+    try:
+        binding = _read_binding(knowledge_root)
+    except FileNotFoundError as exc:
+        return _emit(False, error=str(exc))
+    except json.JSONDecodeError as exc:
+        return _emit(False, error=f"binding.json is not valid JSON: {exc}")
+
+    if args.knowledge_slug and binding.get("knowledge_slug") != args.knowledge_slug:
+        return _emit(
+            False,
+            data={"binding_slug": binding.get("knowledge_slug")},
+            error=(
+                f"knowledge_slug mismatch: binding has '{binding.get('knowledge_slug')}', "
+                f"caller passed '{args.knowledge_slug}'"
+            ),
+        )
+
+    if args.report_source not in VALID_REPORT_SOURCES:
+        return _emit(
+            False,
+            error=(
+                f"invalid --report-source '{args.report_source}'; "
+                f"must be one of {sorted(VALID_REPORT_SOURCES)}"
+            ),
+        )
+
+    projects = binding.setdefault("research_projects", [])
+    if any(p.get("slug") == args.research_slug for p in projects):
+        return _emit(
+            False,
+            data={"existing_slug": args.research_slug},
+            error="research_slug already recorded in this binding; refusing to duplicate",
+        )
+
+    entry = {
+        "slug": args.research_slug,
+        "deposited_at": args.deposited_at or _today(),
+        "report_path": str(Path(args.report_path).resolve()) if args.report_path else "",
+        "report_source": args.report_source,
+    }
+    projects.append(entry)
+
+    written = _write_binding(knowledge_root, binding)
+    return _emit(
+        True,
+        data={
+            "path": str(written),
+            "appended": entry,
+            "research_projects_count": len(projects),
+        },
+    )
+
+
+def cmd_read(args: argparse.Namespace) -> int:
+    knowledge_root = Path(args.knowledge_root).resolve()
+    try:
+        binding = _read_binding(knowledge_root)
+    except FileNotFoundError as exc:
+        return _emit(False, error=str(exc))
+    except json.JSONDecodeError as exc:
+        return _emit(False, error=f"binding.json is not valid JSON: {exc}")
+    return _emit(True, data={"binding": binding, "path": str(_binding_path(knowledge_root))})
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(
+        description="Read/write .cogni-knowledge/binding.json",
+        allow_abbrev=False,
+    )
+    sub = parser.add_subparsers(dest="action", required=True)
+
+    p_init = sub.add_parser("init", help="Create a new binding manifest")
+    p_init.add_argument("--knowledge-root", required=True)
+    p_init.add_argument("--knowledge-slug", required=True)
+    p_init.add_argument("--knowledge-title", required=True)
+    p_init.add_argument("--wiki-path", required=True)
+    p_init.set_defaults(func=cmd_init)
+
+    p_append = sub.add_parser("append-project", help="Record a deposited research project")
+    p_append.add_argument("--knowledge-root", required=True)
+    p_append.add_argument("--knowledge-slug", required=False, default="")
+    p_append.add_argument("--research-slug", required=True)
+    p_append.add_argument("--report-path", required=False, default="")
+    p_append.add_argument("--report-source", required=True, choices=sorted(VALID_REPORT_SOURCES))
+    p_append.add_argument("--deposited-at", required=False, default="")
+    p_append.set_defaults(func=cmd_append_project)
+
+    p_read = sub.add_parser("read", help="Emit the binding manifest")
+    p_read.add_argument("--knowledge-root", required=True)
+    p_read.set_defaults(func=cmd_read)
+
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/cogni-knowledge/scripts/knowledge-binding.py
+++ b/cogni-knowledge/scripts/knowledge-binding.py
@@ -25,6 +25,8 @@ from pathlib import Path
 SCHEMA_VERSION = "0.0.1"
 BINDING_DIRNAME = ".cogni-knowledge"
 BINDING_FILENAME = "binding.json"
+WIKI_DIRNAME = ".cogni-wiki"
+WIKI_CONFIG_FILENAME = "config.json"
 VALID_REPORT_SOURCES = {"web", "local", "wiki", "hybrid"}
 
 
@@ -79,7 +81,7 @@ def cmd_init(args: argparse.Namespace) -> int:
             error="binding already exists at the target; refusing to overwrite",
         )
 
-    wiki_config = wiki_path / ".cogni-wiki" / "config.json"
+    wiki_config = wiki_path / WIKI_DIRNAME / WIKI_CONFIG_FILENAME
     if not wiki_config.is_file():
         return _emit(
             False,
@@ -88,16 +90,14 @@ def cmd_init(args: argparse.Namespace) -> int:
                 "Run cogni-wiki:wiki-setup first or fix the path."
             ),
         )
-    try:
-        wiki_slug = json.loads(wiki_config.read_text(encoding="utf-8")).get("slug", "")
-    except json.JSONDecodeError:
-        wiki_slug = ""
 
+    # wiki_slug is the live truth — resolved from .cogni-wiki/config.json
+    # at every consumer, never cached here. Single source of truth lives
+    # upstream; caching would drift if the user renames the wiki.
     payload = {
         "knowledge_slug": args.knowledge_slug,
         "knowledge_title": args.knowledge_title,
         "wiki_path": str(wiki_path),
-        "wiki_slug": wiki_slug,
         "research_projects": [],
         "topic_lineage": {"covered_themes": [], "open_themes": []},
         "created": _today(),

--- a/cogni-knowledge/scripts/lineage-stamp.py
+++ b/cogni-knowledge/scripts/lineage-stamp.py
@@ -24,6 +24,9 @@ import sys
 from pathlib import Path
 
 FRONTMATTER_DELIM = "---"
+WIKI_DIRNAME = ".cogni-wiki"
+WIKI_CONFIG_FILENAME = "config.json"
+RESEARCH_RAW_PREFIX = "raw/research-"
 
 
 def _emit(success: bool, data: dict | None = None, error: str = "") -> int:
@@ -84,14 +87,14 @@ def main(argv: list[str]) -> int:
     args = parser.parse_args(argv)
 
     wiki_root = Path(args.wiki_root).resolve()
-    if not (wiki_root / ".cogni-wiki" / "config.json").is_file():
+    if not (wiki_root / WIKI_DIRNAME / WIKI_CONFIG_FILENAME).is_file():
         return _emit(False, error=f"not a cogni-wiki root: {wiki_root}")
 
     research_slug = args.research_slug.strip()
     if not research_slug:
         return _emit(False, error="--research-slug must be non-empty")
 
-    research_dir_token = f"raw/research-{research_slug}/"
+    research_dir_token = f"{RESEARCH_RAW_PREFIX}{research_slug}/"
     wiki_dir = wiki_root / "wiki"
     if not wiki_dir.is_dir():
         return _emit(False, error=f"wiki/ subdir missing under {wiki_root}")

--- a/cogni-knowledge/scripts/lineage-stamp.py
+++ b/cogni-knowledge/scripts/lineage-stamp.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""
+lineage-stamp.py — add `derived_from_research: <slug>` to YAML frontmatter
+of wiki pages whose `sources:` list points into `raw/research-<slug>/`.
+
+Idempotent: pages that already carry the field are skipped.
+
+Input:
+  --wiki-root      absolute path to a cogni-wiki root (the dir holding wiki/ and raw/)
+  --research-slug  the cogni-research project slug whose deposit we are stamping
+
+Output (insight-wave envelope):
+  {"success": bool, "data": {"stamped": [...], "skipped": [...], "scanned": N}, "error": "..."}
+
+Stdlib only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+FRONTMATTER_DELIM = "---"
+
+
+def _emit(success: bool, data: dict | None = None, error: str = "") -> int:
+    payload = {"success": success, "data": data or {}, "error": error}
+    print(json.dumps(payload, indent=2, ensure_ascii=False))
+    return 0 if success else 1
+
+
+def _split_frontmatter(text: str) -> tuple[str, str] | None:
+    """Return (frontmatter_block, body) if the file opens with `---\\n...\\n---\\n`.
+    Returns None if no frontmatter is present."""
+    if not text.startswith(FRONTMATTER_DELIM):
+        return None
+    # Match opening `---` line, content, closing `---` line. Only the closing
+    # line's terminator is consumed — any blank line(s) between frontmatter and
+    # body are preserved verbatim in `body`.
+    pattern = re.compile(r"^---[ \t]*\r?\n(.*?)\r?\n---[ \t]*\r?\n", re.DOTALL)
+    m = pattern.match(text)
+    if not m:
+        return None
+    fm = m.group(1)
+    body = text[m.end():]
+    return fm, body
+
+
+def _frontmatter_has_field(fm: str, field: str) -> bool:
+    # Match a top-level key (no leading whitespace).
+    return re.search(rf"(?m)^{re.escape(field)}\s*:", fm) is not None
+
+
+def _sources_reference_research(fm: str, research_dir_token: str) -> bool:
+    """Heuristic: any line in the frontmatter contains the token
+    `raw/research-<slug>/`. Robust enough for the canonical YAML shapes
+    that cogni-wiki emits (`sources:` list-of-strings, list-of-dicts with
+    `path:`, or inline strings). We deliberately do not parse YAML to keep
+    this stdlib-only and tolerant of cogni-wiki's evolving frontmatter."""
+    return research_dir_token in fm
+
+
+def _insert_lineage_field(fm: str, research_slug: str) -> str:
+    """Append `derived_from_research: <slug>` to the frontmatter block."""
+    fm_stripped = fm.rstrip("\n")
+    return f"{fm_stripped}\nderived_from_research: {research_slug}\n"
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(
+        description="Stamp derived_from_research into deposited wiki page frontmatter.",
+        allow_abbrev=False,
+    )
+    parser.add_argument("--wiki-root", required=True)
+    parser.add_argument("--research-slug", required=True)
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report what would be stamped without writing.",
+    )
+    args = parser.parse_args(argv)
+
+    wiki_root = Path(args.wiki_root).resolve()
+    if not (wiki_root / ".cogni-wiki" / "config.json").is_file():
+        return _emit(False, error=f"not a cogni-wiki root: {wiki_root}")
+
+    research_slug = args.research_slug.strip()
+    if not research_slug:
+        return _emit(False, error="--research-slug must be non-empty")
+
+    research_dir_token = f"raw/research-{research_slug}/"
+    wiki_dir = wiki_root / "wiki"
+    if not wiki_dir.is_dir():
+        return _emit(False, error=f"wiki/ subdir missing under {wiki_root}")
+
+    stamped: list[str] = []
+    skipped_already: list[str] = []
+    skipped_unrelated: list[str] = []
+    skipped_no_frontmatter: list[str] = []
+    scanned = 0
+
+    for md_path in sorted(wiki_dir.rglob("*.md")):
+        if not md_path.is_file():
+            continue
+        scanned += 1
+        rel = md_path.relative_to(wiki_root).as_posix()
+
+        text = md_path.read_text(encoding="utf-8")
+        split = _split_frontmatter(text)
+        if split is None:
+            skipped_no_frontmatter.append(rel)
+            continue
+        fm, body = split
+
+        if not _sources_reference_research(fm, research_dir_token):
+            skipped_unrelated.append(rel)
+            continue
+
+        if _frontmatter_has_field(fm, "derived_from_research"):
+            # Already stamped (possibly with a different slug — leave alone;
+            # multi-research-derived pages are surfaced by Phase 2 cycle-guard).
+            skipped_already.append(rel)
+            continue
+
+        new_fm = _insert_lineage_field(fm, research_slug)
+        new_text = f"{FRONTMATTER_DELIM}\n{new_fm}{FRONTMATTER_DELIM}\n{body}"
+
+        if not args.dry_run:
+            md_path.write_text(new_text, encoding="utf-8")
+        stamped.append(rel)
+
+    return _emit(
+        True,
+        data={
+            "wiki_root": str(wiki_root),
+            "research_slug": research_slug,
+            "scanned": scanned,
+            "stamped": stamped,
+            "skipped_already_stamped": skipped_already,
+            "skipped_unrelated": len(skipped_unrelated),
+            "skipped_no_frontmatter": len(skipped_no_frontmatter),
+            "dry_run": args.dry_run,
+        },
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/cogni-knowledge/skills/knowledge-research/SKILL.md
+++ b/cogni-knowledge/skills/knowledge-research/SKILL.md
@@ -1,0 +1,145 @@
+---
+name: knowledge-research
+description: "Research a topic INTO a bound cogni-knowledge base — runs cogni-research on the topic and deposits the findings into the knowledge base's wiki in one prompt. Reads .cogni-knowledge/binding.json to resolve the wiki path so the user does not have to. Every deposited page is stamped with derived_from_research:<slug>, and the project is recorded in the binding's research_projects[] list. Use this skill whenever the user says 'research X into my knowledge base', 'deposit research on X into the eu-ai-act base', 'knowledge research on X', 'add research on X to the knowledge base', 'feed the knowledge base a research run on X'. Knowledge accumulates across runs — the second knowledge-research on a related topic reads what the first deposited."
+allowed-tools: Read, Bash, Glob, AskUserQuestion, Skill
+---
+
+# Knowledge Research
+
+Research a topic and deposit the findings into a bound cogni-knowledge base in one command. This is the **accumulation primitive** — every run of this skill leaves the knowledge base denser than before, and the next run reads what previous runs filed.
+
+This skill is a thin orchestrator over `cogni-wiki:wiki-from-research` (Mode A). The cogni-knowledge value-add is three things on top of `wiki-from-research`:
+
+1. Binding-aware wiki path resolution (no `--wiki-root` from the user — read it from `binding.json`).
+2. Lineage stamping (`derived_from_research: <slug>` on every deposited page).
+3. Binding append (record the project in `research_projects[]` so `knowledge-resume` can list it).
+
+Read `${CLAUDE_PLUGIN_ROOT}/references/differentiation-thesis.md` once at the start of a session to anchor on the accumulation thesis; read `${CLAUDE_PLUGIN_ROOT}/references/delegation-contract.md` to remember the delegation boundary.
+
+## When to run
+
+- User asks to research a topic INTO an existing knowledge base
+- User wants the work to compound — second research on a related topic should read the first
+- User explicitly invokes `/cogni-knowledge:knowledge-research`
+
+## Never run when
+
+- No `binding.json` exists at the resolved knowledge root — offer `cogni-knowledge:knowledge-setup` first. Do not silently create one; the binding is a deliberate commitment.
+- The user wants a one-shot research report with no persistence — point at `cogni-research:research-setup` directly. cogni-knowledge is opinionated about wiki-first.
+
+## Parameters
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `--knowledge-slug` | Yes | Slug of the bound knowledge base. Resolves to `<cwd>/<slug>/` unless `--knowledge-root` overrides. |
+| `--topic` | Yes (prompted) | Free-text research topic. Forwarded to `cogni-wiki:wiki-from-research --topic`. |
+| `--knowledge-root` | No | Override the default knowledge-base directory. Defaults to `<cwd>/<knowledge-slug>/`. |
+| `--research-overrides` | No | Comma-separated `key=value` hints forwarded to `cogni-wiki:wiki-from-research --research-overrides` (e.g. `report_type=detailed,market=dach,target_words=5000`). Default if absent: `report_type=detailed`. The user can still override every value in `cogni-research:research-setup`'s interactive menu. |
+| `--dry-run` | No | Print the resolved plan (binding, wiki path, dispatch) without running. |
+
+If `--topic` is missing, ask the user once. Do not invent a topic.
+
+## Workflow
+
+### 0. Pre-flight
+
+1. Resolve `knowledge_root`:
+   - If `--knowledge-root` is set, use it.
+   - Otherwise, `knowledge_root = <cwd>/<knowledge-slug>/`.
+
+2. Read the binding:
+   ```
+   python3 ${CLAUDE_PLUGIN_ROOT}/scripts/knowledge-binding.py read \
+       --knowledge-root <knowledge_root>
+   ```
+   On `success: false` (binding missing or malformed), abort and offer `knowledge-setup`. Do not auto-create.
+
+3. Extract `wiki_path`, `wiki_slug`, `knowledge_slug` from the binding. Validate the binding's `knowledge_slug` matches `--knowledge-slug` — mismatch indicates the user is pointing at the wrong directory.
+
+4. Confirm the wiki is still there: `<wiki_path>/.cogni-wiki/config.json` must exist. If not, abort with a clear "the binding points at a wiki that no longer exists" error.
+
+5. If `--dry-run`, print the resolved plan (knowledge_slug, wiki_path, topic, research_overrides) and stop.
+
+### 1. Dispatch `cogni-wiki:wiki-from-research` (Mode A)
+
+```
+Skill("cogni-wiki:wiki-from-research",
+      args="--topic '<topic>' --wiki-root <wiki_path> --wiki-slug <wiki_slug> --research-overrides <overrides>")
+```
+
+Default `--research-overrides report_type=detailed` if the caller did not pass any.
+
+`wiki-from-research` will:
+1. Pre-flight (Step 0): wiki collision check, dry-run gate.
+2. Run `cogni-research:research-setup` → `research-report` to produce `cogni-research-<resolved_slug>/output/report.md`.
+3. Skip `wiki-setup` (the wiki already exists; `wiki-from-research` Step 0(2) lands on `wiki_action = resume`).
+4. Dispatch `wiki-ingest --discover research:<resolved_slug>` from `<wiki_path>` as cwd to deposit per-sub-question pages under `<wiki_path>/raw/research-<resolved_slug>/` and `<wiki_path>/wiki/**/*.md`.
+
+Parse the `resolved_slug` from `wiki-from-research`'s final summary (Step 4 prints `research_slug` and project path). If the dispatch fails before the deposit completes, abort; do not stamp lineage or append to the binding for a half-completed run.
+
+### 2. Stamp lineage
+
+```
+python3 ${CLAUDE_PLUGIN_ROOT}/scripts/lineage-stamp.py \
+    --wiki-root <wiki_path> \
+    --research-slug <resolved_slug>
+```
+
+The script adds `derived_from_research: <resolved_slug>` to the YAML frontmatter of every wiki page whose `sources:` list points into `<wiki_path>/raw/research-<resolved_slug>/`. Idempotent — safe even if Step 1 was a resume.
+
+On `success: false`, surface the error but **do not abort the workflow** — lineage stamping is a quality-of-life addition; missing stamps degrade Phase 2's cycle-guard but do not corrupt the wiki or the binding. Print a warning and continue.
+
+### 3. Append the project to the binding
+
+```
+python3 ${CLAUDE_PLUGIN_ROOT}/scripts/knowledge-binding.py append-project \
+    --knowledge-root <knowledge_root> \
+    --knowledge-slug <knowledge_slug> \
+    --research-slug <resolved_slug> \
+    --report-path <abs path to cogni-research-<resolved_slug>/output/report.md> \
+    --report-source web
+```
+
+`report_source` is `web` for Phase 1 invocations — `wiki-from-research` Mode A always runs with `cogni-research`'s default web mode (the skill refuses `report_source ∈ {wiki, hybrid}` projects, see `cogni-wiki/skills/wiki-from-research/SKILL.md` Step 0(3)). Phase 2's `knowledge-report` is the skill that records `report_source=wiki` entries.
+
+On duplicate-slug error from the script (the same `resolved_slug` is already in the binding), surface a warning — this can happen if the user re-ran a research project with the same slug. The wiki pages have been re-deposited (mode: re-ingest), but the binding entry stays as the original deposit's record. Do not abort.
+
+### 4. Final summary
+
+Print ≤ 8 lines:
+
+- Knowledge base: `<knowledge_slug>` at `<knowledge_root>`
+- New deposit: `<resolved_slug>` (topic: `<topic>`)
+- Wiki pages deposited (count from `wiki-from-research`'s Step 4 summary)
+- Pages stamped with lineage (count from `lineage-stamp.py`'s `stamped[]` length)
+- Total deposited projects now: `<count>` (from `knowledge-binding.py append-project`'s `research_projects_count`)
+- Cost (if `wiki-from-research` returned it — sum from `research-report` Phase 6)
+- Suggested next: `knowledge-resume`, `cogni-wiki:wiki-query`, or another `knowledge-research` on an adjacent topic
+
+## Edge cases
+
+- **Topic collision with an existing research project.** `cogni-research:research-setup` (inside `wiki-from-research` Step 1) prompts resume / new / different. The `resolved_slug` we capture in Step 1 reflects the user's choice. If the user picks `resume` of a previously-deposited project, Step 3's binding append will refuse (duplicate slug) — warn and continue; the wiki has been refreshed via `wiki-ingest`'s re-ingest branch.
+- **`wiki-from-research` aborts during pre-flight.** No research has run. Surface the error verbatim; the binding is untouched.
+- **Wiki path resolves to a different cogni-wiki than the binding records.** Step 0(4) catches this. Abort rather than silently writing into the wrong wiki.
+
+## Out of scope
+
+- Does NOT write wiki pages directly — every deposit goes through `cogni-wiki:wiki-ingest`'s lock-protected pipeline.
+- Does NOT modify the research project's files — only the wiki side gets the lineage stamp.
+- Does NOT support `report_source ∈ {wiki, hybrid}` — that is Phase 2's `knowledge-report`.
+
+## Output
+
+- A `cogni-research-<resolved_slug>/` project directory (at the workspace root, per `cogni-research`'s default)
+- New pages under `<wiki_path>/wiki/**/*.md` and raw sources under `<wiki_path>/raw/research-<resolved_slug>/`
+- An updated `<knowledge_root>/.cogni-knowledge/binding.json` with one new entry in `research_projects[]`
+
+No files are written outside the workspace root or the bound knowledge base.
+
+## References
+
+- `${CLAUDE_PLUGIN_ROOT}/references/delegation-contract.md`
+- `cogni-wiki:wiki-from-research` SKILL.md — Mode A contract
+- `cogni-wiki:wiki-ingest` SKILL.md and `references/batch-mode.md` — `--discover research:<slug>` contract
+- `${CLAUDE_PLUGIN_ROOT}/scripts/knowledge-binding.py --help`
+- `${CLAUDE_PLUGIN_ROOT}/scripts/lineage-stamp.py --help`

--- a/cogni-knowledge/skills/knowledge-research/SKILL.md
+++ b/cogni-knowledge/skills/knowledge-research/SKILL.md
@@ -54,9 +54,9 @@ If `--topic` is missing, ask the user once. Do not invent a topic.
    ```
    On `success: false` (binding missing or malformed), abort and offer `knowledge-setup`. Do not auto-create.
 
-3. Extract `wiki_path`, `wiki_slug`, `knowledge_slug` from the binding. Validate the binding's `knowledge_slug` matches `--knowledge-slug` — mismatch indicates the user is pointing at the wrong directory.
+3. Extract `wiki_path` and `knowledge_slug` from the binding. Validate the binding's `knowledge_slug` matches `--knowledge-slug` — mismatch indicates the user is pointing at the wrong directory.
 
-4. Confirm the wiki is still there: `<wiki_path>/.cogni-wiki/config.json` must exist. If not, abort with a clear "the binding points at a wiki that no longer exists" error.
+4. Confirm the wiki is still there: `<wiki_path>/.cogni-wiki/config.json` must exist. If not, abort with a clear "the binding points at a wiki that no longer exists" error. Read the live `slug` from that config file — that is the value to forward as `--wiki-slug` in Step 1 (never cache in the binding).
 
 5. If `--dry-run`, print the resolved plan (knowledge_slug, wiki_path, topic, research_overrides) and stop.
 
@@ -64,7 +64,7 @@ If `--topic` is missing, ask the user once. Do not invent a topic.
 
 ```
 Skill("cogni-wiki:wiki-from-research",
-      args="--topic '<topic>' --wiki-root <wiki_path> --wiki-slug <wiki_slug> --research-overrides <overrides>")
+      args="--topic '<topic>' --wiki-root <wiki_path> --wiki-slug <live_wiki_slug> --research-overrides <overrides>")
 ```
 
 Default `--research-overrides report_type=detailed` if the caller did not pass any.

--- a/cogni-knowledge/skills/knowledge-resume/SKILL.md
+++ b/cogni-knowledge/skills/knowledge-resume/SKILL.md
@@ -44,7 +44,7 @@ Read `${CLAUDE_PLUGIN_ROOT}/references/delegation-contract.md` once at the start
    ```
    On `success: false`, abort and offer `knowledge-setup`. Do not auto-create.
 
-3. Extract from the binding: `knowledge_slug`, `knowledge_title`, `wiki_path`, `wiki_slug`, `research_projects[]`, `created`, `topic_lineage`.
+3. Extract from the binding: `knowledge_slug`, `knowledge_title`, `wiki_path`, `research_projects[]`, `created`, `topic_lineage`. (The bound wiki's own slug, if needed for display, comes live from `<wiki_path>/.cogni-wiki/config.json` — never cached in the binding.)
 
 4. Validate the binding's `knowledge_slug` matches `--knowledge-slug`. Mismatch → abort.
 

--- a/cogni-knowledge/skills/knowledge-resume/SKILL.md
+++ b/cogni-knowledge/skills/knowledge-resume/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: knowledge-resume
+description: "Show status of a cogni-knowledge base — knowledge slug, bound wiki path, deposited research projects, wiki health verdict, and the recommended next action. Delegates structural integrity to cogni-wiki:wiki-resume (which runs wiki-health automatically). Use this skill whenever the user says 'resume the knowledge base', 'knowledge resume', 'knowledge status', 'where was I with the eu-ai-act base', 'what's in my knowledge base', 'show me the knowledge base overview'. Proactively after a long gap between sessions, or right after knowledge-setup or knowledge-research."
+allowed-tools: Read, Bash, Glob, Skill
+---
+
+# Knowledge Resume
+
+Give the user a fast, grounded status view of a cogni-knowledge base so they know what is inside and what the right next action is. This skill is **read-only** with respect to the binding and the wiki — it never writes. The only side effect is that the upstream `cogni-wiki:wiki-resume` may log its health-check invocation in `wiki/log.md`.
+
+Read `${CLAUDE_PLUGIN_ROOT}/references/delegation-contract.md` once at the start of a session so you remember that wiki health checks belong to cogni-wiki, not to cogni-knowledge.
+
+## When to run
+
+- User asks for status, overview, or "where was I" on a knowledge base
+- User returns after a gap and wants orientation
+- Right after `knowledge-setup` or `knowledge-research` finished, to confirm the deposit and suggest the next step
+- Proactively when a session opens in a directory containing `.cogni-knowledge/binding.json`
+
+## Never run when
+
+- The target directory has no `.cogni-knowledge/binding.json` — offer `knowledge-setup` instead.
+
+## Parameters
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `--knowledge-slug` | Yes | Slug of the knowledge base to resume. Resolves to `<cwd>/<slug>/` unless `--knowledge-root` overrides. |
+| `--knowledge-root` | No | Override the default knowledge-base directory. |
+| `--verbose` | No | Forward to `cogni-wiki:wiki-resume --verbose`. Includes recent log activity verbatim. |
+
+## Workflow
+
+### 1. Resolve the knowledge root and read the binding
+
+1. Resolve `knowledge_root`:
+   - If `--knowledge-root` is set, use it.
+   - Otherwise, `knowledge_root = <cwd>/<knowledge-slug>/`.
+
+2. Read the binding:
+   ```
+   python3 ${CLAUDE_PLUGIN_ROOT}/scripts/knowledge-binding.py read \
+       --knowledge-root <knowledge_root>
+   ```
+   On `success: false`, abort and offer `knowledge-setup`. Do not auto-create.
+
+3. Extract from the binding: `knowledge_slug`, `knowledge_title`, `wiki_path`, `wiki_slug`, `research_projects[]`, `created`, `topic_lineage`.
+
+4. Validate the binding's `knowledge_slug` matches `--knowledge-slug`. Mismatch → abort.
+
+### 2. Delegate to `cogni-wiki:wiki-resume`
+
+```
+Skill("cogni-wiki:wiki-resume", args="--wiki-root <wiki_path> [--verbose]")
+```
+
+`wiki-resume` already runs `wiki-health` automatically (see `cogni-wiki/skills/wiki-resume/SKILL.md` — "As of v0.0.27, resume also runs wiki-health automatically"). Do not run `wiki-health` separately; that would log a noisy second invocation.
+
+Capture the wiki-resume output. Look for:
+- The `wiki/context_brief.md` summary (auto-rebuilt by `wiki-ingest`)
+- Entry count and recent log activity
+- Wiki health verdict (broken wikilinks, missing frontmatter, stale drafts)
+
+### 3. Compose the cogni-knowledge summary
+
+Print a ≤ 12-line summary that layers the binding onto the wiki status:
+
+- **Knowledge base.** `<knowledge_title>` (`<knowledge_slug>`), created `<created>`
+- **Wiki path.** `<wiki_path>` — wiki health verdict from Step 2 (one line: "OK" / "N issues — see wiki-resume output above")
+- **Deposited research projects.** `<count>` (list slugs + `deposited_at`, newest first; cap at 5, summarise the rest as "and N more")
+- **Topic lineage.** If `covered_themes` or `open_themes` are non-empty, print them as two short lists. Else omit.
+- **Next action.** Recommend based on state:
+  - If `research_projects` is empty: "Run `knowledge-research --knowledge-slug <slug> --topic '...'` to deposit your first project."
+  - If wiki has structural issues: "Fix structural issues first — see the wiki-resume output above. Then `knowledge-research` for more deposits or `cogni-wiki:wiki-query` to ask the base."
+  - Otherwise: "Run another `knowledge-research` to keep accumulating, or `cogni-wiki:wiki-query --question '...'` to ask the base what it knows."
+
+The full `wiki-resume` output appears verbatim above the summary so the user has the structural detail at hand; cogni-knowledge's contribution is the binding overlay.
+
+## Edge cases
+
+- **Binding exists but `wiki_path` no longer does.** Step 1(4) catches the missing `.cogni-wiki/config.json`. Abort with a clear message.
+- **`wiki-resume` fails.** Surface its error and still print the binding section — the user benefits from at least knowing the deposit count even if the wiki status is broken.
+- **`research_projects[]` references a `report_path` that no longer exists.** Do not abort; flag in the summary with "(report file missing — possibly archived)" next to that entry. The binding is the durable record; the on-disk research project is incidental.
+
+## Out of scope
+
+- Does NOT run `wiki-health` directly — `wiki-resume` already does.
+- Does NOT run `wiki-lint` — that is a tokenful semantic pass that the user invokes deliberately, not on resume.
+- Does NOT write to the binding or the wiki — read-only.
+
+## Output
+
+A status block printed to the user. No files written.
+
+## References
+
+- `${CLAUDE_PLUGIN_ROOT}/references/delegation-contract.md`
+- `cogni-wiki:wiki-resume` SKILL.md
+- `${CLAUDE_PLUGIN_ROOT}/scripts/knowledge-binding.py --help`

--- a/cogni-knowledge/skills/knowledge-setup/SKILL.md
+++ b/cogni-knowledge/skills/knowledge-setup/SKILL.md
@@ -89,7 +89,7 @@ Do not print the full binding JSON in the summary — point at the file path and
 
 ## Edge cases
 
-- **Wiki exists but is for a different domain.** Step 2 detects the existing wiki and re-uses it. This is intentional — a user may want to layer a knowledge base onto an existing wiki. The binding records the wiki_slug from `.cogni-wiki/config.json` so the asymmetry is visible.
+- **Wiki exists but is for a different domain.** Step 2 detects the existing wiki and re-uses it. This is intentional — a user may want to layer a knowledge base onto an existing wiki. The binding records only `wiki_path`; the wiki's own slug is read live from `<wiki_path>/.cogni-wiki/config.json` whenever a consumer needs it, so a wiki rename never causes the binding to drift.
 - **`--knowledge-slug` collides with a sibling directory.** Step 1's binding-existence check protects against double-init; if the sibling is a non-wiki directory, Step 2's foreign-files check fires.
 - **`wiki-setup` crashes mid-run.** No binding has been written. Surface the wiki-setup error; the user can re-run after fixing whatever wiki-setup complained about.
 

--- a/cogni-knowledge/skills/knowledge-setup/SKILL.md
+++ b/cogni-knowledge/skills/knowledge-setup/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: knowledge-setup
+description: "Bootstrap a cogni-knowledge knowledge base — a cogni-wiki + a binding manifest that records every research project deposited into it. Creates the wiki via cogni-wiki:wiki-setup if it does not exist, then writes .cogni-knowledge/binding.json. Use this skill whenever the user says 'set up a knowledge base', 'start a knowledge base on X', 'bootstrap a wiki-first research base', 'new knowledge base for X', 'create a knowledge base', or 'wiki-first research setup'. After setup, the user can run knowledge-research to deposit research projects into the base."
+allowed-tools: Read, Bash, Glob, AskUserQuestion, Skill
+---
+
+# Knowledge Setup
+
+Bootstrap a cogni-knowledge knowledge base. A knowledge base is one directory that holds both a cogni-wiki (`.cogni-wiki/config.json`) and a cogni-knowledge binding manifest (`.cogni-knowledge/binding.json`). The wiki is the substrate; the binding records which research projects have contributed to it.
+
+This skill is a **thin orchestrator**. It does not re-implement wiki bootstrapping — that work belongs to `cogni-wiki:wiki-setup`. The cogni-knowledge value-add is the binding manifest plus the one-command workflow.
+
+Read `${CLAUDE_PLUGIN_ROOT}/references/differentiation-thesis.md` once at the start of a session to anchor on why wiki-first matters; read `${CLAUDE_PLUGIN_ROOT}/references/delegation-contract.md` to remember what cogni-knowledge owns vs. delegates.
+
+## When to run
+
+- User asks to bootstrap, set up, initialize, or start a knowledge base
+- User wants to begin a long-running research area (multiple projects, accumulating findings)
+- User explicitly invokes `/cogni-knowledge:knowledge-setup`
+
+## Never run when
+
+- The target directory already has `.cogni-knowledge/binding.json` — report the existing binding and stop. Re-initialisation is destructive; surface the existing slug and let the user decide.
+- The user wants a one-off research report — point them at `cogni-research:research-setup` directly. cogni-knowledge is opinionated about accumulation.
+
+## Parameters
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `--knowledge-slug` | Yes (prompted) | Kebab-case identifier for the knowledge base, e.g. `eu-ai-act`. Used for the directory name (`<cwd>/<slug>/`) and the `knowledge_slug` field in the binding. |
+| `--knowledge-title` | Yes (prompted) | Human-readable title, e.g. `"EU AI Act knowledge base"`. Used as the `--name` for `cogni-wiki:wiki-setup`. |
+| `--knowledge-root` | No | Override the default knowledge-base directory. Defaults to `<cwd>/<knowledge-slug>/`. Both the wiki and the binding live inside this directory. |
+| `--description` | No | One-sentence description forwarded to `cogni-wiki:wiki-setup --description`. |
+| `--publisher-base-url` | No | Forwarded to `cogni-wiki:wiki-setup --publisher-base-url`. Used as last-resort fallback URL when wiki pages have no per-page publisher URL. |
+
+If `--knowledge-slug` or `--knowledge-title` is missing, ask the user once with AskUserQuestion (call `ToolSearch(query="select:AskUserQuestion")` to load the schema if needed). Do not invent slugs or titles silently.
+
+## Workflow
+
+### 1. Resolve the knowledge root
+
+1. If `--knowledge-root` was passed, use it as-is.
+2. Otherwise, `knowledge_root = <cwd>/<knowledge-slug>/`.
+3. If `<knowledge_root>/.cogni-knowledge/binding.json` already exists: read it, report the existing knowledge_slug/title/wiki_path, and stop. Do not overwrite.
+
+### 2. Pre-flight: wiki vs no wiki
+
+Check `<knowledge_root>/.cogni-wiki/config.json`:
+
+- **Exists** → a wiki is already set up at this path. Skip Step 3 (no need to dispatch `wiki-setup`). Treat the existing wiki as the binding's target.
+- **Does not exist** → Step 3 will dispatch `cogni-wiki:wiki-setup`.
+
+If `<knowledge_root>` exists but contains foreign files (no `.cogni-wiki/`, but non-empty subdirs that are not the standard cogni-wiki layout — `raw/`, `wiki/`, `assets/`), abort: "path exists but is not a wiki — choose a different `--knowledge-root` or move the existing files."
+
+### 3. Dispatch `cogni-wiki:wiki-setup` (only if no wiki exists)
+
+```
+Skill("cogni-wiki:wiki-setup",
+      args="--name '<knowledge-title>' --wiki-root <knowledge_root> [--description ...] [--publisher-base-url ...] --skip-prefill-prompt")
+```
+
+Pass `--skip-prefill-prompt` because cogni-knowledge has its own opinionated seeding (the user's first `knowledge-research` run will seed the wiki domain-specifically — layering canonical foundations on top would clutter the base). The user can still run `cogni-wiki:wiki-prefill` later.
+
+On `wiki-setup` failure, surface the error verbatim and stop. The binding is not written if the wiki was not created.
+
+### 4. Write the binding manifest
+
+```
+python3 ${CLAUDE_PLUGIN_ROOT}/scripts/knowledge-binding.py init \
+    --knowledge-root <knowledge_root> \
+    --knowledge-slug <knowledge_slug> \
+    --knowledge-title "<knowledge_title>" \
+    --wiki-path <knowledge_root>
+```
+
+The script returns the standard `{success, data, error}` envelope. On failure (e.g. binding already exists), surface the error. The script refuses to overwrite an existing binding — Step 1's pre-flight should have caught that, but the script is the second line of defence.
+
+### 5. Final summary
+
+Print a short summary, ≤ 8 lines:
+
+- Knowledge base path (absolute)
+- Knowledge slug and title
+- Wiki path (`<knowledge_root>` — they are the same in the default layout)
+- Binding file path (`<knowledge_root>/.cogni-knowledge/binding.json`)
+- Suggested next action: `cogni-knowledge:knowledge-research --knowledge-slug <slug> --topic '...'`
+
+Do not print the full binding JSON in the summary — point at the file path and let the user inspect it if they want.
+
+## Edge cases
+
+- **Wiki exists but is for a different domain.** Step 2 detects the existing wiki and re-uses it. This is intentional — a user may want to layer a knowledge base onto an existing wiki. The binding records the wiki_slug from `.cogni-wiki/config.json` so the asymmetry is visible.
+- **`--knowledge-slug` collides with a sibling directory.** Step 1's binding-existence check protects against double-init; if the sibling is a non-wiki directory, Step 2's foreign-files check fires.
+- **`wiki-setup` crashes mid-run.** No binding has been written. Surface the wiki-setup error; the user can re-run after fixing whatever wiki-setup complained about.
+
+## Out of scope
+
+- Does NOT write wiki pages — that is `cogni-wiki:wiki-ingest`'s job (transitively via `knowledge-research`).
+- Does NOT pre-fill the wiki with cogni-wiki foundations — `--skip-prefill-prompt` is set deliberately.
+- Does NOT configure cogni-research — that happens during `knowledge-research`, where the topic is known.
+
+## Output
+
+- A directory at `<knowledge_root>/` containing:
+  - `.cogni-wiki/config.json` (from `cogni-wiki:wiki-setup`)
+  - `.cogni-knowledge/binding.json` (from `knowledge-binding.py init`)
+  - Standard wiki layout (`raw/`, `wiki/`, `assets/`, etc.)
+
+No files are written outside `<knowledge_root>/`.
+
+## References
+
+- `${CLAUDE_PLUGIN_ROOT}/references/delegation-contract.md` — what this skill owns vs. delegates
+- `${CLAUDE_PLUGIN_ROOT}/references/differentiation-thesis.md` — why wiki-first
+- `cogni-wiki:wiki-setup` SKILL.md — Step 3 contract
+- `${CLAUDE_PLUGIN_ROOT}/scripts/knowledge-binding.py --help`


### PR DESCRIPTION
## Summary

- Adds a new 15th plugin, **`cogni-knowledge`** at v0.0.1 (Incubating), that proves the wiki-first research thesis: every research run binds to a named knowledge base and deposits into the same persistent cogni-wiki, so knowledge compounds across projects instead of dying in chat history.
- **Thin orchestrator** — no forked agents, no duplicated scripts. Every primitive delegates to `cogni-wiki` or `cogni-research`. The only new state cogni-knowledge owns is `.cogni-knowledge/binding.json`.
- Ships Phase 1 of a 6-phase epic (binding + accumulating research). Phases 2–6 (wiki-roundtrip composition with cycle-guard, query/dashboard/refresh, internal alpha, graduation to Preview, and committed absorption of cogni-research) are documented in [`cogni-knowledge/references/absorption-roadmap.md`](../blob/claude/refine-local-plan-YOBGO/cogni-knowledge/references/absorption-roadmap.md) but **not implemented** here — Phase 1 is intentionally the small MVP.

## What's in the commit(s)

| Area | Content |
|---|---|
| Skills (3) | `knowledge-setup` (bootstrap wiki + binding), `knowledge-research` (research INTO the bound wiki via `cogni-wiki:wiki-from-research` Mode A), `knowledge-resume` (status via `cogni-wiki:wiki-resume`) |
| Scripts (2, stdlib-only) | `knowledge-binding.py` (init/append-project/read against `binding.json`), `lineage-stamp.py` (stamps `derived_from_research: <slug>` into deposited wiki page YAML) |
| References (3) | `differentiation-thesis.md`, `delegation-contract.md`, `absorption-roadmap.md` |
| Plugin scaffold | `plugin.json`, README, CLAUDE.md, CHANGELOG, LICENSE |
| Top-level updates | `marketplace.json` registers cogni-knowledge; description bumped to 15-plugin (v1.0.2); root `CLAUDE.md` header bumped 13→15 |

The simplify-pass commit drops `wiki_slug` from `binding.json` (cached upstream-state would drift on rename — consumers now read live from `.cogni-wiki/config.json`) and lifts hardcoded path tokens into module constants.

The review-cleanup commit replaces remote-container absolute paths in `cogni-knowledge/CLAUDE.md` with relative `../CLAUDE.md` references, and adds a Phase 2 guardrail note to `references/delegation-contract.md` documenting that `report_source` must be wired through from the research project once Phase 2 lifts the wiki/hybrid abort.

## Architectural commitments

1. **Thin orchestrator.** Every primitive delegates to `cogni-research` or `cogni-wiki`. The contract is documented in `cogni-knowledge/references/delegation-contract.md` and is the load-bearing rule: if a behavior exists upstream, this plugin MUST delegate.
2. **Wiki-first, accumulating.** A knowledge base = one cogni-wiki + a binding manifest. Every research run on the bound topic area deposits into the same wiki. Cross-project compounding IS the differentiator vs. OpenAI Deep Research / Perplexity Spaces / GPT Researcher.
3. **No web-only one-shot mode.** Casual reports stay on `cogni-research` directly. cogni-knowledge is opinionated about wiki-first.

## Test plan

- [x] `knowledge-binding.py init` writes a valid `binding.json` with the expected key set (no cached `wiki_slug`).
- [x] `knowledge-binding.py append-project` records a new project entry; duplicate slugs are rejected.
- [x] `knowledge-binding.py read` round-trips through `json.load`.
- [x] `lineage-stamp.py` stamps the correct page, skips unrelated pages, is idempotent on re-run, preserves the blank line between frontmatter and body.
- [x] Negative path: `knowledge-binding.py init` against a directory without `.cogni-wiki/config.json` fails with a clear error.
- [x] `cogni-workspace/scripts/check-skill-names.sh` passes — no generic skill names slipped through the `knowledge-*` prefix.
- [x] `marketplace.json` parses and contains 15 plugins.
- [ ] **End-to-end live run** (requires Claude Code execution): `/cogni-knowledge:knowledge-setup` → `/cogni-knowledge:knowledge-research` → `/cogni-knowledge:knowledge-resume` against a real topic. Deferred to Phase 4 alpha.

## Plan reference

The Phase 1 → Phase 6 roadmap (including the committed absorption of `cogni-research` at v1.0.0) is preserved in-repo at [`cogni-knowledge/references/absorption-roadmap.md`](../blob/claude/refine-local-plan-YOBGO/cogni-knowledge/references/absorption-roadmap.md).

## Out of scope for this PR

- Modifying `cogni-wiki/skills/wiki-from-research/SKILL.md` to add the `--allow-wiki-source` / `--cycle-guard-cleared` opt-in flags (Phase 2 work — depends on `cycle-guard.py` not yet written).
- Any change to `cogni-research`, `cogni-trends`, `cogni-narrative`, or `cogni-portfolio` (Phase 6 absorption work, gated behind Phase 4 alpha go/no-go).
- The data-flow diagram in root `CLAUDE.md` (Phase 5 — premature until cogni-knowledge proves the thesis).

## Follow-up issues (from #263 review)

Non-blocking improvements identified during review, deferred to their own PRs:

- Add a machine-readable summary trailer to `cogni-wiki:wiki-from-research` (eliminates the natural-language parsing of `resolved_slug` in `knowledge-research` Step 1).
- Pre-flight dependency check in `knowledge-setup` for `cogni-wiki` + `cogni-research` presence (today a missing dependency surfaces mid-workflow as a `Skill` tool error rather than a clean abort).
- Phase 2 work covers `report_source` propagation into `binding.json` + `cycle-guard.py`.

https://claude.ai/code/session_01AXybEyFdBYmA3jyx6vhcoU