### PR TITLE
cogni-consult: consult-setup engagement entry-point skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -349,7 +349,7 @@
     {
       "name": "cogni-consult",
       "source": "./cogni-consult",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "maturity": "incubating",
       "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work, and cogni-knowledge is the central research tool across all skills.",
       "keywords": [

--- a/cogni-consult/.claude-plugin/plugin.json
+++ b/cogni-consult/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-consult",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work, and cogni-knowledge is the central research tool across all skills.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-consult/CLAUDE.md
+++ b/cogni-consult/CLAUDE.md
@@ -15,8 +15,12 @@ cogni-consult/
 │   └── data-model.md              Engagement structure + entity schemas
 ├── scripts/
 │   ├── engagement-init.sh         Create engagement directory skeleton
-│   └── engagement-status.sh       Read consult-project.json state → JSON
-└── skills/                        (added by later work: consult-setup, consult-scope,
+│   ├── engagement-status.sh       Read consult-project.json state → JSON
+│   ├── discover-projects.sh       Thin wrapper over the cogni-workspace discovery helper
+│   └── _discover_extractor.py     Per-engagement field extractor for the wrapper
+└── skills/
+    └── consult-setup/SKILL.md     Engagement entry point: scaffold + knowledge-base bind
+                                   + registry (later work: consult-scope,
                                     consult-action-fields, consult-design-thinking,
                                     consult-personas, consult-resume)
 ```
@@ -47,6 +51,8 @@ Full schemas: `references/data-model.md`.
 |--------|---------|
 | `engagement-init.sh` | Create the engagement directory skeleton + consult-project.json |
 | `engagement-status.sh` | Read consult-project.json + derive field/deliverable rollups from `field.json` files → JSON |
+| `discover-projects.sh` | Thin wrapper delegating to `cogni-workspace/scripts/discover-plugin-projects.sh` (registry: `$HOME/.claude/cogni-consult-projects.json`) |
+| `_discover_extractor.py` | Per-engagement JSON field extractor consumed by the discovery wrapper (reads the flat consult-project.json schema) |
 
 All scripts use JSON output: `{"success": bool, "data": {...}, "error": "string"}`.
 All scripts are stdlib-only (bash + python3, no pip dependencies).

--- a/cogni-consult/scripts/_discover_extractor.py
+++ b/cogni-consult/scripts/_discover_extractor.py
@@ -20,7 +20,8 @@ def extract(d: str) -> dict:
     pf = os.path.join(d, "consult-project.json")
     if os.path.exists(pf):
         try:
-            data = json.load(open(pf))
+            with open(pf) as f:
+                data = json.load(f)
             project["slug"] = data.get("slug", project["slug"])
             project["name"] = data.get("name", "")
             project["language"] = data.get("language", "en")

--- a/cogni-consult/scripts/_discover_extractor.py
+++ b/cogni-consult/scripts/_discover_extractor.py
@@ -1,0 +1,37 @@
+"""Per-engagement field extractor for cogni-consult discover-projects.sh.
+
+Loaded by cogni-workspace/scripts/discover-plugin-projects.sh. Must define
+``extract(project_dir: str) -> dict`` returning the per-engagement JSON envelope.
+
+cogni-consult's consult-project.json is FLAT (slug/name/language/key_question/
+workflow_state/plugin_refs/updated at top level) — unlike cogni-consulting's
+nested engagement{}/phases{} schema. There are no phases here: the engagement's
+shape is its action fields, so the envelope carries the scope state and the
+ordered action-field list instead of a phase map.
+"""
+
+import json
+import os
+
+
+def extract(d: str) -> dict:
+    project = {"path": d, "slug": os.path.basename(d)}
+
+    pf = os.path.join(d, "consult-project.json")
+    if os.path.exists(pf):
+        try:
+            data = json.load(open(pf))
+            project["slug"] = data.get("slug", project["slug"])
+            project["name"] = data.get("name", "")
+            project["language"] = data.get("language", "en")
+            project["key_question"] = data.get("key_question", "")
+            project["action_fields"] = data.get("action_fields", [])
+            project["scope_state"] = (data.get("workflow_state") or {}).get(
+                "scope", "pending"
+            )
+            project["plugin_refs"] = data.get("plugin_refs", {})
+            project["updated"] = data.get("updated", data.get("created", ""))
+        except Exception:
+            pass
+
+    return project

--- a/cogni-consult/scripts/discover-projects.sh
+++ b/cogni-consult/scripts/discover-projects.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Discover cogni-consult engagements via the cogni-workspace generic helper.
+# Thin wrapper: locates cogni-workspace, then delegates to
+# cogni-workspace/scripts/discover-plugin-projects.sh with consult-specific
+# manifest, registry, extractor, and find spec. See that script for CLI flags.
+set -euo pipefail
+
+_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+_WORKSPACE_ROOT="${WORKSPACE_PLUGIN_ROOT:-$(ls -td "$HOME"/.claude/plugins/cache/insight-wave/cogni-workspace/*/ 2>/dev/null | head -1)}"
+if [ -z "$_WORKSPACE_ROOT" ] || [ ! -f "$_WORKSPACE_ROOT/scripts/discover-plugin-projects.sh" ]; then
+  _WORKSPACE_ROOT="$(cd "$_SCRIPT_DIR/../../cogni-workspace" 2>/dev/null && pwd || true)"
+fi
+if [ -z "$_WORKSPACE_ROOT" ] || [ ! -f "$_WORKSPACE_ROOT/scripts/discover-plugin-projects.sh" ]; then
+  echo "Error: cogni-workspace not found. Install or update cogni-workspace." >&2
+  exit 1
+fi
+
+exec bash "$_WORKSPACE_ROOT/scripts/discover-plugin-projects.sh" \
+  --plugin cogni-consult \
+  --registry "$HOME/.claude/cogni-consult-projects.json" \
+  --extractor "$_SCRIPT_DIR/_discover_extractor.py" \
+  --find "consult-project.json:*/cogni-consult/*:1" \
+  "$@"

--- a/cogni-consult/scripts/discover-projects.sh
+++ b/cogni-consult/scripts/discover-projects.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 
 _SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-_WORKSPACE_ROOT="${WORKSPACE_PLUGIN_ROOT:-$(ls -td "$HOME"/.claude/plugins/cache/insight-wave/cogni-workspace/*/ 2>/dev/null | head -1)}"
+_WORKSPACE_ROOT="${WORKSPACE_PLUGIN_ROOT:-$(ls -td "$HOME"/.claude/plugins/cache/insight-wave/cogni-workspace/*/ 2>/dev/null | head -1 || true)}"
 if [ -z "$_WORKSPACE_ROOT" ] || [ ! -f "$_WORKSPACE_ROOT/scripts/discover-plugin-projects.sh" ]; then
   _WORKSPACE_ROOT="$(cd "$_SCRIPT_DIR/../../cogni-workspace" 2>/dev/null && pwd || true)"
 fi

--- a/cogni-consult/scripts/engagement-init.sh
+++ b/cogni-consult/scripts/engagement-init.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Create the cogni-consult engagement directory skeleton + consult-project.json.
-# Stub: the consult-setup skill fills in the real scaffolding contract.
+# Idempotent: re-run is safe; consult-project.json existence is the completion marker.
 # Usage: bash engagement-init.sh <engagement-slug> <engagement-name>
 # Output: JSON {"success": bool, "data": {...}, "error": "string"}
 

--- a/cogni-consult/skills/consult-setup/SKILL.md
+++ b/cogni-consult/skills/consult-setup/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: consult-setup
+description: |
+  This skill should be used when the user wants to start a new cogni-consult engagement —
+  the action-fields-WBS consulting plugin. Trigger on: "start a consult engagement",
+  "new cogni-consult engagement", "set up a consult project", "begin an action-fields
+  engagement", "new WBS engagement", "kick off an engagement with cogni-consult", or any
+  request to start structured consulting work explicitly aimed at cogni-consult rather
+  than cogni-consulting (during the evaluation both plugins coexist; route Double Diamond
+  phrasing like "diamond engagement" to cogni-consulting:consulting-setup instead).
+  Scaffolds the engagement directory, binds one cogni-knowledge base, registers the
+  engagement globally, and hands off to consult-scope.
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, Skill, TaskCreate, TaskUpdate
+---
+
+# Engagement Setup
+
+Initialize a cogni-consult engagement: frame the desired outcome with the consultant, scaffold the action-fields-WBS directory structure, bind the one cogni-knowledge base the whole engagement compounds research into, and register the engagement for cross-session discovery. This is the entry point — without it, no later skill has a project to write to.
+
+Setup deliberately stays light: it captures the outcome and the research spine, nothing more. The SMART key question, the five scoping dimensions, and the 3-6 action fields are `consult-scope`'s job; personas ship with `consult-personas`; deliverables emerge inside action fields. If an engagement already exists for this client/topic, redirect to `consult-resume` instead of creating a duplicate.
+
+## Workflow
+
+### 1. Gather Engagement Context
+
+Collect these fields, extracting whatever the user already provided and asking only for what is missing:
+
+- **Engagement name**: Descriptive name (e.g., "ACME DACH Cloud Expansion")
+- **Client**: Company or organization name
+- **Desired outcome**: One sentence describing what success looks like
+- **Market**: One of `dach`, `de`, `fr`, `it`, `pl`, `nl`, `es`, `us`, `uk`, `eu` — collected explicitly, never derived from language (the mapping is ambiguous, e.g. `de` could mean `dach` or `de`)
+- **Language**: ISO 639-1 communication language (default `en`; check a `.workspace-config.json` `language` field in the workspace root first)
+
+Derive the engagement slug from the name in kebab-case — short and recognizable.
+
+### 2. Confirm With the Consultant
+
+Present a summary table (engagement, client, desired outcome, market, language, proposed slug) and iterate until confirmed. The slug doubles as the knowledge-base slug in step 4, so flag that it becomes a directory name in two places.
+
+### 3. Scaffold the Engagement
+
+Run the init script from the workspace root:
+
+```bash
+bash $CLAUDE_PLUGIN_ROOT/scripts/engagement-init.sh "<engagement-slug>" "<engagement-name>"
+```
+
+The script creates `cogni-consult/<slug>/{scope,action-fields,personas,.metadata}/`, writes the three `.metadata/` logs, and writes `consult-project.json` last (its existence is the idempotency key). On `"success": false` with `"engagement already initialized"`, stop and suggest `consult-resume` — never overwrite.
+
+Then enrich `consult-project.json` with `Edit` — never rewrite the file (the `created`/`updated` timestamps the script set must survive):
+
+- Set `language` to the confirmed value (the script hardcodes `"en"`)
+- Leave `key_question`, `action_fields`, and `workflow_state.scope` untouched — those belong to `consult-scope`
+
+### 4. Bind One cogni-knowledge Base
+
+Every deliverable's research runs through a single knowledge base bound here, once, so evidence compounds across the whole engagement instead of fragmenting into throwaway reports.
+
+Dispatch the setup non-interactively, passing everything it would otherwise prompt for:
+
+```
+Skill: cogni-knowledge:knowledge-setup
+  --knowledge-slug <engagement-slug>
+  --knowledge-title "<engagement name> knowledge base"
+  --market <market>
+  --output-language <language>
+  --charter-domain "<desired outcome>"
+  --charter-audience "consultant"
+  --charter-scope "<client>"
+```
+
+Prefer the charter flags over `--no-charter` — the gathered context gives the base a real charter instead of an empty one. After the dispatch succeeds, record the binding in `consult-project.json` via `Edit`:
+
+```json
+"plugin_refs": {
+  "knowledge_base": "<engagement-slug>"
+}
+```
+
+The value is the slug string, not a path. Later skills pass `--knowledge-slug <plugin_refs.knowledge_base>` to every `knowledge-plan`/`knowledge-query` run.
+
+### 5. Register the Engagement Globally
+
+Register the engagement so `consult-resume` finds it from any directory:
+
+```bash
+bash $CLAUDE_PLUGIN_ROOT/scripts/discover-projects.sh --register "<absolute-path-to-engagement-dir>"
+```
+
+The wrapper delegates to the cogni-workspace discovery helper with the cogni-consult registry (`$HOME/.claude/cogni-consult-projects.json`, auto-created on first use). Verify with `bash $CLAUDE_PLUGIN_ROOT/scripts/discover-projects.sh --json`, which lists every known engagement with its scope state.
+
+### 6. Recommend the Next Step
+
+Close by confirming what exists (engagement directory, bound knowledge base, registry entry) and recommend `consult-scope` as the next step — the SMART key question and five scoping dimensions anchor the engagement before any action field is derived. If the user wants to continue immediately, dispatch `Skill("cogni-consult:consult-scope")` in the same session.
+
+## Important Notes
+
+- **State ownership**: `consult-project.json` holds only the `scope` workflow state. Deliverable state lives exclusively in each field's `field.json` — setup never touches it (no fields exist yet). See `$CLAUDE_PLUGIN_ROOT/references/data-model.md`.
+- **One base per engagement**: never bind a second knowledge base; re-runs reuse `plugin_refs.knowledge_base`.
+- **Communication language**: when `language` is set, communicate in that language; technical terms, skill names, and CLI commands stay English.
+- **Evaluation boundary**: cogni-consulting engagements and cogni-consult engagements never share directories; the two plugins are compared, not mixed.

--- a/cogni-consult/skills/consult-setup/SKILL.md
+++ b/cogni-consult/skills/consult-setup/SKILL.md
@@ -4,20 +4,18 @@ description: |
   This skill should be used when the user wants to start a new cogni-consult engagement —
   the action-fields-WBS consulting plugin. Trigger on: "start a consult engagement",
   "new cogni-consult engagement", "set up a consult project", "begin an action-fields
-  engagement", "new WBS engagement", "kick off an engagement with cogni-consult", or any
-  request to start structured consulting work explicitly aimed at cogni-consult rather
-  than cogni-consulting (during the evaluation both plugins coexist; route Double Diamond
-  phrasing like "diamond engagement" to cogni-consulting:consulting-setup instead).
-  Scaffolds the engagement directory, binds one cogni-knowledge base, registers the
-  engagement globally, and hands off to consult-scope.
-allowed-tools: Read, Write, Edit, Bash, Glob, Grep, Skill, TaskCreate, TaskUpdate
+  engagement", or any request to start structured consulting work explicitly aimed at
+  cogni-consult rather than cogni-consulting (route Double Diamond phrasing like
+  "diamond engagement" to cogni-consulting:consulting-setup instead). Scaffolds the
+  engagement directory, binds one cogni-knowledge base, and registers it globally.
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, Skill
 ---
 
 # Engagement Setup
 
 Initialize a cogni-consult engagement: frame the desired outcome with the consultant, scaffold the action-fields-WBS directory structure, bind the one cogni-knowledge base the whole engagement compounds research into, and register the engagement for cross-session discovery. This is the entry point — without it, no later skill has a project to write to.
 
-Setup deliberately stays light: it captures the outcome and the research spine, nothing more. The SMART key question, the five scoping dimensions, and the 3-6 action fields are `consult-scope`'s job; personas ship with `consult-personas`; deliverables emerge inside action fields. If an engagement already exists for this client/topic, redirect to `consult-resume` instead of creating a duplicate.
+Setup deliberately stays light: it captures the outcome and the research spine, nothing more. The SMART key question, the five scoping dimensions, and the 3-6 action fields are `consult-scope`'s job; personas ship with `consult-personas`; deliverables emerge inside action fields. If an engagement already exists for this client/topic, do not create a duplicate — redirect to `consult-resume` once that skill ships; until then, point the user at the existing engagement directory.
 
 ## Workflow
 
@@ -45,11 +43,11 @@ Run the init script from the workspace root:
 bash $CLAUDE_PLUGIN_ROOT/scripts/engagement-init.sh "<engagement-slug>" "<engagement-name>"
 ```
 
-The script creates `cogni-consult/<slug>/{scope,action-fields,personas,.metadata}/`, writes the three `.metadata/` logs, and writes `consult-project.json` last (its existence is the idempotency key). On `"success": false` with `"engagement already initialized"`, stop and suggest `consult-resume` — never overwrite.
+The script creates `cogni-consult/<slug>/{scope,action-fields,personas,.metadata}/`, writes the three `.metadata/` logs, and writes `consult-project.json` last (its existence is the idempotency key). On `"success": false` with `"engagement already initialized"`, stop and point at the existing engagement (via `consult-resume` once it ships) — never overwrite.
 
 Then enrich `consult-project.json` with `Edit` — never rewrite the file (the `created`/`updated` timestamps the script set must survive):
 
-- Set `language` to the confirmed value (the script hardcodes `"en"`)
+- Set `language` to the confirmed value. Skip this edit when the confirmed language is `en` — the script default already matches, and an identical old/new `Edit` errors
 - Leave `key_question`, `action_fields`, and `workflow_state.scope` untouched — those belong to `consult-scope`
 
 ### 4. Bind One cogni-knowledge Base
@@ -66,10 +64,10 @@ Skill: cogni-knowledge:knowledge-setup
   --output-language <language>
   --charter-domain "<desired outcome>"
   --charter-audience "consultant"
-  --charter-scope "<client>"
+  --charter-scope "<client>, <market> market"
 ```
 
-Prefer the charter flags over `--no-charter` — the gathered context gives the base a real charter instead of an empty one. After the dispatch succeeds, record the binding in `consult-project.json` via `Edit`:
+Prefer the charter flags over `--no-charter` — the gathered context gives the base a real charter instead of an empty one. Charter scope means in/out boundaries (geography, segment, horizon), so compose it from the client plus the confirmed market rather than passing a bare client name. After the dispatch succeeds, record the binding in `consult-project.json` via `Edit`:
 
 ```json
 "plugin_refs": {
@@ -91,7 +89,7 @@ The wrapper delegates to the cogni-workspace discovery helper with the cogni-con
 
 ### 6. Recommend the Next Step
 
-Close by confirming what exists (engagement directory, bound knowledge base, registry entry) and recommend `consult-scope` as the next step — the SMART key question and five scoping dimensions anchor the engagement before any action field is derived. If the user wants to continue immediately, dispatch `Skill("cogni-consult:consult-scope")` in the same session.
+Close by confirming what exists (engagement directory, bound knowledge base, registry entry) and recommend `consult-scope` as the next step — the SMART key question and five scoping dimensions anchor the engagement before any action field is derived. Once `consult-scope` ships (it is the next sibling skill), dispatch `Skill("cogni-consult:consult-scope")` in the same session when the user wants to continue immediately; until then, stop here and report that the engagement is ready for scoping.
 
 ## Important Notes
 


### PR DESCRIPTION
Closes #654.

## Summary
- Add `skills/consult-setup/SKILL.md` — the engagement entry point: frame the outcome with the consultant, scaffold `cogni-consult/<engagement-slug>/` via `engagement-init.sh`, then Edit-enrich `consult-project.json` (set `language`; later set `plugin_refs.knowledge_base`) rather than rewriting it (preserves `created`/`updated`; the manifest's existence is the init script's idempotency key).
- Bind exactly one cogni-knowledge base: dispatch `cogni-knowledge:knowledge-setup --knowledge-slug <slug-derived-from-engagement>` with `--market` + `--output-language` collected at setup, plus charter flags from gathered context (avoids the interactive interview / empty-charter state), then record the slug string in `plugin_refs.knowledge_base`. Mirrors `cogni-consulting/skills/consulting-discover/SKILL.md`.
- Add `scripts/discover-projects.sh` (thin wrapper over `cogni-workspace/scripts/discover-plugin-projects.sh`, mode 755) + `scripts/_discover_extractor.py` (mode 644, reads cogni-consult's FLAT consult-project.json schema — not cogni-consulting's nested `engagement{}`/`phases{}`) so the skill registers the engagement in `$HOME/.claude/cogni-consult-projects.json` and resume can find engagements outside the repo.
- Recommend `consult-scope` as the next step.
- Bump `plugin.json` + root `marketplace.json` 0.0.1 → 0.0.2 (`maturity: "incubating"` unchanged — 0.0.x stays Incubating); CLAUDE.md architecture tree + Scripts table gain the new files.

## Scope decisions
- **In:** the one skill plus the registry wrapper/extractor it depends on (cogni-consult had no discovery pair — a verified gap; consult-resume #660 needs it anyway). Market is collected from the user at setup (not derived from `language`: the mapping is ambiguous, e.g. `de`→`dach|de`).
- **Out:** personas (#658), scope dimensions (#655), resume (#660), README/docs (#661) — owned by sibling issues; nothing deferred from this issue's own scope.

## Test plan
- [x] `bash cogni-workspace/scripts/check-skill-names.sh` → OK (consult-setup is domain-prefixed)
- [x] `bash -n` on the wrapper; both manifests parse as JSON
- [x] Extractor fixture test: `extract()` on a scaffolded consult-project.json returns `{path, slug, name, language, key_question, action_fields, scope_state, plugin_refs, updated}`
- [x] `discover-projects.sh --json` dry-run (local cogni-workspace fallback) returns `{"count": 0, "projects": []}` against a clean tree
- [x] /simplify quality pass: 4/4 angles clean; skill-quality-reviewer verdict: pass

Plan record: https://github.com/cogni-work/insight-wave/issues/654#issuecomment-4678032082

🤖 Generated with [Claude Code](https://claude.com/claude-code)
