### PR TITLE
cogni-consult: acting-persona authoring + act-as challenge skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -349,7 +349,7 @@
     {
       "name": "cogni-consult",
       "source": "./cogni-consult",
-      "version": "0.0.3",
+      "version": "0.0.4",
       "maturity": "incubating",
       "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work, and cogni-knowledge is the central research tool across all skills.",
       "keywords": [

--- a/cogni-consult/.claude-plugin/plugin.json
+++ b/cogni-consult/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-consult",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work, and cogni-knowledge is the central research tool across all skills.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-consult/CLAUDE.md
+++ b/cogni-consult/CLAUDE.md
@@ -13,6 +13,9 @@ cogni-consult/
 ├── README.md                      User documentation (stub; full README is planned work)
 ├── references/
 │   ├── data-model.md              Engagement structure + entity schemas
+│   ├── persona-schema.md          Acting-persona schema + acting contract
+│   ├── personas/                  Packaged default advisors (consulting-partner,
+│   │                              project-manager)
 │   └── methods/
 │       └── scope-dimensions.md    SMART key question + 5 dimensions + WBS-close method
 ├── scripts/
@@ -23,17 +26,19 @@ cogni-consult/
 └── skills/
     ├── consult-setup/SKILL.md     Engagement entry point: scaffold + knowledge-base bind
     │                              + registry
-    └── consult-scope/SKILL.md     SMART key question + 5 scoping dimensions
-                                   + 3-6 action fields as the WBS
+    ├── consult-scope/SKILL.md     SMART key question + 5 scoping dimensions
+    │                              + 3-6 action fields as the WBS
+    └── consult-personas/SKILL.md  Acting personas: define from scope, enrich,
+                                   act-as challenge against deliverables
 ```
 
-Later work: consult-action-fields, consult-design-thinking, consult-personas, consult-resume skills.
+Later work: consult-action-fields, consult-design-thinking, consult-resume skills.
 
 ## Design Principles
 
 - **Action fields as WBS** — scoping derives 3-6 action fields from the key question; every deliverable lives inside exactly one field. Progress is tracked per deliverable, not per global phase
 - **Design thinking per deliverable** — each deliverable iterates empathize→define→ideate→prototype→test on its own clock; fields complete when their deliverables do
-- **Acting personas** — stakeholder personas (shipped defaults: engagement partner, project manager) actively challenge deliverable work in their voice, not just describe users
+- **Acting personas** — stakeholder personas (shipped defaults: consulting partner, project manager) actively challenge deliverable work in their voice, not just describe users
 - **Knowledge base as the research spine** — one cogni-knowledge base bound at setup (`plugin_refs.knowledge_base`); all deliverable research runs through it and compounds
 - **Orchestrator, not producer** — manages engagement state; content work dispatches to existing plugins
 - **Path references, not data copies** — cross-references via slugs/paths, no shared DB

--- a/cogni-consult/references/data-model.md
+++ b/cogni-consult/references/data-model.md
@@ -149,22 +149,30 @@ All three logs address work by the same structured coordinates —
 ### personas/{slug}.json (Acting Stakeholder Personas)
 
 Personas in cogni-consult are **acting** personas: the plugin speaks and
-challenges as them during deliverable work (the shipped defaults are an
-engagement partner and a project manager; engagements add client-side
-stakeholders). The schema extends cogni-consulting's design-for persona shape
-with a `role` and `voice`; the append-only trail is a `work_log` addressed by
-WBS coordinates (not a phase log — this plugin has no phases):
+challenges as them during deliverable work (the shipped defaults are a
+consulting partner and a project manager, copied from packaged templates in
+`references/personas/`; engagements add client-side stakeholders). The schema
+extends cogni-consulting's design-for persona shape with a `role` and `voice`
+plus optional `capabilities[]` (what the persona can decide/access — grounds
+what its challenge can credibly demand) and `wants[]` (desired outcomes —
+distinct from `needs[]`, which are unmet requirements); the append-only trail
+is a `work_log` addressed by WBS coordinates (not a phase log — this plugin
+has no phases). Scope-seeded personas start both new arrays empty at
+`hypothesis` maturity; the packaged defaults come pre-populated. Full
+schema: `references/persona-schema.md`.
 
 ```json
 {
-  "slug": "engagement-partner",
-  "name": "Engagement Partner",
+  "slug": "consulting-partner",
+  "name": "Consulting Partner",
   "role": "challenger",
   "voice": "Pushes for so-what clarity, client value, and commercial defensibility",
   "maturity": "hypothesis",
   "context": "Owns the client relationship and the engagement economics",
   "core_tension": "Wants depth but sells speed",
   "empathy_map": { "thinks": [], "feels": [], "says": [], "does": [] },
+  "capabilities": [],
+  "wants": [],
   "needs": [],
   "source": "setup-default",
   "work_log": [

--- a/cogni-consult/references/persona-schema.md
+++ b/cogni-consult/references/persona-schema.md
@@ -1,0 +1,98 @@
+# Persona Entity Schema — Acting Stakeholder Personas
+
+A persona in cogni-consult is an **acting** persona: the plugin speaks and
+challenges as them during deliverable work — they are advisors and critics in
+the room, not just descriptions of people the engagement designs for. Every
+engagement ships two standard advisors (the consulting partner and the project
+manager, copied from `references/personas/`); engagements add client-side
+stakeholders seeded from the scope Stakeholder dimension.
+
+## Lifecycle
+
+```
+hypothesis  ──▶  researched  ──▶  validated
+(created)        (enriched with    (confirmed against real
+                  evidence)         stakeholder feedback)
+```
+
+- **hypothesis**: A conjecture — "we think this stakeholder matters." Requires only name, context, and core tension. Scope-seeded personas start here with empty arrays; the shipped defaults also start at `hypothesis` but come pre-populated with template capabilities/wants/needs (they are advisors whose voice is known up front).
+- **researched**: Enriched with evidence — empathy mapping during deliverable work or knowledge-base synthesis added substance. Empathy map, needs, capabilities, and wants are populated.
+- **validated**: Confirmed against reality — the consultant verified the persona's tensions and wants with the actual stakeholder (or their proxy).
+
+## Schema
+
+```json
+{
+  "slug": "consulting-partner",
+  "name": "Consulting Partner",
+  "role": "challenger",
+  "voice": "Pushes for so-what clarity, client value, and the right framework for the job",
+  "maturity": "hypothesis | researched | validated",
+  "context": "Owns the client relationship and the engagement economics",
+  "core_tension": "Wants depth but sells speed",
+  "empathy_map": {
+    "thinks": [],
+    "feels": [],
+    "says": [],
+    "does": []
+  },
+  "capabilities": [],
+  "wants": [],
+  "needs": [],
+  "source": "setup-default | scope-seeded",
+  "work_log": [
+    {"action_field": "market-evidence", "deliverable": "market-sizing", "action": "challenged", "date": "2026-06-11"}
+  ]
+}
+```
+
+## Field Reference
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `slug` | Yes | Kebab-case identifier, used as filename (`personas/{slug}.json`) |
+| `name` | Yes | Human-readable label — an archetype, not a personal name (unless the engagement identifies specific individuals) |
+| `role` | Yes | How the persona acts in deliverable work — `challenger`, `advisor`, `gatekeeper`, `user` |
+| `voice` | Yes | One-line acting directive: how this persona sounds when it challenges work |
+| `maturity` | Yes | `hypothesis`, `researched`, or `validated` |
+| `context` | Yes | One sentence: who they are, their relationship to the engagement |
+| `core_tension` | Yes | The central conflict they carry — what makes their position demanding |
+| `empathy_map` | No | Think/Feel/Say/Do quadrants. Empty arrays at hypothesis; populated during enrichment |
+| `capabilities` | No | What the persona can decide, access, or do — authority, expertise, resources. Grounds what their challenge can credibly demand |
+| `wants` | No | Desired outcomes and preferences — what would make them champion the work. Distinct from `needs`: wants are aspirations, needs are unmet requirements/friction points |
+| `needs` | No | Short need statements — unmet requirements the work must satisfy. 2-5 items when populated |
+| `source` | Yes | How this persona was created: `setup-default` (packaged template) or `scope-seeded` (from the Stakeholder dimension). Enrichment advances `maturity`, never `source` |
+| `work_log` | No | Append-only trail addressed by WBS coordinates. Each entry: `{action_field, deliverable, action, date}` |
+
+There is no phase log — cogni-consult has no phases. The `work_log` records
+which deliverables the persona touched (created/enriched/challenged), keyed by
+`action_field` + `deliverable` like every other log in the plugin.
+
+## The Acting Contract
+
+When a skill acts as a persona, it speaks **in the persona's voice** and
+grounds every challenge in the persona's fields:
+
+- `capabilities` bound what the persona can credibly demand or veto
+- `wants` shape what would make them accept the work enthusiastically
+- `needs` define the bar the work must clear at minimum
+- `core_tension` and `empathy_map` color *how* they push back
+
+A challenge produced in act-as mode is structured, not free-form: what's
+missing, what they'd push back on, and what would make them accept it. The
+challenge is recorded as a `work_log` entry (`action: "challenged"`) on the
+persona and surfaced with the deliverable.
+
+## Scaling Guidance
+
+| Field | Quick engagement | Standard engagement |
+|-------|------------------|---------------------|
+| slug, name, role, voice, context, core_tension | Required | Required |
+| maturity | `hypothesis` (may stay) | `researched` for personas that matter |
+| empathy_map | Omit or empty | Populated for challenged-against personas |
+| capabilities / wants / needs | 1-2 items each | 2-5 items each |
+| work_log | As challenges happen | As challenges happen |
+
+The two shipped defaults stay lightweight on purpose — they are advisors whose
+voice and tension carry the challenge; enrich them only when the engagement's
+reality diverges from the template.

--- a/cogni-consult/references/personas/consulting-partner.json
+++ b/cogni-consult/references/personas/consulting-partner.json
@@ -1,0 +1,29 @@
+{
+  "slug": "consulting-partner",
+  "name": "Consulting Partner",
+  "role": "challenger",
+  "voice": "Pushes for so-what clarity, client value, commercial defensibility, and the right framework for the job — asks 'what would the client pay for this slide?'",
+  "maturity": "hypothesis",
+  "context": "Owns the client relationship and the engagement economics; advises on which frameworks and methods make each deliverable land",
+  "core_tension": "Wants analytical depth but sells speed and certainty",
+  "empathy_map": {
+    "thinks": [],
+    "feels": [],
+    "says": [],
+    "does": []
+  },
+  "capabilities": [
+    "Can reframe a deliverable around a sharper client question",
+    "Knows which consulting frameworks fit which problem shape",
+    "Can veto work that does not survive a client steering committee"
+  ],
+  "wants": [
+    "Every deliverable to answer the client's so-what in its first section",
+    "Frameworks used because they fit, not because they are familiar"
+  ],
+  "needs": [
+    "A defensible evidence trail behind every recommendation"
+  ],
+  "source": "setup-default",
+  "work_log": []
+}

--- a/cogni-consult/references/personas/project-manager.json
+++ b/cogni-consult/references/personas/project-manager.json
@@ -1,0 +1,29 @@
+{
+  "slug": "project-manager",
+  "name": "Project Manager",
+  "role": "advisor",
+  "voice": "Pushes for delivery realism — timeline, ownership, scope discipline; asks 'who does this, by when, and what slips if it grows?'",
+  "maturity": "hypothesis",
+  "context": "Manages the engagement plan; advises on sequencing the action fields and keeping every deliverable shippable",
+  "core_tension": "Protects the timeline while the work keeps wanting to grow",
+  "empathy_map": {
+    "thinks": [],
+    "feels": [],
+    "says": [],
+    "does": []
+  },
+  "capabilities": [
+    "Can resequence deliverables across action fields when dependencies bite",
+    "Tracks effort against the engagement budget",
+    "Can split an oversized deliverable into shippable pieces"
+  ],
+  "wants": [
+    "Every deliverable to have a clear owner and a realistic next step",
+    "Scope changes made explicit, never absorbed silently"
+  ],
+  "needs": [
+    "Deliverable states in the WBS manifests kept honest, so status reads from files not memory"
+  ],
+  "source": "setup-default",
+  "work_log": []
+}

--- a/cogni-consult/skills/consult-personas/SKILL.md
+++ b/cogni-consult/skills/consult-personas/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: consult-personas
+description: |
+  This skill should be used when the user wants to manage or invoke the acting
+  stakeholder personas of a cogni-consult engagement — defining personas from
+  the scope's Stakeholder dimension, enriching one with evidence, or having a
+  persona challenge a deliverable in its own voice. Trigger on: "set up the
+  personas", "add a stakeholder persona", "enrich the persona", "challenge
+  this deliverable as the partner", "act as the project manager", "persona
+  review", "what would the partner say", or when a design-thinking test stage
+  requests a persona challenge. Route design-for persona phrasing tied to
+  Double Diamond phases ("discover personas", "persona for the define phase")
+  to the cogni-consulting plugin instead — cogni-consult personas act and
+  challenge, they are not phase artifacts.
+allowed-tools: Read, Write, Edit, Bash, Skill
+---
+
+# Acting Stakeholder Personas
+
+Define, enrich, and act as the engagement's stakeholder personas. Personas in
+cogni-consult are advisors and critics in the room: every engagement carries
+the two shipped defaults — the consulting partner (frameworks and commercial
+defensibility) and the project manager (delivery realism) — plus client-side
+stakeholders seeded from scoping. The schema and acting contract live in
+`$CLAUDE_PLUGIN_ROOT/references/persona-schema.md`; the packaged default
+templates live in `$CLAUDE_PLUGIN_ROOT/references/personas/`.
+
+## Workflow
+
+### 1. Prerequisite Gate
+
+When arriving via an in-session handoff (e.g. a design-thinking test stage
+naming the deliverable), the engagement directory is already known — skip
+discovery. Otherwise locate the engagement:
+
+```bash
+bash $CLAUDE_PLUGIN_ROOT/scripts/discover-projects.sh --json
+```
+
+and confirm the intended engagement with the user when more than one is
+registered. Read `<engagement-dir>/consult-project.json`. If it is missing
+(or discovery returned zero engagements): dispatch
+`Skill("cogni-consult:consult-setup")` and stop — write nothing. Scoping is
+NOT a prerequisite — the two default advisors are useful from day one; only
+scope-seeding (step 3) needs a completed scope.
+
+When `language` is set, hold the conversation in that language; technical
+terms, slugs, and file names stay English.
+
+### 2. Ensure the Default Advisors Exist
+
+Check `personas/consulting-partner.json` and `personas/project-manager.json`.
+For each that is absent, copy the packaged template:
+
+```bash
+cp $CLAUDE_PLUGIN_ROOT/references/personas/consulting-partner.json <engagement-dir>/personas/
+cp $CLAUDE_PLUGIN_ROOT/references/personas/project-manager.json <engagement-dir>/personas/
+```
+
+Never overwrite an existing persona file — an engagement may have enriched
+its defaults, and that history is the consultant's. This step is idempotent;
+run it on every invocation.
+
+### 3. Define Personas from the Scope (mode: define)
+
+When the consultant wants engagement-specific stakeholders and
+`workflow_state.scope` is `"complete"`: read `scope/key-question.md`, take the
+`## Stakeholder` section's prose, and propose 1-4 persona candidates — each
+with a kebab-case slug, name, one-line `context`, and a `core_tension`
+hypothesis. Confirm with the consultant (names, count, tensions), then
+`Write` each confirmed persona to `personas/<slug>.json` per the schema:
+`maturity: "hypothesis"`, `source: "scope-seeded"`, a drafted `role` and
+`voice`, empty `empathy_map`/`capabilities`/`wants`/`needs`/`work_log`.
+
+When scope is not complete, say so and offer the defaults-only path — do not
+dispatch consult-scope unless the consultant wants to scope now.
+
+### 4. Enrich a Persona (mode: enrich)
+
+Given a persona slug and evidence (consultant knowledge, knowledge-base
+synthesis, stakeholder conversations): `Edit` the persona file to populate
+`empathy_map`, `needs`, `capabilities`, and `wants`, and advance `maturity`
+to `"researched"` when at least two quadrants carry evidence-based entries
+(`"validated"` only when the consultant confirms against the real
+stakeholder). Append a `work_log` entry
+(`{"action_field": ..., "deliverable": ..., "action": "enriched", "date": ...}`)
+when the enrichment happened in service of a specific deliverable; omit the
+entry for general enrichment.
+
+### 5. Act as a Persona (mode: challenge)
+
+Given a deliverable (its artifact path under
+`action-fields/<field-slug>/`) and one or more persona slugs — default to
+both shipped advisors plus any persona whose `context` touches the
+deliverable's topic:
+
+1. Read the persona file and the deliverable artifact.
+2. Adopt the persona: speak in its `voice`, bounded by its `capabilities`,
+   aiming at its `wants`, holding the work to its `needs`, colored by its
+   `core_tension`.
+3. Return the structured challenge, in character:
+   - **What's missing** — gaps the persona would spot first
+   - **Push-backs** — claims or choices they would contest, and why
+   - **Acceptance bar** — what would make this persona accept the deliverable
+4. Record it: append a `work_log` entry to that persona's
+   `personas/<slug>.json` (`{"action_field": "<field-slug>", "deliverable":
+   "<deliverable-slug>", "action": "challenged", "date": "<ISO date>"}`) via
+   `Edit`, and append (or update) a `## Persona Challenges` section in the
+   deliverable artifact summarizing each persona's challenge and the
+   consultant's disposition (accepted / revised / rejected with reason).
+5. When the field's manifest entry carries a `persona_review` field, advance
+   it (`pending` → `in-progress` when challenges start, → `complete` when the
+   consultant has dispositioned every challenge); when it doesn't, the
+   `work_log` entries and the artifact section are the record — never create
+   the field on an entry that lacks it.
+
+The challenge informs — it never blocks. The consultant decides what to
+revise; revision itself belongs to the deliverable's producing route, not to
+this skill.
+
+### 6. Close the Session
+
+Summarize what changed: personas created/enriched, deliverables challenged
+and by whom, and any challenge the consultant still needs to disposition.
+When a challenged deliverable needs rework, point at its producing route as
+the next step.
+
+## Important Notes
+
+- **Acting, not gating**: personas challenge in their own voice and ground
+  every demand in their `capabilities`/`wants`/`needs`; they advise the
+  consultant, who decides. See the Acting Contract in
+  `$CLAUDE_PLUGIN_ROOT/references/persona-schema.md`.
+- **Never overwrite**: existing `personas/*.json` files are enriched via
+  `Edit`, never re-copied from templates — enrichment history survives.
+- **State ownership**: persona files own persona state; deliverable state
+  stays in the field's `field.json`. This skill never edits
+  `consult-project.json`.
+- **WBS coordinates everywhere**: `work_log` entries are addressed by
+  `action_field` + `deliverable`, like every log in the plugin — there are
+  no phases.


### PR DESCRIPTION
Closes #658.

## Summary
- New skill `skills/consult-personas/SKILL.md`: seeds personas from the scope Stakeholder dimension (reads `scope/key-question.md` prose, proposes candidates for consultant confirmation, writes `personas/<slug>.json` at maturity `hypothesis`), idempotently copies the two packaged defaults on every invocation (never overwriting), enriches personas with evidence, and runs **act-as mode** — adopt a persona's voice grounded in its capabilities/wants/needs against a deliverable and return a structured challenge (what's missing, push-backs, acceptance bar) recorded to the persona's `work_log` and a `## Persona Challenges` section in the deliverable artifact.
- New reference `references/persona-schema.md`: adapted from cogni-consulting's design-for persona schema, extended with `role`, `voice`, `capabilities[]`, and `wants[]` (distinct from `needs[]`), the acting contract, and the hypothesis→researched→validated lifecycle. `phase_log` is replaced by the WBS-addressed `work_log`; the quality-gate-personas section is dropped (acting personas ARE the challenge mechanism here).
- Two packaged templates: `references/personas/consulting-partner.json` (frameworks / commercial-defensibility advisor) and `references/personas/project-manager.json` (delivery / timeline / scope-discipline advisor).
- `references/data-model.md`: personas block gains the two optional arrays with the wants-vs-needs distinction; the shipped default is renamed engagement-partner → consulting-partner consistently (example JSON + prose); CLAUDE.md's Acting-personas bullet follows.
- `CLAUDE.md`: architecture tree lists the new skill, persona-schema.md, and personas/; `consult-personas` removed from "Later work".
- Version bump 0.0.3 → 0.0.4 in plugin.json and marketplace.json.

## Scope decisions
- **Full scope** — skill, schema, default templates, and act-as mode all ship here.
- act-as mode does not edit the design-thinking sibling (it is the caller, on an unmerged branch); `persona_review` on field.json deliverable entries stays an optional "when present" surface — the skill advances it only when the entry already carries it and never creates it (its schema documentation lands with the WBS-manager sibling PR).
- Nothing deferred — siblings (knowledge integration, consult-resume) are already filed.

## Expected merge conflicts with sibling PRs #667/#668 (trivial, resolved by merge order)
- Version bumps (all three PRs bump cogni-consult 0.0.3→0.0.4 in plugin.json/marketplace.json) — take 0.0.4 once, re-bump to the next patch on later merges.
- CLAUDE.md "Later work" line — each branch removes its own skill name; take all removals.

## Plan record
https://github.com/cogni-work/insight-wave/issues/658#issuecomment-4679800662

## Test plan
- [ ] check-skill-names.sh passes; check-breadcrumbs.py reports 0 new.
- [ ] Both persona templates parse as JSON and conform to persona-schema.md (field order, enums, maturity hypothesis).
- [ ] persona-schema.md documents capabilities/wants/needs distinction, the acting contract, work_log WBS coordinates, and no phase_log / quality-gate sections.
- [ ] SKILL.md: idempotent never-overwrite defaults copy; scope-seeding gated on completed scope; challenge mode records work_log + artifact section and never creates persona_review.
- [ ] data-model.md + CLAUDE.md consistently say "consulting partner"; plugin.json + marketplace.json both 0.0.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)