### PR TITLE
cogni-consult: consult-scope keystone skill (key question + dimensions + WBS action fields)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -349,7 +349,7 @@
     {
       "name": "cogni-consult",
       "source": "./cogni-consult",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "maturity": "incubating",
       "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work, and cogni-knowledge is the central research tool across all skills.",
       "keywords": [

--- a/cogni-consult/.claude-plugin/plugin.json
+++ b/cogni-consult/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-consult",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work, and cogni-knowledge is the central research tool across all skills.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-consult/CLAUDE.md
+++ b/cogni-consult/CLAUDE.md
@@ -12,18 +12,22 @@ cogni-consult/
 ├── CLAUDE.md                      This developer guide
 ├── README.md                      User documentation (stub; full README is planned work)
 ├── references/
-│   └── data-model.md              Engagement structure + entity schemas
+│   ├── data-model.md              Engagement structure + entity schemas
+│   └── methods/
+│       └── scope-dimensions.md    SMART key question + 5 dimensions + WBS-close method
 ├── scripts/
 │   ├── engagement-init.sh         Create engagement directory skeleton
 │   ├── engagement-status.sh       Read consult-project.json state → JSON
 │   ├── discover-projects.sh       Thin wrapper over the cogni-workspace discovery helper
 │   └── _discover_extractor.py     Per-engagement field extractor for the wrapper
 └── skills/
-    └── consult-setup/SKILL.md     Engagement entry point: scaffold + knowledge-base bind
-                                   + registry (later work: consult-scope,
-                                    consult-action-fields, consult-design-thinking,
-                                    consult-personas, consult-resume)
+    ├── consult-setup/SKILL.md     Engagement entry point: scaffold + knowledge-base bind
+    │                              + registry
+    └── consult-scope/SKILL.md     SMART key question + 5 scoping dimensions
+                                   + 3-6 action fields as the WBS
 ```
+
+Later work: consult-action-fields, consult-design-thinking, consult-personas, consult-resume skills.
 
 ## Design Principles
 

--- a/cogni-consult/references/data-model.md
+++ b/cogni-consult/references/data-model.md
@@ -15,9 +15,8 @@ cogni-consult/{engagement-slug}/
 │   ├── method-log.json                    # Methods proposed and selected per deliverable
 │   └── decision-log.json                  # Key decisions with rationale
 ├── scope/
-│   ├── key-question.md                    # SMART key question
-│   ├── dimensions.md                      # The 5 scoping dimensions
-│   └── action-fields.md                   # Derived action-field list (3-6 fields)
+│   └── key-question.md                    # SMART key question + 5 scoping dimensions
+│                                          #   + derived action-field list (3-6 fields)
 ├── action-fields/
 │   └── {field-slug}/                      # One directory per WBS action field
 │       ├── field.json                     # Single source of truth for the field's deliverable states
@@ -39,6 +38,11 @@ the engagement is complete when all fields are) — never stored. The engagement
 root only stores the `scope` state, because scoping precedes the existence of
 any field. This keeps every deliverable transition a one-file write and makes
 drift between copies structurally impossible.
+
+The scope transition itself is tracked only via `workflow_state.scope` and the
+root `updated` date — it is not logged in `.metadata/execution-log.json`, whose
+entries are addressed by `action_field` + `deliverable` (no field exists yet at
+scope time).
 
 ## Entity Schemas
 

--- a/cogni-consult/references/methods/scope-dimensions.md
+++ b/cogni-consult/references/methods/scope-dimensions.md
@@ -1,0 +1,90 @@
+---
+name: Scope Dimensions
+inputs: [desired-outcome]
+outputs: [key-question, scoping-dimensions, action-fields]
+duration_estimate: "20-40 min with consultant"
+requires_plugins: []
+---
+
+# Scope Dimensions
+
+Anchor the engagement in one SMART framing question and five scoping dimensions, then close by declaring the 3-6 action fields that become the engagement's work-breakdown structure. The Key Question is the reference point every deliverable converges against — a sharp scope here makes every action field cheaper and crisper to work.
+
+## When to Use
+
+- Every engagement, immediately after setup — scoping precedes the existence of any action field
+- Re-run when the engagement pivots (new sponsor, changed market context, scope dispute)
+
+## The Key Question
+
+One framing question for the whole engagement, tested against SMART:
+
+| Criterion | Test |
+|---|---|
+| **S**pecific | Names the actor, the domain, and the decision — no "improve things" vagueness |
+| **M**easurable | Success can be observed or counted; ties to the Success-factors dimension below |
+| **A**chievable | Within the client's capability and mandate to act on |
+| **R**ealistic | Answerable within the engagement's resources and access |
+| **T**ime-oriented | Carries an explicit horizon ("by FY27", "within 12 months") |
+
+Draft it together with the consultant: propose 2–3 candidate framings from the desired outcome, stress each against the five criteria, and converge on one. A question failing two or more criteria is reframed, not accepted.
+
+## The Five Scoping Dimensions
+
+Work through each dimension as a guided conversation, capturing concise structured notes:
+
+1. **Strategic Context** — strategic market context; company context; main competitors and customers and their behavior. What larger movement is this engagement embedded in?
+2. **Scope** — the project focus; which companies/areas are affected; what is explicitly OUT of scope; adjacent problems being solved in parallel (and by whom).
+3. **Stakeholder** — who is responsible; who is affected; their interests; how decisions are made (governance, veto points, cadence).
+4. **Constraints / Barriers** — risks and mitigations; capability/competence gaps; missing facts, data, or analysis; resource and time restrictions; leadership or commitment gaps.
+5. **Success factors** — how success is measured; key deliverables; KPIs; other performance measures the sponsor will actually be judged on.
+
+## Action Fields — the WBS Close
+
+Close by naming the main areas of action needed to resolve the central problem — 3–6 fields, each one line. Unlike research-seed approaches, action fields here ARE the work-breakdown structure: every later deliverable lives inside exactly one of them. Each field carries a kebab-case slug, a title, and a one-line framing (its intent phrased as a question or charge); the persistence shape is defined in `references/data-model.md`.
+
+## Output Convention
+
+Write the result to `scope/key-question.md`:
+
+```markdown
+---
+slug: key-question
+updated: {ISO date}
+---
+
+# Key Question
+
+> {the SMART key question}
+
+## SMART check
+{one line per criterion: how the question satisfies it}
+
+## Strategic Context
+...
+
+## Scope
+**In:** ...
+**Out:** ...
+**Adjacent:** ...
+
+## Stakeholder
+...
+
+## Constraints / Barriers
+...
+
+## Success factors
+...
+
+## Action fields
+1. **{Field title}** (`{field-slug}`) — {one-line intent}
+2. ...
+```
+
+## Quality Signals
+
+- The key question fits in one sentence a sponsor would recognize as *their* question
+- Every dimension has at least one concrete, falsifiable statement (names, numbers, dates)
+- The out-of-scope list is non-empty — a scope with nothing excluded is not a scope
+- Action fields map forward: each should be concrete enough to host named deliverables, and together they cover the key question without overlap

--- a/cogni-consult/skills/consult-scope/SKILL.md
+++ b/cogni-consult/skills/consult-scope/SKILL.md
@@ -9,7 +9,7 @@ description: |
   consult-setup hands off a freshly scaffolded engagement for scoping. Route Double
   Diamond phrasing ("0-scope phase", "diamond scoping") to
   cogni-consulting:consulting-scope instead.
-allowed-tools: Read, Write, Edit, Bash, Glob, Grep, Skill
+allowed-tools: Read, Write, Edit, Bash, Skill
 ---
 
 # Engagement Scoping
@@ -26,7 +26,7 @@ When arriving via an in-session `consult-setup` handoff, the engagement director
 bash $CLAUDE_PLUGIN_ROOT/scripts/discover-projects.sh --json
 ```
 
-and confirm the intended engagement with the user when more than one is registered.
+and confirm the intended engagement with the user when more than one is registered. When discovery returns zero engagements, treat it the same as a missing `consult-project.json` — redirect to `consult-setup` as below.
 
 Read `<engagement-dir>/consult-project.json`. If it is missing, redirect: "There's no engagement yet — let's run `consult-setup` first to scaffold one." Then dispatch `Skill("cogni-consult:consult-setup")` and stop — write nothing. The same Read supplies everything this skill needs (name, language, `workflow_state.scope`) and anchors the later `Edit` calls.
 
@@ -34,7 +34,7 @@ When `workflow_state.scope` is already `complete`, this is a re-scope (pivot): c
 
 ### 2. Open the Scoping Conversation
 
-Read `$CLAUDE_PLUGIN_ROOT/references/methods/scope-dimensions.md`, then set `workflow_state.scope` to `"in-progress"` via `Edit` — never rewrite `consult-project.json` (the `created`/`updated` timestamps and `plugin_refs` set by setup must survive).
+Read `$CLAUDE_PLUGIN_ROOT/references/methods/scope-dimensions.md`, then set `workflow_state.scope` to `"in-progress"` and `updated` to today's ISO date in one `Edit` — never rewrite `consult-project.json` (the `created` timestamp and `plugin_refs` set by setup must survive; `updated` covers scope edits per the data model, so an interrupted session still shows fresh modification).
 
 When `language` is set, hold the conversation in that language; technical terms, slugs, and file names stay English.
 

--- a/cogni-consult/skills/consult-scope/SKILL.md
+++ b/cogni-consult/skills/consult-scope/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: consult-scope
+description: |
+  This skill should be used when the user wants to scope a cogni-consult engagement —
+  framing the SMART key question, working the five scoping dimensions, and deriving
+  the 3-6 action fields that become the engagement's work-breakdown structure.
+  Trigger on: "scope the engagement", "consult scope", "frame the key question",
+  "define action fields", "run scoping for the consult engagement", or when
+  consult-setup hands off a freshly scaffolded engagement for scoping. Route Double
+  Diamond phrasing ("0-scope phase", "diamond scoping") to
+  cogni-consulting:consulting-scope instead.
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, Skill
+---
+
+# Engagement Scoping
+
+Produce the keystone deliverable of a cogni-consult engagement: one SMART key question, five scoping dimensions, and 3-6 action fields declared as the work-breakdown structure every later skill works inside. The method itself — SMART table, dimension prompts, output template, quality signals — lives in `$CLAUDE_PLUGIN_ROOT/references/methods/scope-dimensions.md`; this skill owns the conversation flow and the state writes.
+
+## Workflow
+
+### 1. Prerequisite Gate
+
+When arriving via an in-session `consult-setup` handoff, the engagement directory is already known — skip discovery. Otherwise locate the engagement:
+
+```bash
+bash $CLAUDE_PLUGIN_ROOT/scripts/discover-projects.sh --json
+```
+
+and confirm the intended engagement with the user when more than one is registered.
+
+Read `<engagement-dir>/consult-project.json`. If it is missing, redirect: "There's no engagement yet — let's run `consult-setup` first to scaffold one." Then dispatch `Skill("cogni-consult:consult-setup")` and stop — write nothing. The same Read supplies everything this skill needs (name, language, `workflow_state.scope`) and anchors the later `Edit` calls.
+
+When `workflow_state.scope` is already `complete`, this is a re-scope (pivot): confirm with the consultant before proceeding, and follow the re-run guard in step 4.
+
+### 2. Open the Scoping Conversation
+
+Read `$CLAUDE_PLUGIN_ROOT/references/methods/scope-dimensions.md`, then set `workflow_state.scope` to `"in-progress"` via `Edit` — never rewrite `consult-project.json` (the `created`/`updated` timestamps and `plugin_refs` set by setup must survive).
+
+When `language` is set, hold the conversation in that language; technical terms, slugs, and file names stay English.
+
+### 3. Key Question, Then the Five Dimensions
+
+Draft the key question collaboratively with the consultant following the method reference's SMART procedure, and `Edit` the converged question into `consult-project.json` `key_question`.
+
+Then walk the five dimensions (Strategic Context, Scope, Stakeholder, Constraints/Barriers, Success factors) as a guided conversation per the method reference, capturing concise structured notes per dimension.
+
+### 4. Derive the Action Fields (WBS Close)
+
+Close by naming 3-6 action fields per the method reference — each with a kebab-case slug, a title, and a one-line framing. Confirm the set with the consultant, then persist it in two writes:
+
+1. One `Edit` of `consult-project.json`: set `action_fields` to the complete ordered list of **slug strings** (e.g. `["market-evidence", "portfolio-fit", "go-to-market"]`). The root never holds field objects — `engagement-status.sh` rejects non-string entries as a malformed project file.
+2. One `Write` per field of the stub `action-fields/<field-slug>/field.json` (the `Write` scaffolds the directory; schema owner is `$CLAUDE_PLUGIN_ROOT/references/data-model.md`):
+
+```json
+{
+  "slug": "<field-slug>",
+  "title": "<Field Title>",
+  "framing": "<one-line intent>",
+  "deliverables": []
+}
+```
+
+**Re-run guard**: on a re-scope, never overwrite an existing `field.json` — it is the single source of truth for that field's deliverable states. For a field that survives the pivot, leave its file untouched; only add stubs for genuinely new fields. When a field is dropped from `action_fields[]`, leave its directory in place and note the removal in the conversation summary — deleting deliverable history is the consultant's call, not the skill's.
+
+### 5. Write the Scope Deliverable
+
+`Write` `scope/key-question.md` following the Output Convention template in the method reference.
+
+### 6. Close the Scope
+
+`Edit` `consult-project.json`: set `workflow_state.scope` to `"complete"` and `updated` to today's ISO date. Summarize what now exists — the key question, one line per dimension, and the action-field WBS — and recommend working the first action field's deliverables as the next step (via `consult-action-fields` once it ships; until then, point at the scaffolded `action-fields/` directories).
+
+## Important Notes
+
+- **State ownership**: `consult-project.json` holds only the `scope` workflow state and the action-field slug list; everything per-field lives in that field's `field.json`. See `$CLAUDE_PLUGIN_ROOT/references/data-model.md`.
+- **One deliverable file**: scoping produces a single `scope/key-question.md` — key question, dimensions, and action-field list are one guided conversation and one artifact, not three files.
+- **Edit, never rewrite**: all `consult-project.json` changes go through `Edit` so setup-owned fields (`created`, `plugin_refs`, `language`) survive.

--- a/cogni-consult/skills/consult-setup/SKILL.md
+++ b/cogni-consult/skills/consult-setup/SKILL.md
@@ -89,7 +89,7 @@ The wrapper delegates to the cogni-workspace discovery helper with the cogni-con
 
 ### 6. Recommend the Next Step
 
-Close by confirming what exists (engagement directory, bound knowledge base, registry entry) and recommend `consult-scope` as the next step — the SMART key question and five scoping dimensions anchor the engagement before any action field is derived. Once `consult-scope` ships (it is the next sibling skill), dispatch `Skill("cogni-consult:consult-scope")` in the same session when the user wants to continue immediately; until then, stop here and report that the engagement is ready for scoping.
+Close by confirming what exists (engagement directory, bound knowledge base, registry entry) and recommend `consult-scope` as the next step — the SMART key question and five scoping dimensions anchor the engagement before any action field is derived. When the user wants to continue immediately, dispatch `Skill("cogni-consult:consult-scope")` in the same session; otherwise stop here and report that the engagement is ready for scoping.
 
 ## Important Notes
 


### PR DESCRIPTION
Closes #655.

## Summary
- Add `cogni-consult/skills/consult-scope/SKILL.md` — the keystone phase-1 skill: draft + SMART-stress-test one key question with the consultant, work the five scoping dimensions (Strategic Context, Scope, Stakeholder, Constraints/Barriers, Success factors), and close by naming 3-6 action fields as the engagement WBS.
- Add `cogni-consult/references/methods/scope-dimensions.md` — adapted from cogni-consulting's `key-question-scoping.md`, stripped of Double Diamond phase/type framing and repointed to `scope/key-question.md`, with a WBS-close section.
- Skill writes `scope/key-question.md` (per the method reference's Output Convention, frontmatter `slug`/`updated`), Edits `consult-project.json` (`key_question`, `action_fields`, `workflow_state.scope`, `updated`), and scaffolds `action-fields/{slug}/field.json` stubs (the Write creates each directory).
- Prerequisite gate: redirect to `consult-setup` when `consult-project.json` is missing.
- Re-run safe: a re-scope never overwrites an existing `field.json` that already carries deliverable state.
- Unblock the in-session handoff: `consult-setup` step 6 now dispatches `consult-scope` unconditionally instead of "once it ships".
- Update `references/data-model.md`: `scope/` tree reflects the single-file reality (`scope/key-question.md` only) and the State Ownership section states that scope transitions are tracked via `workflow_state.scope` + root `updated`, not the execution log.
- Bump `cogni-consult` 0.0.2 -> 0.0.3 in `plugin.json` and mirror in `marketplace.json`; CLAUDE.md architecture tree lists `consult-scope` as shipped.

## Scope decisions
- **Full scope in one PR.** The issue is a single shippable increment. Nothing deferred.
- **Deliberate deviation from issue prose — `action_fields[]` shape.** The issue says write action-field entries as objects `(slug, name, one-line intent, planned deliverables)` into `consult-project.json`. The SHIPPED code contract disagrees: `engagement-status.sh` validates `action_fields` as a list of kebab-case slug STRINGS and rejects objects as a 'malformed project file'. The rich per-field shape (`slug`/`title`/`framing`/`deliverables[]`) lives in `action-fields/{slug}/field.json` per `references/data-model.md`. This PR follows code reality: slug strings in `consult-project.json`, rich `field.json` stubs per directory. Reviewer: please confirm this is the intended contract (it matches the merged data model from the scaffold PR) rather than the issue prose.
- **One output file, not three.** `data-model.md` listed `scope/key-question.md`, `scope/dimensions.md`, and `scope/action-fields.md`; the issue explicitly collapses scoping into one guided conversation and one file. Followed the issue and updated `data-model.md` to match.
- **Single schema home.** A simplify pass deduplicated the field-declaration mechanics: the method reference stays methodology-level, `data-model.md` owns the `field.json` schema, and the skill carries only the operational write sequence.

## Test plan
- [ ] In an engagement with no `consult-project.json`, invoking consult-scope redirects to `consult-setup` and writes nothing.
- [ ] In a setup engagement, running consult-scope produces `scope/key-question.md` with frontmatter `slug: key-question` and an ISO `updated` date, a SMART check, all five dimensions, and a 3-6 item action-field list.
- [ ] After scoping, `consult-project.json` has a non-empty `key_question`, an `action_fields` array of kebab-case slug STRINGS, `workflow_state.scope: "complete"`, a refreshed `updated` date — and `bash cogni-consult/scripts/engagement-status.sh <engagement-dir>` returns `success: true`.
- [ ] Each named action field has an `action-fields/{slug}/` directory containing a `field.json` stub `{slug, title, framing, deliverables: []}`.
- [ ] Re-running consult-scope on an engagement whose fields already have deliverables does not blank an existing `field.json`'s `deliverables[]`.
- [ ] `plugin.json` and `marketplace.json` both show `cogni-consult` at `0.0.3`; CLAUDE.md lists `consult-scope` as shipped; `data-model.md`'s `scope/` tree lists only `key-question.md`.
- [x] `bash cogni-workspace/scripts/check-skill-names.sh` passes; breadcrumb guard passes; both JSON manifests parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)