### PR TITLE
cogni-workspace: cut ask skill off cogni-wiki onto cogni-knowledge

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -78,7 +78,7 @@
     {
       "name": "cogni-workspace",
       "source": "./cogni-workspace",
-      "version": "0.6.31",
+      "version": "0.6.32",
       "maturity": "preview",
       "description": "Foundation-layer plugin for insight-wave marketplace plugins. Manages shared infrastructure (env vars, settings), MCP server installation and Desktop config patching, theme management, theme picker, plugin discovery, workspace health, an interactive workspace-configuration dashboard, Obsidian vault integration, and a bundled vendor-curated insight-wave reference wiki queryable via the ask skill.",
       "keywords": [

--- a/cogni-workspace/.claude-plugin/plugin.json
+++ b/cogni-workspace/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-workspace",
-  "version": "0.6.31",
+  "version": "0.6.32",
   "description": "Foundation-layer plugin for insight-wave marketplace plugins. Manages shared infrastructure (env vars, settings), MCP server installation and Desktop config patching, theme management, theme picker, plugin discovery, workspace health, an interactive workspace-configuration dashboard, Obsidian vault integration, and a bundled vendor-curated insight-wave reference wiki queryable via the ask skill.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-workspace/README.md
+++ b/cogni-workspace/README.md
@@ -34,7 +34,7 @@ In the Claude Code / Claude Cowork plugin model, workspace-level state (paths, e
 5. **Diagnose** workspace health — five-tier report (foundation, env vars, plugin registry, themes, dependencies)
 6. **Install MCP servers** — clone and build git-based MCP servers, detect native app MCPs, and patch Claude Desktop config so rendering plugins find their tools without manual JSON editing
 7. **Obsidian integration** — scaffold `.obsidian/` vault or incrementally update terminal profiles, handled as sub-steps of manage-workspace
-8. **Ask the bundled wiki** — `ask` wraps `cogni-wiki:wiki-query` against a vendor-curated insight-wave reference wiki bundled at `wiki/` so users can ask grounded questions about plugins, skills, agents, architecture, and conventions without grepping source files
+8. **Ask the bundled wiki** — `ask` reads a vendor-curated insight-wave reference wiki bundled at `wiki/` (self-contained index-first grounded read) so users can ask grounded questions about plugins, skills, agents, architecture, and conventions without grepping source files
 
 ## What it means for you
 
@@ -169,7 +169,6 @@ cogni-workspace has no required plugin dependencies — it is the foundation lay
 | cogni-help | No | Referenced inline in workspace skills for issue filing and guided help |
 | cogni-portfolio | No | install-mcp references cogni-portfolio as a consumer of excalidraw MCP in the installation plan |
 | cogni-claims | No | workspace-status references cogni-claims as a provider plugin for the claude-in-chrome MCP server check |
-| cogni-wiki | No | `ask` wraps `cogni-wiki:wiki-query` to read the bundled insight-wave reference wiki |
 
 ## Contributing
 

--- a/cogni-workspace/skills/ask/SKILL.md
+++ b/cogni-workspace/skills/ask/SKILL.md
@@ -22,7 +22,7 @@ allowed-tools: Read, Glob, Grep, Bash
 
 Answer questions about the insight-wave plugin ecosystem by reading the bundled wiki. Never answer from model memory — every claim in the answer must trace to a specific wiki page.
 
-This skill is a thin wrapper around the cogni-wiki query pattern, hardcoded to the wiki bundled at `${CLAUDE_PLUGIN_ROOT}/wiki/`. The wiki is **vendor-curated and read-only by intent** — it ships with this plugin and is refreshed in lockstep with cogni-workspace updates. Users who want a personal knowledge base should run `cogni-wiki:wiki-setup` to create their own separate wiki.
+This skill is self-contained: it does a Karpathy-style, index-first grounded read (read the index → read the relevant pages → synthesize with citations) directly over the wiki bundled at `${CLAUDE_PLUGIN_ROOT}/wiki/`, using only `Read`/`Glob`/`Grep` — no external plugin dispatch. The wiki is **vendor-curated and read-only by intent** — it ships with this plugin and is refreshed in lockstep with cogni-workspace updates. Users who want a personal knowledge base should run `cogni-knowledge:knowledge-setup` to create their own separate, compounding knowledge base.
 
 ## When to run
 
@@ -33,7 +33,7 @@ This skill is a thin wrapper around the cogni-wiki query pattern, hardcoded to t
 ## Never run when
 
 - The bundled wiki is missing — report that the cogni-workspace install may be corrupted and offer to re-install
-- The user explicitly wants to query a different wiki (a personal one they set up themselves) — defer to `cogni-wiki:wiki-query` instead
+- The user explicitly wants to query a different knowledge base (a personal one they set up themselves) — defer to `cogni-knowledge:knowledge-query` for a bound personal knowledge base instead
 
 ## Parameters
 
@@ -79,7 +79,7 @@ Rules:
 
 ### 6. Do NOT file the answer back
 
-Unlike a personal `cogni-wiki:wiki-query`, this skill does **not** offer to file the answer back as a new page. The bundled wiki is vendor-curated and read-only. If the user wants to capture insights, they should run `cogni-wiki:wiki-setup` to create their own wiki and ingest sources there.
+Unlike a personal `cogni-knowledge:knowledge-query`, this skill does **not** offer to file the answer back as a new page. The bundled wiki is vendor-curated and read-only. If the user wants to capture insights, they should run `cogni-knowledge:knowledge-setup` to create their own knowledge base and ingest sources there.
 
 ## Output
 
@@ -95,4 +95,3 @@ A grounded answer with inline `[[page-slug]]` citations and a short trail of pag
 
 - The bundled wiki SCHEMA: `${CLAUDE_PLUGIN_ROOT}/wiki/SCHEMA.md`
 - The wiki's index: `${CLAUDE_PLUGIN_ROOT}/wiki/wiki/index.md`
-- For deeper Karpathy-pattern context: `cogni-wiki/references/karpathy-pattern.md`


### PR DESCRIPTION
Closes #500.

## Summary
- Reroute the `ask` skill's documentation off `cogni-wiki:` onto `cogni-knowledge:` so cogni-wiki can be archived (Epic C grep-guard #507 asserts zero `cogni-wiki:` dispatches; this unblocks the Epic B exit audit #504).
- **No behavior change:** `ask` already does self-contained, index-first grounded reads over the bundled vendor wiki (`allowed-tools: Read, Glob, Grep, Bash` — no Skill/Task dispatch). The only ties to cogni-wiki were prose.
- Repoint personal-knowledge-base guidance from `cogni-wiki:wiki-setup`/`wiki-query` to `cogni-knowledge:knowledge-setup`/`knowledge-query`.
- Remove the dangling `cogni-wiki/references/karpathy-pattern.md` reference (no equivalent exists in cogni-knowledge).
- Fix README: rewrite the inaccurate "`ask` wraps `cogni-wiki:wiki-query`" claim and drop the obsolete cogni-wiki dependency-table row.
- Bump cogni-workspace `0.6.31` → `0.6.32` in plugin.json and marketplace.json.

## Why not wire in wiki-grounding.py
The issue suggested wiring `ask` to cogni-knowledge's `scripts/wiki-grounding.py rank`. That approach is wrong for two verified reasons:
1. **Flat-pages incompatibility.** `collect_pages()` walks only typed subdirs (`sources/`, `syntheses/`, `concepts/`, `entities/` via `_TYPE_DIRS`). The bundled wiki at `cogni-workspace/wiki/wiki/` has a FLAT `pages/` dir (211 files, no typed subdirs), so `rank` returns zero pages — wiring it in would break `ask`.
2. **New cross-plugin coupling.** cogni-workspace today has no upward plugin runtime deps and a self-contained bundled wiki. Calling a cogni-knowledge script would introduce exactly the kind of dependency the migration is trying to remove.

The correct fix keeps `ask` self-contained and only retires the cogni-wiki prose.

## Scope decisions
- **In:** all `cogni-wiki:` prose references in `ask/SKILL.md` (lines 25, 36, 82, 98) and `README.md` (line 37 item 8, line 172 dependency row), plus version bumps.
- **Out (intentionally kept verbatim):** the `${CLAUDE_PLUGIN_ROOT}/wiki/.cogni-wiki/config.json` existence check (SKILL.md:49) and the `.cogni-wiki/` architecture-tree entry (README.md:125) — real on-disk data-dir paths, not `cogni-wiki:` dispatch syntax; #507 targets the colon-dispatch form only.
- **Deferred:** none. The migration goal is fully met by the prose reroute.

## Test plan
- [x] `grep -c 'cogni-wiki:' cogni-workspace/skills/ask/SKILL.md` → 0
- [x] `grep -c 'cogni-wiki:' cogni-workspace/README.md` → 0 (the `.cogni-wiki/` path entry, no colon, remains)
- [x] karpathy-pattern.md reference removed from `ask/SKILL.md`
- [x] `allowed-tools` unchanged (`Read, Glob, Grep, Bash`) — no dispatch introduced
- [x] plugin.json + marketplace.json parse cleanly; cogni-workspace at `0.6.32`
- [x] `check-skill-names.sh` OK; breadcrumb guard 0 files affected
