### PR TITLE
cogni-knowledge: generic sub-index renderer for all 7 wiki page types

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -326,7 +326,7 @@
     {
       "name": "cogni-knowledge",
       "source": "./cogni-knowledge",
-      "version": "0.1.115",
+      "version": "0.1.116",
       "maturity": "preview",
       "description": "Wiki-first research that compounds. Binds each run to a cogni-wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`. The shallow `knowledge-query` rung is read-only by default and can optionally file its answer back as an un-verified synthesis page via `--file-back`.",
       "keywords": [

--- a/cogni-knowledge/.claude-plugin/plugin.json
+++ b/cogni-knowledge/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-knowledge",
-  "version": "0.1.115",
+  "version": "0.1.116",
   "description": "Wiki-first research that compounds. Binds each run to a cogni-wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`. The shallow `knowledge-query` rung is read-only by default and can optionally file its answer back as an un-verified synthesis page via `--file-back`.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-knowledge/scripts/concepts_index.py
+++ b/cogni-knowledge/scripts/concepts_index.py
@@ -6,477 +6,59 @@ enumerates the wiki's concept pages, groups them by theme, and emits one
 `## <theme>` section per theme — each with an engine-owned, narrator-authored
 lead-in span and a bullet per concept (one-line summary + `[[slug]]` wikilink).
 
-This is the DETERMINISTIC SPINE only. The renderer writes the structure and the
-bullets; it never writes lead-in PROSE — it lays down an empty/placeholder
-`MACHINE-OWNED:CONCEPTS-LEADIN:<theme>` span that the concepts-outliner agent
-fills in later, and it carries an already-authored lead-in forward verbatim on
-every re-render so it never clobbers the narrator's prose.
-
-Theme derivation is wiki-resident — it never reads `plan.json` (which lives
-per-research-project under `<project>/.metadata/` and is not wiki-resident,
-while a concept page accretes claims across many projects). Instead each
-concept's backing SOURCE slugs (its `sources:` frontmatter — exactly the union
-of its claims' backlinks, per concept-store.py) are looked up in
-`wiki/index.md`, where every source bullet sits under its `## <theme>` heading
-(filed at ingest via `wiki_index_update.py --category`). A concept is assigned
-the MAJORITY theme across its backing sources (ties broken by `wiki/index.md`
-heading order); concepts with no resolvable theme go into a single trailing
-`## Uncategorized` group so none are dropped.
+This is now a thin **type-config wrapper** around the generic `sub_index.py`
+renderer (the per-type machine-owned sub-index for any of the seven wiki page
+types). All the rendering logic — wiki-resident theme derivation, the
+`MACHINE-OWNED:CONCEPTS-LEADIN` carry-forward, the locked/atomic/idempotent
+`render` vs lock-free `stage` subcommands, the human-page guard, and the
+`{success, data, error}` envelope — lives in `sub_index.py`; this file pins the
+`concepts` configuration (`sub_index.REGISTRY["concepts"]`) and keeps the
+byte-stable CLI (`render --wiki-root --wiki-scripts-dir` / `stage --wiki-root`,
+envelope key `concept_count`) so existing callers and `test_concepts_index.sh`
+are unaffected.
 
 Subcommands:
 
   - `render` — write `wiki/concepts/index.md` live, under `_wiki_lock` +
-               `atomic_write_text`, only when the full proposed text differs
+               `atomic_write_text`, only when the proposed text differs
                byte-for-byte (idempotent: re-running an unchanged wiki is a
-               no-op with no stamp/date churn — the lead-in spans are
-               stamp-free and there is no date field on the page).
+               no-op).
   - `stage`  — write the proposed page to `<wiki-root>/.cogni-wiki/
-               concepts-index-proposed.md` WITHOUT the lock and WITHOUT
-               touching the live file (single-writer staging area, paralleling
-               `portal-proposed.md`).
-
-`_wiki_lock` is imported from cogni-wiki's `_wikilib` via `--wiki-scripts-dir`
-(the `concept-store.py` / `overview_update.py` posture) so the live write
-serialises on the same `<wiki-root>/.cogni-wiki/.lock` as every other
-shared-state wiki write. The transform helpers (`extract_machine_block`,
-`upsert_machine_block`, `atomic_write_text`, `frontmatter_scalar`, `slugify`)
-are reused verbatim from `_knowledge_lib`.
-
-Fail-soft posture: a missing wiki-scripts dir, a `_wikilib` import failure, a
-non-wiki `--wiki-root`, or any write error returns a `{"success": false, ...}`
-envelope and writes nothing partial — the caller logs it loudly and never
-rolls back.
+               concepts-index-proposed.md` WITHOUT the lock and WITHOUT touching
+               the live file.
 
 Stdlib only. No pip dependencies. POSIX only on `render` (`_wiki_lock` uses
 `fcntl.flock`); `stage` is lock-free. Python 3.9 floor (the `from __future__
-import annotations` below lets the `X | None` / `list[dict]` annotations parse
-on 3.9, matching `_knowledge_lib`).
-
-Output is a `{"success": bool, "data": {...}, "error": "..."}` JSON envelope
-(pretty-printed with `indent=2`), per the cross-plugin script convention.
+import annotations` below matches `_knowledge_lib` / `sub_index`).
 """
 
 from __future__ import annotations
 
 import argparse
-import json
-import re
 import sys
 from pathlib import Path
 from typing import Optional
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from _knowledge_lib import (  # noqa: E402
-    atomic_write_text,
-    extract_machine_block,
-    frontmatter_scalar,
-    parse_distilled_claims,
-    slugify,
+from sub_index import (  # noqa: E402
+    REGISTRY,
+    render_index,
+    stage_index,
 )
 
-CONCEPTS_DIR_REL = ("wiki", "concepts")
-INDEX_REL = ("wiki", "concepts", "index.md")
-PORTAL_INDEX_REL = ("wiki", "index.md")
-STAGE_REL = (".cogni-wiki", "concepts-index-proposed.md")
-
-PAGE_H1 = "# Concepts"
-# Single stable ownership marker emitted right after the H1. Its ABSENCE on an
-# existing, non-empty index.md is how the renderer recognises a human-authored
-# page and refuses to touch it (mirrors concept-store.py's skipped_human_page
-# guard, which keys on the absence of the SUMMARY sentinel).
-OWNERSHIP_MARKER = "<!-- MACHINE-OWNED:CONCEPTS-INDEX -->"
-INTRO_LINE = (
-    "_Auto-generated concept map. Per-theme lead-ins are narrated by the "
-    "concepts-outliner; concept bullets are regenerated on each finalize._"
-)
-LEADIN_PREFIX = "CONCEPTS-LEADIN:"
-LEADIN_PLACEHOLDER = "_(theme lead-in pending narration)_"
-UNCATEGORIZED = "Uncategorized"
-
-# A source bullet in wiki/index.md: a list item whose first wikilink names the
-# source slug, e.g. `- [[some-source]] — title`. Anchored to a list line so a
-# `[[wikilink]]` inside a PORTAL-LEADIN prose span is never mistaken for a
-# source membership.
-_SOURCE_BULLET_RE = re.compile(r"^\s*-\s.*?\[\[([a-z0-9][a-z0-9\-]*)\]\]")
-# A level-2 heading line (`## <theme label>`); level-1 (`# `) and level-3+ are
-# not theme sections in the portal layout.
-_THEME_HEADING_RE = re.compile(r"^##[ \t]+(.+?)[ \t]*$")
-# `sources:` frontmatter list entries: `  - wiki://<slug>` (concept-store.py
-# renders the backing-source union exactly this way).
-_SOURCE_FM_RE = re.compile(r"^\s*-\s*wiki://([a-z0-9][a-z0-9\-]*)\s*$")
-
-
-def _emit(success: bool, data: Optional[dict] = None, error: str = "") -> int:
-    """Print the `{success, data, error}` envelope; return a shell exit code."""
-    payload = {"success": success, "data": data or {}, "error": error}
-    print(json.dumps(payload, indent=2, ensure_ascii=False))
-    return 0 if success else 1
-
-
-def _import_wiki_lock(wiki_scripts_dir: str):
-    """Import `_wiki_lock` from cogni-wiki's `_wikilib`, or return an error.
-
-    Mirrors concept-store.py / overview_update.py: resolve the dir, push it on
-    `sys.path`, import. Returns `(_wiki_lock, None)` on success or
-    `(None, error_message)` so the caller emits a fail-soft envelope instead of
-    crashing.
-    """
-    wiki_scripts = Path(wiki_scripts_dir).resolve()
-    if not wiki_scripts.is_dir():
-        return None, f"wiki-scripts dir not found: {wiki_scripts}"
-    sys.path.insert(0, str(wiki_scripts))
-    try:
-        from _wikilib import _wiki_lock  # noqa: E402
-    except Exception as exc:  # ImportError or anything the module raises
-        return None, f"could not import _wiki_lock from {wiki_scripts}: {exc}"
-    return _wiki_lock, None
-
-
-# --- theme membership from wiki/index.md --------------------------------------
-
-
-def _parse_portal_themes(portal_text: str) -> "tuple[dict, list]":
-    """Walk `wiki/index.md`, returning `(source_slug -> theme_label,
-    [theme_label, ...])`.
-
-    Splits the portal into `## <theme>` sections (document order) and records,
-    per section, the source slugs named by its bullet list items. The theme
-    order list preserves the order themes appear in the portal — the concepts
-    index renders its sections in the same order. Only sections that actually
-    contain ≥1 source bullet contribute a theme (a non-theme `## ` heading with
-    no source bullets — e.g. an intro — is naturally skipped). The FIRST theme a
-    source is seen under wins, so a stray duplicate bullet can't flip a source's
-    theme.
-    """
-    source_theme: dict = {}
-    theme_order: list = []
-    current_theme: Optional[str] = None
-    for line in (portal_text or "").splitlines():
-        hm = _THEME_HEADING_RE.match(line)
-        if hm:
-            current_theme = hm.group(1).strip()
-            continue
-        if current_theme is None:
-            continue
-        sm = _SOURCE_BULLET_RE.match(line)
-        if sm:
-            slug = sm.group(1)
-            if slug not in source_theme:
-                source_theme[slug] = current_theme
-            if current_theme not in theme_order:
-                theme_order.append(current_theme)
-    return source_theme, theme_order
-
-
-def _concept_sources(concept_text: str) -> "list[str]":
-    """Backing source slugs for a concept page: its `sources:` frontmatter list
-    (`- wiki://<slug>`), which concept-store.py renders as exactly the union of
-    the page's claims' backlinks. Returns [] when the block is absent."""
-    m = re.match(
-        r"^---[ \t]*\r?\n(.*?)\r?\n---[ \t]*(?:\r?\n|\Z)",
-        concept_text or "",
-        re.DOTALL,
-    )
-    if not m:
-        return []
-    slugs: list = []
-    in_sources = False
-    for line in m.group(1).splitlines():
-        if re.match(r"^sources:[ \t]*$", line):
-            in_sources = True
-            continue
-        if in_sources:
-            sm = _SOURCE_FM_RE.match(line)
-            if sm:
-                if sm.group(1) not in slugs:
-                    slugs.append(sm.group(1))
-                continue
-            # A non-list, non-blank line at column 0 ends the block.
-            if line[:1] not in (" ", "\t") and line.strip() != "":
-                in_sources = False
-    return slugs
-
-
-def _assign_theme(
-    source_slugs: "list[str]",
-    source_theme: dict,
-    theme_order: "list[str]",
-) -> Optional[str]:
-    """Majority theme across a concept's backing sources; ties broken by portal
-    heading order (the theme that appears earliest in `wiki/index.md` wins).
-    Returns None when no backing source resolves to a theme (→ Uncategorized)."""
-    counts: dict = {}
-    for slug in source_slugs:
-        theme = source_theme.get(slug)
-        if theme:
-            counts[theme] = counts.get(theme, 0) + 1
-    if not counts:
-        return None
-    best_n = max(counts.values())
-    tied = [t for t, n in counts.items() if n == best_n]
-    if len(tied) == 1:
-        return tied[0]
-    # Tie → earliest by portal heading order; themes absent from theme_order
-    # (shouldn't happen, since counts keys come from source_theme values) sort
-    # last but stably.
-    return min(tied, key=lambda t: (theme_order.index(t) if t in theme_order else len(theme_order), t))
-
-
-# --- one-line concept summary -------------------------------------------------
-
-
-def _summary_oneline(concept_text: str, title: str) -> str:
-    """One-line summary for a concept bullet: the first non-heading prose line
-    of the SUMMARY machine block, else the first distilled claim's text, else
-    the title. Whitespace/newlines are collapsed to a single line."""
-    inner = extract_machine_block(concept_text, "SUMMARY")
-    if inner:
-        for raw in inner.splitlines():
-            line = raw.strip()
-            if line and not line.startswith("#"):
-                return _collapse(line)
-    claims = parse_distilled_claims(concept_text)
-    if claims:
-        text = (claims[0].get("text") or "").strip()
-        if text:
-            return _collapse(text)
-    return _collapse(title) if title else ""
-
-
-def _collapse(text: str) -> str:
-    """Collapse internal whitespace runs (incl. newlines) to single spaces."""
-    return re.sub(r"\s+", " ", text).strip()
-
-
-# --- page assembly ------------------------------------------------------------
-
-
-def _gather_concepts(concepts_dir: Path) -> "list[dict]":
-    """Read every `wiki/concepts/*.md` except `index.md`, returning
-    `[{slug, title, sources, summary}, ...]` sorted by slug (deterministic)."""
-    out: list = []
-    for page in sorted(concepts_dir.glob("*.md")):
-        if page.name == "index.md":
-            continue
-        try:
-            text = page.read_text(encoding="utf-8")
-        except OSError:
-            continue
-        slug = page.stem
-        title = frontmatter_scalar(text, "title") or slug
-        out.append({
-            "slug": slug,
-            "title": title,
-            "sources": _concept_sources(text),
-            "summary": _summary_oneline(text, title),
-        })
-    out.sort(key=lambda c: c["slug"])
-    return out
-
-
-def _leadin_name(theme_label: str, used: "dict") -> str:
-    """Stable per-theme lead-in block name `CONCEPTS-LEADIN:<theme-slug>`,
-    de-duplicated if two labels slugify the same."""
-    base = slugify(theme_label) or "theme"
-    name = base
-    n = 2
-    while name in used:
-        name = f"{base}-{n}"
-        n += 1
-    used[name] = theme_label
-    return LEADIN_PREFIX + name
-
-
-def _render_leadin(name: str, inner: str) -> str:
-    """A stamp-free `MACHINE-OWNED:<name>` lead-in span (idempotent: no date)."""
-    return (
-        f"<!-- MACHINE-OWNED:{name}:START -->\n"
-        f"{inner}\n"
-        f"<!-- MACHINE-OWNED:{name}:END -->"
-    )
-
-
-def _build_page(
-    concepts: "list[dict]",
-    source_theme: dict,
-    theme_order: "list[str]",
-    existing_text: str,
-) -> str:
-    """Assemble the full proposed `wiki/concepts/index.md` text.
-
-    Themes render in portal order; a trailing `## Uncategorized` collects
-    concepts with no resolvable theme. Each section carries a per-theme lead-in
-    span whose inner is CARRIED FORWARD verbatim from `existing_text` when
-    already present (so the narrator's prose is never clobbered) and a stable
-    placeholder otherwise. Concept bullets within a section are sorted by slug.
-    """
-    # Bucket concepts by theme.
-    buckets: dict = {}
-    for c in concepts:
-        theme = _assign_theme(c["sources"], source_theme, theme_order) or UNCATEGORIZED
-        buckets.setdefault(theme, []).append(c)
-
-    # Section order: portal theme order (only themes that have concepts), then
-    # any concept-only themes not in the portal (defensive; alpha), then
-    # Uncategorized last.
-    ordered: list = [t for t in theme_order if t in buckets and t != UNCATEGORIZED]
-    extras = sorted(t for t in buckets if t not in theme_order and t != UNCATEGORIZED)
-    ordered.extend(extras)
-    if UNCATEGORIZED in buckets:
-        ordered.append(UNCATEGORIZED)
-
-    used_names: dict = {}
-    parts: list = [PAGE_H1, OWNERSHIP_MARKER, "", INTRO_LINE, ""]
-    for theme in ordered:
-        name = _leadin_name(theme, used_names)
-        carried = extract_machine_block(existing_text, name)
-        inner = carried if carried is not None else LEADIN_PLACEHOLDER
-        parts.append(f"## {theme}")
-        parts.append("")
-        parts.append(_render_leadin(name, inner))
-        parts.append("")
-        for c in sorted(buckets[theme], key=lambda x: x["slug"]):
-            summary = c["summary"]
-            bullet = f"- {summary} [[{c['slug']}]]" if summary else f"- [[{c['slug']}]]"
-            parts.append(bullet)
-        parts.append("")
-    return "\n".join(parts).rstrip() + "\n"
-
-
-def _is_human_page(existing_text: str) -> bool:
-    """An existing index.md with content but NO ownership marker is a
-    hand-authored page the renderer must not touch."""
-    return bool(existing_text.strip()) and OWNERSHIP_MARKER not in existing_text
-
-
-def _assemble(wiki_root: Path, existing_text: str) -> str:
-    """Pure read+build: parse the portal themes and concept pages off disk and
-    assemble the full proposed `index.md` text against `existing_text` (so an
-    already-authored lead-in is carried forward). The single assembly path used
-    by both the unlocked `_prepare` read and the locked re-read in `cmd_render`."""
-    portal_path = wiki_root.joinpath(*PORTAL_INDEX_REL)
-    portal_text = portal_path.read_text(encoding="utf-8") if portal_path.is_file() else ""
-    source_theme, theme_order = _parse_portal_themes(portal_text)
-    concepts_dir = wiki_root.joinpath(*CONCEPTS_DIR_REL)
-    concepts = _gather_concepts(concepts_dir) if concepts_dir.is_dir() else []
-    return _build_page(concepts, source_theme, theme_order, existing_text)
-
-
-def _prepare(args) -> "tuple[Optional[dict], Optional[str]]":
-    """Shared read+assemble for both subcommands. Returns `(payload, error)`
-    where payload carries `wiki_root`, `index_path`, `existing_text`,
-    `proposed`, `concept_count`, `theme_count`. Never writes."""
-    wiki_root = Path(args.wiki_root).resolve()
-    if not (wiki_root / "wiki").is_dir():
-        return None, f"wiki_root has no wiki/ dir: {wiki_root}"
-    index_path = wiki_root.joinpath(*INDEX_REL)
-
-    existing_text = ""
-    if index_path.is_file():
-        try:
-            existing_text = index_path.read_text(encoding="utf-8")
-        except OSError as exc:
-            return None, f"concepts index not readable: {exc}"
-
-    concepts_dir = wiki_root.joinpath(*CONCEPTS_DIR_REL)
-    proposed = _assemble(wiki_root, existing_text)
-    theme_count = proposed.count("\n## ") + (1 if proposed.startswith("## ") else 0)
-    return {
-        "wiki_root": wiki_root,
-        "index_path": index_path,
-        "existing_text": existing_text,
-        "proposed": proposed,
-        "concept_count": _gather_count(concepts_dir),
-        "theme_count": theme_count,
-    }, None
-
-
-def _gather_count(concepts_dir: Path) -> int:
-    """Count of concept pages (excluding the index.md the renderer owns)."""
-    if not concepts_dir.is_dir():
-        return 0
-    return sum(1 for p in concepts_dir.glob("*.md") if p.name != "index.md")
+# The concepts type config — byte-stable with the legacy constants this file
+# used to declare inline (dir `wiki/concepts/`, H1 `# Concepts`, ownership marker
+# `MACHINE-OWNED:CONCEPTS-INDEX`, lead-in prefix `CONCEPTS-LEADIN:`, envelope
+# count key `concept_count`).
+CONCEPTS_CONFIG = REGISTRY["concepts"]
 
 
 def cmd_render(args) -> int:
-    _wiki_lock, err = _import_wiki_lock(args.wiki_scripts_dir)
-    if err:
-        return _emit(False, error=err)
-    payload, err = _prepare(args)
-    if err:
-        return _emit(False, error=err)
-    index_path = payload["index_path"]
-    existing_text = payload["existing_text"]
-    proposed = payload["proposed"]
-
-    if _is_human_page(existing_text):
-        return _emit(True, data={
-            "path": str(index_path),
-            "subcommand": "render",
-            "changed": False,
-            "skipped_human_page": True,
-        })
-
-    try:
-        with _wiki_lock(payload["wiki_root"]):
-            # Re-read under the lock so a concurrent writer can't be clobbered.
-            current = ""
-            if index_path.is_file():
-                current = index_path.read_text(encoding="utf-8")
-            if _is_human_page(current):
-                return _emit(True, data={
-                    "path": str(index_path),
-                    "subcommand": "render",
-                    "changed": False,
-                    "skipped_human_page": True,
-                })
-            # Rebuild against the locked-read text so a lead-in authored between
-            # the unlocked _prepare read and now is still carried forward.
-            if current != existing_text:
-                proposed = _assemble(payload["wiki_root"], current)
-            changed = proposed != current
-            if changed:
-                index_path.parent.mkdir(parents=True, exist_ok=True)
-                atomic_write_text(index_path, proposed)
-    except OSError as exc:
-        return _emit(False, error=f"concepts index write failed: {exc}")
-
-    return _emit(True, data={
-        "path": str(index_path),
-        "subcommand": "render",
-        "changed": changed,
-        "concept_count": payload["concept_count"],
-        "theme_count": payload["theme_count"],
-    })
+    return render_index(CONCEPTS_CONFIG, args.wiki_root, args.wiki_scripts_dir)
 
 
 def cmd_stage(args) -> int:
-    payload, err = _prepare(args)
-    if err:
-        return _emit(False, error=err)
-    stage_path = payload["wiki_root"].joinpath(*STAGE_REL)
-    live = payload["existing_text"]
-    proposed = payload["proposed"]
-    would_change = (not _is_human_page(live)) and (proposed != live)
-    header = (
-        "<!-- staged proposal for wiki/concepts/index.md — written by "
-        "concepts_index.py stage; NOT the live page -->\n"
-        f"<!-- status: {'would-update' if would_change else 'no-change'}; "
-        f"concepts={payload['concept_count']}; themes={payload['theme_count']}; "
-        f"live-is-human-page={str(_is_human_page(live)).lower()} -->\n\n"
-    )
-    try:
-        stage_path.parent.mkdir(parents=True, exist_ok=True)
-        atomic_write_text(stage_path, header + proposed)
-    except OSError as exc:
-        return _emit(False, error=f"staged proposal write failed: {exc}")
-    return _emit(True, data={
-        "path": str(stage_path),
-        "subcommand": "stage",
-        "would_change": would_change,
-        "concept_count": payload["concept_count"],
-        "theme_count": payload["theme_count"],
-    })
+    return stage_index(CONCEPTS_CONFIG, args.wiki_root)
 
 
 def _build_parser() -> argparse.ArgumentParser:

--- a/cogni-knowledge/scripts/sub_index.py
+++ b/cogni-knowledge/scripts/sub_index.py
@@ -1,0 +1,705 @@
+#!/usr/bin/env python3
+"""sub_index.py — generic deterministic renderer for wiki/<type>/index.md.
+
+The generalization of `concepts_index.py`: one shared renderer that produces a
+curated, machine-owned per-type sub-index for ANY of the seven cogni-knowledge
+wiki page types — `concepts`, `entities`, `summaries`, `learnings`, `sources`,
+`questions`, `syntheses`. `concepts_index.py` is now a thin type-config wrapper
+that delegates here, preserving its byte-stable CLI (so `test_concepts_index.sh`
+passes unchanged).
+
+Each sub-index enumerates the wiki pages of one type, groups them by theme, and
+emits one `## <theme>` section per theme — each with an engine-owned,
+narrator-authored lead-in span (`MACHINE-OWNED:<TYPE>-LEADIN:<theme>`) and a
+bullet per page (one-line summary + `[[slug]]` wikilink). This is the
+DETERMINISTIC SPINE only: the renderer writes the structure and the bullets; it
+never writes lead-in PROSE — it lays down an empty/placeholder lead-in span that
+a narrator fills in later, and it carries an already-authored lead-in forward
+verbatim on every re-render so it never clobbers the narrator's prose.
+
+Theme handling is wiki-resident — it never reads `plan.json`. Section ORDER for
+every type comes from `wiki/index.md`'s `## <theme>` heading order (the portal,
+filed at ingest via `wiki_index_update.py --category`). Per-page theme
+ASSIGNMENT is the one axis that varies by type, expressed as a `theme_fn`:
+
+  - `theme_via_backing_sources` (concept/entity/summary/learning/synthesis) —
+    look up each backing SOURCE slug from the page's `sources:` frontmatter in
+    the portal and take the MAJORITY theme (ties broken by portal order).
+  - `theme_via_own_slug` (source) — a source bullet sits under its own theme
+    heading in the portal, so the page's OWN slug resolves the theme directly.
+  - `theme_via_frontmatter` (question) — the page carries an authoritative
+    `theme_label:` frontmatter field (the cleanest signal, no portal round-trip).
+
+A page with no resolvable theme goes into a single trailing `## Uncategorized`
+group so none are dropped.
+
+Subcommands (both take `--type <type>`):
+
+  - `render` — write `wiki/<type>/index.md` live, under `_wiki_lock` +
+               `atomic_write_text`, only when the proposed text differs
+               byte-for-byte (idempotent: re-running an unchanged wiki is a
+               no-op with no stamp/date churn).
+  - `stage`  — write the proposed page to the type's `<wiki-root>/.cogni-wiki/
+               <type>-index-proposed.md` WITHOUT the lock and WITHOUT touching
+               the live file.
+
+`_wiki_lock` is imported from cogni-wiki's `_wikilib` via `--wiki-scripts-dir`
+(the `concept-store.py` posture) so the live write serialises on the same
+`<wiki-root>/.cogni-wiki/.lock` as every other shared-state wiki write. The
+transform helpers (`extract_machine_block`, `atomic_write_text`,
+`frontmatter_scalar`, `parse_distilled_claims`, `slugify`) are reused verbatim
+from `_knowledge_lib`.
+
+Fail-soft posture: a missing wiki-scripts dir, a `_wikilib` import failure, a
+non-wiki `--wiki-root`, an unknown `--type`, or any write error returns a
+`{"success": false, ...}` envelope and writes nothing partial.
+
+Stdlib only. No pip dependencies. POSIX only on `render` (`_wiki_lock` uses
+`fcntl.flock`); `stage` is lock-free. Python 3.9 floor (the `from __future__
+import annotations` below lets the `X | None` / `list[dict]` annotations parse
+on 3.9, matching `_knowledge_lib`).
+
+Output is a `{"success": bool, "data": {...}, "error": "..."}` JSON envelope
+(pretty-printed with `indent=2`), per the cross-plugin script convention.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Optional
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _knowledge_lib import (  # noqa: E402
+    atomic_write_text,
+    extract_machine_block,
+    frontmatter_scalar,
+    parse_distilled_claims,
+    parse_pre_extracted_claims,
+    slugify,
+)
+
+PORTAL_INDEX_REL = ("wiki", "index.md")
+
+# A source bullet in wiki/index.md: a list item whose first wikilink names the
+# source slug, e.g. `- [[some-source]] — title`. Anchored to a list line so a
+# `[[wikilink]]` inside a *-LEADIN prose span is never mistaken for a source
+# membership.
+_SOURCE_BULLET_RE = re.compile(r"^\s*-\s.*?\[\[([a-z0-9][a-z0-9\-]*)\]\]")
+# A level-2 heading line (`## <theme label>`); level-1 (`# `) and level-3+ are
+# not theme sections in the portal layout.
+_THEME_HEADING_RE = re.compile(r"^##[ \t]+(.+?)[ \t]*$")
+# `sources:` frontmatter list entries: `  - wiki://<slug>` (concept-store.py
+# renders the backing-source union exactly this way).
+_SOURCE_FM_RE = re.compile(r"^\s*-\s*wiki://([a-z0-9][a-z0-9\-]*)\s*$")
+
+
+# --- per-type configuration ---------------------------------------------------
+
+
+@dataclass(frozen=True)
+class TypeConfig:
+    """The 10 per-type knobs that were module-level constants in
+    `concepts_index.py`, plus the two callables that capture per-type variation
+    (theme assignment + one-line summary). Everything else in this module is
+    type-agnostic and reads these fields."""
+
+    type_name: str
+    dir_rel: tuple
+    index_rel: tuple
+    stage_rel: tuple
+    page_h1: str
+    ownership_marker: str
+    intro_line: str
+    leadin_prefix: str
+    leadin_placeholder: str
+    uncategorized: str
+    count_key: str          # envelope data key for the page count
+    count_label: str        # stage-header label (`<label>=<n>`)
+    index_display: str      # human path in the stage header
+    writer_name: str        # script name in the stage header (byte-stable)
+    theme_fn: Callable      # (slug, text, source_theme, theme_order) -> theme|None
+    summary_fn: Callable     # (text, title) -> str
+
+
+def _collapse(text: str) -> str:
+    """Collapse internal whitespace runs (incl. newlines) to single spaces."""
+    return re.sub(r"\s+", " ", text).strip()
+
+
+# --- theme assignment strategies ----------------------------------------------
+
+
+def _concept_sources(page_text: str) -> "list[str]":
+    """Backing source slugs for a page: its `sources:` frontmatter list
+    (`- wiki://<slug>`), which concept-store.py renders as exactly the union of
+    the page's claims' backlinks. Returns [] when the block is absent."""
+    m = re.match(
+        r"^---[ \t]*\r?\n(.*?)\r?\n---[ \t]*(?:\r?\n|\Z)",
+        page_text or "",
+        re.DOTALL,
+    )
+    if not m:
+        return []
+    slugs: list = []
+    in_sources = False
+    for line in m.group(1).splitlines():
+        if re.match(r"^sources:[ \t]*$", line):
+            in_sources = True
+            continue
+        if in_sources:
+            sm = _SOURCE_FM_RE.match(line)
+            if sm:
+                if sm.group(1) not in slugs:
+                    slugs.append(sm.group(1))
+                continue
+            # A non-list, non-blank line at column 0 ends the block.
+            if line[:1] not in (" ", "\t") and line.strip() != "":
+                in_sources = False
+    return slugs
+
+
+def theme_via_backing_sources(
+    slug: str,
+    text: str,
+    source_theme: dict,
+    theme_order: "list[str]",
+) -> Optional[str]:
+    """Majority theme across a page's backing sources; ties broken by portal
+    heading order (earliest in `wiki/index.md` wins). Returns None when no
+    backing source resolves to a theme (→ Uncategorized). Used by the four
+    distilled types + synthesis (all of which carry a `sources:` wiki:// list)."""
+    counts: dict = {}
+    for s in _concept_sources(text):
+        theme = source_theme.get(s)
+        if theme:
+            counts[theme] = counts.get(theme, 0) + 1
+    if not counts:
+        return None
+    best_n = max(counts.values())
+    tied = [t for t, n in counts.items() if n == best_n]
+    if len(tied) == 1:
+        return tied[0]
+    return min(
+        tied,
+        key=lambda t: (theme_order.index(t) if t in theme_order else len(theme_order), t),
+    )
+
+
+def theme_via_own_slug(
+    slug: str,
+    text: str,
+    source_theme: dict,
+    theme_order: "list[str]",
+) -> Optional[str]:
+    """A source page's own slug sits under its theme heading in the portal
+    (filed at ingest via `wiki_index_update.py --category`), so the theme is a
+    direct lookup of the page's OWN slug. Used by the `source` type."""
+    return source_theme.get(slug)
+
+
+def theme_via_frontmatter(
+    slug: str,
+    text: str,
+    source_theme: dict,
+    theme_order: "list[str]",
+) -> Optional[str]:
+    """The page carries an authoritative `theme_label:` frontmatter field
+    (question-store.py writes it on every `type: question` node) — the cleanest
+    theme signal, no portal round-trip. Used by the `question` type."""
+    label = frontmatter_scalar(text, "theme_label")
+    return label.strip() if label and label.strip() else None
+
+
+# --- one-line summary strategies ----------------------------------------------
+
+
+def summary_distilled(text: str, title: str) -> str:
+    """One-line summary for a concept/entity/summary/learning bullet: the first
+    non-heading prose line of the SUMMARY machine block, else the first distilled
+    claim's text, else the title."""
+    inner = extract_machine_block(text, "SUMMARY")
+    if inner:
+        for raw in inner.splitlines():
+            line = raw.strip()
+            if line and not line.startswith("#"):
+                return _collapse(line)
+    claims = parse_distilled_claims(text)
+    if claims:
+        ctext = (claims[0].get("text") or "").strip()
+        if ctext:
+            return _collapse(ctext)
+    return _collapse(title) if title else ""
+
+
+def summary_source(text: str, title: str) -> str:
+    """One-line summary for a source bullet: the first pre-extracted claim's
+    text (the most informative one-liner, since the title already renders via
+    the `[[slug]]` wikilink), else the title."""
+    claims = parse_pre_extracted_claims(text)
+    if claims:
+        ctext = (claims[0].get("text") or "").strip()
+        if ctext:
+            return _collapse(ctext)
+    return _collapse(title) if title else ""
+
+
+def summary_title(text: str, title: str) -> str:
+    """One-line summary = the page title. Used by `question` (the title IS the
+    query text) and `synthesis` (the title IS the research topic)."""
+    return _collapse(title) if title else ""
+
+
+# --- the seven type configs ---------------------------------------------------
+
+
+def _make_cfg(
+    type_name: str,
+    page_h1: str,
+    intro_line: str,
+    theme_fn: Callable,
+    summary_fn: Callable,
+    *,
+    count_key: str = "page_count",
+    writer_name: str = "sub_index.py",
+) -> TypeConfig:
+    """Build a TypeConfig, deriving the eight mechanical fields from `type_name`
+    (the wiki dir == the type name for all seven types): the dir/index/stage
+    paths, the `MACHINE-OWNED:<TYPE>-INDEX` marker, the `<TYPE>-LEADIN:` prefix,
+    the lead-in placeholder + Uncategorized label, the stage-header display path,
+    and the count label. Only the genuinely per-type values are passed in;
+    `concepts` additionally overrides `count_key`/`writer_name` to stay
+    byte-stable with the legacy concepts_index.py (envelope key `concept_count`,
+    stage header naming `concepts_index.py`)."""
+    upper = type_name.upper()
+    return TypeConfig(
+        type_name=type_name,
+        dir_rel=("wiki", type_name),
+        index_rel=("wiki", type_name, "index.md"),
+        stage_rel=(".cogni-wiki", f"{type_name}-index-proposed.md"),
+        page_h1=page_h1,
+        ownership_marker=f"<!-- MACHINE-OWNED:{upper}-INDEX -->",
+        intro_line=intro_line,
+        leadin_prefix=f"{upper}-LEADIN:",
+        leadin_placeholder="_(theme lead-in pending narration)_",
+        uncategorized="Uncategorized",
+        count_key=count_key,
+        count_label=type_name,
+        index_display=f"wiki/{type_name}/index.md",
+        writer_name=writer_name,
+        theme_fn=theme_fn,
+        summary_fn=summary_fn,
+    )
+
+
+REGISTRY: "dict[str, TypeConfig]" = {
+    # `concepts` is byte-stable with the legacy concepts_index.py output via the
+    # two explicit overrides (the derived marker/prefix/paths already match).
+    "concepts": _make_cfg(
+        "concepts", "# Concepts",
+        "_Auto-generated concept map. Per-theme lead-ins are narrated by the "
+        "concepts-outliner; concept bullets are regenerated on each finalize._",
+        theme_via_backing_sources, summary_distilled,
+        count_key="concept_count", writer_name="concepts_index.py",
+    ),
+    "entities": _make_cfg(
+        "entities", "# Entities",
+        "_Auto-generated entity map. Per-theme lead-ins are narrated by the "
+        "engine; entity bullets are regenerated on each finalize._",
+        theme_via_backing_sources, summary_distilled,
+    ),
+    "summaries": _make_cfg(
+        "summaries", "# Summaries",
+        "_Auto-generated summary map. Per-theme lead-ins are narrated by the "
+        "engine; summary bullets are regenerated on each finalize._",
+        theme_via_backing_sources, summary_distilled,
+    ),
+    "learnings": _make_cfg(
+        "learnings", "# Learnings",
+        "_Auto-generated learning map. Per-theme lead-ins are narrated by the "
+        "engine; learning bullets are regenerated on each finalize._",
+        theme_via_backing_sources, summary_distilled,
+    ),
+    "sources": _make_cfg(
+        "sources", "# Sources",
+        "_Auto-generated source map. Per-theme lead-ins are narrated by the "
+        "engine; source bullets are regenerated on each ingest._",
+        theme_via_own_slug, summary_source,
+    ),
+    "questions": _make_cfg(
+        "questions", "# Research questions",
+        "_Auto-generated research-question map. Per-theme lead-ins are narrated "
+        "by the engine; question bullets are regenerated on each ingest._",
+        theme_via_frontmatter, summary_title,
+    ),
+    "syntheses": _make_cfg(
+        "syntheses", "# Syntheses",
+        "_Auto-generated synthesis map. Per-theme lead-ins are narrated by the "
+        "engine; synthesis bullets are regenerated on each finalize._",
+        theme_via_backing_sources, summary_title,
+    ),
+}
+
+
+# --- envelope + lock ----------------------------------------------------------
+
+
+def _emit(success: bool, data: Optional[dict] = None, error: str = "") -> int:
+    """Print the `{success, data, error}` envelope; return a shell exit code."""
+    payload = {"success": success, "data": data or {}, "error": error}
+    print(json.dumps(payload, indent=2, ensure_ascii=False))
+    return 0 if success else 1
+
+
+def _import_wiki_lock(wiki_scripts_dir: str):
+    """Import `_wiki_lock` from cogni-wiki's `_wikilib`, or return an error.
+    Returns `(_wiki_lock, None)` on success or `(None, error_message)` so the
+    caller emits a fail-soft envelope instead of crashing."""
+    wiki_scripts = Path(wiki_scripts_dir).resolve()
+    if not wiki_scripts.is_dir():
+        return None, f"wiki-scripts dir not found: {wiki_scripts}"
+    sys.path.insert(0, str(wiki_scripts))
+    try:
+        from _wikilib import _wiki_lock  # noqa: E402
+    except Exception as exc:  # ImportError or anything the module raises
+        return None, f"could not import _wiki_lock from {wiki_scripts}: {exc}"
+    return _wiki_lock, None
+
+
+# --- theme membership from wiki/index.md --------------------------------------
+
+
+def _parse_portal_themes(portal_text: str) -> "tuple[dict, list]":
+    """Walk `wiki/index.md`, returning `(source_slug -> theme_label,
+    [theme_label, ...])`. Splits the portal into `## <theme>` sections
+    (document order) and records, per section, the source slugs named by its
+    bullet list items. The FIRST theme a source is seen under wins."""
+    source_theme: dict = {}
+    theme_order: list = []
+    current_theme: Optional[str] = None
+    for line in (portal_text or "").splitlines():
+        hm = _THEME_HEADING_RE.match(line)
+        if hm:
+            current_theme = hm.group(1).strip()
+            continue
+        if current_theme is None:
+            continue
+        sm = _SOURCE_BULLET_RE.match(line)
+        if sm:
+            slug = sm.group(1)
+            if slug not in source_theme:
+                source_theme[slug] = current_theme
+            if current_theme not in theme_order:
+                theme_order.append(current_theme)
+    return source_theme, theme_order
+
+
+# --- page assembly ------------------------------------------------------------
+
+
+def _gather_pages(
+    cfg: TypeConfig,
+    pages_dir: Path,
+    source_theme: dict,
+    theme_order: "list[str]",
+) -> "list[dict]":
+    """Read every `wiki/<type>/*.md` except `index.md`, returning
+    `[{slug, title, theme, summary}, ...]` sorted by slug (deterministic). The
+    per-type `theme_fn` / `summary_fn` capture the only axes that vary by type."""
+    out: list = []
+    for page in sorted(pages_dir.glob("*.md")):
+        if page.name == "index.md":
+            continue
+        try:
+            text = page.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        slug = page.stem
+        title = frontmatter_scalar(text, "title") or slug
+        out.append({
+            "slug": slug,
+            "title": title,
+            "theme": cfg.theme_fn(slug, text, source_theme, theme_order),
+            "summary": cfg.summary_fn(text, title),
+        })
+    out.sort(key=lambda c: c["slug"])
+    return out
+
+
+def _leadin_name(cfg: TypeConfig, theme_label: str, used: "dict") -> str:
+    """Stable per-theme lead-in block name `<TYPE>-LEADIN:<theme-slug>`,
+    de-duplicated if two labels slugify the same."""
+    base = slugify(theme_label) or "theme"
+    name = base
+    n = 2
+    while name in used:
+        name = f"{base}-{n}"
+        n += 1
+    used[name] = theme_label
+    return cfg.leadin_prefix + name
+
+
+def _render_leadin(name: str, inner: str) -> str:
+    """A stamp-free `MACHINE-OWNED:<name>` lead-in span (idempotent: no date)."""
+    return (
+        f"<!-- MACHINE-OWNED:{name}:START -->\n"
+        f"{inner}\n"
+        f"<!-- MACHINE-OWNED:{name}:END -->"
+    )
+
+
+def _build_page(
+    cfg: TypeConfig,
+    pages: "list[dict]",
+    theme_order: "list[str]",
+    existing_text: str,
+) -> str:
+    """Assemble the full proposed `wiki/<type>/index.md` text.
+
+    Themes render in portal order; a trailing `## Uncategorized` collects pages
+    with no resolvable theme. Each section carries a per-theme lead-in span whose
+    inner is CARRIED FORWARD verbatim from `existing_text` when already present
+    (so the narrator's prose is never clobbered) and a stable placeholder
+    otherwise. Bullets within a section are sorted by slug."""
+    buckets: dict = {}
+    for c in pages:
+        theme = c["theme"] or cfg.uncategorized
+        buckets.setdefault(theme, []).append(c)
+
+    ordered: list = [t for t in theme_order if t in buckets and t != cfg.uncategorized]
+    extras = sorted(t for t in buckets if t not in theme_order and t != cfg.uncategorized)
+    ordered.extend(extras)
+    if cfg.uncategorized in buckets:
+        ordered.append(cfg.uncategorized)
+
+    used_names: dict = {}
+    parts: list = [cfg.page_h1, cfg.ownership_marker, "", cfg.intro_line, ""]
+    for theme in ordered:
+        name = _leadin_name(cfg, theme, used_names)
+        carried = extract_machine_block(existing_text, name)
+        inner = carried if carried is not None else cfg.leadin_placeholder
+        parts.append(f"## {theme}")
+        parts.append("")
+        parts.append(_render_leadin(name, inner))
+        parts.append("")
+        for c in sorted(buckets[theme], key=lambda x: x["slug"]):
+            summary = c["summary"]
+            bullet = f"- {summary} [[{c['slug']}]]" if summary else f"- [[{c['slug']}]]"
+            parts.append(bullet)
+        parts.append("")
+    return "\n".join(parts).rstrip() + "\n"
+
+
+def _is_human_page(cfg: TypeConfig, existing_text: str) -> bool:
+    """An existing index.md with content but NO ownership marker is a
+    hand-authored page the renderer must not touch."""
+    return bool(existing_text.strip()) and cfg.ownership_marker not in existing_text
+
+
+def _assemble(cfg: TypeConfig, wiki_root: Path, existing_text: str) -> str:
+    """Pure read+build: parse the portal themes and pages off disk and assemble
+    the full proposed `index.md` text against `existing_text` (so an
+    already-authored lead-in is carried forward)."""
+    portal_path = wiki_root.joinpath(*PORTAL_INDEX_REL)
+    portal_text = portal_path.read_text(encoding="utf-8") if portal_path.is_file() else ""
+    source_theme, theme_order = _parse_portal_themes(portal_text)
+    pages_dir = wiki_root.joinpath(*cfg.dir_rel)
+    pages = _gather_pages(cfg, pages_dir, source_theme, theme_order) if pages_dir.is_dir() else []
+    return _build_page(cfg, pages, theme_order, existing_text)
+
+
+def _gather_count(pages_dir: Path) -> int:
+    """Count of pages (excluding the index.md the renderer owns)."""
+    if not pages_dir.is_dir():
+        return 0
+    return sum(1 for p in pages_dir.glob("*.md") if p.name != "index.md")
+
+
+def _prepare(cfg: TypeConfig, wiki_root_arg: str) -> "tuple[Optional[dict], Optional[str]]":
+    """Shared read+assemble for both subcommands. Returns `(payload, error)`
+    where payload carries `wiki_root`, `index_path`, `existing_text`,
+    `proposed`, `page_count`, `theme_count`. Never writes."""
+    wiki_root = Path(wiki_root_arg).resolve()
+    if not (wiki_root / "wiki").is_dir():
+        return None, f"wiki_root has no wiki/ dir: {wiki_root}"
+    index_path = wiki_root.joinpath(*cfg.index_rel)
+
+    existing_text = ""
+    if index_path.is_file():
+        try:
+            existing_text = index_path.read_text(encoding="utf-8")
+        except OSError as exc:
+            return None, f"{cfg.type_name} index not readable: {exc}"
+
+    pages_dir = wiki_root.joinpath(*cfg.dir_rel)
+    proposed = _assemble(cfg, wiki_root, existing_text)
+    theme_count = proposed.count("\n## ") + (1 if proposed.startswith("## ") else 0)
+    return {
+        "wiki_root": wiki_root,
+        "index_path": index_path,
+        "existing_text": existing_text,
+        "proposed": proposed,
+        "page_count": _gather_count(pages_dir),
+        "theme_count": theme_count,
+    }, None
+
+
+# --- public render / stage entry points (called by concepts_index.py too) -----
+
+
+def render_index(cfg: TypeConfig, wiki_root_arg: str, wiki_scripts_dir: str) -> int:
+    """`render` subcommand body for one type. Locked, atomic, idempotent,
+    no-clobber. Returns a shell exit code (and prints the envelope)."""
+    _wiki_lock, err = _import_wiki_lock(wiki_scripts_dir)
+    if err:
+        return _emit(False, error=err)
+    payload, err = _prepare(cfg, wiki_root_arg)
+    if err:
+        return _emit(False, error=err)
+    index_path = payload["index_path"]
+    existing_text = payload["existing_text"]
+    proposed = payload["proposed"]
+
+    if _is_human_page(cfg, existing_text):
+        return _emit(True, data={
+            "path": str(index_path),
+            "subcommand": "render",
+            "changed": False,
+            "skipped_human_page": True,
+        })
+
+    changed = False
+    try:
+        with _wiki_lock(payload["wiki_root"]):
+            # Re-read under the lock so a concurrent writer can't be clobbered.
+            current = ""
+            if index_path.is_file():
+                current = index_path.read_text(encoding="utf-8")
+            if _is_human_page(cfg, current):
+                return _emit(True, data={
+                    "path": str(index_path),
+                    "subcommand": "render",
+                    "changed": False,
+                    "skipped_human_page": True,
+                })
+            # Rebuild against the locked-read text so a lead-in authored between
+            # the unlocked _prepare read and now is still carried forward.
+            if current != existing_text:
+                proposed = _assemble(cfg, payload["wiki_root"], current)
+            changed = proposed != current
+            if changed:
+                index_path.parent.mkdir(parents=True, exist_ok=True)
+                atomic_write_text(index_path, proposed)
+    except OSError as exc:
+        return _emit(False, error=f"{cfg.type_name} index write failed: {exc}")
+
+    return _emit(True, data={
+        "path": str(index_path),
+        "subcommand": "render",
+        "changed": changed,
+        cfg.count_key: payload["page_count"],
+        "theme_count": payload["theme_count"],
+    })
+
+
+def stage_index(cfg: TypeConfig, wiki_root_arg: str) -> int:
+    """`stage` subcommand body for one type. Lock-free; never touches the live
+    page. Returns a shell exit code (and prints the envelope)."""
+    payload, err = _prepare(cfg, wiki_root_arg)
+    if err:
+        return _emit(False, error=err)
+    stage_path = payload["wiki_root"].joinpath(*cfg.stage_rel)
+    live = payload["existing_text"]
+    proposed = payload["proposed"]
+    would_change = (not _is_human_page(cfg, live)) and (proposed != live)
+    header = (
+        f"<!-- staged proposal for {cfg.index_display} — written by "
+        f"{cfg.writer_name} stage; NOT the live page -->\n"
+        f"<!-- status: {'would-update' if would_change else 'no-change'}; "
+        f"{cfg.count_label}={payload['page_count']}; themes={payload['theme_count']}; "
+        f"live-is-human-page={str(_is_human_page(cfg, live)).lower()} -->\n\n"
+    )
+    try:
+        stage_path.parent.mkdir(parents=True, exist_ok=True)
+        atomic_write_text(stage_path, header + proposed)
+    except OSError as exc:
+        return _emit(False, error=f"staged proposal write failed: {exc}")
+    return _emit(True, data={
+        "path": str(stage_path),
+        "subcommand": "stage",
+        "would_change": would_change,
+        cfg.count_key: payload["page_count"],
+        "theme_count": payload["theme_count"],
+    })
+
+
+# --- CLI ----------------------------------------------------------------------
+
+
+def _resolve_cfg(type_name: str) -> "tuple[Optional[TypeConfig], Optional[str]]":
+    cfg = REGISTRY.get(type_name)
+    if cfg is None:
+        known = ", ".join(sorted(REGISTRY))
+        return None, f"unknown --type {type_name!r}; known types: {known}"
+    return cfg, None
+
+
+def cmd_render(args) -> int:
+    cfg, err = _resolve_cfg(args.type)
+    if err:
+        return _emit(False, error=err)
+    return render_index(cfg, args.wiki_root, args.wiki_scripts_dir)
+
+
+def cmd_stage(args) -> int:
+    cfg, err = _resolve_cfg(args.type)
+    if err:
+        return _emit(False, error=err)
+    return stage_index(cfg, args.wiki_root)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Generic deterministic renderer for wiki/<type>/index.md "
+                    "(the per-type machine-owned sub-indexes).",
+    )
+    sub = parser.add_subparsers(dest="subcommand", required=True)
+
+    rn = sub.add_parser(
+        "render",
+        help="Write wiki/<type>/index.md live (locked, atomic, idempotent, "
+             "no-clobber).",
+    )
+    rn.add_argument("--type", required=True, choices=sorted(REGISTRY),
+                    help="The wiki page type to render an index for.")
+    rn.add_argument("--wiki-root", required=True)
+    rn.add_argument("--wiki-scripts-dir", required=True,
+                    help="cogni-wiki wiki-ingest/scripts dir (for _wiki_lock).")
+    rn.set_defaults(func=cmd_render)
+
+    st = sub.add_parser(
+        "stage",
+        help="Write the proposed page to "
+             "<wiki-root>/.cogni-wiki/<type>-index-proposed.md without the lock "
+             "and without touching the live page.",
+    )
+    st.add_argument("--type", required=True, choices=sorted(REGISTRY),
+                    help="The wiki page type to stage an index for.")
+    st.add_argument("--wiki-root", required=True)
+    st.set_defaults(func=cmd_stage)
+
+    return parser
+
+
+def main(argv: Optional["list[str]"] = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/cogni-knowledge/tests/test_sub_index.sh
+++ b/cogni-knowledge/tests/test_sub_index.sh
@@ -1,0 +1,296 @@
+#!/usr/bin/env bash
+# test_sub_index.sh — deterministic-renderer test for the generic sub_index.py.
+#
+# sub_index.py is the generalization of concepts_index.py: one shared renderer
+# that produces a curated, machine-owned per-type sub-index for ANY of the seven
+# cogni-knowledge wiki page types. concepts_index.py now delegates to it (its own
+# byte-stable contract is locked by test_concepts_index.sh). This test locks the
+# GENERALIZED contract: every type renders a `wiki/<type>/index.md` with the right
+# `MACHINE-OWNED:<TYPE>-INDEX` marker + `<TYPE>-LEADIN:<theme>` sentinels, groups
+# pages by their (per-type-derived) theme, and re-renders byte-idempotently.
+#
+# Asserts, parameterized across all 7 types (sources, questions, syntheses,
+# entities, summaries, learnings, concepts):
+#   1. render creates wiki/<type>/index.md; the envelope is well-formed and
+#      reports changed:true with the per-type page count.
+#   2. The page carries the `# <H1>` heading and the `MACHINE-OWNED:<TYPE>-INDEX`
+#      ownership marker.
+#   3. A page resolves to its theme via the type's theme strategy (backing
+#      `sources:` for distilled/synthesis, own-slug-in-portal for source,
+#      `theme_label:` frontmatter for question); a page with no resolvable theme
+#      lands under `## Uncategorized`.
+#   4. Each page renders its one-line summary + a `[[slug]]` wikilink; each theme
+#      lead-in lives in a `MACHINE-OWNED:<TYPE>-LEADIN:<slug>` placeholder span.
+#   5. BYTE-IDEMPOTENT: re-rendering an unchanged wiki reports changed:false and
+#      leaves the page byte-identical.
+#   6. stage writes <wiki-root>/.cogni-wiki/<type>-index-proposed.md without the
+#      lock and without touching the live page.
+# Plus, once (representative types):
+#   7. CARRY-FORWARD: a narrator-authored lead-in survives a re-render (sources).
+#   8. HUMAN-PAGE: an index.md with content but no ownership marker is skipped
+#      (questions).
+#   9. python3.9 floor: sub_index.py carries `from __future__ import annotations`
+#      and parses cleanly under ast.parse.
+#
+# bash 3.2 + stdlib python3 only. Posix only (render uses fcntl.flock via
+# cogni-wiki's _wiki_lock).
+
+set -eu
+
+PLUGIN_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT="$PLUGIN_ROOT/scripts/sub_index.py"
+SCRIPTS_DIR="$PLUGIN_ROOT/scripts"
+WSD="$PLUGIN_ROOT/../cogni-wiki/skills/wiki-ingest/scripts"
+
+. "$(dirname "$0")/fixtures/test_helpers.sh"
+
+if [ ! -f "$SCRIPT" ]; then
+  red "FAIL: sub_index.py not found at $SCRIPT"
+  exit 1
+fi
+if [ ! -d "$WSD" ]; then
+  red "FAIL: cogni-wiki wiki-ingest scripts not found at $WSD (needed for _wiki_lock)"
+  exit 1
+fi
+
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+errors=0
+
+field() { python3 -c 'import sys,json;d=json.load(sys.stdin);print(eval("d"+sys.argv[1]))' "$1"; }
+
+# Print the `## <theme>` heading the `[[slug]]` bullet renders under, or empty.
+bullet_section() {
+  python3 - "$1" "$2" <<'PY'
+import sys, re
+slug, path = sys.argv[1], sys.argv[2]
+cur = None
+for line in open(path, encoding="utf-8"):
+    m = re.match(r"^##\s+(.+?)\s*$", line)
+    if m:
+        cur = m.group(1)
+        continue
+    if re.match(r"^\s*-\s", line) and ("[[" + slug + "]]") in line:
+        print(cur or "")
+        break
+PY
+}
+
+# --- fixture wiki ------------------------------------------------------------
+WIKI="$WORK/wiki-root"
+mkdir -p "$WIKI/.cogni-wiki" \
+  "$WIKI/wiki/concepts" "$WIKI/wiki/entities" "$WIKI/wiki/summaries" \
+  "$WIKI/wiki/learnings" "$WIKI/wiki/sources" "$WIKI/wiki/questions" \
+  "$WIKI/wiki/syntheses"
+echo '{"schema_version":"0.0.8","entries_count":0}' > "$WIKI/.cogni-wiki/config.json"
+
+# Portal: Regulatory Scope owns the backing source src-scope-a (which is itself a
+# source page, so the `sources` type resolves its own slug here). src-loose is
+# under NO theme heading, so anything backed only by it lands in Uncategorized.
+cat > "$WIKI/wiki/index.md" <<'EOF'
+# Knowledge Portal
+
+## Regulatory Scope
+
+- [[src-scope-a]] — Scope source A
+
+## Enforcement
+
+- [[src-enf-a]] — Enforcement source A
+EOF
+
+# A distilled/synthesis page: block-style `sources:` of `wiki://<backing-slug>`
+# (theme_via_backing_sources). dir is the type name; type frontmatter varies.
+mk_backed() {
+  dir="$1"; slug="$2"; ptype="$3"; title="$4"; summary="$5"; backing="$6"
+  {
+    printf -- '---\n'
+    printf 'title: %s\n' "$title"
+    printf 'type: %s\n' "$ptype"
+    printf 'sources:\n'
+    printf -- '  - wiki://%s\n' "$backing"
+    printf -- '---\n'
+    printf '# %s\n' "$title"
+    printf -- '<!-- MACHINE-OWNED:SUMMARY:START -->\n'
+    printf '%s\n' "$summary"
+    printf -- '<!-- MACHINE-OWNED:SUMMARY:END -->\n'
+  } > "$WIKI/wiki/$dir/$slug.md"
+}
+
+# A source page: inline `sources: ["<URL>"]` + pre_extracted_claims
+# (theme_via_own_slug — the page's OWN slug is looked up in the portal).
+mk_source() {
+  slug="$1"; title="$2"; claim="$3"
+  {
+    printf -- '---\n'
+    printf 'title: %s\n' "$title"
+    printf 'type: source\n'
+    printf 'sources: ["https://example.org/%s"]\n' "$slug"
+    printf 'pre_extracted_claims:\n'
+    printf -- '  - id: clm-001\n'
+    printf '    text: %s\n' "$claim"
+    printf '    excerpt_quote: %s\n' "$claim"
+    printf '    excerpt_position: 1\n'
+    printf -- '---\n'
+    printf '# %s\nbody\n' "$title"
+  } > "$WIKI/wiki/sources/$slug.md"
+}
+
+# A question page: `theme_label:` frontmatter (theme_via_frontmatter).
+mk_question() {
+  slug="$1"; title="$2"; theme="$3"
+  {
+    printf -- '---\n'
+    printf 'title: %s\n' "$title"
+    printf 'type: question\n'
+    if [ -n "$theme" ]; then printf 'theme_label: %s\n' "$theme"; fi
+    printf -- '---\n'
+    printf '# %s\n' "$title"
+  } > "$WIKI/wiki/questions/$slug.md"
+}
+
+# Backing-source types: themed page backed by src-scope-a (Regulatory Scope),
+# loose page backed by src-loose (no theme heading -> Uncategorized).
+for t in concepts entities summaries learnings; do
+  mk_backed "$t" "$t-themed" "${t%s}" "${t} themed" "A themed ${t} page." src-scope-a
+  mk_backed "$t" "$t-loose"  "${t%s}" "${t} loose"  "A loose ${t} page."  src-loose
+done
+# syntheses: summary is the title (summary_fn=summary_title); still backing-sourced.
+mk_backed syntheses syntheses-themed synthesis "Syntheses themed" "ignored" src-scope-a
+mk_backed syntheses syntheses-loose  synthesis "Syntheses loose"  "ignored" src-loose
+
+# sources: src-scope-a is named in the portal (Regulatory Scope); src-loose is not.
+mk_source src-scope-a "Scope Source A" "The regime applies to all providers."
+mk_source src-loose   "Loose Source"   "An unfiled source with no theme."
+
+# questions: q-themed carries theme_label, q-loose carries none.
+mk_question q-themed "Who must comply?" "Regulatory Scope"
+mk_question q-loose  "An unthemed question?" ""
+
+# Per-type expected (type, themed_slug, loose_slug).
+# A bash-3.2-safe parallel-array loop (no associative arrays).
+TYPES="concepts entities summaries learnings syntheses sources questions"
+themed_for() { case "$1" in
+  sources) echo "src-scope-a" ;; questions) echo "q-themed" ;; *) echo "$1-themed" ;;
+esac; }
+loose_for() { case "$1" in
+  sources) echo "src-loose" ;; questions) echo "q-loose" ;; *) echo "$1-loose" ;;
+esac; }
+
+# --- 1-6. per-type render contract -------------------------------------------
+for T in $TYPES; do
+  U=$(echo "$T" | tr 'a-z' 'A-Z')
+  THEMED=$(themed_for "$T"); LOOSE=$(loose_for "$T")
+  IDX="$WIKI/wiki/$T/index.md"
+
+  OUT=$(python3 "$SCRIPT" render --type "$T" --wiki-root "$WIKI" --wiki-scripts-dir "$WSD")
+  if [ "$(echo "$OUT" | field '["success"]')" = "True" ] && [ -f "$IDX" ]; then
+    green "PASS[$T]: render creates wiki/$T/index.md"
+  else
+    red "FAIL[$T]: render did not create the index"; echo "$OUT"; errors=$((errors+1))
+  fi
+  [ "$(echo "$OUT" | field '["data"]["changed"]')" = "True" ] \
+    && green "PASS[$T]: first render reports changed:true" \
+    || { red "FAIL[$T]: first render changed != true"; errors=$((errors+1)); }
+
+  assert_grep "MACHINE-OWNED:$U-INDEX" "$IDX" "[$T] page ownership marker"
+  [ "$(bullet_section "$THEMED" "$IDX")" = "Regulatory Scope" ] \
+    && green "PASS[$T]: themed page -> Regulatory Scope" \
+    || { red "FAIL[$T]: $THEMED not under Regulatory Scope"; errors=$((errors+1)); }
+  [ "$(bullet_section "$LOOSE" "$IDX")" = "Uncategorized" ] \
+    && green "PASS[$T]: loose page -> Uncategorized fallback" \
+    || { red "FAIL[$T]: $LOOSE not under Uncategorized"; errors=$((errors+1)); }
+  assert_grep "\[\[$THEMED\]\]" "$IDX" "[$T] themed bullet has [[slug]] wikilink"
+  assert_grep "MACHINE-OWNED:$U-LEADIN:regulatory-scope:START" "$IDX" \
+    "[$T] Regulatory Scope lead-in sentinel span present"
+  assert_grep 'theme lead-in pending narration' "$IDX" \
+    "[$T] fresh render uses the lead-in placeholder"
+
+  # BYTE-IDEMPOTENT re-render
+  cp "$IDX" "$WORK/$T.before"
+  OUT=$(python3 "$SCRIPT" render --type "$T" --wiki-root "$WIKI" --wiki-scripts-dir "$WSD")
+  [ "$(echo "$OUT" | field '["data"]["changed"]')" = "False" ] \
+    && green "PASS[$T]: unchanged re-render reports changed:false" \
+    || { red "FAIL[$T]: idempotent re-render changed != false"; errors=$((errors+1)); }
+  if cmp -s "$WORK/$T.before" "$IDX"; then
+    green "PASS[$T]: re-render is byte-identical (no stamp churn)"
+  else
+    red "FAIL[$T]: re-render mutated the page"; errors=$((errors+1))
+  fi
+
+  # stage (lock-free) writes the proposal, never touches the live page.
+  SWIKI="$WORK/stage-$T"
+  mkdir -p "$SWIKI/wiki/$T" "$SWIKI/.cogni-wiki"
+  echo '{"schema_version":"0.0.8","entries_count":0}' > "$SWIKI/.cogni-wiki/config.json"
+  cp "$WIKI/wiki/index.md" "$SWIKI/wiki/index.md"
+  cp "$WIKI/wiki/$T/$THEMED.md" "$SWIKI/wiki/$T/$THEMED.md"
+  OUT=$(python3 "$SCRIPT" stage --type "$T" --wiki-root "$SWIKI")
+  STAGED="$SWIKI/.cogni-wiki/$T-index-proposed.md"
+  [ "$(echo "$OUT" | field '["success"]')" = "True" ] && [ -f "$STAGED" ] \
+    && green "PASS[$T]: stage writes the proposed page" \
+    || { red "FAIL[$T]: stage did not write the proposal"; echo "$OUT"; errors=$((errors+1)); }
+  [ ! -f "$SWIKI/wiki/$T/index.md" ] \
+    && green "PASS[$T]: stage does not touch the live page" \
+    || { red "FAIL[$T]: stage wrote the live page"; errors=$((errors+1)); }
+done
+
+# --- 7. CARRY-FORWARD (sources type) -----------------------------------------
+SIDX="$WIKI/wiki/sources/index.md"
+python3 - "$SIDX" "$SCRIPTS_DIR" <<'PY'
+import sys
+sys.path.insert(0, sys.argv[2])
+from _knowledge_lib import upsert_machine_block
+p = sys.argv[1]
+t = open(p, encoding="utf-8").read()
+t = upsert_machine_block(
+    t, "SOURCES-LEADIN:regulatory-scope",
+    "Authored framing: the primary sources establishing regulatory scope.")
+open(p, "w", encoding="utf-8").write(t)
+PY
+OUT=$(python3 "$SCRIPT" render --type sources --wiki-root "$WIKI" --wiki-scripts-dir "$WSD")
+assert_grep 'Authored framing: the primary sources' "$SIDX" \
+  "sources: authored lead-in carried forward across re-render (no clobber)"
+
+# --- 8. HUMAN-PAGE skip (questions type) -------------------------------------
+HWIKI="$WORK/human-wiki"
+mkdir -p "$HWIKI/wiki/questions" "$HWIKI/.cogni-wiki"
+echo '{"schema_version":"0.0.8","entries_count":0}' > "$HWIKI/.cogni-wiki/config.json"
+cp "$WIKI/wiki/index.md" "$HWIKI/wiki/index.md"
+cp "$WIKI/wiki/questions/q-themed.md" "$HWIKI/wiki/questions/q-themed.md"
+printf '# My hand-written question index\n\nNothing machine-owned here.\n' \
+  > "$HWIKI/wiki/questions/index.md"
+cp "$HWIKI/wiki/questions/index.md" "$WORK/human.before"
+OUT=$(python3 "$SCRIPT" render --type questions --wiki-root "$HWIKI" --wiki-scripts-dir "$WSD")
+[ "$(echo "$OUT" | field '["data"]["skipped_human_page"]')" = "True" ] \
+  && green "PASS: human-authored questions index skipped (skipped_human_page)" \
+  || { red "FAIL: human page not skipped"; echo "$OUT"; errors=$((errors+1)); }
+if cmp -s "$WORK/human.before" "$HWIKI/wiki/questions/index.md"; then
+  green "PASS: human page left byte-untouched"
+else
+  red "FAIL: human page was modified"; errors=$((errors+1))
+fi
+
+# --- 9. unknown type is a clean fail-soft error ------------------------------
+if python3 "$SCRIPT" stage --type bogus --wiki-root "$WIKI" >/dev/null 2>&1; then
+  red "FAIL: unknown --type did not error"; errors=$((errors+1))
+else
+  green "PASS: unknown --type rejected (argparse choices guard)"
+fi
+
+# --- 10. python3.9 floor -----------------------------------------------------
+assert_grep 'from __future__ import annotations' "$SCRIPT" \
+  "sub_index.py carries the py3.9 future-annotations import"
+if python3 -c "import ast,sys; ast.parse(open(sys.argv[1],encoding='utf-8').read())" "$SCRIPT"; then
+  green "PASS: sub_index.py parses cleanly (ast.parse)"
+else
+  red "FAIL: sub_index.py has a syntax error"; errors=$((errors+1))
+fi
+
+# --- summary -----------------------------------------------------------------
+if [ "$errors" -eq 0 ]; then
+  green "ALL PASS: test_sub_index.sh"
+  exit 0
+else
+  red "FAILED: $errors assertion(s) in test_sub_index.sh"
+  exit 1
+fi


