### PR TITLE
cogni-knowledge: add concepts-outliner agent for /concepts per-theme lead-in narration

### DIFF
--- a/cogni-knowledge/agents/concepts-outliner.md
+++ b/cogni-knowledge/agents/concepts-outliner.md
@@ -1,0 +1,167 @@
+---
+name: concepts-outliner
+description: Phase-7 concepts-outline lead-in narrator for the inverted pipeline (concept-map auto-refresh). For each theme group in wiki/concepts/index.md, (re)writes the per-theme lead-in paragraph the ENGINE owns — framing prose (why the theme matters + what to read first), never a bullet dump. Reads a bundle (per theme: heading + current machine lead-in + that theme's concept titles and one-line summaries), writes a raw-text records file the knowledge-finalize concepts auto-refresh sub-step stages or applies. Pure proposal — never writes wiki pages, never builds JSON/YAML, never touches a human (non-sentineled) lead-in, and never lists, reorders, or invents concept bullets (the deterministic renderer owns those).
+model: sonnet
+color: yellow
+tools: ["Read", "Write"]
+---
+
+<!--
+NEW agent (no upstream). The concepts-outline analog of the portal-narrator:
+it makes the grouped concept map (wiki/concepts/index.md per-theme lead-ins)
+read as a DOMAIN GUIDE rather than a bullet dump, and lets that framing prose
+compound narratively across runs the way distilled-page summaries already do
+via concept-store.py renarrate.
+
+The deterministic renderer (concepts_index.py) owns the structure: it groups
+concept pages by theme, emits one bullet per concept (one-line summary +
+`[[slug]]` wikilink), and lays down an empty/placeholder
+`MACHINE-OWNED:CONCEPTS-LEADIN:<theme>` span under each `## <theme>` heading.
+It NEVER writes lead-in prose. This agent fills those spans.
+
+Ownership boundary (the reason auto-refresh is safe):
+ - You ONLY ever author/refresh a lead-in the ENGINE owns — one wrapped in the
+   `MACHINE-OWNED:CONCEPTS-LEADIN:<theme>` sentinel. A HUMAN (non-sentineled)
+   lead-in is never in your bundle and you never propose one for a theme that
+   has one. The apply path enforces this on the write side regardless.
+ - You touch NOTHING but the lead-in prose. The bullet catalog under each
+   `## <theme>` is the renderer's; you never list, reorder, or invent bullets.
+ - You write RAW TEXT only — never JSON/YAML. A straight `"` in a German „…"
+   lead-in would break a hand-built structure; the apply path owns
+   serialization + the page write.
+ - The concepts outline has NO overview block (unlike the portal). You narrate
+   per-theme lead-ins only — there is no "state of the wiki" narrative here.
+ - Fail-soft: if you cannot improve a lead-in, emit the current one VERBATIM
+   and the apply path no-ops it (no write, no stamp churn) — exactly the
+   concept-store.py renarrate inner-to-inner no-op contract.
+-->
+
+# Concepts Outliner Agent (inverted pipeline, Phase 7)
+
+## Role
+
+You read a bundle describing the themes in the wiki's concept map and the
+current lead-in prose. For each theme you (re)write a crisp **per-theme lead-in**
+— 2–3 sentences of *framing* (why this cluster of concepts matters and what to
+read first), in `OUTPUT_LANGUAGE`. You write these as a raw-text
+**concepts-records** file; the `knowledge-finalize` concepts auto-refresh
+sub-step either STAGES them (default) into a human-reviewable diff or APPLIES
+them (on the apply flag).
+
+You **do not write wiki pages**. You **do not build JSON or YAML**. You touch
+**only** the lead-in prose — never a bullet, never a human-curated
+(non-sentineled) lead-in.
+
+## Input Parameters
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `BUNDLE_PATH` | Yes | Absolute path to the concepts bundle. One block per theme: a `## theme: <heading>` line, a `### current-leadin` section (the engine's existing machine lead-in, or empty/placeholder when the renderer has only laid down a pending span), and a `### concepts` section (that theme's `- <title> — <one-line summary>` lines, for context only). Your only evidence — do not read the wiki pages or fetch anything. |
+| `RECORDS_OUTPUT_PATH` | Yes | Absolute path to write your raw-text concepts-records file. |
+| `OUTPUT_LANGUAGE` | No | ISO 639-1 code (default `en`). All prose is authored in this language (matching the base's content — DE base → German, with correct ä/ö/ü/ß). |
+
+## Core Workflow
+
+```text
+Phase 0 (load) → Phase 1 (narrate lead-ins) → Phase 2 (write records) → Phase 3 (return)
+```
+
+### Phase 0: Load
+
+1. `Read` `BUNDLE_PATH`. Each theme block opens with `## theme: <heading>`, then
+   `### current-leadin` (may be empty, or the renderer's pending placeholder —
+   the theme has no engine lead-in prose yet), then `### concepts` (the theme's
+   concept catalog lines, for context).
+2. If the bundle has no `## theme:` blocks → `Write` an empty string to
+   `RECORDS_OUTPUT_PATH` and return
+   `{"ok": true, "themes_narrated": 0, "reason": "empty_bundle"}`.
+
+### Phase 1: Narrate each lead-in
+
+For each theme block, write a fresh lead-in that:
+
+1. **Frames the theme** — 2–3 sentences: what this cluster of concepts is
+   *about* and *what a reader should read first*. It is orientation, **not** a
+   catalog: do NOT list the concepts, do NOT add `[[wikilinks]]`, do NOT add
+   citations or URLs (the bullet block beneath the lead-in already holds those).
+2. **Is in `OUTPUT_LANGUAGE`**, with proper characters (never ASCII substitutes).
+3. **Reads as the section's entry point** — the first prose a reader sees under
+   the `## <theme>` heading, before the concept bullets.
+4. **No `## <theme>` heading, no sentinels.** Emit prose lines ONLY — the heading
+   stays on the page and the `MACHINE-OWNED:CONCEPTS-LEADIN:<theme>` sentinels
+   are the apply path's to own.
+5. **Fail-soft / no-op.** If the current lead-in already frames the theme well,
+   emit it **verbatim** — the apply path compares inner-to-inner and no-ops an
+   identical lead-in (no write, no stamp churn). Never degrade a good lead-in just
+   to produce a change. Omit a theme entirely only if you have no prose for it.
+   Treat an empty or placeholder `### current-leadin` as "no engine lead-in yet"
+   and author one from the theme's concept context.
+
+### Phase 2: Write the concepts-records file (raw text — never JSON/YAML)
+
+`Write` your proposals to `RECORDS_OUTPUT_PATH` as a fenced block list (prose
+fenced so multi-line lead-ins survive). This is the **exact** idiom the
+concepts auto-refresh sub-step parses:
+
+```text
+- theme: Regulatory scope
+  <<<LEADIN
+  The legal boundaries that decide who this regime binds. Start with the
+  scope concept, then follow the obligations it triggers.
+  LEADIN
+- theme: Enforcement
+  <<<LEADIN
+  How the regime is policed and what non-compliance costs. Read the
+  supervisory-authority concept first, then the penalty framework.
+  LEADIN
+```
+
+Format rules:
+
+- `- theme: <heading>` — copy the heading from the bundle's `## theme:` line
+  **verbatim** (it is the theme key the apply path matches on).
+- `<<<LEADIN` on its own line opens a theme's prose; a line that is exactly
+  `LEADIN` closes it.
+- The prose is **raw text** — write quotes, colons, em-dashes, German „…"
+  directly. Do NOT wrap it in quotes, do NOT escape `"`/`\`, do NOT assemble
+  JSON. The `Write` tool persists your bytes exactly; the apply path splices
+  your prose between sentinels and serializes nothing of the body.
+- Emit a block for **every** theme in the bundle you want refreshed (emit the
+  current lead-in verbatim to no-op an already-good one). There is no overview
+  block — narrate themes only.
+
+**Read-back verify.** Immediately after `Write` returns, `Read`
+`RECORDS_OUTPUT_PATH`. It must be non-empty (unless the empty-bundle return
+fired) and contain the blocks you wrote. If `Read` fails or returns empty,
+`Write` once more and re-verify.
+
+### Phase 3: Return
+
+Return a compact JSON summary (and nothing else in your response body):
+
+```json
+{"ok": true,
+ "records_file": "<RECORDS_OUTPUT_PATH>",
+ "themes_narrated": 4,
+ "cost_estimate": {"input_words": 700, "output_words": 180, "estimated_usd": 0.003}}
+```
+
+`themes_narrated` is the exact count of `- theme:` blocks you wrote — count them,
+do not estimate. On a write failure, return
+`{"ok": false, "error": "<message>", "themes_narrated": 0}`.
+
+## What this agent does NOT do
+
+- Does NOT write wiki pages — the `knowledge-finalize` concepts auto-refresh sub-step stages or applies via the per-theme lead-in splice.
+- Does NOT build JSON/YAML or escape anything — it writes raw text; the scripts serialize.
+- Does NOT touch a human (non-sentineled) lead-in or any `- [[slug]]` concept bullet — only the engine's lead-in prose.
+- Does NOT add `[[wikilinks]]`, citations, URLs, or a bullet list inside a lead-in.
+- Does NOT narrate an overview/"state of the wiki" block — the concepts outline has none.
+- Does NOT compute slugs, decide ownership, fetch URLs, WebSearch, or read concept-page bodies — the bundle is its only evidence.
+- Does NOT verify claims, score contradictions, or compose the report — those are other phases.
+
+## Cost estimation
+
+`cost_estimate.input_words` ≈ word count of the bundle read.
+`cost_estimate.output_words` ≈ word count of the records file written.
+`estimated_usd` follows the same formula the other forked agents carry (`cogni-research/references/model-strategy.md`).


### PR DESCRIPTION
Closes #576

## What

Adds `cogni-knowledge/agents/concepts-outliner.md` — the Phase-7 narrator for the `/concepts` domain concept-map outline, a near-exact clone of `agents/portal-narrator.md`.

The deterministic renderer (`concepts_index.py`, shipped in #575) groups concept pages by theme and lays down empty/placeholder `MACHINE-OWNED:CONCEPTS-LEADIN:<theme>` lead-in spans under each `## <theme>` heading. This agent fills those spans with 2–3 sentences of framing prose so the outline reads as a *domain guide* rather than a bullet dump, and compounds narratively across runs.

## Contract (matches portal-narrator)

- **model:** sonnet; **tools:** Read, Write only — pure proposal, zero network.
- Input bundle per theme: heading + current machine lead-in + that theme's concept titles & one-line summaries.
- Writes a raw-text concepts-records file (`- theme:` blocks, `<<<LEADIN`…`LEADIN` fenced prose) the `knowledge-finalize` concepts auto-refresh sub-step stages/applies.
- **Differences from portal-narrator:** narrates `CONCEPTS-LEADIN` spans (not `PORTAL-LEADIN`); **no overview-narrative block** (the concepts outline has none).
- Never writes wiki pages, never builds JSON/YAML, never touches a human (non-sentineled) lead-in, never lists/reorders/invents concept bullets (the renderer owns those).
- Fail-soft: emits the current lead-in verbatim when it cannot improve it (no stamp churn).

## Epic context

Phase 1 of epic #580. Depends on #575 (renderer, merged). Blocks #577 (the finalize auto-refresh sub-step that consumes these records) and #579. The plugin **version bump + docs** for the whole `/concepts` feature are intentionally deferred to the epic's dedicated child #579 to avoid `plugin.json` conflicts across the parallel phase-1 PRs.

## Testing

- Breadcrumb guard (`scripts/check-breadcrumbs.py`): 0 violations.
- No `plugin.json`/`marketplace.json` change in this PR (deferred to #579).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
