### PR TITLE
cogni-consulting: integrate 0-scope into the setup and resume flow

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -284,7 +284,7 @@
     {
       "name": "cogni-consulting",
       "source": "./cogni-consulting",
-      "version": "0.0.16",
+      "version": "0.0.17",
       "maturity": "incubating",
       "description": "Double Diamond consulting orchestrator. Runs structured engagements through five gated, number-prefixed phases (0-Scope, 1-Discover, 2-Define, 3-Develop, 4-Deliver) coordinating six insight-wave plugins under a Diamond Coach. Includes SMART Key Question scoping, Lean Canvas authoring, and lightweight how-might-we engagements for bounded challenges.",
       "keywords": [

--- a/cogni-consulting/.claude-plugin/plugin.json
+++ b/cogni-consulting/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-consulting",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "description": "Double Diamond consulting orchestrator. Runs structured engagements through five gated, number-prefixed phases (0-Scope, 1-Discover, 2-Define, 3-Develop, 4-Deliver) coordinating six insight-wave plugins under a Diamond Coach. Includes SMART Key Question scoping, Lean Canvas authoring, and lightweight how-might-we engagements for bounded challenges.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-consulting/skills/consulting-resume/SKILL.md
+++ b/cogni-consulting/skills/consulting-resume/SKILL.md
@@ -96,9 +96,12 @@ Present the recommended next action from the status output:
 
 > **Recommended next step**: Continue the Define phase — 4 assumptions still unverified. Run `consulting-define` to complete assumption verification and synthesize the problem statement.
 
-Offer to proceed with the recommendation immediately.
+Offer to proceed with the recommendation immediately. The recommended skill is one of `consulting-scope` (0-Scope), `consulting-discover` (1-Discover), `consulting-define` (2-Define), `consulting-develop` (3-Develop), or `consulting-deliver` (4-Deliver).
 
-If all phases are complete, congratulate the consultant and suggest `consulting-export` for the final deliverable package. When the status output recommends `consulting-scope` (a fresh engagement whose `0-scope` phase is still pending), give one line of context ("Scope is still unframed — let's anchor the Key Question before Discover"), then dispatch `Skill("cogni-consulting:consulting-scope")` — don't just name it. The engagement state and Diamond Coach persona are already loaded, so skip scope's redundant re-reads.
+Two special cases:
+
+- **All phases complete** — congratulate the consultant and suggest `consulting-export` for the final deliverable package.
+- **`0-scope` still pending** (fresh engagement; the status output recommends `consulting-scope`) — this is the one exception to the offer-first rule: don't pause at an offer. Give one line of context ("Scope is still unframed — let's anchor the Key Question before Discover"), then dispatch `Skill("cogni-consulting:consulting-scope")` directly. Skip re-reading only what is already loaded (`references/diamond-coach.md` and the engagement state); still read scope's `references/methods/key-question-scoping.md` method file and run its `update-phase.sh` state transition.
 
 ### 6. Support Phase Re-entry (Iteration)
 

--- a/cogni-consulting/skills/consulting-resume/SKILL.md
+++ b/cogni-consulting/skills/consulting-resume/SKILL.md
@@ -98,7 +98,7 @@ Present the recommended next action from the status output:
 
 Offer to proceed with the recommendation immediately.
 
-If all phases are complete, congratulate the consultant and suggest `consulting-export` for the final deliverable package. A fresh engagement whose `0-scope` phase is still pending routes to `consulting-scope` — the Key Question scoping that anchors every downstream phase.
+If all phases are complete, congratulate the consultant and suggest `consulting-export` for the final deliverable package. When the status output recommends `consulting-scope` (a fresh engagement whose `0-scope` phase is still pending), give one line of context ("Scope is still unframed — let's anchor the Key Question before Discover"), then dispatch `Skill("cogni-consulting:consulting-scope")` — don't just name it. The engagement state and Diamond Coach persona are already loaded, so skip scope's redundant re-reads.
 
 ### 6. Support Phase Re-entry (Iteration)
 

--- a/cogni-consulting/skills/consulting-setup/SKILL.md
+++ b/cogni-consulting/skills/consulting-setup/SKILL.md
@@ -223,7 +223,7 @@ Based on this assessment, offer an appropriate engagement shape:
 
 Present the assessment and recommended shape to the consultant. They may override — a consultant who knows the domain deeply might want lightweight even for a complex HMW, while a less experienced consultant might want full phases for a simple one.
 
-**For all other engagements**: If the user seems eager to dive in, transition directly to the `consulting-scope` skill — the 0-scope phase frames the SMART Key Question and the five scoping dimensions before divergent Discover work begins. If they seem uncertain, end with a clear next-step pointer — they can start any time with `consulting-scope` or check status with `consulting-resume`. Read the room rather than always asking.
+**For all other engagements**: If the user seems eager to dive in, dispatch `Skill("cogni-consulting:consulting-scope")` in this same session — the SMART Key Question and the five scoping dimensions frame the engagement before divergent Discover work begins. The Diamond Coach persona and the freshly written `consulting-project.json` are already in context, so satisfy scope's prerequisite gate and context-load from memory rather than re-reading. If they seem uncertain, offer scoping now and dispatch on confirmation. Only if they explicitly want to stop here, end with a clear next-step pointer — they can resume any time with `consulting-scope` or check status with `consulting-resume`. Skipping 0-scope is the consultant's explicit choice, never the default.
 
 ## Example
 

--- a/cogni-consulting/skills/consulting-setup/SKILL.md
+++ b/cogni-consulting/skills/consulting-setup/SKILL.md
@@ -7,7 +7,7 @@ description: |
   "I have a new client", "kick off a strategy engagement", "set up a consulting project",
   "let's work on [client topic]", "I need to frame a problem", "new diamond project",
   "vision framing", "double diamond", "set up the engagement", "begin a new analysis",
-  "scope a new piece of work", "new consulting project", or any mention of starting structured
+  "new consulting project", or any mention of starting structured
   problem-to-solution work for a client. Also trigger when the user describes a client situation
   that implies a new engagement is needed (e.g., "Telekom wants us to look at their cloud strategy").
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep, Skill, TaskCreate, TaskUpdate
@@ -183,26 +183,29 @@ Read `$CLAUDE_PLUGIN_ROOT/references/vision-classes.md` for the selected vision 
 
 > **Your Diamond engagement plan:**
 >
-> **Discover** (diverge) — Build understanding of the problem landscape
+> **0-Scope** (frame) — Anchor the engagement before divergent work
+> - SMART Key Question + five scoping dimensions via consulting-scope
+>
+> **1-Discover** (diverge) — Build understanding of the problem landscape
 > - Desk research via cogni-knowledge
 > - Industry trend scan via cogni-trends
 > - Competitive baseline via cogni-portfolio
 >
-> **Define** (converge) — Frame the core challenge
+> **2-Define** (converge) — Frame the core challenge
 > - Assumption verification via cogni-claims
 > - Affinity clustering + HMW synthesis (guided)
 >
-> **Develop** (diverge) — Generate and explore options
+> **3-Develop** (diverge) — Generate and explore options
 > - Value modeling via cogni-trends
 > - Proposition framing via cogni-portfolio
 > - Scenario planning (guided)
 >
-> **Deliver** (converge) — Validate and package outcomes
+> **4-Deliver** (converge) — Validate and package outcomes
 > - Final claims verification
 > - Business case modeling (guided)
 > - Deliverable generation via consulting-export
 >
-> This is a starting framework — methods adapt as understanding deepens. Ready to begin Discover?
+> This is a starting framework — methods adapt as understanding deepens. Ready to anchor the scope?
 
 ### 7. Transition to Next Phase
 
@@ -221,9 +224,9 @@ Based on this assessment, offer an appropriate engagement shape:
 - **Medium HMW** (mixed — e.g., process redesign, training program, offsite planning): Use the standard 4 phases but keep them lightweight. Recommend cogni-knowledge for a focused desk research sprint in Discover to ground the design in evidence.
 - **Heavy HMW** (multiple dimensions high — e.g., new product, market strategy, organizational change): Use the full 4-phase diamond with cogni-knowledge recommended in Discover and potentially cogni-portfolio for competitive context. This is close to a standard vision class engagement but with the HMW framing.
 
-Present the assessment and recommended shape to the consultant. They may override — a consultant who knows the domain deeply might want lightweight even for a complex HMW, while a less experienced consultant might want full phases for a simple one.
+Present the assessment and recommended shape to the consultant. They may override — a consultant who knows the domain deeply might want lightweight even for a complex HMW, while a less experienced consultant might want full phases for a simple one. Then continue into scoping with the same dispatch protocol below — HMW engagements start at 0-scope like every other engagement, and for lightweight HMW `consulting-scope` runs in compressed form (the HMW question often *is* the Key Question, so the phase reduces to confirming it plus scope and success factors).
 
-**For all other engagements**: If the user seems eager to dive in, dispatch `Skill("cogni-consulting:consulting-scope")` in this same session — the SMART Key Question and the five scoping dimensions frame the engagement before divergent Discover work begins. The Diamond Coach persona and the freshly written `consulting-project.json` are already in context, so satisfy scope's prerequisite gate and context-load from memory rather than re-reading. If they seem uncertain, offer scoping now and dispatch on confirmation. Only if they explicitly want to stop here, end with a clear next-step pointer — they can resume any time with `consulting-scope` or check status with `consulting-resume`. Skipping 0-scope is the consultant's explicit choice, never the default.
+**Dispatch protocol (all engagements)**: If the user seems eager to dive in, dispatch `Skill("cogni-consulting:consulting-scope")` in this same session — the SMART Key Question and the five scoping dimensions frame the engagement before divergent Discover work begins. Skip re-reading only what is already in context (`references/diamond-coach.md` and the freshly written `consulting-project.json`); still run scope's `update-phase.sh` state transition and read its `references/methods/key-question-scoping.md` method file. If they seem uncertain, offer scoping now and dispatch on confirmation. Only if they explicitly want to stop here, end with a clear next-step pointer — they can resume any time with `consulting-scope` or check status with `consulting-resume`. Skipping 0-scope is the consultant's explicit choice, never the default.
 
 ## Example
 


### PR DESCRIPTION
Closes #650.

## Summary
- `consulting-setup` now actively dispatches into `consulting-scope` via the Skill tool as the natural next move after scaffolding, instead of only suggesting the consultant run it next.
- `consulting-resume` now drives the consultant into scoping by dispatching `consulting-scope` when the status output recommends it (`0-scope` still `pending`), rather than just pointing at the skill in its Recommend-Next-Action block.
- Bumps `cogni-consulting` to v0.0.17 in both `plugin.json` and `marketplace.json`.

## Scope decisions
- In scope: the two pointer→dispatch conversions (setup-side eager-transition at the close of Step 7, and resume-side pending-0-scope routing) plus the mandatory dual version bump. The Skill tool was already in both skills' `allowed-tools`, and `consulting-scope`'s sole prerequisite (a scaffolded `consulting-project.json`) is satisfied at both call sites, so no entry-contract change is needed.
- Read-the-room behavior is preserved: setup still respects an uncertain consultant (offer, dispatch on confirmation) and an explicit stop (next-step pointer); the change is that the default path now actually crosses the boundary. "Skipping 0-scope is the consultant's explicit choice, never the default."
- A pre-commit simplify pass folded in reviewer findings: deduplicated the rule statements, anchored resume's condition on the `engagement-status.sh` recommendation (the existing routing source of truth), and added skip-redundant-re-reads guidance since the inline dispatch makes scope's context-load steps redundant.
- Out of scope (noted by the altitude reviewer, deliberately advisory): `consulting-discover`'s soft-gate "recommend running consulting-scope first" remains name-only — that gate is intentionally non-blocking for legacy engagements.
- Deferred: nothing.

## Test plan
- [ ] Run `consulting-setup` for a fresh engagement and confirm it dispatches `consulting-scope` inline (eager path) or offers-then-dispatches (uncertain path) rather than dead-ending after scaffolding.
- [ ] Run `consulting-resume` on an engagement whose `0-scope` phase is `pending` and confirm it dispatches `consulting-scope` rather than only recommending it.
- [ ] Confirm `consulting-scope`'s prerequisite gate still passes when entered this way (consulting-project.json present, same session).
- [x] Breadcrumb guard: 0 new violations (`scripts/check-breadcrumbs.py`).
- [x] Skill-name check passes; both `plugin.json` and `marketplace.json` show `0.0.17`.

Plan record: https://github.com/cogni-work/insight-wave/issues/650#issuecomment-4673855260

🤖 Generated with [Claude Code](https://claude.com/claude-code)
