### PR TITLE
cogni-knowledge: declare curated wiki-output layout + 0.0.8 schema contract

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -326,7 +326,7 @@
     {
       "name": "cogni-knowledge",
       "source": "./cogni-knowledge",
-      "version": "0.1.113",
+      "version": "0.1.114",
       "maturity": "preview",
       "description": "Wiki-first research that compounds. Binds each run to a cogni-wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`. The shallow `knowledge-query` rung is read-only by default and can optionally file its answer back as an un-verified synthesis page via `--file-back`.",
       "keywords": [

--- a/cogni-knowledge/.claude-plugin/plugin.json
+++ b/cogni-knowledge/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-knowledge",
-  "version": "0.1.113",
+  "version": "0.1.114",
   "description": "Wiki-first research that compounds. Binds each run to a cogni-wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`. The shallow `knowledge-query` rung is read-only by default and can optionally file its answer back as an un-verified synthesis page via `--file-back`.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-knowledge/CLAUDE.md
+++ b/cogni-knowledge/CLAUDE.md
@@ -21,6 +21,33 @@ A "knowledge base" is one directory that contains both:
 
 They live as siblings. The wiki is the substrate; the binding records which research projects have contributed.
 
+## Wiki output layout
+
+The inverted pipeline deposits its knowledge into `wiki/` as a **curated, progressively-disclosed** tree (`schema_version` 0.0.8) — a single curated front door over per-type machine-owned sub-indexes, not a flat dump:
+
+```
+wiki/
+├── index.md            ← single curated front door: overview intro + per-theme
+│                          map linking the sub-indexes below; the former
+│                          overview.md narrative folds into this intro
+├── concepts/index.md   ← per-type sub-index (rendered by concepts_index.py)
+├── sources/index.md    ┐
+├── questions/index.md  │
+├── syntheses/index.md  │ per-type machine-owned sub-indexes
+├── entities/index.md   │
+├── summaries/index.md  │
+├── learnings/index.md  ┘
+└── meta/               ← visible control files: log.md, context_brief.md,
+                           open_questions.md
+```
+
+`schema_version` 0.0.8 is **additive and read-forward** — it declares the curated layout on top of the existing per-type-directory contract, exactly as the 0.0.6 (`sources/`) and 0.0.7 (`questions/`) bumps did. **0.0.5 stays the hard-fail boundary** (pre-migration wikis abort). This is the wiki `schema_version`, distinct from the cogni-knowledge plugin version (`plugin.json`).
+
+Two contract notes the rest of the layout work depends on:
+
+- **Per-type `wiki/<type>/index.md` is a machine-owned sub-index, not a page** — generated, never authored, so it is **exempt from the `entries_count`, `orphan_page`, and `reverse_link_missing` checks**, parallel to the existing `is_audit_slug` (`lint-*` / `health-*`) exemption. The lint/health enforcement of this exemption lands in a follow-up child.
+- **`wiki/meta/` is the declared target** for the visible control files (`log.md`, `context_brief.md`, `open_questions.md`). The actual path centralization — with a legacy fallback — is a separate follow-up; until it lands, the legacy flat `wiki/context_brief.md` / `wiki/open_questions.md` paths remain valid. Layout *declaration* (this contract) and layout *seeding* / *path move* are deliberately separate children of the curated-layout epic.
+
 ## Skills
 
 | Skill | Role |

--- a/cogni-knowledge/skills/knowledge-setup/SKILL.md
+++ b/cogni-knowledge/skills/knowledge-setup/SKILL.md
@@ -240,9 +240,53 @@ Static next-action guidance (printed on skip / "pick later"):
 - A directory at `<knowledge_root>/` containing:
   - `.cogni-wiki/config.json` (from `cogni-wiki:wiki-setup`)
   - `.cogni-knowledge/binding.json` (from `knowledge-binding.py init`)
-  - Standard wiki layout (`raw/`, `wiki/`, `assets/`, etc.)
+  - `raw/`, `assets/`, and the curated `wiki/` output layout below.
 
 No files are written outside `<knowledge_root>/`.
+
+### Curated wiki-output layout (contract, `schema_version` 0.0.8)
+
+The inverted pipeline deposits its knowledge into `wiki/` as a **curated,
+progressively-disclosed** tree — a single front door over per-type sub-indexes,
+not a flat dump:
+
+```
+wiki/
+├── index.md            ← single curated front door: overview intro + per-theme
+│                          map linking the sub-indexes below. The former
+│                          `overview.md` narrative folds into this intro.
+├── concepts/index.md   ← per-type sub-index (exists today via concepts_index.py)
+├── sources/index.md    ┐
+├── questions/index.md  │
+├── syntheses/index.md  │ per-type machine-owned sub-indexes
+├── entities/index.md   │
+├── summaries/index.md  │
+├── learnings/index.md  ┘
+└── meta/               ← visible control files: log.md, context_brief.md,
+                           open_questions.md
+```
+
+**`schema_version` 0.0.8 is additive and read-forward.** It declares this
+curated layout on top of the existing per-type-directory contract. As with the
+0.0.6 (`sources/`) and 0.0.7 (`questions/`) bumps, an older-but-post-migration
+wiki reads forward without a rewrite; **0.0.5 remains the hard-fail boundary**
+(pre-migration wikis still abort). This is the wiki `schema_version`, distinct
+from the cogni-knowledge plugin version.
+
+**This child declares the contract only — no behavior change.** Layout seeding
+for new wikis, the `wiki/meta/` control-file path centralization (with a legacy
+fallback), and the lint/health enforcement of the exemption below each land in
+their own follow-up children of this epic. Until the path centralization lands,
+the legacy flat paths `wiki/context_brief.md` and `wiki/open_questions.md`
+remain valid; `wiki/meta/` is the **declared target** the rest of the layout
+work builds toward.
+
+**Per-type `index.md` is a machine-owned sub-index, not a page.** Each
+`wiki/<type>/index.md` is generated, not authored, so it is **exempt from the
+`entries_count`, `orphan_page`, and `reverse_link_missing` checks** — the same
+structural exemption the lint/health tooling already grants `is_audit_slug`
+pages (`lint-*` / `health-*`). Declaring the exemption here gives the
+lint/health-enforcement follow-up a contract to point at.
 
 ## References
 


### PR DESCRIPTION
Closes #589.

Epic #596 phase 1 — contract-only foundation. Declares the new curated wiki-output layout and `schema_version` 0.0.8 as a CONTRACT ONLY. No script behavior, no seeding, no vendored-engine edit.

## Summary
- **knowledge-setup/SKILL.md `## Output`**: replaces the bare "Standard wiki layout" bullet with an explicit annotated curated tree — `wiki/index.md` single curated front door (overview intro + per-theme map linking sub-indexes), per-type `wiki/<type>/index.md` sub-indexes (sources/questions/syntheses/entities/summaries/learnings, alongside existing concepts/), and visible `wiki/meta/` (log.md, context_brief.md, open_questions.md). Documents that `overview.md` folds into the index intro and advertises `schema_version` 0.0.8 as additive/read-forward (0.0.5 stays the hard-fail boundary, like 0.0.6/0.0.7).
- **B1 reader contract**: a per-type `wiki/<type>/index.md` is a machine-owned sub-index, exempt from `entries_count` / `orphan_page` / `reverse_link_missing` — parallel to the `is_audit_slug` exemption — so the lint/health-enforcement follow-up has a contract to point at.
- **cogni-knowledge/CLAUDE.md**: new `## Wiki output layout` section after `## Architecture` with the matching annotated tree + contract notes.
- **plugin.json + marketplace.json**: 0.1.113 → 0.1.114.

## Scope decisions
- IN: knowledge-setup/SKILL.md + cogni-knowledge/CLAUDE.md contract text, version bump. Fully delivers #589's acceptance criteria (docs describe the new layout + schema_version 0.0.8; no code-path changes; existing tests unaffected).
- `wiki/meta/` is declared as the **target** contract layout (additive, read-forward). Legacy flat `wiki/context_brief.md` / `wiki/open_questions.md` paths remain valid until path centralization lands — a separate epic child, not part of this PR.
- OUT (separate, already-filed epic #596 children — not deferred scope of this issue): layout seeding, `wiki/meta/` path centralization + legacy fallback, lint/health enforcement of the B1 exemption. The vendored `SCHEMA.md` template lives only under `scripts/vendor/cogni-wiki/` and is gated on Archive epic #512 — explicitly NOT touched here. Confirmed no first-party SCHEMA.md exists.
- The `0.0.8` in this contract is the cogni-wiki **schema_version**, distinct from the cogni-knowledge **plugin** version (0.1.114).

## Test plan
- [x] `git diff --stat` touches only knowledge-setup/SKILL.md, CLAUDE.md, plugin.json, marketplace.json — no files under scripts/vendor/, no script logic.
- [x] plugin.json and marketplace.json both read 0.1.114; both JSON files parse.
- [x] Maintainer-breadcrumb guard clean (0 violations); SKILL.md carries no #NNN refs.
- [x] `tests/test_skill_contracts.sh` ALL PASS; the 2 failing `test_knowledge_setup_probe.sh` assertions pre-exist on `main` (stale knowledge-refresh probe checks, unrelated to this change — flagged as separate follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
