### PR TITLE
cogni-knowledge: centralize control-file paths (indirection layer)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -326,7 +326,7 @@
     {
       "name": "cogni-knowledge",
       "source": "./cogni-knowledge",
-      "version": "0.1.114",
+      "version": "0.1.115",
       "maturity": "preview",
       "description": "Wiki-first research that compounds. Binds each run to a cogni-wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`. The shallow `knowledge-query` rung is read-only by default and can optionally file its answer back as an un-verified synthesis page via `--file-back`.",
       "keywords": [

--- a/cogni-knowledge/.claude-plugin/plugin.json
+++ b/cogni-knowledge/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-knowledge",
-  "version": "0.1.114",
+  "version": "0.1.115",
   "description": "Wiki-first research that compounds. Binds each run to a cogni-wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`. The shallow `knowledge-query` rung is read-only by default and can optionally file its answer back as an un-verified synthesis page via `--file-back`.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-knowledge/scripts/_knowledge_lib.py
+++ b/cogni-knowledge/scripts/_knowledge_lib.py
@@ -103,6 +103,75 @@ def atomic_write_text(path: Path, text: str) -> Path:
     return _atomic_write_via(path, lambda fh: fh.write(text))
 
 
+# ---------------------------------------------------------------------------
+# Control-file path indirection (curated wiki-output layout, schema 0.0.8).
+#
+# The three wiki control files (`log.md`, `context_brief.md`,
+# `open_questions.md`) are migrating from the flat `wiki/` root into a
+# `wiki/meta/` subtree. Routing every cogni-knowledge reader/writer through
+# these helpers makes that relocation a one-line change here instead of a
+# call-site sweep.
+#
+# Resolution rule (read-side fallback): prefer `wiki/meta/<file>` when it
+# already exists on disk, else fall back to legacy `wiki/<file>`. The
+# canonical *write* location stays legacy `wiki/` for now — the vendored
+# cogni-wiki engine still reads/writes the flat paths (out of scope until the
+# Archive sequencing lands), so flipping the write target here would desync
+# those readers. When the paired vendored update + base migrator land, the
+# flip is a single edit to `_CANONICAL_META` below.
+# ---------------------------------------------------------------------------
+
+# Flip to True (in lockstep with the vendored-reader update + base migrator)
+# to make `wiki/meta/` the canonical *write* location. While False, helpers
+# resolve to `wiki/meta/<file>` only when that file already exists (read-side
+# fallback), keeping writes byte-identical to the legacy layout.
+_CANONICAL_META = False
+
+_CONTROL_FILES = {
+    "log": "log.md",
+    "context-brief": "context_brief.md",
+    "open-questions": "open_questions.md",
+}
+
+
+def meta_dir(wiki_root) -> Path:
+    """The curated control-file directory: `<wiki_root>/wiki/meta`."""
+    return Path(wiki_root) / "wiki" / "meta"
+
+
+def _resolve_control_path(wiki_root, name: str) -> Path:
+    """Resolve a control file's path under `wiki_root`.
+
+    `name` is one of `_CONTROL_FILES`' keys (`log`, `context-brief`,
+    `open-questions`). Prefers `wiki/meta/<file>` when it exists on disk (or
+    unconditionally once `_CANONICAL_META` is flipped), else legacy
+    `wiki/<file>`. Path-only — never creates, opens, or locks the file.
+    """
+    if name not in _CONTROL_FILES:
+        raise ValueError(f"unknown control file: {name!r}")
+    filename = _CONTROL_FILES[name]
+    root = Path(wiki_root)
+    meta_candidate = root / "wiki" / "meta" / filename
+    if _CANONICAL_META or meta_candidate.exists():
+        return meta_candidate
+    return root / "wiki" / filename
+
+
+def log_path(wiki_root) -> Path:
+    """Resolved path to the wiki activity log (`log.md`)."""
+    return _resolve_control_path(wiki_root, "log")
+
+
+def context_brief_path(wiki_root) -> Path:
+    """Resolved path to the orientation brief (`context_brief.md`)."""
+    return _resolve_control_path(wiki_root, "context-brief")
+
+
+def open_questions_path(wiki_root) -> Path:
+    """Resolved path to the open-questions register (`open_questions.md`)."""
+    return _resolve_control_path(wiki_root, "open-questions")
+
+
 # Slug grammar matches cogni-wiki's wikilink regex
 # (cogni-wiki/.../wiki-ingest/scripts/_wikilib.py:WIKILINK_RE), so a slug
 # emitted here is a legal `[[wikilink]]` target without further translation.

--- a/cogni-knowledge/scripts/control-path.py
+++ b/cogni-knowledge/scripts/control-path.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""
+control-path.py — resolve a wiki control-file path for cogni-knowledge flows.
+
+The three wiki control files (`log.md`, `context_brief.md`,
+`open_questions.md`) are migrating from the flat `wiki/` root into a
+`wiki/meta/` subtree (curated wiki-output layout, schema 0.0.8). This CLI is
+the single grep-able resolution point SKILL.md prose calls instead of
+hardcoding `"${WIKI_ROOT}/wiki/log.md"`, so the eventual relocation is a
+one-line change in `_knowledge_lib` rather than a ~100-call-site sweep:
+
+    LOG=$(python3 .../control-path.py log --wiki-root "$WIKI_ROOT")
+    echo "..." >> "$LOG"
+
+Prints ONLY the resolved absolute path to stdout (so the shell can capture it
+with `$(...)`); diagnostics and the JSON error envelope go to stderr. Resolves
+`wiki/meta/<file>` when it already exists on disk (read-side fallback), else
+legacy `wiki/<file>` — delegating to the `_knowledge_lib` helpers so the
+script and any Python importer share one source of truth.
+
+stdlib-only. Python 3.8+.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import _knowledge_lib as kl  # noqa: E402
+
+
+_RESOLVERS = {
+    "log": kl.log_path,
+    "context-brief": kl.context_brief_path,
+    "open-questions": kl.open_questions_path,
+}
+
+
+def _fail(error: str) -> int:
+    """Emit a JSON error envelope on stderr and return exit code 1."""
+    json.dump({"success": False, "data": {}, "error": error}, sys.stderr)
+    sys.stderr.write("\n")
+    return 1
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(
+        description="Resolve a wiki control-file path (prefer wiki/meta/, "
+        "fall back to legacy wiki/).",
+    )
+    parser.add_argument(
+        "control_file",
+        choices=sorted(_RESOLVERS),
+        help="Which control file to resolve.",
+    )
+    parser.add_argument(
+        "--wiki-root",
+        required=True,
+        help="Absolute path to the wiki root (the directory containing wiki/).",
+    )
+    args = parser.parse_args(argv)
+
+    wiki_root = Path(args.wiki_root)
+    if not wiki_root.is_dir():
+        return _fail(f"--wiki-root is not a directory: {args.wiki_root}")
+
+    resolved = _RESOLVERS[args.control_file](wiki_root)
+    # Print only the resolved path so `$(...)` captures it cleanly.
+    sys.stdout.write(str(resolved.resolve()) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/cogni-knowledge/skills/knowledge-compose/SKILL.md
+++ b/cogni-knowledge/skills/knowledge-compose/SKILL.md
@@ -375,7 +375,8 @@ N_WORDS=<words from composer return>
 N_CITES=<the script-derived count from Step 5's print(len(cites)) — NOT the composer return's "citations" field>
 N_DCL=<data.claim_kinds.distilled from Step 4.5, default 0>
 N_ACL=<data.claim_kinds.answer from Step 4.5, default 0>
-echo "## [${DATE_STAMP}] compose | project=${TOPIC} draft=v${N} words=${N_WORDS} citations=${N_CITES} dcl=${N_DCL} acl=${N_ACL}" >> "${WIKI_ROOT}/wiki/log.md"
+LOG_PATH=$(python3 "${CLAUDE_PLUGIN_ROOT}/scripts/control-path.py" log --wiki-root "${WIKI_ROOT}")
+echo "## [${DATE_STAMP}] compose | project=${TOPIC} draft=v${N} words=${N_WORDS} citations=${N_CITES} dcl=${N_DCL} acl=${N_ACL}" >> "${LOG_PATH}"
 ```
 
 The `dcl=<n>` suffix is the cross-run record of the distilled-citation rate, and `acl=<n>` the question-node answer-citation rate — the cross-source-convergence loops firing (or not) show up directly in `wiki/log.md`.

--- a/cogni-knowledge/skills/knowledge-distill/SKILL.md
+++ b/cogni-knowledge/skills/knowledge-distill/SKILL.md
@@ -534,7 +534,8 @@ TOPIC=<topic from plan.json>
 N_CONCEPTS=<len(created_slugs) + len(updated_slugs)>
 N_ATTACHED=<claims_attached_total>
 N_DEDUPED=<claims_deduped_total>
-echo "## [${DATE_STAMP}] distill | project=${TOPIC} concepts=${N_CONCEPTS} claims=${N_ATTACHED} deduped=${N_DEDUPED}" >> "${WIKI_ROOT}/wiki/log.md"
+LOG_PATH=$(python3 "${CLAUDE_PLUGIN_ROOT}/scripts/control-path.py" log --wiki-root "${WIKI_ROOT}")
+echo "## [${DATE_STAMP}] distill | project=${TOPIC} concepts=${N_CONCEPTS} claims=${N_ATTACHED} deduped=${N_DEDUPED}" >> "${LOG_PATH}"
 ```
 
 The `distill` prefix is additive-safe — cogni-wiki readers bucket an unknown prefix in their catch-all without crashing (same posture `compose`/`verify`/`finalize` had before cogni-wiki formalized them).

--- a/cogni-knowledge/skills/knowledge-finalize/SKILL.md
+++ b/cogni-knowledge/skills/knowledge-finalize/SKILL.md
@@ -759,16 +759,19 @@ from _knowledge_lib import gap_sq_ids_from_coverage
 print(",".join(gap_sq_ids_from_coverage(os.environ["PROJECT_PATH"])))
 ' 2>/dev/null || true)
 
+LOG_PATH=$(python3 "${CLAUDE_PLUGIN_ROOT}/scripts/control-path.py" log --wiki-root "${WIKI_ROOT}")
 if [ -n "$GAP_SQS" ]; then
     printf '## [%s] finalize | project=%s slug=%s draft=v%s round=%s sources=%s sqs=%s\n' \
         "$DATE_STAMP" "$TOPIC" "$SYNTHESIS_SLUG" "$DRAFT_VERSION" "$REVISION_ROUND" "$N_SOURCES" "$GAP_SQS" \
-        >> "${WIKI_ROOT}/wiki/log.md"
+        >> "${LOG_PATH}"
 else
     printf '## [%s] finalize | project=%s slug=%s draft=v%s round=%s sources=%s\n' \
         "$DATE_STAMP" "$TOPIC" "$SYNTHESIS_SLUG" "$DRAFT_VERSION" "$REVISION_ROUND" "$N_SOURCES" \
-        >> "${WIKI_ROOT}/wiki/log.md"
+        >> "${LOG_PATH}"
 fi
 ```
+
+`control-path.py log` resolves the canonical `log.md` location (legacy `wiki/log.md` today, `wiki/meta/log.md` once the layout flip lands) so the finalize log append does not hardcode the path — see `scripts/control-path.py`.
 
 `KNOWLEDGE_SCRIPTS` is `${CLAUDE_PLUGIN_ROOT}/scripts` (the cogni-knowledge scripts dir holding `_knowledge_lib.py`). The `sqs=` suffix is additive: cogni-wiki's `LOG_LINE_RE` parses `## [date] op | rest` and treats `rest` as opaque, so pre-existing readers ignore it. It is what cogni-wiki's `rebuild_open_questions.py::attribute_close` substring-scans (after stripping the `sq:` prefix from the checklist id) to credit-close a research-time gap `closed … by finalize`.
 

--- a/cogni-knowledge/skills/knowledge-ingest/SKILL.md
+++ b/cogni-knowledge/skills/knowledge-ingest/SKILL.md
@@ -371,10 +371,11 @@ DATE_STAMP=$(date -u +%F)
 TOPIC=<topic from plan.json>
 N_INGESTED=<len(ingested[]) written this run>
 N_CLAIMS=<sum of claims_extracted across this-run ingested[]>
-echo "## [${DATE_STAMP}] ingest | project=${TOPIC} sources=${N_INGESTED} claims=${N_CLAIMS}" >> "${WIKI_ROOT}/wiki/log.md"
+LOG_PATH=$(python3 "${CLAUDE_PLUGIN_ROOT}/scripts/control-path.py" log --wiki-root "${WIKI_ROOT}")
+echo "## [${DATE_STAMP}] ingest | project=${TOPIC} sources=${N_INGESTED} claims=${N_CLAIMS}" >> "${LOG_PATH}"
 ```
 
-The `ingest` prefix is already in cogni-wiki's log-format enum (see `cogni-wiki/CLAUDE.md`).
+The `ingest` prefix is already in cogni-wiki's log-format enum (see `cogni-wiki/CLAUDE.md`). `control-path.py log` resolves the canonical `log.md` location (legacy `wiki/log.md` today, `wiki/meta/log.md` once the layout flip lands) so no flow hardcodes the path — see `scripts/control-path.py`.
 
 ### 6. Final summary
 

--- a/cogni-knowledge/skills/knowledge-resume/SKILL.md
+++ b/cogni-knowledge/skills/knowledge-resume/SKILL.md
@@ -102,10 +102,10 @@ python3 "${WIKI_HEALTH_SCRIPTS}/health.py" --wiki-root "<wiki_path>"
 
 Parse the JSON envelope and capture `data.errors`, `data.warnings`, and `data.stats` (`entries_count_actual`, `entries_count_drift`, `claim_drift_count`). The one-line verdict for Step 3 is **OK** when `errors` is empty, else `N issues — <first error class(es)>`; surface `entries_count_drift` / `claim_drift_count` as warnings when non-zero. On `success: false` (e.g. `<wiki_path>/.cogni-wiki/config.json` absent), surface the error and still print the binding section per Edge cases.
 
-**2b. Context brief + recent log (direct reads).** Read the wiki's own orientation surfaces directly — both fail-soft (a missing file is omitted, never an abort):
+**2b. Context brief + recent log (direct reads).** Read the wiki's own orientation surfaces directly — both fail-soft (a missing file is omitted, never an abort). Resolve each path through the control-file resolver (legacy `wiki/<file>` today, `wiki/meta/<file>` once the layout flip lands — prefers `wiki/meta/` when present) rather than hardcoding it:
 
-- `Read <wiki_path>/wiki/context_brief.md` (auto-rebuilt by ingest/finalize) for the one-paragraph summary.
-- `Read <wiki_path>/wiki/log.md` for recent activity — show the **last 3** lines by default, the **last 10** when `--verbose` is set.
+- `CONTEXT_BRIEF=$(python3 "${CLAUDE_PLUGIN_ROOT}/scripts/control-path.py" context-brief --wiki-root "<wiki_path>")`, then `Read "$CONTEXT_BRIEF"` (auto-rebuilt by ingest/finalize) for the one-paragraph summary.
+- `LOG_PATH=$(python3 "${CLAUDE_PLUGIN_ROOT}/scripts/control-path.py" log --wiki-root "<wiki_path>")`, then `Read "$LOG_PATH"` for recent activity — show the **last 3** lines by default, the **last 10** when `--verbose` is set.
 - Entry count comes from `<wiki_path>/.cogni-wiki/config.json` (`entries_count`), cross-checked against `data.stats.entries_count_actual` from 2a.
 
 For each deposited project (cap at 5, newest first), read its inverted-pipeline depth so the summary shows how far each project got, not just that it exists:

--- a/cogni-knowledge/skills/knowledge-verify/SKILL.md
+++ b/cogni-knowledge/skills/knowledge-verify/SKILL.md
@@ -414,7 +414,8 @@ TOPIC=<topic from plan.json>
 N_VERBATIM=<counts.verbatim from final verify>
 N_PARAPHRASE=<counts.paraphrase from final verify>
 N_UNSUPPORTED=<counts.unsupported from final verify>
-echo "## [${DATE_STAMP}] verify | project=${TOPIC} draft=v${CURRENT_DRAFT_VERSION} round=${REVISION_ROUND} verbatim=${N_VERBATIM} paraphrase=${N_PARAPHRASE} unsupported=${N_UNSUPPORTED}" >> "${WIKI_ROOT}/wiki/log.md"
+LOG_PATH=$(python3 "${CLAUDE_PLUGIN_ROOT}/scripts/control-path.py" log --wiki-root "${WIKI_ROOT}")
+echo "## [${DATE_STAMP}] verify | project=${TOPIC} draft=v${CURRENT_DRAFT_VERSION} round=${REVISION_ROUND} verbatim=${N_VERBATIM} paraphrase=${N_PARAPHRASE} unsupported=${N_UNSUPPORTED}" >> "${LOG_PATH}"
 ```
 
 Note on the `verify` prefix: cogni-wiki's log-format enum (per `cogni-wiki/CLAUDE.md` §"Key Conventions") does not yet list `verify`, but readers count unknown prefixes in their catch-all bucket without crashing — `verify` is additive and safe. Same additive-prefix posture as the `compose` line.

--- a/cogni-knowledge/tests/test_compose_contract.sh
+++ b/cogni-knowledge/tests/test_compose_contract.sh
@@ -47,6 +47,18 @@ assert_grep 'probe_plugin cogni-wiki' "$COMPOSE" "knowledge-compose: probes cogn
 assert_grep 'RESUME_FROM_OUTLINE' "$COMPOSE" "knowledge-compose: F11 — passes RESUME_FROM_OUTLINE to composer"
 assert_grep 'writer-outline-v' "$COMPOSE" "knowledge-compose: F11 — detects writer-outline-vN.json for recovery"
 assert_grep 'wiki/log.md' "$COMPOSE" "knowledge-compose: appends to wiki/log.md"
+assert_grep 'control-path.py" log' "$COMPOSE" "knowledge-compose: resolves the log path via control-path.py (no hardcoded wiki/log.md write target)"
+
+# Curated-layout control-file indirection (schema 0.0.8): every executable
+# log.md WRITER routes its `>>` append through the control-path.py resolver,
+# so NO knowledge-* SKILL hardcodes the literal `>> "${WIKI_ROOT}/wiki/log.md"`
+# write target. The `>>`-anchored pattern naturally exempts the prose-template
+# skills (knowledge-update / -prefill / -query mention wiki/log.md only as
+# documentation, with no shell redirect to indirect).
+for _wskill in knowledge-ingest knowledge-compose knowledge-verify knowledge-distill knowledge-finalize; do
+  assert_not_grep '>> "${WIKI_ROOT}/wiki/log.md"' "$PLUGIN_ROOT/skills/$_wskill/SKILL.md" \
+    "$_wskill: no bare \`>> \"\${WIKI_ROOT}/wiki/log.md\"\` write — must route through control-path.py (#590)"
+done
 # #385: the skill captures the per-kind citation breakdown from citation-store.py
 # build and surfaces the distilled-citation (dcl-) rate — the measurement the
 # inert-loop issue asked for (0 dcl- on a converging base is the symptom).

--- a/cogni-knowledge/tests/test_finalize_contract.sh
+++ b/cogni-knowledge/tests/test_finalize_contract.sh
@@ -69,6 +69,7 @@ assert_grep 'resolve-refresh-candidate' "$FIN" "knowledge-finalize: Step 9 clear
 assert_grep '\-\-cites' "$FIN" "knowledge-finalize: Step 9 passes --cites for the citation-overlap refresh-candidate clear"
 assert_grep 'CITED_SOURCE_SLUGS_FULL_CSV' "$FIN" "knowledge-finalize: captures the untruncated cited-source CSV for the Step 9 --cites clear"
 assert_grep 'wiki/log.md' "$FIN" "knowledge-finalize: appends to wiki/log.md"
+assert_grep 'control-path.py" log' "$FIN" "knowledge-finalize: resolves the log path via control-path.py (no hardcoded wiki/log.md write target)"
 # #291: Step 9.5 best-effort sweeps the merged-away verify-shards/ fan-out scratch
 # after deposit. Anchors the housekeeping layer like Step 2's guard is anchored.
 assert_grep 'verify-shards' "$FIN" "knowledge-finalize: Step 9.5 sweeps verify-shards/ after deposit (#291)"

--- a/cogni-knowledge/tests/test_ingest_contract.sh
+++ b/cogni-knowledge/tests/test_ingest_contract.sh
@@ -51,6 +51,7 @@ assert_grep 'Task(source-ingester' "$INGEST" "knowledge-ingest: dispatches sourc
 assert_grep 'backlink_audit.py' "$INGEST" "knowledge-ingest: calls backlink_audit.py directly (clean-break)"
 assert_grep 'wiki_index_update.py' "$INGEST" "knowledge-ingest: calls wiki_index_update.py directly (clean-break)"
 assert_grep 'wiki/log.md' "$INGEST" "knowledge-ingest: appends to wiki/log.md"
+assert_grep 'control-path.py" log' "$INGEST" "knowledge-ingest: resolves the log path via control-path.py (no hardcoded wiki/log.md write target)"
 assert_grep 'probe_plugin cogni-wiki' "$INGEST" "knowledge-ingest: probes cogni-wiki"
 assert_grep 'Task' "$INGEST" "knowledge-ingest: Task listed in allowed-tools"
 # #302 (Slice 14): Step 4 bumps entries_count by the count of NEWLY-INDEXED

--- a/cogni-knowledge/tests/test_knowledge_lib.sh
+++ b/cogni-knowledge/tests/test_knowledge_lib.sh
@@ -106,6 +106,44 @@ def assert_atomic_write_roundtrip():
     assert leftover == [], leftover
 
 
+def assert_control_paths():
+    # Curated-layout control-file resolver (schema 0.0.8): prefer
+    # wiki/meta/<file> when it exists on disk, else legacy wiki/<file>.
+    base = work / "ctrl"
+    legacy = base / "legacy"
+    (legacy / "wiki").mkdir(parents=True)
+    (legacy / "wiki" / "log.md").write_text("legacy", encoding="utf-8")
+    # Legacy-only fixture: all three resolve to the flat wiki/ paths.
+    assert kl.log_path(legacy) == legacy / "wiki" / "log.md", kl.log_path(legacy)
+    assert kl.context_brief_path(legacy) == legacy / "wiki" / "context_brief.md", \
+        kl.context_brief_path(legacy)
+    assert kl.open_questions_path(legacy) == legacy / "wiki" / "open_questions.md", \
+        kl.open_questions_path(legacy)
+    # meta_dir is unconditional (the write target).
+    assert kl.meta_dir(legacy) == legacy / "wiki" / "meta", kl.meta_dir(legacy)
+    # A file absent from BOTH layouts still resolves to the legacy path
+    # (read-side fallback, write target stays legacy while _CANONICAL_META=False).
+    assert kl.open_questions_path(legacy) == legacy / "wiki" / "open_questions.md"
+
+    # meta-present fixture: a control file that already lives in wiki/meta/
+    # resolves there; one that does not still falls back to legacy.
+    meta = base / "meta"
+    (meta / "wiki" / "meta").mkdir(parents=True)
+    (meta / "wiki" / "log.md").write_text("legacy", encoding="utf-8")
+    (meta / "wiki" / "meta" / "log.md").write_text("meta", encoding="utf-8")
+    assert kl.log_path(meta) == meta / "wiki" / "meta" / "log.md", kl.log_path(meta)
+    # context_brief.md present only in legacy → legacy wins (per-file fallback).
+    (meta / "wiki" / "context_brief.md").write_text("legacy", encoding="utf-8")
+    assert kl.context_brief_path(meta) == meta / "wiki" / "context_brief.md", \
+        kl.context_brief_path(meta)
+    # Unknown control-file name raises (guards a typo'd CLI subcommand).
+    try:
+        kl._resolve_control_path(legacy, "bogus")
+        assert False, "expected ValueError for unknown control file"
+    except ValueError:
+        pass
+
+
 def assert_slugify():
     # #303: German umlauts transliterate by convention (ä→ae …) BEFORE the
     # keep-regex strip, so `für` → `fuer` (not `f-r`); remaining Latin scripts
@@ -1130,6 +1168,7 @@ check("strip_inline_citation_markers", assert_strip_inline_citation_markers)
 check("identity", assert_identity)
 check("canonicalization", assert_canonicalization)
 check("atomic_write_roundtrip", assert_atomic_write_roundtrip)
+check("control_paths", assert_control_paths)
 check("slugify", assert_slugify)
 check("ref_heading", assert_ref_heading)
 check("first_url", assert_first_url)
@@ -1169,6 +1208,7 @@ grade() {
 grade identity                "three-way identity — normalize_url and atomic_write are the same objects in candidate-store, fetch-cache, _knowledge_lib"
 grade canonicalization        "canonicalization — scheme/host lowercased, trailing slash stripped, utm_+ref dropped, fragment removed, path case preserved"
 grade atomic_write_roundtrip  "atomic_write round-trips payload and leaves no .tmp debris"
+grade control_paths           "control-file resolver (0.0.8) — log/context_brief/open_questions prefer wiki/meta/ when present, else legacy wiki/; meta_dir unconditional; unknown name→ValueError"
 grade slugify                 "slugify — German umlaut transliteration (für→fuer), NFKD de-accent, empty/non-alnum→'' contract, max-len truncation"
 grade ref_heading             "ref_heading — localized reference heading (de→Referenzen), default/unknown→References"
 grade first_url               "first_url — JSON-list + non-JSON fallback URL extraction, no charset over-strip, file:// first-class incl. space-in-path (#572)"

--- a/cogni-knowledge/tests/test_verify_contract.sh
+++ b/cogni-knowledge/tests/test_verify_contract.sh
@@ -76,6 +76,7 @@ assert_grep '\-\-draft "' "$VERIFY" "knowledge-verify: passes --draft to the pre
 assert_grep 'even when .*remaining_ids.* is empty' "$VERIFY" "knowledge-verify: runs shard every round to clear stale fragments (review)"
 assert_grep 'probe_plugin cogni-wiki' "$VERIFY" "knowledge-verify: probes cogni-wiki (clean-break)"
 assert_grep 'wiki/log.md' "$VERIFY" "knowledge-verify: appends to wiki/log.md"
+assert_grep 'control-path.py" log' "$VERIFY" "knowledge-verify: resolves the log path via control-path.py (no hardcoded wiki/log.md write target)"
 # Match the actual log-line shape (`## [DATE] verify | project=...`) rather
 # than the bare word `verify`, which would also match the skill name.
 assert_grep '\] verify | project=' "$VERIFY" "knowledge-verify: emits the '## [DATE] verify | project=...' log-line shape"


### PR DESCRIPTION
Refs #590. Depends on #589 (merged). Epic #596, Phase P2.

Ships the **path-indirection infrastructure** for the three wiki control files (`log.md`, `context_brief.md`, `open_questions.md`) so that relocating them to `wiki/meta/` later is a one-line helper change instead of a ~100-call-site edit — while keeping the canonical location at legacy `wiki/` for now so out-of-scope vendored readers do not desync.

## Summary
- Add `scripts/control-path.py` — a stdlib-only resolver CLI: `control-path.py {log|context-brief|open-questions} --wiki-root ` prints the resolved absolute path to stdout (JSON `{success,data,error}` envelope + exit 1 on a missing/invalid `--wiki-root`). Makes "no caller hardcodes `wiki/log.md`" a grep-able invariant.
- Add path helpers to `scripts/_knowledge_lib.py`: `meta_dir()`, `log_path()`, `context_brief_path()`, `open_questions_path()` over one shared `_resolve_control_path()` with **prefer-`meta/`-then-legacy** fallback. The single resolver is the one place control-file paths are constructed — the canonical-location flip is a one-line edit to `_CANONICAL_META`.
- Route the 5 cogni-knowledge-native `log.md` **write** sites (ingest / compose / verify / distill / finalize×2 branches) and the `knowledge-resume` **reader** (`context_brief.md` + `log.md`) through the resolver. Writers still resolve to legacy `wiki/` (the current canonical), so behaviour is byte-identical this PR.
- Strengthen the 4 contract tests (ingest/finalize/compose/verify) with a `control-path.py` resolver-call assertion + a `>>`-anchored cross-SKILL invariant (no `knowledge-*` SKILL hardcodes a `>> "${WIKI_ROOT}/wiki/log.md"` write); add `test_knowledge_lib.sh` unit cases for the prefer-meta/legacy fallback.
- Bump `cogni-knowledge` 0.1.114 → 0.1.115 (`plugin.json` + repo-root `marketplace.json`).

## Scope decisions
- **In:** the indirection layer + native call-site routing + the read fallback that satisfies the acceptance (legacy-layout fixture reads legacy; `meta/`-layout fixture reads `meta/`).
- **Kept at legacy `wiki/` (deliberately not flipped):** the canonical write location. Flipping it now would desync vendored readers (`rebuild_open_questions.py::attribute_close`, `render_dashboard.py`, `wiki_queue.py` read hardcoded `wiki/log.md`) and `context_brief.md` / `open_questions.md` are *written only* by vendored scripts — all `#512`-gated, out of scope.
- **Out of scope (untouched):** `scripts/vendor/cogni-wiki/**`. `knowledge-health` is untouched — it only *names* `log.md` in prose; its actual log write is inside the vendored `health.py`.

## Open questions
- The 3 prose-template log references (`knowledge-update`, `knowledge-prefill`, `knowledge-query`) are **not** executable `>>` appends — they are documentation-template lines with no shell variable to indirect, so they are left unchanged. Should they be **converted into real indirected writers** (a behavior change — those skills do not own a `WIKI_ROOT` append today, beyond this issue's "indirect the existing writers" scope)? Confirm the 5-writer scope is the intended #590 increment, or direct the conversion as a separate child.

**Resolved:** The 5-writer scope is confirmed as this PR's intended #590 increment. The 3 prose-template references carry `wiki/log.md` only as documentation text (no `>>` append, no `WIKI_ROOT` variable to indirect), so there is nothing to route there; converting them into real writers is a behavior change left to the still-open, `#512`-gated #590. No separate child filed (lean-tracker).

## Deferred (already tracked — no new issues filed, lean-tracker)
- Flip the canonical control-file location to `wiki/meta/` (one-line in `_resolve_control_path`) — gated on the vendored-reader update + #512.
- Update the vendored cogni-wiki reader/writer constants to `wiki/meta/` in lockstep — #512-gated vendored-engine edit (tracked by epic #512 / phase-3+ children #593/#601/#595).
- Existing-base migrator → already tracked as **#594**.

## Review notes
- `skill-quality-reviewer` returned `needs_revision` with a single `structural_issue` flagged `introduced_by_change: false`: `knowledge-finalize/SKILL.md` is ~1347 lines (over skill-creator's ~500-line soft cap). This is **pre-existing** body bloat the path-indirection change neither introduced nor worsened — annotated here per the soft-gate contract, not a blocker for this PR.

## Test plan
- [x] `bash tests/test_knowledge_lib.sh` — new `control_paths` unit cases (legacy-only fixture → `wiki/`; `meta/`-present → `wiki/meta/`; unknown name → ValueError).
- [x] `control-path.py log --wiki-root ` prints the legacy path; `` prints the `meta/` path; missing `--wiki-root` exits 1 with a JSON error envelope.
- [x] `bash tests/test_{ingest,finalize,compose,verify}_contract.sh` pass with the resolver-call assertions; the `>>`-anchored cross-SKILL invariant confirms zero bare `wiki/log.md` write targets remain in the 5 writers.
- [x] `plugin.json` + `marketplace.json` both show v0.1.115.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
