### PR TITLE
cogni-knowledge 0.1.17: name the Skill(...) dispatch convention once (#350)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -277,7 +277,7 @@
     {
       "name": "cogni-knowledge",
       "source": "./cogni-knowledge",
-      "version": "0.1.16",
+      "version": "0.1.17",
       "maturity": "preview",
       "description": "Wiki-first research that compounds. Binds a cogni-wiki knowledge base to a project so every research run deposits into the same persistent, queryable, interlinked markdown wiki — and so future runs read what previous runs filed instead of starting from zero. The v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) forks dedicated agents locally and runs zero-network claim verification against pre-extracted source claims (citation-consistent — opt-in live-source resweep via knowledge-refresh --resweep); the optional Phase 4.5 distillation pass deduplicates claims and grows a concept/entity web that successive runs enrich rather than duplicate. The differentiator vs. one-shot deep-research tools (OpenAI Deep Research, Perplexity Spaces, GPT Researcher) is the binding: knowledge accumulates across projects instead of dying in chat history.",
       "keywords": [

--- a/cogni-knowledge/.claude-plugin/plugin.json
+++ b/cogni-knowledge/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-knowledge",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "description": "Wiki-first research that compounds. Binds a cogni-wiki knowledge base to a project so every research run deposits into the same persistent, queryable, interlinked markdown wiki — and so future runs read what previous runs filed instead of starting from zero. The v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) forks dedicated agents locally and runs zero-network claim verification against pre-extracted source claims (citation-consistent — opt-in live-source resweep via knowledge-refresh --resweep); the optional Phase 4.5 distillation pass deduplicates claims and grows a concept/entity web that successive runs enrich rather than duplicate. The differentiator vs. one-shot deep-research tools (OpenAI Deep Research, Perplexity Spaces, GPT Researcher) is the binding: knowledge accumulates across projects instead of dying in chat history.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-knowledge/CHANGELOG.md
+++ b/cogni-knowledge/CHANGELOG.md
@@ -1,5 +1,27 @@
 # cogni-knowledge changelog
 
+## 0.1.17 — 2026-05-29 — Convention surface — Skill(...) dispatch contract named once
+
+**Closes #350** ([deferred-from PR #349 suggestion 5](https://github.com/cogni-work/insight-wave/pull/349#issuecomment-4570497287)).
+
+Documentation-only. Zero behavioural change. Zero script, schema, or agent
+changes.
+
+Adds one new section — `## How \`Skill(...)\` blocks are written` — to
+`references/delegation-contract.md`. Extends the existing
+`delegation-contract.md` bullet in the References section of each of the five
+orchestrator SKILL.md files (`knowledge-setup`, `knowledge-resume`,
+`knowledge-dashboard`, `knowledge-refresh`, `knowledge-query`) to also point
+at the new section title — `knowledge-refresh:16`'s "Read
+`delegation-contract.md` once per session" line is extended in place. No
+per-site clarifier is added at any dispatch block (rejected as high-noise
+after monorepo audit — see PR body for the comparison). No `Skill(...)`
+dispatch block is modified.
+
+Tests: 6 new contract asserts in `test_skill_contracts.sh` (Slice 17) — one
+pins the new section heading in `delegation-contract.md`; five loop over the
+orchestrators and assert each cross-references the new section title.
+
 ## 0.1.16 — 2026-05-29
 
 Resolves **#337** approach **(b) semantic-honesty surfacing** in full, and ships a minimal **(a) opt-in skeleton** as `knowledge-refresh --resweep`. The Phase 6 `knowledge-verify` contract is, by design, **zero-network** (`references/inverted-pipeline.md` Phase 6: <5 min vs cogni-claims' 20–30 min; `agents/wiki-verifier.md` §"What this agent does NOT do": *"Does NOT WebFetch or WebSearch"*) — verdicts score the draft sentence against the cited page's `pre_extracted_claims:` extracted at ingest time, not against the live source URL. The dashboard, the synthesis frontmatter, and the finalize/verify summaries previously presented this as "verified" without qualifying what was actually checked, leaving two unchecked links: (1) extraction fidelity (the `source-ingester`'s `excerpt_position` sanity-check is positional, not semantic) and (2) live ground-truth drift (URLs 404, paywalls appear, content gets rewritten between ingest and read). This release closes the **honesty** gap on every reader-facing surface and adds an explicit **opt-in** path to the upstream `cogni-wiki:wiki-claims-resweep` primitive for operators who want live-source ground-truth on a cadence. Mirrors the #340/PR-#347 + #335 observability-first posture: surface, never auto-resolve. Maturity stays **Preview**.

--- a/cogni-knowledge/references/delegation-contract.md
+++ b/cogni-knowledge/references/delegation-contract.md
@@ -59,6 +59,22 @@ These are point-in-time forks — drift from upstream is acceptable and document
 4. If the skill needs new state, it goes in `binding.json` — never in a parallel manifest.
 5. Scripts (`knowledge-*.py`) stay stdlib-only. Anything that needs a library belongs upstream.
 
+## How `Skill(...)` blocks are written
+
+Every fenced code block of the shape
+
+    ```
+    Skill("<plugin>:<skill>", args="…")
+    ```
+
+in a cogni-knowledge **orchestrator** SKILL.md (`knowledge-setup`, `knowledge-resume`, `knowledge-dashboard`, `knowledge-refresh`, `knowledge-query`) is a **dispatch contract**: the orchestrating LLM MUST execute the call via the Skill tool, not output the literal text. The fenced shape (rather than inline backticks) is the canonical surface so the call survives copy-paste, line-wrap, and downstream rendering, and so contract tests can pin it with `grep`. The dispatch verb in the preceding prose — `Dispatch:`, `Delegate to`, or equivalent — reinforces the contract but the fenced block is the source of truth.
+
+Phase skills (`knowledge-plan` … `knowledge-finalize`) **do not dispatch other skills**; they run Bash + agent dispatch only. If a future phase skill needs to dispatch a downstream skill, this convention applies to it too.
+
+Scope: cogni-knowledge-internal. Sibling plugins (`cogni-wiki`, `cogni-research`, etc.) document their own dispatch conventions independently — this section does not constrain them.
+
+Rationale (#350): named the convention so future readers and reviewers find it once, rather than re-deriving it from prose verbs at each site.
+
 ## What about Phase 2's `--allow-wiki-source` flag on `wiki-from-research`?
 
 Phase 2 modifies `cogni-wiki:wiki-from-research` to lift its current abort on `report_source ∈ {wiki, hybrid}` projects, gated behind a new `--allow-wiki-source --cycle-guard-cleared` opt-in. This is the right pattern: the cycle-guard logic lives in cogni-knowledge (it is cogni-knowledge-specific — there is no general-purpose meaning to "research lineage" in `cogni-wiki`), but the deposit pathway lives in `cogni-wiki`. We add an opt-in flag instead of forking the deposit pathway.

--- a/cogni-knowledge/skills/knowledge-dashboard/SKILL.md
+++ b/cogni-knowledge/skills/knowledge-dashboard/SKILL.md
@@ -217,7 +217,7 @@ Counting `claim_drift` findings: pick the freshest audit (`ls -1 <wiki_path>/wik
 
 ## References
 
-- `${CLAUDE_PLUGIN_ROOT}/references/delegation-contract.md` — the delegation boundary
+- `${CLAUDE_PLUGIN_ROOT}/references/delegation-contract.md` — the delegation boundary and §"How `Skill(...)` blocks are written"
 - `cogni-wiki:wiki-dashboard` SKILL.md — the upstream contract
 - `${CLAUDE_PLUGIN_ROOT}/scripts/knowledge-binding.py --help`
 - `${CLAUDE_PLUGIN_ROOT}/scripts/pipeline-summary.py --help` — per-project depth (`project`) + fetch-cache health (`cache-health`)

--- a/cogni-knowledge/skills/knowledge-query/SKILL.md
+++ b/cogni-knowledge/skills/knowledge-query/SKILL.md
@@ -131,7 +131,7 @@ No files are written outside `<wiki_path>/` and only by upstream `wiki-query`.
 
 ## References
 
-- `${CLAUDE_PLUGIN_ROOT}/references/delegation-contract.md` — the delegation boundary
+- `${CLAUDE_PLUGIN_ROOT}/references/delegation-contract.md` — the delegation boundary and §"How `Skill(...)` blocks are written"
 - `cogni-wiki:wiki-query` SKILL.md — the upstream contract
 - `${CLAUDE_PLUGIN_ROOT}/scripts/knowledge-binding.py --help`
 - `${CLAUDE_PLUGIN_ROOT}/scripts/pipeline-summary.py cache-health --help` — fetch-cache health for the footer

--- a/cogni-knowledge/skills/knowledge-refresh/SKILL.md
+++ b/cogni-knowledge/skills/knowledge-refresh/SKILL.md
@@ -13,7 +13,7 @@ Close the self-healing loop for a bound cogni-knowledge base. Wiki pages age —
 
 This skill is a pure orchestrator — pull-mode is a thin pass-through; push-mode composes existing `cogni-knowledge` phase skills via `Skill(...)`, never re-implementing them. **Push-mode dispatches zero cogni-research skills** — the v0.1.0 clean break (decision-1) means cogni-research is 0% of the runtime path. The legacy push-mode (which re-ran the old research+ingest chain) was replaced by the seven-phase inverted pipeline at v0.0.26.
 
-Read `${CLAUDE_PLUGIN_ROOT}/references/delegation-contract.md` once per session to remember the delegation boundary.
+Read `${CLAUDE_PLUGIN_ROOT}/references/delegation-contract.md` once per session to remember the delegation boundary and the Skill-dispatch convention (§"How `Skill(...)` blocks are written").
 
 ## When to run
 

--- a/cogni-knowledge/skills/knowledge-refresh/SKILL.md
+++ b/cogni-knowledge/skills/knowledge-refresh/SKILL.md
@@ -234,7 +234,7 @@ No files are written directly by this skill — every artefact comes from a down
 
 ## References
 
-- `${CLAUDE_PLUGIN_ROOT}/references/delegation-contract.md` — the delegation boundary
+- `${CLAUDE_PLUGIN_ROOT}/references/delegation-contract.md` — the delegation boundary and §"How `Skill(...)` blocks are written"
 - `${CLAUDE_PLUGIN_ROOT}/references/inverted-pipeline.md` — the seven-phase chain push-mode drives
 - `cogni-wiki:wiki-refresh` SKILL.md — pull-mode dispatch target
 - `cogni-wiki:wiki-lint` SKILL.md — push-mode staleness source

--- a/cogni-knowledge/skills/knowledge-resume/SKILL.md
+++ b/cogni-knowledge/skills/knowledge-resume/SKILL.md
@@ -136,7 +136,7 @@ A status block printed to the user. No files written.
 
 ## References
 
-- `${CLAUDE_PLUGIN_ROOT}/references/delegation-contract.md`
+- `${CLAUDE_PLUGIN_ROOT}/references/delegation-contract.md` — delegation boundary + §"How `Skill(...)` blocks are written"
 - `cogni-wiki:wiki-resume` SKILL.md
 - `${CLAUDE_PLUGIN_ROOT}/scripts/knowledge-binding.py --help`
 - `${CLAUDE_PLUGIN_ROOT}/scripts/pipeline-summary.py --help` — per-project depth (`project`) + fetch-cache verdict (`cache-health`)

--- a/cogni-knowledge/skills/knowledge-setup/SKILL.md
+++ b/cogni-knowledge/skills/knowledge-setup/SKILL.md
@@ -137,7 +137,7 @@ No files are written outside `<knowledge_root>/`.
 
 ## References
 
-- `${CLAUDE_PLUGIN_ROOT}/references/delegation-contract.md` — what this skill owns vs. delegates
+- `${CLAUDE_PLUGIN_ROOT}/references/delegation-contract.md` — what this skill owns vs. delegates (incl. §"How `Skill(...)` blocks are written")
 - `${CLAUDE_PLUGIN_ROOT}/references/differentiation-thesis.md` — why wiki-first
 - `cogni-wiki:wiki-setup` SKILL.md — Step 3 contract
 - `${CLAUDE_PLUGIN_ROOT}/scripts/knowledge-binding.py --help`

--- a/cogni-knowledge/tests/test_skill_contracts.sh
+++ b/cogni-knowledge/tests/test_skill_contracts.sh
@@ -365,6 +365,20 @@ assert_not_grep 'link_dir' "$FINALIZE" "knowledge-finalize: no link_dir path-pre
 assert_not_grep 'audit-only' "$INGEST" "knowledge-ingest: no 'audit-only' backlink deferral — apply-plan writes backlinks (#308)"
 assert_grep 'theme_label' "$INGEST" "knowledge-ingest: files sources under the sub-question theme_label category (#307)"
 
+# --- Slice 17 (#350) Skill(...) dispatch convention named once + cross-referenced ---
+# Convention surface — the dispatch contract lives in delegation-contract.md
+# under §"How `Skill(...)` blocks are written", and every orchestrator skill
+# cross-references it via that section title. Locks in #350's middle path:
+# central statement + light cross-refs instead of per-site clarifiers.
+DELEGATION_CONTRACT="$PLUGIN_ROOT/references/delegation-contract.md"
+assert_grep 'How `Skill(...)` blocks are written' "$DELEGATION_CONTRACT" \
+  "delegation-contract.md names the Skill(...) dispatch convention (#350)"
+for orch in knowledge-setup knowledge-resume knowledge-dashboard knowledge-refresh knowledge-query; do
+  ORCH_SKILL="$PLUGIN_ROOT/skills/${orch}/SKILL.md"
+  assert_grep 'How `Skill(...)` blocks are written' "$ORCH_SKILL" \
+    "${orch}: cross-references the Skill-dispatch convention (#350)"
+done
+
 if [ $errors -eq 0 ]; then
   green "ALL PASS"
   exit 0


### PR DESCRIPTION
## Summary

Closes #350 — names the `Skill(...)` dispatch convention once in
`cogni-knowledge/references/delegation-contract.md` and cross-references
it from each of the 5 orchestrator SKILL.md files. Resolves PR #349's
deferred suggestion 5 (*"Execute as a `Skill` tool call, not literal text"*)
without per-site clutter.

## What changed

1. **`cogni-knowledge/references/delegation-contract.md`** — new section
   `## How \`Skill(...)\` blocks are written` (~16 lines). States the
   dispatch contract, the fenced-block canonical shape, the verb-reinforcement
   convention, and the cogni-knowledge-internal scope (sibling plugins are
   explicitly out of scope).

2. **Orchestrator SKILL.md cross-references** — extension of the existing
   `delegation-contract.md` reference in each of the 5 orchestrators:
   - `knowledge-setup/SKILL.md` — References bullet extended.
   - `knowledge-resume/SKILL.md` — References bullet extended.
   - `knowledge-dashboard/SKILL.md` — References bullet extended.
   - `knowledge-query/SKILL.md` — References bullet extended.
   - `knowledge-refresh/SKILL.md` — existing body line at L16 ("Read
     `delegation-contract.md` once per session…") extended in place
     **and** the References-section bullet at L237 extended for symmetry
     with the other four orchestrators (added in review fix-up).

   In-place extension keeps the noise floor low — no new bullets, no
   blockquotes, no new headings; just one new section name appended to a
   reference that was already there.

3. **`cogni-knowledge/tests/test_skill_contracts.sh`** — 6 new asserts
   (Slice 17): one pins the new section heading in `delegation-contract.md`;
   five loop over the orchestrator skills and assert each cross-references
   the new section title.

4. **Version bump + CHANGELOG** — `cogni-knowledge` 0.1.16 → 0.1.17 in
   both `plugin.json` and the matching `marketplace.json` entry. One
   CHANGELOG entry under `0.1.17 — Convention surface`. **Plugin
   description is NOT touched** (description compaction is #351's scope).

## What did NOT change

- Zero `Skill(...)` **dispatch block** was modified, removed, renumbered, or
  re-wrapped. Confirmed via `grep -rn 'Skill(\"'` returning the same 15
  dispatch sites pre/post PR.
- Zero per-site clarifier (*"Execute as a `Skill` tool call, not literal
  text"*) added — rejected as high-noise after monorepo audit (§*Why not
  per-site* below).
- Zero changes to: scripts, agents, fixtures, frontmatter schema,
  `binding.json` / `verify-vN.json` / `citation-manifest.json` shapes,
  per-run behaviour, hot-path or cold-path runtime.
- Zero changes to **any sibling plugin** (`cogni-wiki`, `cogni-research`,
  …). The issue body explicitly excluded them; this PR honours that boundary.
- Zero changes to `cogni-knowledge/.claude-plugin/plugin.json::description`
  (reserved for #351).

## Why not per-site clarifier

Reviewer suggestion 5 on PR #349 proposed adding *"Execute as a `Skill`
tool call, not literal text"* next to **every** `Skill(...)` block.
Monorepo audit found:

- 15 `Skill(...)` dispatch sites in cogni-knowledge alone (5 SKILL.md files).
- Zero plugins in the monorepo use that clarifier today.
- Zero LLM regressions observed of treating a `Skill(...)` block as
  literal display text — the convention is currently held implicitly by
  the dispatch verb (`Dispatch:` / `Delegate to`) + fenced block.

Adding the per-site clarifier would (a) add 15 boilerplate lines for
near-zero discoverability gain, (b) set a precedent that should cascade
to sibling plugins (otherwise the monorepo drifts). The centralized-once
approach gets the discoverability win without either cost.

## Why not wontfix

Three reasons: a future LLM regression would surface as silent zero-work;
future reviewers would re-raise the same suggestion every release; and
implicit contracts age badly. Naming the contract once costs ~15 lines
across the plugin.

## Review fix-up (e4d609a9)

Review on this PR caught a consistency nit: knowledge-refresh's
References-section bullet at L237 was unextended (only its body line at
L16 carried the cross-ref), leaving asymmetry with the other 4
orchestrators whose References bullets WERE extended. Extended L237 in
place to match. Test still passes (the assert only requires one occurrence
per file; knowledge-refresh now has two, intentional duplication matching
the rest of the orchestrator set).

## Test plan

- [x] `for t in cogni-knowledge/tests/test_*.sh; do bash "$t" || exit 1; done` — ALL GREEN
- [x] `grep -rn 'Skill(\"' cogni-knowledge/skills/ --include='SKILL.md' | wc -l` returns **15** (the 15 dispatch sites unchanged).
- [x] `grep -c 'How \`Skill(...)\` blocks are written' cogni-knowledge/skills/*/SKILL.md` returns **1** for each of the 5 orchestrators (knowledge-refresh: 2 after review fix-up).
- [x] PR diff: 10 files, +60/-8 lines. (Plan's stale cap was ≤ 9 files due to undercounting `knowledge-refresh:16`'s in-place extension as a separate touch; the 10th file is the planned 5th orchestrator. Lines are well within the ≤ 60 cap.)
- [x] CLA check passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
