### PR TITLE
cogni-knowledge: portal-lead-in staleness signal in knowledge-dashboard

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -326,7 +326,7 @@
     {
       "name": "cogni-knowledge",
       "source": "./cogni-knowledge",
-      "version": "0.1.77",
+      "version": "0.1.78",
       "maturity": "preview",
       "description": "Wiki-first research that compounds. Binds each run to a cogni-wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`.",
       "keywords": [

--- a/cogni-knowledge/.claude-plugin/plugin.json
+++ b/cogni-knowledge/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-knowledge",
-  "version": "0.1.77",
+  "version": "0.1.78",
   "description": "Wiki-first research that compounds. Binds each run to a cogni-wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-knowledge/scripts/pipeline-summary.py
+++ b/cogni-knowledge/scripts/pipeline-summary.py
@@ -306,6 +306,101 @@ def cmd_cache_health(args: argparse.Namespace) -> int:
     )
 
 
+# --- portal-staleness ---------------------------------------------------------
+# Reads the curated-portal staleness stamp the #491 auto-refresh writes but
+# nothing read yet. `wiki_index_update.py --set-leadin` stamps each engine-owned
+# lead-in span with `MACHINE-OWNED:PORTAL-LEADIN:START refreshed:<date> bullets:<N>`,
+# where <N> is the slug-bullet count under that theme at stamp time. Drift = the
+# theme's CURRENT slug-bullet count exceeds the stamped <N> by more than the
+# threshold (the lead-in prose no longer reflects what's accumulated under it).
+#
+# The section/heading/sentinel regexes mirror cogni-wiki's wiki_index_update.py
+# (HEADING_RE, _LEADIN_START_RE) so this reader stays in lockstep with the
+# producer. They are reimplemented locally on purpose: the dependency direction
+# is cogni-knowledge -> cogni-wiki only, and this is a read-only script.
+DEFAULT_PORTAL_STALENESS_THRESHOLD = 2
+_HEADING_RE = re.compile(r"^(#{2,3})\s+(.*?)\s*$")
+_LEADIN_START_RE = re.compile(
+    r"^\s*<!--\s*MACHINE-OWNED:PORTAL-LEADIN:START\b[^>]*-->\s*$"
+)
+_LEADIN_END_RE = re.compile(r"^\s*<!--\s*MACHINE-OWNED:PORTAL-LEADIN:END\s*-->\s*$")
+_LEADIN_BULLETS_RE = re.compile(r"\bbullets:(\d+)\b")
+# A slug-bullet is an index row: a `- ` list item carrying a `[[<slug>]]`
+# wikilink. Sufficient to count rows the way `_extract_slug_from_line` does
+# producer-side, without importing it.
+_SLUG_BULLET_RE = re.compile(r"^\s*-\s.*\[\[[^\]]+\]\]")
+
+
+def _portal_stale_themes(index_text: str, threshold: int) -> list[dict]:
+    """Return per-theme drift records for themes whose machine lead-in is stale
+    by more than `threshold`. A theme with no machine lead-in span carries no
+    stamp and is skipped; a theme whose START stamp lacks a parseable
+    `bullets:<N>` is also skipped (nothing to compare against)."""
+    lines = index_text.splitlines()
+    # Section bounds: each `## `/`### ` heading opens a section that runs to the
+    # next heading (or EOF).
+    sections: list[tuple[str, int, int]] = []  # (theme, body_start, body_end_excl)
+    cur_theme: str | None = None
+    cur_start = 0
+    for i, line in enumerate(lines):
+        m = _HEADING_RE.match(line)
+        if m:
+            if cur_theme is not None:
+                sections.append((cur_theme, cur_start, i))
+            cur_theme = m.group(2).strip()
+            cur_start = i + 1
+    if cur_theme is not None:
+        sections.append((cur_theme, cur_start, len(lines)))
+
+    stale: list[dict] = []
+    for theme, start, end in sections:
+        stamped: int | None = None
+        live = 0
+        in_leadin = False
+        for line in lines[start:end]:
+            if _LEADIN_START_RE.match(line):
+                in_leadin = True
+                mb = _LEADIN_BULLETS_RE.search(line)
+                if mb:
+                    stamped = int(mb.group(1))
+                continue
+            if _LEADIN_END_RE.match(line):
+                in_leadin = False
+                continue
+            if in_leadin:
+                continue  # lead-in prose never carries slug-bullets
+            if _SLUG_BULLET_RE.match(line):
+                live += 1
+        if stamped is None:
+            continue  # no engine-owned stamp -> not a drift candidate
+        delta = live - stamped
+        if delta > threshold:
+            stale.append({
+                "theme": theme,
+                "stamped_bullets": stamped,
+                "live_bullets": live,
+                "delta": delta,
+            })
+    return stale
+
+
+def cmd_portal_staleness(args: argparse.Namespace) -> int:
+    threshold = args.threshold
+    index_path = Path(args.wiki_root) / "wiki" / "index.md"
+    # Fail-soft: a base with no portal (or an unreadable index) is not an error;
+    # it simply has nothing stale to report. Mirrors cmd_cache_health's degrade.
+    try:
+        index_text = index_path.read_text(encoding="utf-8")
+    except OSError:
+        return _emit(True, {"stale_count": 0, "threshold": threshold, "stale_themes": []})
+    stale = _portal_stale_themes(index_text, threshold)
+    return _emit(True, {
+        "stale_count": len(stale),
+        "threshold": threshold,
+        "stale_themes": stale,
+    })
+
+
 def main(argv: list[str]) -> int:
     parser = argparse.ArgumentParser(
         description="Read-side summaries of the v0.1.0 inverted pipeline.",
@@ -320,6 +415,18 @@ def main(argv: list[str]) -> int:
     p_cache = sub.add_parser("cache-health", help="Knowledge-base-global fetch-cache health.")
     p_cache.add_argument("--knowledge-root", required=True)
     p_cache.set_defaults(func=cmd_cache_health)
+
+    p_portal = sub.add_parser(
+        "portal-staleness",
+        help="Per-theme curated-portal lead-in drift (live slug-bullets vs the "
+             "stamped bullets:<N>); silent on zero drift.",
+    )
+    p_portal.add_argument("--wiki-root", required=True)
+    p_portal.add_argument(
+        "--threshold", type=int, default=DEFAULT_PORTAL_STALENESS_THRESHOLD,
+        help="A theme is stale when live - stamped exceeds this (default %(default)s).",
+    )
+    p_portal.set_defaults(func=cmd_portal_staleness)
 
     args = parser.parse_args(argv)
     return args.func(args)

--- a/cogni-knowledge/skills/knowledge-dashboard/SKILL.md
+++ b/cogni-knowledge/skills/knowledge-dashboard/SKILL.md
@@ -117,6 +117,15 @@ python3 ${CLAUDE_PLUGIN_ROOT}/scripts/pipeline-summary.py cache-health \
 
 Capture `entries`, `negative_ratio`, `oldest_age_days`, `max_age_days`, `verdict`.
 
+Then read the curated-portal lead-in staleness signal once. `knowledge-finalize`'s portal auto-refresh stamps each engine-owned per-theme lead-in with a `bullets:<N>` count; this read-only check reports themes whose live bullet count has since drifted past the stamp (the lead-in prose no longer reflects what accumulated under it). Pure observability — it never triggers a refresh:
+
+```
+python3 ${CLAUDE_PLUGIN_ROOT}/scripts/pipeline-summary.py portal-staleness \
+    --wiki-root <wiki_path>
+```
+
+Capture `stale_count` and `stale_themes[]`. This is **knowledge-base-global** (one portal per bound wiki), so it surfaces once in the `## Pipeline health` block — never as a per-project column.
+
 Then read the wiki-global live-source resweep cadence once. `cogni-wiki:wiki-claims-resweep` writes `<wiki_path>/.cogni-wiki/last-resweep.json` (lock-wrapped, single-writer-per-wiki); the dashboard only reads it. Absent file → render `never`, no error:
 
 ```
@@ -172,6 +181,9 @@ Fetch-cache (**knowledge-base-global** — one shared cache across all projects,
 (If `cache-health` reports `verdict: empty`:)
 No fetched sources yet — run `knowledge-fetch` to populate the cache.
 
+(Only when `stale_count > 0` — render nothing on zero drift so a healthy base stays silent:)
+Stale portal lead-ins: <stale_count> theme(s) — <stale_themes[].theme joined by ', '> drifted past their stamped bullet count. Re-run `knowledge-finalize --apply-portal` (or `knowledge-refresh --mode push`) to refresh the lead-ins.
+
 ## Claim verification scope
 
 **Verification semantics** — every citation in every synthesis below was scored as `verbatim` / `paraphrase` / `synthesis` / `unsupported` against the cited page's `pre_extracted_claims:` block, extracted from the source body **at ingest time**. This is the inverted pipeline's structural cost win versus cogni-claims (<5 min per finalize vs ~25 min): the check is **zero-network** — **no live-source re-fetch ever happens at verify time** (`references/inverted-pipeline.md` Phase 6; `agents/wiki-verifier.md` §"What this agent does NOT do"). So "verified" here means **citation-consistent, not ground-truthed**. Two corollaries:
@@ -209,6 +221,7 @@ Counting `claim_drift` findings: pick the freshest audit (`ls -1 <wiki_path>/wik
 - **Empty `research_projects[]`.** Section 2's table is replaced with the empty-state line; the rest of the overlay renders normally.
 - **Legacy deposit (no `.metadata/` manifests).** `pipeline-summary.py project` returns zeros + `phase_reached: "none"`; render the per-project pipeline columns as `—` rather than `0` so the row reads as "no inverted-pipeline data" rather than "ran with zero results".
 - **`pipeline-summary.py cache-health` fails.** Render the `## Pipeline health` block with a one-line "fetch-cache health unavailable" note and keep going — the rest of the overlay is still useful.
+- **`pipeline-summary.py portal-staleness` fails.** Omit the stale-lead-ins line entirely and keep going — the signal is purely advisory, and its absence reads the same as a zero-drift base (both render nothing). The script is already fail-soft on a missing/unreadable `index.md` (returns `stale_count: 0`), so a non-zero exit here means a genuine script error, not an empty portal.
 - **No `wiki/audits/` directory.** Treat as "no lint audits yet" — section 2 still renders.
 - **Audit file present but no `claim_drift` markers.** Report `0 claim_drift findings`.
 - **Missing `<wiki_path>/.cogni-wiki/last-resweep.json` (no resweep ever run on this base).** Treat as `never`; the `## Claim verification scope` block + short summary still render normally with the `--resweep` suggestion.
@@ -233,5 +246,5 @@ Counting `claim_drift` findings: pick the freshest audit (`ls -1 <wiki_path>/wik
 - `${CLAUDE_PLUGIN_ROOT}/references/delegation-contract.md` — the delegation boundary and §"How `Skill(...)` blocks are written"
 - `cogni-wiki:wiki-dashboard` SKILL.md — the upstream contract
 - `${CLAUDE_PLUGIN_ROOT}/scripts/knowledge-binding.py --help`
-- `${CLAUDE_PLUGIN_ROOT}/scripts/pipeline-summary.py --help` — per-project depth (`project`) + fetch-cache health (`cache-health`)
+- `${CLAUDE_PLUGIN_ROOT}/scripts/pipeline-summary.py --help` — per-project depth (`project`) + fetch-cache health (`cache-health`) + portal-lead-in drift (`portal-staleness`)
 - `cogni-wiki:wiki-claims-resweep` SKILL.md — writes `<wiki_path>/.cogni-wiki/last-resweep.json` (the resweep cadence pointer this overlay reads)

--- a/cogni-knowledge/skills/knowledge-dashboard/SKILL.md
+++ b/cogni-knowledge/skills/knowledge-dashboard/SKILL.md
@@ -117,7 +117,7 @@ python3 ${CLAUDE_PLUGIN_ROOT}/scripts/pipeline-summary.py cache-health \
 
 Capture `entries`, `negative_ratio`, `oldest_age_days`, `max_age_days`, `verdict`.
 
-Then read the curated-portal lead-in staleness signal once. `knowledge-finalize`'s portal auto-refresh stamps each engine-owned per-theme lead-in with a `bullets:<N>` count; this read-only check reports themes whose live bullet count has since drifted past the stamp (the lead-in prose no longer reflects what accumulated under it). Pure observability — it never triggers a refresh:
+Then read the curated-portal lead-in staleness signal once. `knowledge-finalize`'s portal auto-refresh stamps each engine-owned per-theme lead-in with a `bullets:<N>` count; this read-only check reports themes whose live bullet count has since drifted more than a small threshold (the `threshold` field, default 2) past the stamp (the lead-in prose no longer reflects what accumulated under it). Pure observability — it never triggers a refresh:
 
 ```
 python3 ${CLAUDE_PLUGIN_ROOT}/scripts/pipeline-summary.py portal-staleness \
@@ -182,7 +182,7 @@ Fetch-cache (**knowledge-base-global** — one shared cache across all projects,
 No fetched sources yet — run `knowledge-fetch` to populate the cache.
 
 (Only when `stale_count > 0` — render nothing on zero drift so a healthy base stays silent:)
-Stale portal lead-ins: <stale_count> theme(s) — <stale_themes[].theme joined by ', '> drifted past their stamped bullet count. Re-run `knowledge-finalize --apply-portal` (or `knowledge-refresh --mode push`) to refresh the lead-ins.
+Stale portal lead-ins: <stale_count> theme(s) — <stale_themes[].theme, first 5 joined by ', ', then '…and <N> more' when there are over 5> drifted more than `<threshold>` bullets past their stamped count. Re-run `knowledge-finalize --apply-portal` (or `knowledge-refresh --mode push`) to refresh the lead-ins.
 
 ## Claim verification scope
 

--- a/cogni-knowledge/tests/test_portal_staleness.sh
+++ b/cogni-knowledge/tests/test_portal_staleness.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# test_portal_staleness.sh — contract test for pipeline-summary.py portal-staleness.
+#
+# The #491 curated-portal auto-refresh stamps each engine-owned lead-in span with
+# `MACHINE-OWNED:PORTAL-LEADIN:START refreshed:<date> bullets:<N>`, where <N> is
+# the slug-bullet count under that theme at stamp time. This subcommand is the
+# read-only consumer of that stamp (the producer shipped ahead of it): drift =
+# a theme's live slug-bullet count exceeds the stamped <N> by more than the
+# threshold.
+#
+# Asserts:
+#   1. A theme stale by > threshold is flagged with correct stamped/live/delta.
+#   2. A theme within threshold is NOT flagged.
+#   3. A theme with no machine lead-in span (no stamp) is skipped.
+#   4. A zero-drift base yields stale_count 0 + empty list (silent — the
+#      acceptance criterion).
+#   5. A missing index.md is fail-soft success (stale_count 0).
+#   6. --threshold overrides the default (2).
+#
+# bash 3.2 + stdlib python3 only.
+
+set -eu
+
+PLUGIN_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT="$PLUGIN_ROOT/scripts/pipeline-summary.py"
+
+. "$(dirname "$0")/fixtures/test_helpers.sh"
+
+if [ ! -f "$SCRIPT" ]; then
+  red "FAIL: pipeline-summary.py not found at $SCRIPT"; exit 1
+fi
+
+field() { python3 -c 'import sys,json;d=json.load(sys.stdin);print(eval("d"+sys.argv[1]))' "$1"; }
+
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+errors=0
+
+WIKI="$WORK/wiki-root"
+mkdir -p "$WIKI/wiki"
+cat > "$WIKI/wiki/index.md" <<'EOF'
+# Index
+
+## AI Act
+<!-- MACHINE-OWNED:PORTAL-LEADIN:START refreshed:2026-05-01 bullets:2 -->
+This theme covers the EU AI Act. Read the obligations first.
+<!-- MACHINE-OWNED:PORTAL-LEADIN:END -->
+- [[src-a]] — first source
+- [[src-b]] — second source
+- [[src-c]] — third source
+- [[src-d]] — fourth source
+- [[src-e]] — fifth source
+
+## Data Act
+<!-- MACHINE-OWNED:PORTAL-LEADIN:START refreshed:2026-05-01 bullets:1 -->
+Framing for the Data Act.
+<!-- MACHINE-OWNED:PORTAL-LEADIN:END -->
+- [[d-a]] — one
+- [[d-b]] — two
+
+## Human-curated (no machine lead-in)
+- [[h-a]] — alpha
+- [[h-b]] — beta
+- [[h-c]] — gamma
+- [[h-d]] — delta
+- [[h-e]] — epsilon
+EOF
+
+# --- 1 + 2 + 3: default threshold (2) on the mixed base -----------------------
+OUT=$(python3 "$SCRIPT" portal-staleness --wiki-root "$WIKI")
+[ "$(echo "$OUT" | field '["success"]')" = "True" ] && green "PASS: portal-staleness envelope success" || { red "FAIL: not success"; errors=$((errors+1)); }
+[ "$(echo "$OUT" | field '["data"]["stale_count"]')" = "1" ] && green "PASS: exactly one stale theme (AI Act, delta 3 > 2)" || { red "FAIL: stale_count != 1"; errors=$((errors+1)); }
+[ "$(echo "$OUT" | field '["data"]["stale_themes"][0]["theme"]')" = "AI Act" ] && green "PASS: stale theme is 'AI Act'" || { red "FAIL: wrong stale theme"; errors=$((errors+1)); }
+[ "$(echo "$OUT" | field '["data"]["stale_themes"][0]["stamped_bullets"]')" = "2" ] && green "PASS: stamped_bullets=2" || { red "FAIL: stamped_bullets wrong"; errors=$((errors+1)); }
+[ "$(echo "$OUT" | field '["data"]["stale_themes"][0]["live_bullets"]')" = "5" ] && green "PASS: live_bullets=5" || { red "FAIL: live_bullets wrong"; errors=$((errors+1)); }
+[ "$(echo "$OUT" | field '["data"]["stale_themes"][0]["delta"]')" = "3" ] && green "PASS: delta=3" || { red "FAIL: delta wrong"; errors=$((errors+1)); }
+# Data Act (delta 1) is within threshold → not flagged; Human-curated has no stamp → skipped.
+echo "$OUT" | grep -q "Data Act" && { red "FAIL: Data Act flagged despite within-threshold delta"; errors=$((errors+1)); } || green "PASS: within-threshold theme (Data Act) not flagged"
+echo "$OUT" | grep -q "Human-curated" && { red "FAIL: no-machine-lead-in theme flagged"; errors=$((errors+1)); } || green "PASS: no-machine-lead-in theme skipped"
+
+# --- 6: --threshold override --------------------------------------------------
+# threshold 0 → Data Act (delta 1 > 0) AND AI Act (delta 3 > 0) both flag.
+OUT0=$(python3 "$SCRIPT" portal-staleness --wiki-root "$WIKI" --threshold 0)
+[ "$(echo "$OUT0" | field '["data"]["stale_count"]')" = "2" ] && green "PASS: --threshold 0 flags both stamped themes" || { red "FAIL: threshold-0 stale_count != 2"; errors=$((errors+1)); }
+# threshold 5 → nobody is stale (max delta is 3).
+OUT5=$(python3 "$SCRIPT" portal-staleness --wiki-root "$WIKI" --threshold 5)
+[ "$(echo "$OUT5" | field '["data"]["stale_count"]')" = "0" ] && green "PASS: --threshold 5 flags nothing (silent)" || { red "FAIL: threshold-5 stale_count != 0"; errors=$((errors+1)); }
+
+# --- 4: zero-drift base is silent ---------------------------------------------
+WIKI2="$WORK/wiki-clean"
+mkdir -p "$WIKI2/wiki"
+cat > "$WIKI2/wiki/index.md" <<'EOF'
+# Index
+
+## Fresh theme
+<!-- MACHINE-OWNED:PORTAL-LEADIN:START refreshed:2026-06-05 bullets:2 -->
+Lead-in authored at the same moment the two bullets landed.
+<!-- MACHINE-OWNED:PORTAL-LEADIN:END -->
+- [[f-a]] — one
+- [[f-b]] — two
+EOF
+OUTC=$(python3 "$SCRIPT" portal-staleness --wiki-root "$WIKI2")
+[ "$(echo "$OUTC" | field '["data"]["stale_count"]')" = "0" ] && green "PASS: zero-drift base reports stale_count 0 (silent)" || { red "FAIL: zero-drift stale_count != 0"; errors=$((errors+1)); }
+[ "$(echo "$OUTC" | field '["data"]["stale_themes"]')" = "[]" ] && green "PASS: zero-drift stale_themes empty" || { red "FAIL: zero-drift list not empty"; errors=$((errors+1)); }
+
+# --- 5: missing index.md is fail-soft success ---------------------------------
+OUTM=$(python3 "$SCRIPT" portal-staleness --wiki-root "$WORK/does-not-exist")
+[ "$(echo "$OUTM" | field '["success"]')" = "True" ] && green "PASS: missing index.md is fail-soft success" || { red "FAIL: missing index not success"; errors=$((errors+1)); }
+[ "$(echo "$OUTM" | field '["data"]["stale_count"]')" = "0" ] && green "PASS: missing index.md stale_count 0" || { red "FAIL: missing index stale_count != 0"; errors=$((errors+1)); }
+
+if [ "$errors" -eq 0 ]; then
+  green "All portal-staleness tests passed."
+  exit 0
+else
+  red "$errors portal-staleness test(s) failed."
+  exit 1
+fi


### PR DESCRIPTION
Closes #515.

Follow-up from #491 / PR #513 (curated-portal auto-refresh, option 4b). `wiki_index_update.py --set-leadin` stamps each engine-owned portal lead-in with `refreshed:<date> bullets:<N>`, but nothing read the stamp yet — the producer shipped ahead of the consumer. This adds the read-only drift consumer.

## Summary
- New `pipeline-summary.py portal-staleness --wiki-root <root> [--threshold N]` subcommand: walks `<wiki-root>/wiki/index.md` per `## <theme>` section, parses the stamped `bullets:<N>` from the `MACHINE-OWNED:PORTAL-LEADIN:START` sentinel, counts the live `- … [[slug]] …` slug-bullet rows, and returns `{stale_count, threshold, stale_themes:[{theme, stamped_bullets, live_bullets, delta}]}`. A theme is stale when `delta = live - stamped > threshold` (default 2). Themes with no machine lead-in span are skipped silently; a missing/unreadable `index.md` is fail-soft success (`stale_count: 0`).
- `knowledge-dashboard` overlay now calls `portal-staleness` and renders a one-line `stale portal lead-ins: M theme(s)` signal in the `## Pipeline health` block — **only when `stale_count > 0`** (acceptance: zero-drift bases are silent). Fail-soft: a failed call omits the line and keeps going, same posture as the existing cache-health failure note.
- Pure observability: no auto-refresh trigger, no write path. The section/stamp/slug-bullet parsing is reimplemented locally in stdlib — **no cogni-wiki import** (the dependency direction stays cogni-knowledge → cogni-wiki). The local `_HEADING_RE` / `_LEADIN_START_RE` mirror `wiki_index_update.py` L74/L107 so the reader stays in lockstep with the producer.
- Plugin version bump 0.1.77 → 0.1.78, mirrored in `marketplace.json`.

## Acceptance
- [x] The dashboard surface reports the count of themes whose machine lead-in is stale by the threshold.
- [x] Zero-drift bases are silent (the dashboard line renders only when `stale_count > 0`).

## Test plan
- `bash cogni-knowledge/tests/test_portal_staleness.sh` — 14 assertions: stale-by->threshold flagged with correct stamped/live/delta, within-threshold not flagged, no-machine-lead-in skipped, `--threshold` override (0 flags both, 5 flags none), zero-drift base silent, missing index.md fail-soft.
- `bash cogni-knowledge/tests/test_dashboard_contract.sh` — ALL PASS (existing surfaces survive).
- `bash cogni-knowledge/tests/test_pipeline_summary.sh` — ALL PASS.

## Scope decisions
- **Deferred (follow-up):** the cogni-wiki-side `wiki-health` info-count leg of the issue's "and/or". It adds cross-plugin blast radius (a `cogni-wiki/.../health.py` change) not required to meet the acceptance, which the cogni-knowledge dashboard surface already satisfies.

Plan record: https://github.com/cogni-work/insight-wave/issues/515#issuecomment-4629095230

🤖 Generated with [Claude Code](https://claude.com/claude-code)