### PR DESCRIPTION
Refs #592. Epic #596 phase 1 (curated wiki-output layout).

Generalizes the **shipped** deterministic `concepts_index.py` renderer into a shared `scripts/sub_index.py` that renders ANY `wiki/<type>/index.md` for the 7 page types (sources, questions, syntheses, entities, summaries, learnings, concepts). The 10 type-specific constants become a `TypeConfig`; the generic theme-grouping / lead-in carry-forward / render+stage / fail-soft `{success,data,error}` envelope / `_wiki_lock` machinery is reused as-is. `concepts_index.py` is reduced to a thin per-type delegate — its CLI entry point, subcommands, and envelope (`concept_count`) stay **byte-stable**, so `tests/test_concepts_index.sh` passes unchanged.

## What changed
- **New `scripts/sub_index.py`** — the generic renderer. Per-type variation is two callables on a `TypeConfig`:
  - `theme_fn`: `theme_via_backing_sources` (concept/entity/summary/learning/synthesis — majority theme over the page's `sources:` wiki:// slugs), `theme_via_own_slug` (source — the page's own slug sits under its portal theme heading), `theme_via_frontmatter` (question — the authoritative `theme_label:` field, no portal round-trip).
  - `summary_fn`: SUMMARY-block/distilled-claim (distilled), first pre-extracted claim (source), title (question/synthesis).
  - Per-type `MACHINE-OWNED:<TYPE>-INDEX` page marker + `<TYPE>-LEADIN:<theme>` sentinels mirroring `CONCEPTS-LEADIN`. A `render`/`stage` CLI with `--type`.
