### PR TITLE
cogni-trends: reroute value-modeler Phase 2 evidence dispatch to cogni-knowledge

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -93,7 +93,7 @@
     {
       "name": "cogni-trends",
       "source": "./cogni-trends",
-      "version": "0.6.4",
+      "version": "0.6.5",
       "maturity": "preview",
       "description": "Strategic trend scouting and TIPS reporting pipeline. Combines the Smarter Service Trendradar (4 dimensions) with TIPS (Trends, Implications, Possibilities, Solutions): trend-scout → value-modeler → trend-research → trend-synthesis and/or trend-booklet → verify-trend-report. Evidence-backed CxO reports and reusable industry catalogs across DE/FR/IT/PL/NL/ES + US/UK.",
       "keywords": [

--- a/cogni-trends/.claude-plugin/plugin.json
+++ b/cogni-trends/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-trends",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "description": "Strategic trend scouting and TIPS reporting pipeline. Combines the Smarter Service Trendradar (4 dimensions) with TIPS (Trends, Implications, Possibilities, Solutions): trend-scout → value-modeler → trend-research → trend-synthesis and/or trend-booklet → verify-trend-report. Evidence-backed CxO reports and reusable industry catalogs across DE/FR/IT/PL/NL/ES + US/UK.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-trends/CHANGELOG.md
+++ b/cogni-trends/CHANGELOG.md
@@ -1,5 +1,26 @@
 # cogni-trends changelog
 
+## 0.6.5 — 2026-06-06 — value-modeler Phase 2 evidence dispatch rerouted to cogni-knowledge
+
+`value-modeler` Phase 2 (`references/workflow-phases/phase-2-solutions.md`) no longer
+dispatches the deprecated cogni-wiki / cogni-research surfaces for two of its three
+solution-evidence sites:
+
+- **Vendor wiki (Step 2.6.A)** — the optional `cogni-wiki:wiki-query` dispatch is replaced by
+  cogni-knowledge's re-homed native discovery primitive,
+  `wiki-grounding.py rank --wiki-root … --question … --theme-label …`, then `Read` of the ranked
+  `data.pages[]` + inline synthesis. No plugin dispatch, no binding, no file-back.
+- **Open-mode published cases (Step 2.6.B)** — the `cogni-research:section-researcher` dispatch is
+  replaced by a native cogni-knowledge research pass (inline `WebSearch` + `WebFetch`, or
+  `cogni-knowledge:knowledge-ingest-source` per discovered URL), preserving the ≤ 4-sub-query budget.
+
+The per-ST dispatch budget table and the `data-model.md` attribution prose (`source: "wiki"`,
+`published_cases[]` preamble) are updated to match. Output shape (`vendor_references[]`,
+`published_cases[]`, per-ST mutual exclusivity) and all `source` field *values* are unchanged —
+downstream writers are unaffected. The uploaded-corpus `cogni-research:local-researcher` site
+(Step 2.6 point 4, `source: "uploads"`) is deliberately untouched; it is carved out to a separate
+follow-up gated on cogni-knowledge local-source ingest. Part of the FMO Migrate epic (Epic B).
+
 ## 0.6.4 — 2026-05-29 — Discoverability — manifest description compacted (closes #351 for this plugin)
 
 `description` in `.claude-plugin/plugin.json` and the matching `marketplace.json`

--- a/cogni-trends/references/data-model.md
+++ b/cogni-trends/references/data-model.md
@@ -771,14 +771,14 @@ New fields (all optional, backward compatible — existing STs without these fie
   - `roi_claim` (string, optional): Quantified ROI when available from portfolio evidence (e.g., `"€4.2M avoided OPEX"`).
   - `source` (string, required): Where the reference came from inside the portfolio — `"customers"` (a `named_customers[]` entry),
     `"propositions"` (an `evidence[]` entry tagged vendor-authored), `"uploads"` (document corpus via `cogni-research:local-researcher`),
-    or `"wiki"` (a `cogni-wiki:wiki-query` result).
+    or `"wiki"` (a `wiki-grounding.py rank` hit over the vendor's case-study wiki).
   - `source_ref` (string, required): Portfolio-relative path or entity ref with optional JSON Pointer. Must resolve inside `cogni-portfolio/{portfolio_ref}/`.
   - `portfolio_grounding_entry_ref` (string, required): `{feature_slug}--{market_slug}` key linking this reference back to one of the ST's `portfolio_grounding[]` entries.
   - `source_origin` (string, required): Always `"vendor"` for this array.
   - `publication_date` (string, optional): ISO-8601 date (YYYY-MM) for recency sorting.
 - **`published_cases`** (array, optional — populated only when `tips-project.json → study_mode == "open"` or absent):
-  Published industry case studies sourced via a dedicated `cogni-research:section-researcher` dispatch in
-  value-modeler Step 2.6. Complements the trend-signal research with concrete implementation proof.
+  Published industry case studies sourced via a native cogni-knowledge research pass (inline `WebSearch` + `WebFetch`,
+  or `cogni-knowledge:knowledge-ingest-source` per URL) in value-modeler Step 2.6. Complements the trend-signal research with concrete implementation proof.
   - `vendor_or_customer` (string, required): Who implemented the case (vendor or customer name).
   - `outcome` (string, required): One-line outcome summary.
   - `source_url` (string, required): Public URL to the case study.

--- a/cogni-trends/skills/value-modeler/references/workflow-phases/phase-2-solutions.md
+++ b/cogni-trends/skills/value-modeler/references/workflow-phases/phase-2-solutions.md
@@ -594,8 +594,8 @@ do not HALT. A misconfigured vendor project should still produce a report.
 
 | Mode | Dispatch budget per ST |
 |------|-----------------------|
-| vendor | max 2 `cogni-research:local-researcher` calls + max 2 `cogni-wiki:wiki-query` calls + plain JSON reads (unbounded) |
-| open | max 1 `cogni-research:section-researcher` call with ≤ 4 sub-queries |
+| vendor | max 2 `cogni-research:local-researcher` calls + max 2 `wiki-grounding.py rank` calls (+ `Read` of the ranked pages) + plain JSON reads (unbounded) |
+| open | max 1 native cogni-knowledge research pass (inline `WebSearch` + `WebFetch`, or `cogni-knowledge:knowledge-ingest-source` per URL) with ≤ 4 sub-queries |
 
 ### 2.6.A: Vendor Mode — Source References from the Portfolio Corpus
 
@@ -640,10 +640,13 @@ For each ST where the `solution_blueprint.building_blocks[]` contains any block 
    Limit to max 4 sub-questions per dispatch. Each matching file becomes a `vendor_references[]`
    entry with `source: "uploads"` and `source_ref: "uploads/{filename}"`.
 
-5. **Vendor wiki (optional)** — when `vendor_source.case_study_wiki` is set, dispatch
-   `cogni-wiki:wiki-query` once per ST against that wiki path with the same sub-question style.
-   Each hit becomes a `vendor_references[]` entry with `source: "wiki"` and
-   `source_ref: "{wiki_path}#{page_slug}"`.
+5. **Vendor wiki (optional)** — when `vendor_source.case_study_wiki` is set, rank that wiki
+   natively with cogni-knowledge's re-homed discovery primitive (no plugin dispatch, no binding,
+   no file-back):
+   `python3 ${CLAUDE_PLUGIN_ROOT}/../cogni-knowledge/scripts/wiki-grounding.py rank --wiki-root {vendor_source.case_study_wiki} --question "<sub-question>" --theme-label "{ST.name}"`
+   once per ST with the same sub-question style. `Read` each returned `data.pages[].page_path`
+   (joined to the wiki root) and synthesize the outcome claim inline. Each covering page becomes a
+   `vendor_references[]` entry with `source: "wiki"` and `source_ref: "{wiki_path}#{page_slug}"`.
 
 6. **Dedupe.** If the same underlying customer appears across sources (e.g., a customer entry
    plus an uploaded case study describing the same engagement), keep the richest entry —
@@ -660,9 +663,11 @@ Applies when `study_mode == "open"` (explicitly set at Phase 0 or absent). This 
 dedicated case-study research pass that complements today's trend-signal research — the report's
 "Why You" gains a `Referenzbeispiele` block of concrete industry implementations.
 
-For each ST, dispatch **one** `cogni-research:section-researcher` call with ≤ 4 sub-queries
-drawn from the templates below. The agent already handles market localization and parallel
-search — do not reinvent that here.
+For each ST, run **one** native cogni-knowledge research pass with ≤ 4 sub-queries drawn from
+the templates below — inline `WebSearch` over each query plus `WebFetch` of the strongest hits,
+synthesizing the results directly (or, when a knowledge base is bound, deposit each discovered
+published-case URL via `cogni-knowledge:knowledge-ingest-source` and read it back). Handle market
+localization (the DACH template below) and run the queries in parallel where possible.
 
 **Query templates** (substitute `{st.name}`, `{lead_block.capability}`, `{industry.primary_en}`,
 `{industry.subsector_en}`, localized variants from `tips-project.json → industry.*_de`, and
@@ -685,7 +690,7 @@ search — do not reinvent that here.
 two hits from `cisco.com` collapse to the single strongest one. This prevents a single vendor's
 reference library from dominating the ST's evidence.
 
-**Target output.** 2–3 `published_cases[]` entries per ST when feasible. When the agent returns
+**Target output.** 2–3 `published_cases[]` entries per ST when feasible. When the pass yields
 fewer than 2 usable hits, keep what was found and emit an empty array if nothing usable was
 returned — the writer downstream falls back to plain capability prose for that ST.
 


### PR DESCRIPTION
Closes #499.

## Summary

Reroutes the two **unblocked** external-dispatch sites in `value-modeler` Phase 2 (`references/workflow-phases/phase-2-solutions.md`) off the deprecated cogni-wiki / cogni-research surfaces onto cogni-knowledge — part of the FMO Migrate epic (#505), phase-1 child.

- **Vendor wiki (Step 2.6.A, point 5)** — the optional `cogni-wiki:wiki-query` dispatch → cogni-knowledge's re-homed native discovery primitive: `python3 ${CLAUDE_PLUGIN_ROOT}/../cogni-knowledge/scripts/wiki-grounding.py rank --wiki-root … --question … --theme-label …`, then `Read` each ranked `data.pages[].page_path` and synthesize inline. No plugin dispatch, no binding, no file-back.
- **Open-mode published cases (Step 2.6.B)** — the `cogni-research:section-researcher` dispatch → a native cogni-knowledge research pass (inline `WebSearch` + `WebFetch`, or `cogni-knowledge:knowledge-ingest-source` per discovered URL), preserving the ≤ 4-sub-query budget.
- Per-ST dispatch budget table (vendor + open rows) and `data-model.md` attribution prose (`source: "wiki"`, `published_cases[]` preamble) updated to match.
- Patch-bump cogni-trends `0.6.4 → 0.6.5` (plugin.json + marketplace.json + CHANGELOG entry).

## Scope decisions

- **Output shape & budgets preserved.** `vendor_references[]` (with `source: "wiki"`), `published_cases[]`, and per-ST mutual exclusivity are unchanged — downstream writers are unaffected. Only the dispatch mechanism and attribution prose change; `source` field *values* are untouched.
- **Carved out (NOT touched):** the uploaded-corpus `cogni-research:local-researcher` site (Step 2.6 point 4, `source: "uploads"`) → follow-up #546, blocked on cogni-knowledge local-source ingest (#533). `source: "uploads"` provenance stays reserved.
- **Optional default-KB nicety not in this issue's closure surface** — giving vendor-wiki runs without an explicit `vendor_source.case_study_wiki` a per-domain default knowledge base needs a registry/lookup (not a dispatch swap); the current skip-when-unset behavior is preserved and the nicety can be filed as its own follow-up if a real run needs it.
- Documentation/skill-reference reroute — no executable code added (`wiki-grounding.py` already ships in cogni-knowledge).

## Test plan

- [x] No live `cogni-wiki:wiki-query` / `cogni-research:section-researcher` dispatch remains in 2.6.A / 2.6.B / budget table (only the out-of-scope `local-researcher` name survives, in step 4 + the vendor budget row).
- [x] wiki-grounding.py invoked via the correct cross-plugin path with a valid `rank` grammar; Read iterates `data.pages[].page_path` (the CLI envelope field).
- [x] ≤ 4-sub-query budget stated for the open-mode replacement.
- [x] `data-model.md` `"wiki"` parenthetical + `published_cases[]` preamble name the cogni-knowledge replacements; `"uploads"` parenthetical and all `source` values unchanged.
- [x] plugin.json + marketplace.json both read `0.6.5`; both parse; CHANGELOG leads with the `0.6.5` entry.
- [x] Breadcrumb guard: 0 new violations. Skill-name check: OK.

Plan record: https://github.com/cogni-work/insight-wave/issues/499#issuecomment-4639641888
