### PR TITLE
fix(cogni-visual): render Bottom-Banner on every slide layout

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -115,7 +115,7 @@
     {
       "name": "cogni-visual",
       "source": "./cogni-visual",
-      "version": "0.16.23",
+      "version": "0.16.24",
       "maturity": "preview",
       "description": "Transform polished narratives and structured data into visual deliverables — presentation briefs, slide decks, scrollable web narratives, poster storyboards, single-page infographics, and visual assets. Supports Excalidraw, Pencil MCP, PPTX, and HTML rendering.",
       "keywords": [

--- a/cogni-visual/.claude-plugin/plugin.json
+++ b/cogni-visual/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-visual",
-  "version": "0.16.23",
+  "version": "0.16.24",
   "description": "Transform polished narratives and structured data into visual deliverables \u2014 presentation briefs, slide decks, scrollable web narratives, poster storyboards, single-page infographics, and visual assets. Supports Excalidraw, Pencil MCP, PPTX, and HTML rendering.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-visual/skills/render-html-slides/SKILL.md
+++ b/cogni-visual/skills/render-html-slides/SKILL.md
@@ -110,7 +110,7 @@ Write the parsed data to `{brief_dir}/cogni-visual/slide-data.json`:
 - Speaker-Notes is a multi-line YAML string (after `|`) — preserve the full text
 - Mermaid diagrams appear in the `Diagram:` field as multi-line strings
 - IS/DOES/MEANS labels come from the `Label:` field inside each box — but the Python script handles localization, so just pass the text content
-- Bottom-Banner can be a dict with `Text:` key or a plain string. Write it to the top-level `bottom_banner` field — the renderer emits it as a shared footer on **every** layout (title-slide, closing-slide, content layouts, and unrecognized layouts alike). The legacy form, nested as `Bottom-Banner` inside `fields`, is still accepted by the renderer.
+- Bottom-Banner can be a dict with `Text:` key or a plain string. Write it to the top-level `bottom_banner` field — the renderer emits it as a shared footer on **every** layout. The legacy nested form (`Bottom-Banner` inside `fields`) is also accepted.
 
 ### Phase 2: Theme → Design Variables
 

--- a/cogni-visual/skills/render-html-slides/SKILL.md
+++ b/cogni-visual/skills/render-html-slides/SKILL.md
@@ -110,7 +110,7 @@ Write the parsed data to `{brief_dir}/cogni-visual/slide-data.json`:
 - Speaker-Notes is a multi-line YAML string (after `|`) — preserve the full text
 - Mermaid diagrams appear in the `Diagram:` field as multi-line strings
 - IS/DOES/MEANS labels come from the `Label:` field inside each box — but the Python script handles localization, so just pass the text content
-- Bottom-Banner can be a dict with `Text:` key or a plain string
+- Bottom-Banner can be a dict with `Text:` key or a plain string. Write it to the top-level `bottom_banner` field — the renderer emits it as a shared footer on **every** layout (title-slide, closing-slide, content layouts, and unrecognized layouts alike). The legacy form, nested as `Bottom-Banner` inside `fields`, is still accepted by the renderer.
 
 ### Phase 2: Theme → Design Variables
 

--- a/cogni-visual/skills/render-html-slides/references/01-layout-renderers.md
+++ b/cogni-visual/skills/render-html-slides/references/01-layout-renderers.md
@@ -12,12 +12,10 @@ The Python script expects these field names and structures.
 ### Bottom-Banner (all layouts)
 
 `Bottom-Banner` is layout-independent. Parse it to the **top-level** `bottom_banner`
-field on the slide (a sibling of `fields`, not inside it). The renderer emits it as
-a shared footer on every layout — including `title-slide`, `closing-slide`, and any
-unrecognized layout — so it is not repeated in the per-layout contracts below. The
-value may be a dict with a `Text:` key or a plain string. The legacy form, nested as
-`Bottom-Banner` inside `fields` (shown in some layout examples below), is still
-accepted by the renderer.
+field (a sibling of `fields`); the renderer emits it as a shared footer on every
+layout, so it is not repeated in the per-layout contracts below. The value may be a
+dict with a `Text:` key or a plain string. The legacy nested form (`Bottom-Banner`
+inside `fields`, shown in some examples below) is also accepted.
 
 ### title-slide
 

--- a/cogni-visual/skills/render-html-slides/references/01-layout-renderers.md
+++ b/cogni-visual/skills/render-html-slides/references/01-layout-renderers.md
@@ -11,11 +11,11 @@ The Python script expects these field names and structures.
 
 ### Bottom-Banner (all layouts)
 
-`Bottom-Banner` is layout-independent. Parse it to the **top-level** `bottom_banner`
-field (a sibling of `fields`); the renderer emits it as a shared footer on every
-layout, so it is not repeated in the per-layout contracts below. The value may be a
+`Bottom-Banner` is layout-independent — it renders as a shared footer on every
+layout, so its contract is documented once here rather than per layout. Parse it to
+the **top-level** `bottom_banner` field (a sibling of `fields`). The value may be a
 dict with a `Text:` key or a plain string. The legacy nested form (`Bottom-Banner`
-inside `fields`, shown in some examples below) is also accepted.
+inside `fields`, shown in some per-layout examples below) is also accepted.
 
 ### title-slide
 

--- a/cogni-visual/skills/render-html-slides/references/01-layout-renderers.md
+++ b/cogni-visual/skills/render-html-slides/references/01-layout-renderers.md
@@ -9,6 +9,16 @@ the field contracts when parsing the brief in Phase 1.
 Each layout's YAML fields must be preserved exactly when parsing into `slide-data.json`.
 The Python script expects these field names and structures.
 
+### Bottom-Banner (all layouts)
+
+`Bottom-Banner` is layout-independent. Parse it to the **top-level** `bottom_banner`
+field on the slide (a sibling of `fields`, not inside it). The renderer emits it as
+a shared footer on every layout — including `title-slide`, `closing-slide`, and any
+unrecognized layout — so it is not repeated in the per-layout contracts below. The
+value may be a dict with a `Text:` key or a plain string. The legacy form, nested as
+`Bottom-Banner` inside `fields` (shown in some layout examples below), is still
+accepted by the renderer.
+
 ### title-slide
 
 ```yaml

--- a/cogni-visual/skills/render-html-slides/scripts/generate-html-slides.py
+++ b/cogni-visual/skills/render-html-slides/scripts/generate-html-slides.py
@@ -192,9 +192,17 @@ def render_bullets(bullets, css_class=""):
     return f"      <ul{cls}>\n{items}\n      </ul>"
 
 
-def render_bottom_banner(fields):
-    """Render a bottom banner if present in slide fields."""
-    banner = fields.get("Bottom-Banner")
+def render_bottom_banner(slide):
+    """Render a bottom banner if present.
+
+    The banner may live at the slide top level (``bottom_banner`` — the
+    canonical Phase-1 location) or inside ``fields["Bottom-Banner"]`` (the
+    legacy form some layout briefs use). Read both so the banner renders on
+    every layout regardless of which shape Phase 1 produced.
+    """
+    banner = slide.get("bottom_banner")
+    if not banner:
+        banner = slide.get("fields", {}).get("Bottom-Banner")
     if not banner:
         return ""
     text = banner.get("Text", "") if isinstance(banner, dict) else str(banner)
@@ -1721,7 +1729,7 @@ def assemble_html(slide_data, dv, transition="fade", aspect_ratio="16:9", langua
 
         # Render slide content
         content_html = render_slide(slide, dv, language)
-        banner_html = render_bottom_banner(slide.get("fields", {}))
+        banner_html = render_bottom_banner(slide)
 
         # Slide title (not shown on title-slide or closing-slide)
         title_html = ""

--- a/cogni-visual/skills/render-html-slides/scripts/generate-html-slides.py
+++ b/cogni-visual/skills/render-html-slides/scripts/generate-html-slides.py
@@ -195,14 +195,10 @@ def render_bullets(bullets, css_class=""):
 def render_bottom_banner(slide):
     """Render a bottom banner if present.
 
-    The banner may live at the slide top level (``bottom_banner`` — the
-    canonical Phase-1 location) or inside ``fields["Bottom-Banner"]`` (the
-    legacy form some layout briefs use). Read both so the banner renders on
-    every layout regardless of which shape Phase 1 produced.
+    Accepts the canonical top-level ``bottom_banner`` and the legacy
+    ``fields["Bottom-Banner"]`` so the banner renders on every layout.
     """
-    banner = slide.get("bottom_banner")
-    if not banner:
-        banner = slide.get("fields", {}).get("Bottom-Banner")
+    banner = slide.get("bottom_banner") or slide.get("fields", {}).get("Bottom-Banner")
     if not banner:
         return ""
     text = banner.get("Text", "") if isinstance(banner, dict) else str(banner)


### PR DESCRIPTION
## Summary

Fixes #242 — `render-html-slides` silently dropped the `Bottom-Banner` on `title-slide` and the unregistered `challenge` layout (`grep "Firmitas" out.html` returned 0).

**Root cause — a key-location contract mismatch.** Phase-1 parsing writes the banner to the top-level `bottom_banner` field (per SKILL.md), but `render_bottom_banner` read only `fields["Bottom-Banner"]`. Content layouts whose reference docs nested the banner inside `fields` happened to land where the script read, so they rendered; top-level banners were lost. Banner injection is already layout-independent (the `assemble_html` slide loop), so the only defect was the read location.

## Changes

- **Renderer** (`generate-html-slides.py`): `render_bottom_banner` now takes the whole `slide` and reads top-level `bottom_banner` first, falling back to the legacy `fields["Bottom-Banner"]`. Covers every layout, including the generic fallback that `challenge` dispatches to.
- **Docs**: realign `SKILL.md` Phase 1 and `references/01-layout-renderers.md` to one canonical contract — top-level `bottom_banner`, renders on any layout; legacy nested form still accepted.
- **Version**: bump `cogni-visual` `0.16.23 → 0.16.24` in `plugin.json` and `marketplace.json`.

## Test plan

- [x] Title-slide carrying the banner at top-level (plain string) renders — was 0 before, now present.
- [x] Legacy `stat-card-with-context` banner nested in `fields` (dict with `Text:`) still renders unchanged.
- [x] `challenge` layout (generic fallback) renders its top-level banner.
- [x] Fixture deck produces 3 `bottom-banner` divs; banner sits in `slide-content` as a bottom-anchored footer with no title overlap.

Closes #242

https://claude.ai/code/session_01EfrmMZLi4xeV1f6sPGrA1D

---
_Generated by [Claude Code](https://claude.ai/code/session_01EfrmMZLi4xeV1f6sPGrA1D)_