- **`scripts/concepts_index.py`** now delegates to `sub_index.py` with the concepts config; CLI/subcommands/constants byte-stable.
- **New `tests/test_sub_index.sh`** — per-type render assertion for all 7 types (correct marker, all 3 theme strategies, lead-in placeholder, `[[slug]]` bullet) + byte-identical no-op re-render (`changed:false` + `cmp -s`), plus carry-forward (sources), human-page skip (questions), unknown-type guard, py3.9 floor.
- Version bump `0.1.115 → 0.1.116` (plugin.json + root marketplace.json).

## Scope (partial)
INCLUDED: the shared renderer + delegation + per-type render capability proven by test. This is the CORE generalization — the rendering capability for all 7 types now exists and is test-covered.

DEFERRED (filed as epic #596 DoD follow-ups, added to the epic's `## Tracks`): the 6 per-type pipeline call-site wirings, each a separable single-SKILL concern. Bundling all six SKILL.md edits would exceed a reviewable PR and risk the byte-stable `test_concepts_index.sh` invariant the core must preserve. The concepts wiring already exists (knowledge-finalize sub-step 3.6).

## Test plan
- `bash cogni-knowledge/tests/test_concepts_index.sh` — passes UNCHANGED (byte-stable delegation; 24 assertions).
- `bash cogni-knowledge/tests/test_sub_index.sh` — passes (all 7 types render + byte-identical no-op re-render).
- `bash cogni-knowledge/tests/test_backfill_concepts_index.sh` — passes (subprocess CLI unchanged).
- `plugin.json` + `marketplace.json` versions match (0.1.116).

## Follow-up issues (deferred per-type wiring, in epic #596 DoD)
- #617 — Wire `sources/index.md` render into knowledge-ingest
- #618 — Wire `questions/index.md` render into knowledge-ingest Step 4.5
- #619 — Wire `entities`/`summaries`/`learnings` index.md render into knowledge-distill
- #620 — Wire `syntheses/index.md` render into knowledge-finalize 3.7

🤖 Generated with [Claude Code](https://claude.com/claude-code)
