### PR TITLE
cogni-knowledge: fix knowledge-finalize slug source (basename, not project-config.json)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -326,7 +326,7 @@
     {
       "name": "cogni-knowledge",
       "source": "./cogni-knowledge",
-      "version": "0.1.68",
+      "version": "0.1.70",
       "maturity": "preview",
       "description": "Wiki-first research that compounds. Binds each run to a cogni-wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`.",
       "keywords": [

--- a/cogni-knowledge/.claude-plugin/plugin.json
+++ b/cogni-knowledge/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-knowledge",
-  "version": "0.1.68",
+  "version": "0.1.70",
   "description": "Wiki-first research that compounds. Binds each run to a cogni-wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-knowledge/skills/knowledge-finalize/SKILL.md
+++ b/cogni-knowledge/skills/knowledge-finalize/SKILL.md
@@ -232,7 +232,7 @@ python3 ${CLAUDE_PLUGIN_ROOT}/scripts/cycle-guard.py \
     --report-source wiki
 ```
 
-`<project-slug>` is the slug field from `<project_path>/.metadata/project-config.json::slug` (the cogni-research project slug recorded at compose time). `--report-source wiki` is hard-coded — the inverted pipeline only ever produces wiki-mode deposits, so the legacy `_read_report_source` fallback isn't relevant here.
+`<project-slug>` is the **project directory basename** (`$(basename <project_path>)`) — already `slugify(<topic>)-<YYYY-MM-DD>` and globally unique within the base, an artifact the inverted pipeline actually produces. (The inverted pipeline does **not** write the legacy cogni-research `.metadata/project-config.json`, so do not look for a `slug` field there.) `--report-source wiki` is hard-coded — the inverted pipeline only ever produces wiki-mode deposits, so the legacy `_read_report_source` fallback isn't relevant here.
 
 The script's manifest-shape fallback walks `<project>/.metadata/citation-manifest.json` when the legacy `02-sources/data/src-*.md` glob is empty. Confirm `data.input_shape == "citation-manifest"` in the JSON envelope as a positive signal the adapter ran (informational; not a gate).
 

--- a/cogni-knowledge/skills/knowledge-finalize/SKILL.md
+++ b/cogni-knowledge/skills/knowledge-finalize/SKILL.md
@@ -232,7 +232,7 @@ python3 ${CLAUDE_PLUGIN_ROOT}/scripts/cycle-guard.py \
     --report-source wiki
 ```
 
-`<project-slug>` is the **project directory basename** (`$(basename <project_path>)`) — already `slugify(<topic>)-<YYYY-MM-DD>` and globally unique within the base, an artifact the inverted pipeline actually produces. (The inverted pipeline does **not** write the legacy cogni-research `.metadata/project-config.json`, so do not look for a `slug` field there.) `--report-source wiki` is hard-coded — the inverted pipeline only ever produces wiki-mode deposits, so the legacy `_read_report_source` fallback isn't relevant here.
+`<project-slug>` is the **project directory basename** (`$(basename <project_path>)`) — already `slugify(<topic>)-<YYYY-MM-DD>` and globally unique within the base, an artifact the inverted pipeline actually produces. The inverted pipeline does **not** write the legacy cogni-research `.metadata/project-config.json`, so do not look for a `slug` field there. `--report-source wiki` is hard-coded — the inverted pipeline only ever produces wiki-mode deposits, so the legacy `_read_report_source` fallback isn't relevant here.
 
 The script's manifest-shape fallback walks `<project>/.metadata/citation-manifest.json` when the legacy `02-sources/data/src-*.md` glob is empty. Confirm `data.input_shape == "citation-manifest"` in the JSON envelope as a positive signal the adapter ran (informational; not a gate).
 


### PR DESCRIPTION
Closes #457.

## Summary
- `knowledge-finalize` Step 4 documented `<project-slug>` as the `slug` field of `<project_path>/.metadata/project-config.json` — a cogni-research artifact the inverted pipeline never writes, so an operator following the SKILL verbatim hit a missing-file dead end. The same slug feeds Step 9 (`append-project --research-slug`) and Step 11's `derived_from_research` lineage stamp.
- Re-source the slug from the **project directory basename** (`$(basename <project_path>)`), which is already `slugify(<topic>)-<YYYY-MM-DD>` and globally unique within the base — an artifact the inverted pipeline actually produces.
- Explicitly note the inverted pipeline does not write the legacy `.metadata/project-config.json`, so operators stop looking for a `slug` field there.

## Scope decisions
- **In:** the SKILL.md prose correction (line 235) and the patch version bump (plugin.json + marketplace.json) per repo convention for any SKILL change.
- **Out (intentionally):** `scripts/cycle-guard.py` is correct as-is — its `PROJECT_CONFIG_RELPATH` is the legacy input shape and it already has a working citation-manifest fallback; the defect is purely operator-facing prose. `scripts/knowledge-binding.py`'s `--research-slug` help is accurate and untouched. The `references/*.md` historical mentions (alpha-findings, absorption-roadmap) are out of scope.
- **Version:** bumps cogni-knowledge to **0.1.70**, stepping clear of sibling PR #470 (already review-passed, taking 0.1.69). If the merge order flips, rebase to the next free patch.

## Plan record
https://github.com/cogni-work/insight-wave/issues/457#issuecomment-4615732390

## Test plan
- [x] `git grep -n 'project-config.json::slug' cogni-knowledge/skills/knowledge-finalize/SKILL.md` → no hits.
- [x] Line 235 names the project directory basename as the slug source and states the inverted pipeline does not write `.metadata/project-config.json`.
- [x] The `--report-source wiki` sentence is preserved.
- [x] `git diff --stat origin/main` shows only SKILL.md + the two manifests (cycle-guard.py unchanged).
- [x] `plugin.json` and `marketplace.json` cogni-knowledge version both read `0.1.70`; marketplace.json parses clean.
- [x] Maintainer-breadcrumb guard exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
