### PR TITLE
cogni-knowledge: guard the Vendored-from SHA provenance marker in parity test

### DIFF
--- a/cogni-knowledge/tests/test_vendored_engine_parity.sh
+++ b/cogni-knowledge/tests/test_vendored_engine_parity.sh
@@ -62,6 +62,16 @@ done < <(find "$VENDOR_ROOT" -type f ! -name 'README.md' -not -path '*/__pycache
 # not byte-identity.
 if [ -f "$PLUGIN_ROOT/scripts/vendor/README.md" ]; then
   green "PASS: vendor provenance README present"
+  # The README carries a durable `Vendored-from: <sha> (date)` line recording the
+  # cogni-wiki origin commit the vendored copy was taken from — the post-archive
+  # provenance anchor. Guard it from silent removal: require a Vendored-from line
+  # with an exactly-40-hex-char SHA, anchored at line start.
+  if grep -Eq '^Vendored-from: [0-9a-f]{40}\b' "$PLUGIN_ROOT/scripts/vendor/README.md"; then
+    green "PASS: vendor provenance Vendored-from SHA marker present"
+  else
+    red "FAIL: scripts/vendor/README.md missing a 'Vendored-from: <40-hex-sha>' provenance marker"
+    errors=$((errors + 1))
+  fi
 else
   red "FAIL: scripts/vendor/README.md provenance note missing"
   errors=$((errors + 1))


### PR DESCRIPTION
Closes #551.

## Summary
- `tests/test_vendored_engine_parity.sh` asserted only that `scripts/vendor/README.md` is *present*, leaving the durable post-archive `Vendored-from: <sha> (date)` provenance line with no regression guard — a future edit could silently remove it.
- Adds a nested assertion inside the existing README-present branch: grep the README for a `^Vendored-from: <40-hex-char-sha>` line, raising a FAIL (via the existing `errors` accumulator) when the marker is absent or malformed.
- bash 3.2 + stdlib only (`grep -Eq`), consistent with the existing test. No version bump (test-only change — not skills/agents/structure per the repo bump convention; v0.1.102 is already claimed by an in-flight sibling PR, so bumping here would collide).

## Scope decisions
- In scope: the one assertion in the one named test file. The marker exists today (`scripts/vendor/README.md` line 35), so this is pure auditability hardening — it guards the marker from silent removal.
- A missing README still fails first at the outer `[ -f ... ]` check, so the new grep runs only when the file is present (no spurious double-fail).

## Test plan (verified locally)
- `bash cogni-knowledge/tests/test_vendored_engine_parity.sh` passes, printing `PASS: vendor provenance Vendored-from SHA marker present` alongside the existing README-present PASS (28 files byte-identical, 0 skipped).
- Blanking the `Vendored-from:` SHA line → test FAILs with exit 1 and the new marker-missing message; restoring → passes again.
- The regex requires exactly 40 hex chars (a 39-char truncation is rejected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
