### PR TITLE
cogni-knowledge: opt-in --file-back deposit for knowledge-query

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -326,7 +326,7 @@
     {
       "name": "cogni-knowledge",
       "source": "./cogni-knowledge",
-      "version": "0.1.87",
+      "version": "0.1.88",
       "maturity": "preview",
       "description": "Wiki-first research that compounds. Binds each run to a cogni-wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`.",
       "keywords": [

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -328,7 +328,7 @@
       "source": "./cogni-knowledge",
       "version": "0.1.88",
       "maturity": "preview",
-      "description": "Wiki-first research that compounds. Binds each run to a cogni-wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`.",
+      "description": "Wiki-first research that compounds. Binds each run to a cogni-wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`. The shallow `knowledge-query` rung is read-only by default and can optionally file its answer back as an un-verified synthesis page via `--file-back`.",
       "keywords": [
         "knowledge-base",
         "wiki-first",

--- a/cogni-knowledge/.claude-plugin/plugin.json
+++ b/cogni-knowledge/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-knowledge",
-  "version": "0.1.87",
+  "version": "0.1.88",
   "description": "Wiki-first research that compounds. Binds each run to a cogni-wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-knowledge/.claude-plugin/plugin.json
+++ b/cogni-knowledge/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cogni-knowledge",
   "version": "0.1.88",
-  "description": "Wiki-first research that compounds. Binds each run to a cogni-wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`.",
+  "description": "Wiki-first research that compounds. Binds each run to a cogni-wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`. The shallow `knowledge-query` rung is read-only by default and can optionally file its answer back as an un-verified synthesis page via `--file-back`.",
   "author": {
     "name": "Stephan de Haas",
     "email": "stephan@cogni-work.ai"

--- a/cogni-knowledge/skills/knowledge-query/SKILL.md
+++ b/cogni-knowledge/skills/knowledge-query/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: knowledge-query
-description: "Ask a question against a bound cogni-knowledge base — resolves the wiki path from binding.json, ranks the covering pages via the shared wiki-grounding primitive, reads them, and synthesizes a cited answer natively (no cogni-wiki dispatch). The shallow rung of the query↔research depth ladder: one question, index-first read of ≤12 pages, no web, no verify. Use this skill whenever the user says 'query my <slug> knowledge base', 'ask the eu-ai-act base about X', or 'knowledge-query <slug>'."
-allowed-tools: Read, Write, Bash, Glob, AskUserQuestion
+description: "Ask a question against a bound cogni-knowledge base — resolve its wiki path from binding.json, rank and read the covering pages, and synthesize a cited answer natively. The shallow rung of the query↔research ladder: one question, index-first read of ≤12 pages, no web, no verify; read-only by default, with an opt-in `--file-back` deposit as an un-verified synthesis page. Use when the user says 'query my <slug> knowledge base', 'ask the <slug> base about X', or 'knowledge-query <slug> [--file-back]'."
+allowed-tools: Read, Write, Bash, Glob, AskUserQuestion, ToolSearch
 ---
 
 # Knowledge Query
@@ -175,8 +175,20 @@ When `--file-back yes` is passed, deposit the synthesized answer as a wiki page 
 the **shallow-rung analog** of the deep rung's `knowledge-finalize` synthesis
 deposit, reusing the same vendored write lockstep (no new write path). The
 shallow rung runs **no verify pass**, so the deposit is **honestly labeled
-un-verified**. Do not deposit on a `uncovered` verdict (there is no grounded
-answer to file) or when the answer admits it could not be grounded.
+un-verified**.
+
+**Deposit-eligibility gate (operationalized — tie to the observable coverage
+verdict + cited pages, not to an LLM self-judgement):**
+
+- **`uncovered` verdict** → **never deposit** (Step 1 already short-circuited to
+  the footer; there is no grounded answer to file).
+- **`covered` verdict** → deposit.
+- **`partial` verdict** → deposit **only when ≥1 covering page was actually read
+  in Step 2 AND cited via a `[[<slug>]]` wikilink in the synthesized answer**.
+  A partial answer that cited no page (the base confirmed nothing concrete) is
+  not depositable — skip the write and say so. The cited-page set is the
+  observable signal; it is also the `sources:` list the deposit records (4.4)
+  and the backlink target set (4.5.3), so the three stay consistent.
 
 **4.1 Resolve the vendored write lockstep.** Resolve the `wiki-ingest` script
 dir vendored-first, exactly as `knowledge-finalize` / `knowledge-ingest-source`
@@ -243,11 +255,11 @@ id: <SYNTHESIS_SLUG>
 title: <question verbatim>
 type: synthesis
 tags: [synthesis, knowledge-query]
-created: <YYYY-MM-DD UTC>
+created: <YYYY-MM-DD UTC — but see created:-preservation on overwrite below>
 updated: <YYYY-MM-DD UTC>
 sources:
-  - wiki://<covering-page-slug-1>
-  - wiki://<covering-page-slug-2>
+  - wiki://<cited-page-slug-1>
+  - wiki://<cited-page-slug-2>
 verification: unverified_shallow_rung
 ---
 
@@ -258,12 +270,23 @@ verification: unverified_shallow_rung
 <the synthesized answer from Step 2, with its bare [[slug]] citations preserved>
 ```
 
-`sources:` lists one `wiki://<slug>` entry per covering page read in Step 2 (the
-`data.pages[].slug` values), so the deposit is grounded and de-orphaned. The
+`sources:` lists one `wiki://<slug>` entry per covering page **actually cited**
+in the answer (the `[[<slug>]]` wikilinks in the synthesized body — the same set
+the deposit-eligibility gate keys on), not every page read in Step 2 — so the
+deposit is grounded and de-orphaned without claiming evidence it did not use. The
 `type: synthesis` + `knowledge-query` tag distinguishes a query-filed-back page
 from a `knowledge-finalize` deposit in the same `wiki/syntheses/` directory.
 Quote the `title:` via `json.dumps(..., ensure_ascii=False)` so a
 colon-containing question deposits valid YAML (the `knowledge-finalize` posture).
+
+**`created:`-preservation on `--overwrite`.** On a fresh deposit, stamp both
+`created:` and `updated:` to today (UTC). On an `--overwrite` re-deposit, **read
+the existing page's `created:` frontmatter and carry it forward** (the page's
+birth date is durable), and set only `updated:` to today — matching the
+`knowledge-finalize` / `concept-store.py` posture that never clobbers `created:`
+across re-writes. Read the prior `created:` via the same `_knowledge_lib`
+frontmatter helpers (`_FRONTMATTER_RE` / `_unquote_scalar`) before composing the
+new page.
 
 **4.5 Post-write lockstep (lighter than `knowledge-finalize`).** Run the
 vendored index/config/backlink helpers — the same ones `knowledge-ingest`
@@ -283,11 +306,14 @@ unique-by-construction and needs no lock):
    (the page is already discoverable; reconcilable via
    `wiki-lint --fix=entries_count_drift`).
 3. **Backlink audit (best-effort)** — curate a `targets[]` plan inserting one
-   bare `[[<SYNTHESIS_SLUG>]]` sentence under each covering page's `## See also`,
-   then `python3 "$WIKI_INGEST_SCRIPTS/backlink_audit.py" --wiki-root "$WIKI_ROOT"
-   --new-page "$SYNTHESIS_SLUG" --apply-plan -`. **Fail-soft** — a backlink
-   failure never blocks the deposit; never invent a backlink to an unrelated
-   page.
+   bare `[[<SYNTHESIS_SLUG>]]` sentence under the `## See also` of **each cited
+   page only** — the same `sources:` set written in 4.4 (the pages cited via
+   `[[<slug>]]` in the answer), **not** every page read in Step 2. Backlinking an
+   uncited-but-read page would over-link the synthesis to evidence it did not
+   use. Then `python3 "$WIKI_INGEST_SCRIPTS/backlink_audit.py" --wiki-root
+   "$WIKI_ROOT" --new-page "$SYNTHESIS_SLUG" --apply-plan -`. **Fail-soft** — a
+   backlink failure never blocks the deposit; never invent a backlink to an
+   unrelated page.
 
 **4.6 Log line.** Append one line to `<WIKI_ROOT>/wiki/log.md`:
 `## [<YYYY-MM-DD>] synthesis | <SYNTHESIS_SLUG> — <short question>` (the same

--- a/cogni-knowledge/skills/knowledge-query/SKILL.md
+++ b/cogni-knowledge/skills/knowledge-query/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: knowledge-query
-description: "Ask a question against a bound cogni-knowledge base — resolve its wiki path from binding.json, rank and read the covering pages, and synthesize a cited answer natively. The shallow rung of the query↔research ladder: one question, index-first read of ≤12 pages, no web, no verify; read-only by default, with an opt-in `--file-back` deposit as an un-verified synthesis page. Use when the user says 'query my <slug> knowledge base', 'ask the <slug> base about X', or 'knowledge-query <slug> [--file-back]'."
+description: "Ask a question against a bound cogni-knowledge base — resolve its wiki path from binding.json, rank and read the covering pages, and synthesize a cited answer natively. The shallow rung of the query↔research ladder: one question, index-first read of ≤12 pages, no web, no verify; read-only by default, opt-in `--file-back` deposits an un-verified synthesis page. Use when the user says 'query my <slug> knowledge base', 'ask the <slug> base about X', or 'knowledge-query <slug> [--file-back]'."
 allowed-tools: Read, Write, Bash, Glob, AskUserQuestion, ToolSearch
 ---
 
@@ -255,7 +255,7 @@ id: <SYNTHESIS_SLUG>
 title: <question verbatim>
 type: synthesis
 tags: [synthesis, knowledge-query]
-created: <YYYY-MM-DD UTC — but see created:-preservation on overwrite below>
+created: <YYYY-MM-DD UTC>
 updated: <YYYY-MM-DD UTC>
 sources:
   - wiki://<cited-page-slug-1>

--- a/cogni-knowledge/skills/knowledge-query/SKILL.md
+++ b/cogni-knowledge/skills/knowledge-query/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: knowledge-query
 description: "Ask a question against a bound cogni-knowledge base — resolves the wiki path from binding.json, ranks the covering pages via the shared wiki-grounding primitive, reads them, and synthesizes a cited answer natively (no cogni-wiki dispatch). The shallow rung of the query↔research depth ladder: one question, index-first read of ≤12 pages, no web, no verify. Use this skill whenever the user says 'query my <slug> knowledge base', 'ask the eu-ai-act base about X', or 'knowledge-query <slug>'."
-allowed-tools: Read, Bash, Glob, AskUserQuestion
+allowed-tools: Read, Write, Bash, Glob, AskUserQuestion
 ---
 
 # Knowledge Query
@@ -43,6 +43,9 @@ Read `${CLAUDE_PLUGIN_ROOT}/references/differentiation-thesis.md` once per sessi
 | `--knowledge-root` | No | Override the default knowledge-base directory. Defaults to `cogni-knowledge/<knowledge-slug>/` (relative to the current working directory). |
 | `--max-pages` | No | Cap on how many ranked pages to read and synthesize from. Default 12 (the shallow-rung ceiling). Passed to `wiki-grounding.py rank --top-k`. |
 | `--theme` | No | Optional thematic label folded into the ranking (passed to `wiki-grounding.py rank --theme-label`) to sharpen page selection on a broad question. |
+| `--file-back` | No | Opt-in synthesis deposit. **Absent → read-only** (the default; no writes, no prompt — autonomous/cron runs stay clean). `yes` → deposit the synthesized answer as an honestly-labeled un-verified `type: synthesis` wiki page (Step 4). |
+| `--synthesis-slug` | No | Override the auto-derived deposit slug (only meaningful with `--file-back yes`). |
+| `--overwrite` | No | With `--file-back yes`, replace an existing `wiki/syntheses/<slug>.md` instead of aborting on the collision guard. |
 
 If `--question` is missing, ask the user once via `AskUserQuestion` (single free-text question — load the schema via `ToolSearch(query="select:AskUserQuestion")` if needed). Do not invent a question.
 
@@ -161,13 +164,139 @@ Knowledge base: <knowledge_slug> · <N> deposited projects · fetch-cache: <M> s
 
 `<N>` is `len(research_projects)` from the binding; `<M>`/`<U>` come from `cache-health`. The footer reminds the user which base the answer came from, how much evidence the inverted pipeline has cached, and points at the status skill.
 
-### 4. No writes
+### 4. Deposit the answer (opt-in, `--file-back` only)
 
-This skill is **read-only** — it never modifies the binding **or** the wiki. It
-reads ranked pages and synthesizes; it does not file the answer back as a
-`type: synthesis` page (the `--file-back` deposit parity is a deferred
-follow-up). The binding's `research_projects[]` records inverted-pipeline
-deposits (from `knowledge-finalize`), not query answers.
+**Default: skip entirely.** When `--file-back` is absent, this skill is
+**read-only** — it never modifies the binding **or** the wiki. It reads ranked
+pages and synthesizes; the workflow ends at Step 3's footer and writes nothing.
+This keeps the per-run no-write invariant intact for autonomous / cron runs.
+
+When `--file-back yes` is passed, deposit the synthesized answer as a wiki page —
+the **shallow-rung analog** of the deep rung's `knowledge-finalize` synthesis
+deposit, reusing the same vendored write lockstep (no new write path). The
+shallow rung runs **no verify pass**, so the deposit is **honestly labeled
+un-verified**. Do not deposit on a `uncovered` verdict (there is no grounded
+answer to file) or when the answer admits it could not be grounded.
+
+**4.1 Resolve the vendored write lockstep.** Resolve the `wiki-ingest` script
+dir vendored-first, exactly as `knowledge-finalize` / `knowledge-ingest-source`
+do (the deposit reuses the already-vendored helpers — never a new script):
+
+```
+resolve_wiki_scripts() {  # $1 = skill name, e.g. wiki-ingest
+  local skill="$1"
+  local vend="${CLAUDE_PLUGIN_ROOT}/scripts/vendor/cogni-wiki/skills/${skill}/scripts"
+  test -d "$vend" && { echo "$vend"; return 0; }
+  local sib="${CLAUDE_PLUGIN_ROOT}/../cogni-wiki/skills/${skill}/scripts"
+  test -d "$sib" && { echo "$sib"; return 0; }
+  local newest ver
+  newest=$(for d in "${CLAUDE_PLUGIN_ROOT}/../../cogni-wiki/"*/skills/"${skill}"/scripts; do
+    [ -d "$d" ] || continue
+    ver=${d%/skills/${skill}/scripts}; ver=${ver##*/}
+    case "$ver" in ''|*[!0-9.]*) continue ;; esac
+    printf '%s\n' "$d"
+  done | sort -V | tail -1)
+  [ -n "$newest" ] && { echo "$newest"; return 0; }
+  return 1
+}
+WIKI_INGEST_SCRIPTS=$(resolve_wiki_scripts wiki-ingest) \
+  || { echo "cogni-wiki wiki-ingest scripts not found — cannot --file-back"; exit 1; }
+```
+
+`WIKI_ROOT` is the `wiki_path` already resolved in Step 0; confirm
+`<WIKI_ROOT>/wiki/` is writeable before continuing.
+
+**4.2 Derive the synthesis slug.** Single source of truth —
+`_knowledge_lib.slugify` (the same helper `knowledge-finalize` uses). Pass the
+question via env var (never interpolate untrusted text into a Python literal):
+
+```
+SYNTHESIS_SLUG=$(KNOWLEDGE_SCRIPTS="${CLAUDE_PLUGIN_ROOT}/scripts" \
+  QUESTION="<question>" \
+  python3 -c '
+import os, sys
+sys.path.insert(0, os.environ["KNOWLEDGE_SCRIPTS"])
+from _knowledge_lib import slugify
+print(slugify(os.environ["QUESTION"]) or "")
+')
+```
+
+If `--synthesis-slug` was passed, use it instead. On an empty result, abort and
+ask the user to supply `--synthesis-slug`. The resolved string must match
+`[a-z0-9][a-z0-9-]{0,79}`.
+
+**4.3 Collision guard.** If `<WIKI_ROOT>/wiki/syntheses/<SYNTHESIS_SLUG>.md`
+already exists, **do not blind-overwrite**: abort with a clear message naming
+the existing page and offering `--overwrite` (replace) or `--synthesis-slug`
+(deposit under a new slug). Only proceed past an existing page when `--overwrite`
+was passed.
+
+**4.4 Write the synthesis page.** Atomically write
+`<WIKI_ROOT>/wiki/syntheses/<SYNTHESIS_SLUG>.md` via
+`_knowledge_lib.atomic_write_text`. The frontmatter labels the deposit
+un-verified; the body leads with a visible blockquote so a human reading the
+page in Obsidian is never misled:
+
+```yaml
+---
+id: <SYNTHESIS_SLUG>
+title: <question verbatim>
+type: synthesis
+tags: [synthesis, knowledge-query]
+created: <YYYY-MM-DD UTC>
+updated: <YYYY-MM-DD UTC>
+sources:
+  - wiki://<covering-page-slug-1>
+  - wiki://<covering-page-slug-2>
+verification: unverified_shallow_rung
+---
+
+> **Un-verified shallow-rung answer.** Filed from `knowledge-query` — grounded
+> in the cited wiki pages but **not** claim-verified (the shallow rung runs no
+> verify pass). Treat as a convenience capture, not a vetted synthesis.
+
+<the synthesized answer from Step 2, with its bare [[slug]] citations preserved>
+```
+
+`sources:` lists one `wiki://<slug>` entry per covering page read in Step 2 (the
+`data.pages[].slug` values), so the deposit is grounded and de-orphaned. The
+`type: synthesis` + `knowledge-query` tag distinguishes a query-filed-back page
+from a `knowledge-finalize` deposit in the same `wiki/syntheses/` directory.
+Quote the `title:` via `json.dumps(..., ensure_ascii=False)` so a
+colon-containing question deposits valid YAML (the `knowledge-finalize` posture).
+
+**4.5 Post-write lockstep (lighter than `knowledge-finalize`).** Run the
+vendored index/config/backlink helpers — the same ones `knowledge-ingest`
+Step 4 runs (each acquires and releases its own `_wiki_lock` internally, so the
+calls are sequential and deadlock-free; the synthesis page itself is
+unique-by-construction and needs no lock):
+
+1. **Index update** — sanitize the one-sentence summary via
+   `_knowledge_lib.sanitize_summary` (env-var pattern), then
+   `python3 "$WIKI_INGEST_SCRIPTS/wiki_index_update.py" --wiki-root "$WIKI_ROOT"
+   --slug "$SYNTHESIS_SLUG" --summary "$CLEAN_SUMMARY" --category "Syntheses"
+   --max-summary 240`. Capture the envelope; `data.action == "inserted"` means a
+   new row landed.
+2. **entries_count bump** — only when 4.5.1 inserted a new row (not on an
+   `--overwrite` re-deposit): `python3 "$WIKI_INGEST_SCRIPTS/config_bump.py"
+   --wiki-root "$WIKI_ROOT" --key entries_count --delta 1`. Non-fatal on failure
+   (the page is already discoverable; reconcilable via
+   `wiki-lint --fix=entries_count_drift`).
+3. **Backlink audit (best-effort)** — curate a `targets[]` plan inserting one
+   bare `[[<SYNTHESIS_SLUG>]]` sentence under each covering page's `## See also`,
+   then `python3 "$WIKI_INGEST_SCRIPTS/backlink_audit.py" --wiki-root "$WIKI_ROOT"
+   --new-page "$SYNTHESIS_SLUG" --apply-plan -`. **Fail-soft** — a backlink
+   failure never blocks the deposit; never invent a backlink to an unrelated
+   page.
+
+**4.6 Log line.** Append one line to `<WIKI_ROOT>/wiki/log.md`:
+`## [<YYYY-MM-DD>] synthesis | <SYNTHESIS_SLUG> — <short question>` (the same
+prefix the deep rung uses), so the deposit is visible in the wiki log.
+
+The binding is **not** touched — `research_projects[]` records inverted-pipeline
+deposits (from `knowledge-finalize`), not shallow-rung query answers. After
+depositing, add one line to the printed answer noting the page path and that it
+was filed un-verified.
 
 ## Edge cases
 
@@ -179,14 +308,19 @@ deposits (from `knowledge-finalize`), not query answers.
 
 - **Multi-question scoping.** This skill takes one question per run; chaining is a future enhancement.
 - **Deep web-verified reporting.** That is `knowledge-compose --source wiki` (the deep rung).
-- **Filing the answer back as a synthesis page** (`--file-back` parity) — a deferred follow-up; this rung is read-only.
+- **Verifying a filed-back answer.** The opt-in `--file-back` deposit (Step 4) is honestly labeled `verification: unverified_shallow_rung` — the shallow rung runs no claim-alignment pass. A vetted synthesis is the deep rung's `knowledge-finalize` deposit, not this one.
+- **`--file-back auto` (prompt-to-deposit) and multi-question deposits** — a future enhancement; today `--file-back` is the explicit `yes`/absent opt-in only.
 
 ## Output
 
 - The synthesized, `[[slug]]`-cited answer grounded in the ranked wiki pages.
 - One footer line appended: `Knowledge base: <slug> · <N> deposited projects · ...`
 
-No files are written.
+By default **no files are written** (read-only). When `--file-back yes` is
+passed, the answer is additionally deposited as
+`<wiki>/syntheses/<slug>.md` (`type: synthesis`, `verification:
+unverified_shallow_rung`) with the index row, `entries_count` bump, backlinks,
+and a `wiki/log.md` line (Step 4).
 
 ## References
 
@@ -194,3 +328,5 @@ No files are written.
 - `${CLAUDE_PLUGIN_ROOT}/scripts/wiki-grounding.py` — the shared `rank` discovery primitive (index-first page selection)
 - `${CLAUDE_PLUGIN_ROOT}/scripts/knowledge-binding.py --help`
 - `${CLAUDE_PLUGIN_ROOT}/scripts/pipeline-summary.py cache-health --help` — fetch-cache health for the footer
+- `${CLAUDE_PLUGIN_ROOT}/scripts/vendor/cogni-wiki/skills/wiki-ingest/scripts/` — the vendored `wiki_index_update.py` / `config_bump.py` / `backlink_audit.py` write lockstep the `--file-back` deposit (Step 4) reuses
+- `${CLAUDE_PLUGIN_ROOT}/skills/knowledge-finalize/SKILL.md` — the deep-rung synthesis deposit the shallow-rung `--file-back` mirrors (verified vs un-verified)

--- a/cogni-knowledge/tests/test_skill_contracts.sh
+++ b/cogni-knowledge/tests/test_skill_contracts.sh
@@ -335,6 +335,19 @@ done
 assert_not_grep 'Skill("cogni-wiki:wiki-query' "$QUERY" "knowledge-query: no longer dispatches cogni-wiki:wiki-query (native shallow rung on the vendored engine)"
 assert_grep 'wiki-grounding.py' "$QUERY" "knowledge-query: consumes the shared wiki-grounding primitive directly"
 
+# knowledge-query opt-in --file-back deposit (shallow-rung synthesis parity):
+# read-only is the DEFAULT (flag absent), but when the skill documents the
+# --file-back deposit path it MUST reuse the vendored write lockstep
+# (wiki_index_update.py + config_bump.py), label the deposit honestly as
+# un-verified, and carry Write in allowed-tools. Conditional so a future
+# read-only-only variant of the skill is not falsely failed.
+if grep -q -- '--file-back' "$QUERY"; then
+  assert_grep 'wiki_index_update.py' "$QUERY" "knowledge-query: --file-back deposit reuses the vendored wiki_index_update.py (no new write path)"
+  assert_grep 'config_bump.py' "$QUERY" "knowledge-query: --file-back deposit reuses the vendored config_bump.py entries_count bump"
+  assert_grep 'unverified_shallow_rung' "$QUERY" "knowledge-query: --file-back deposit honestly labels the page verification: unverified_shallow_rung"
+  assert_grep 'allowed-tools:.*Write' "$QUERY" "knowledge-query: allowed-tools includes Write for the --file-back deposit path"
+fi
+
 # knowledge-dashboard renders natively on the vendored render_dashboard.py /
 # build_graph.py and no longer dispatches cogni-wiki:wiki-dashboard (FMO Phase 8
 # d2 re-home). It keeps the cogni-wiki probe above as the vendored-first /


### PR DESCRIPTION
Closes #532.

## Summary
- Adds an opt-in `--file-back` flag to `knowledge-query` that deposits the synthesized shallow-rung answer as a `type: synthesis` wiki page — the shallow-rung analog of `knowledge-finalize`'s deep-rung deposit.
- Default stays **read-only** (flag absent → byte-identical current behavior, no prompt, clean for cron/autonomous runs). The deposit fires only on explicit `--file-back yes`.
- Reuses the already-vendored write lockstep — `wiki_index_update.py` (`--category Syntheses --max-summary 240`) → `config_bump.py` (`--key entries_count --delta 1`) → `backlink_audit.py` — resolved vendored-first via the existing `resolve_wiki_scripts wiki-ingest` function, exactly as `knowledge-finalize` does. **No new scripts.**
- The deposited page is **honestly labeled un-verified**: `verification: unverified_shallow_rung` frontmatter + a `knowledge-query` tag distinguishing it from finalize deposits + a visible body blockquote (the shallow rung does no claim-alignment pass).
- Collision guard: abort with a clear message if `wiki/syntheses/<slug>.md` already exists (offer `--overwrite` / `--synthesis-slug`) rather than blind-overwriting.
- Adds `Write` to the skill's `allowed-tools`, needed only on the deposit path.

## Scope decisions
- **Page type:** decided as `type: synthesis` + `knowledge-query` tag + `verification: unverified_shallow_rung` (over a lighter `query-note` kind) so the deposit joins the same `Syntheses` index + backlink graph as finalize deposits, while the verification frontmatter + blockquote carry the honesty.
- **Default-off:** the deposit is gated behind `--file-back yes`; flag absent is byte-identical to today's read-only behavior, preserving the per-run no-write invariant for autonomous/cron runs.
- **Deferred (pre-existing, not newly opened by this issue):** the `--file-back auto` AskUserQuestion prompt variant and multi-question scoping (already an "Out of scope" line). Neither is silently dropped work this issue asked for.
- **Not reused:** the full finalize verify pipeline (cycle-guard, verify manifest, contradictor/reviewer, lint/health gate, portal refresh) — deliberately omitted because the shallow rung is no-web/no-verify; mirroring it would violate the rung's contract. Only the lightweight index/config/backlink lockstep is reused.
- Bumps `cogni-knowledge` plugin.json `0.1.87 → 0.1.88` and mirrors it in `marketplace.json` (repo Version Management convention).

## Test plan
- [x] `bash cogni-knowledge/tests/test_skill_contracts.sh` passes (4 new conditional `--file-back` assertions: vendored `wiki_index_update.py` + `config_bump.py` references, `unverified_shallow_rung` label, `Write` in allowed-tools).
- [x] Full `cogni-knowledge/tests/*.sh` suite green (52/52).
- [x] `plugin.json` + `marketplace.json` valid JSON; versions mirrored at 0.1.88.
- [x] No new scripts under `cogni-knowledge/scripts/` — the deposit references only the vendored `wiki_index_update.py` / `config_bump.py` / `backlink_audit.py` via `resolve_wiki_scripts`.

Plan record: https://github.com/cogni-work/insight-wave/issues/532#issuecomment-4637342687
