### PR TITLE
cogni-knowledge: knowledge-refresh-synthesis --all batch refresh mode

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -326,7 +326,7 @@
     {
       "name": "cogni-knowledge",
       "source": "./cogni-knowledge",
-      "version": "0.1.127",
+      "version": "0.1.128",
       "maturity": "preview",
       "description": "Wiki-first research that compounds. Binds each run to a cogni-wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`. The shallow `knowledge-query` rung is read-only by default and can optionally file its answer back as an un-verified synthesis page via `--file-back`.",
       "keywords": [

--- a/cogni-knowledge/.claude-plugin/plugin.json
+++ b/cogni-knowledge/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-knowledge",
-  "version": "0.1.127",
+  "version": "0.1.128",
   "description": "Wiki-first research that compounds. Binds each run to a cogni-wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`. The shallow `knowledge-query` rung is read-only by default and can optionally file its answer back as an un-verified synthesis page via `--file-back`.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-knowledge/skills/knowledge-refresh-synthesis/SKILL.md
+++ b/cogni-knowledge/skills/knowledge-refresh-synthesis/SKILL.md
@@ -92,15 +92,17 @@ skill, so the pre-flight is just binding resolution.
    abort with: "pass either `--synthesis-slug <slug>` (refresh one) or `--all` (refresh every
    open candidate), not both". Then branch:
    - **`--all` set** → skip Step 1's `AskUserQuestion` and run **[Batch mode (`--all`)](#batch-mode---all)**
-     below, which loops Steps 1–6 over every entry in the `CANDIDATES` snapshot.
+     below, which loops the per-candidate flow (Step 1 selection non-interactive, then Steps 2–6)
+     over every entry in the `CANDIDATES` snapshot.
    - **otherwise** (default / `--synthesis-slug`) → run the single-candidate flow, Steps 1–7,
      unchanged.
 
 ### Batch mode (`--all`)
 
-Refresh every open candidate in one run. This **reuses Steps 1–6 verbatim as the per-candidate
-loop body** — it adds no new refresh logic, only iteration + fail-soft accounting + an aggregate
-summary. Single-candidate mode (default / `--synthesis-slug`) is unaffected.
+Refresh every open candidate in one run. This **reuses Steps 2–6 verbatim as the per-candidate
+loop body** (Step 1's candidate selection is made non-interactively from the snapshot) — it adds
+no new refresh logic, only iteration + fail-soft accounting + an aggregate summary.
+Single-candidate mode (default / `--synthesis-slug`) is unaffected.
 
 Initialise `RESULTS = []`. For each `candidate` in the `CANDIDATES` snapshot (Step 0.4), in
 order:
@@ -249,9 +251,11 @@ union is on disk, so re-running this skill resumes from a clean, already-unioned
 
 | Synthesis | Sources unioned | Verify (vb/par/uns/syn) | Status |
 |---|---|---|---|
-| `<synthesis_slug>` | `<K>` | `<verbatim>/<paraphrase>/<unsupported>/<synthesis>` | ✅ ok |
-| `<synthesis_slug>` | — | — | ❌ failed — `<failed_phase>: <error>` |
+| `<synthesis_slug>` | `<K>` | `<verbatim>/<paraphrase>/<unsupported>/<synthesis>` | ok |
+| `<synthesis_slug>` | — | — | failed — `<failed_phase>: <error>` |
 | … | | | |
+
+`vb/par/uns/syn` = verbatim/paraphrase/unsupported/synthesis counts; `Status` ∈ `ok` | `failed` (matching the `RESULTS` row enum); a failed row shows `—` for the verify column it never reached.
 
 - Batch tally: `<ok_count>` refreshed, `<failed_count>` failed, of `<len(CANDIDATES)>` open candidate(s).
 - Each `✅ ok` candidate's `refresh_candidates[]` entry was cleared by its `knowledge-finalize`

--- a/cogni-knowledge/skills/knowledge-refresh-synthesis/SKILL.md
+++ b/cogni-knowledge/skills/knowledge-refresh-synthesis/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: knowledge-refresh-synthesis
-description: "This skill refreshes one existing synthesis in a bound cogni-knowledge base from a newly-landed source — union-not-rederive. Given a synthesis flagged in binding.json::refresh_candidates[] (populated by synthesis-impact.py at ingest-source time), it unions the new source into that synthesis's existing project ingest-manifest rather than re-deriving the manifest via wiki-grounding (which under-maps and thins the synthesis), then runs knowledge-compose -> knowledge-verify -> knowledge-finalize --overwrite as one orchestrated flow. A pure orchestrator over existing phase skills. Use this skill whenever the user says 'refresh this synthesis from the new source', 'update the <topic> synthesis with the source I just ingested', 'extend an existing synthesis instead of re-running it', 'a new source supersedes my synthesis — fold it in', or 'resolve a refresh candidate without thinning the synthesis'."
+description: "This skill refreshes one existing synthesis in a bound cogni-knowledge base from a newly-landed source — union-not-rederive. Given a synthesis flagged in binding.json::refresh_candidates[] (populated by synthesis-impact.py at ingest-source time), it unions the new source into that synthesis's existing project ingest-manifest rather than re-deriving the manifest via wiki-grounding (which under-maps and thins the synthesis), then runs knowledge-compose -> knowledge-verify -> knowledge-finalize --overwrite as one orchestrated flow. A pure orchestrator over existing phase skills. Pass --all to refresh every open refresh candidate in one fail-soft batch run instead of one synthesis per invocation. Use this skill whenever the user says 'refresh this synthesis from the new source', 'update the <topic> synthesis with the source I just ingested', 'extend an existing synthesis instead of re-running it', 'a new source supersedes my synthesis — fold it in', 'resolve a refresh candidate without thinning the synthesis', or 'refresh all my open refresh candidates in one run'."
 allowed-tools: Read, Bash, Glob, AskUserQuestion, Skill
 ---
 
@@ -47,7 +47,8 @@ remember the delegation boundary and the `Skill(...)`-dispatch convention.
 | Parameter | Required | Description |
 |-----------|----------|-------------|
 | `--knowledge-slug` | Yes | Slug of the bound knowledge base. Resolves to `cogni-knowledge/<slug>/` unless `--knowledge-root` overrides. |
-| `--synthesis-slug <slug>` | No | The synthesis to refresh. When omitted, the open `refresh_candidates[]` are surfaced via `AskUserQuestion` and the user picks one. When set, it must match an `open` candidate. |
+| `--synthesis-slug <slug>` | No | The synthesis to refresh. When omitted (and `--all` is not set), the open `refresh_candidates[]` are surfaced via `AskUserQuestion` and the user picks one. When set, it must match an `open` candidate. **Mutually exclusive with `--all`.** |
+| `--all` | No | Batch mode: refresh **every** `open` candidate in the Step 0 snapshot in one orchestrated, fail-soft run (skips the Step 1 `AskUserQuestion`). **Mutually exclusive with `--synthesis-slug`** — passing both is an error. |
 | `--knowledge-root` | No | Override the default knowledge-base directory. |
 
 ## Workflow
@@ -81,6 +82,46 @@ skill, so the pre-flight is just binding resolution.
    `detected_at`, `status`. If `CANDIDATES` is empty, print
    "no open refresh candidates — nothing to refresh (try `knowledge-refresh --mode push` for time-based staleness)"
    and exit 0.
+
+   `CANDIDATES` is the **batch-mode iteration snapshot** — capture it once here and never
+   re-read it mid-loop. `knowledge-finalize` clears each `refresh_candidates[]` entry as that
+   synthesis lands (Step 6), so re-reading the shrinking binding between candidates would skip
+   the not-yet-processed ones.
+
+5. **Mode dispatch.** `--all` and `--synthesis-slug` are mutually exclusive — if both are set,
+   abort with: "pass either `--synthesis-slug <slug>` (refresh one) or `--all` (refresh every
+   open candidate), not both". Then branch:
+   - **`--all` set** → skip Step 1's `AskUserQuestion` and run **[Batch mode (`--all`)](#batch-mode---all)**
+     below, which loops Steps 1–6 over every entry in the `CANDIDATES` snapshot.
+   - **otherwise** (default / `--synthesis-slug`) → run the single-candidate flow, Steps 1–7,
+     unchanged.
+
+### Batch mode (`--all`)
+
+Refresh every open candidate in one run. This **reuses Steps 1–6 verbatim as the per-candidate
+loop body** — it adds no new refresh logic, only iteration + fail-soft accounting + an aggregate
+summary. Single-candidate mode (default / `--synthesis-slug`) is unaffected.
+
+Initialise `RESULTS = []`. For each `candidate` in the `CANDIDATES` snapshot (Step 0.4), in
+order:
+
+1. Set `SYNTHESIS_SLUG = candidate.synthesis_slug` and `NEW_SOURCE_SLUGS =
+   candidate.triggered_by_source` (this is Step 1's selection, made non-interactively from the
+   snapshot — no `AskUserQuestion`).
+2. Run **Steps 2 → 3 → 4 → 5 → 6** exactly as written for that candidate.
+3. **Fail-soft:** if any step aborts for this candidate — a missing/stale synthesis page or
+   project scaffold (Step 2), a `K == 0`-and-still-failing union, or a `compose`/`verify`/
+   `finalize` failure (Steps 4–6) — **record the failure and continue to the next candidate;
+   never abort the whole batch.** Append a row
+   `{synthesis_slug, sources_unioned: <K>, verify: "<verbatim>/<paraphrase>/<unsupported>/<synthesis>" or "—", status: "ok" | "failed", note: <failed_phase>:<error> when failed}`
+   to `RESULTS`. A successful candidate appends the same row shape with `status: "ok"` and its
+   verify counts.
+4. Do **not** clear the candidate yourself — Step 6's `knowledge-finalize` already clears each
+   `refresh_candidates[]` entry as it lands (single-candidate Step 6 note), and that is just as
+   true inside the loop.
+
+When the loop finishes, emit the **batch summary** (Step 7's batch variant) and stop — do not
+fall through to the single-synthesis Step 7.
 
 ### 1. Identify the candidate
 
@@ -191,15 +232,30 @@ On failure, capture `{failed_phase: "finalize", error}`, report, and stop.
 
 ### 7. Summary
 
-≤ 8 lines:
+**Single-candidate mode** (default / `--synthesis-slug`) — ≤ 8 lines:
 
 - Refreshed synthesis: `<SYNTHESIS_SLUG>` (project `<derived_from_research>`)
 - New source(s) unioned in: `<NEW_SOURCE_SLUGS>` (or "none new — re-composed against existing manifest")
 - Evidence base: `<N>` sources (was `<N-K>`)
 - Verify verdict: `<verbatim>/<paraphrase>/<unsupported>/<synthesis>`
-- The `refresh_candidates[]` entry was cleared by finalize (Step 9)
+- The `refresh_candidates[]` entry was cleared by finalize (Step 6)
 - Suggested next: `/cogni-knowledge:knowledge-resume` to confirm the deposit, or
   `/cogni-knowledge:knowledge-dashboard` to re-render the overlay
 
 If any phase failed, report `<failed_phase>: <error>` instead and note that the manifest
 union is on disk, so re-running this skill resumes from a clean, already-unioned state.
+
+**Batch mode (`--all`)** — one per-synthesis summary table over `RESULTS`, then a tally line:
+
+| Synthesis | Sources unioned | Verify (vb/par/uns/syn) | Status |
+|---|---|---|---|
+| `<synthesis_slug>` | `<K>` | `<verbatim>/<paraphrase>/<unsupported>/<synthesis>` | ✅ ok |
+| `<synthesis_slug>` | — | — | ❌ failed — `<failed_phase>: <error>` |
+| … | | | |
+
+- Batch tally: `<ok_count>` refreshed, `<failed_count>` failed, of `<len(CANDIDATES)>` open candidate(s).
+- Each `✅ ok` candidate's `refresh_candidates[]` entry was cleared by its `knowledge-finalize`
+  (Step 6); each `❌ failed` candidate's entry remains `open`, so re-running `--all` (or the
+  single-candidate path on that slug) resumes it from its on-disk, already-unioned manifest.
+- Suggested next: `/cogni-knowledge:knowledge-resume` to confirm the deposits, or
+  `/cogni-knowledge:knowledge-dashboard` to re-render the overlay.


### PR DESCRIPTION
Closes #633.

## Summary
- Add a `--all` flag to `knowledge-refresh-synthesis` that loops the existing per-candidate refresh flow (Steps 1–6: union manifest → compose → verify → finalize) over **every** open `binding.json::refresh_candidates[]` entry in one orchestrated run, instead of one synthesis per invocation.
- Iterate the snapshot of open candidates captured once at Step 0 — `knowledge-finalize` clears each entry as it lands, so re-reading the shrinking binding mid-loop would skip not-yet-processed candidates.
- Fail-soft per candidate: one candidate's compose/verify/finalize failure or missing project scaffold records a failed row and continues; it never aborts the remaining candidates.
- Per-synthesis batch summary table at the end (one row per candidate: synthesis slug, sources unioned, verify verdict, pass/fail) + a tally line, replacing the single-synthesis Step 7 summary in batch mode.
- `--all` and `--synthesis-slug` are mutually exclusive (explicit abort if both given); `--all` skips the Step 1 `AskUserQuestion`. Default and `--synthesis-slug` single-candidate behavior is unchanged.
- Add a discoverability clause to the skill description; bump plugin.json 0.1.127 → 0.1.128, mirrored in marketplace.json.
- Drive-by: corrected a pre-existing stale `(Step 9)` cross-reference in the single-candidate summary to `(Step 6)` (finalize is this skill's Step 6).

## Scope
- **In:** the `--all` batch loop + summary table, mutual-exclusion guard, description clause, version bump. Full acceptance criterion of #633 (deferred from #631).
- **Out:** nothing deferred — no new scripts or agents; the loop reuses the same `knowledge-compose`/`knowledge-verify`/`knowledge-finalize` `Skill(...)` calls the single-candidate path already uses.

## Test plan
- [ ] `--all` on a base with ≥2 open candidates refreshes every one in a single run + prints the per-synthesis summary table.
- [ ] Fail-soft: a missing project scaffold / failing compose on one candidate reports a failed row and the rest still refresh.
- [ ] Iteration set is the Step-0 snapshot (finalize clears each as it lands; loop still processes the captured set).
- [ ] `--all` + `--synthesis-slug` together errors with the mutual-exclusion message.
- [ ] Default / `--synthesis-slug`-only single-candidate behavior is byte-unchanged.
- [ ] Empty open candidates still prints the no-open-candidates message and exits 0.
- [ ] plugin.json is 0.1.128 and marketplace.json mirrors it.
