### PR TITLE
cogni-consulting: align consulting-resume dashboard template with Example table

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -284,7 +284,7 @@
     {
       "name": "cogni-consulting",
       "source": "./cogni-consulting",
-      "version": "0.0.17",
+      "version": "0.0.18",
       "maturity": "incubating",
       "description": "Double Diamond consulting orchestrator. Runs structured engagements through five gated, number-prefixed phases (0-Scope, 1-Discover, 2-Define, 3-Develop, 4-Deliver) coordinating six insight-wave plugins under a Diamond Coach. Includes SMART Key Question scoping, Lean Canvas authoring, and lightweight how-might-we engagements for bounded challenges.",
       "keywords": [

--- a/cogni-consulting/.claude-plugin/plugin.json
+++ b/cogni-consulting/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-consulting",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "description": "Double Diamond consulting orchestrator. Runs structured engagements through five gated, number-prefixed phases (0-Scope, 1-Discover, 2-Define, 3-Develop, 4-Deliver) coordinating six insight-wave plugins under a Diamond Coach. Includes SMART Key Question scoping, Lean Canvas authoring, and lightweight how-might-we engagements for bounded challenges.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-consulting/skills/consulting-resume/SKILL.md
+++ b/cogni-consulting/skills/consulting-resume/SKILL.md
@@ -74,13 +74,13 @@ The consultant should feel like picking up a well-organized notebook, not readin
 **Acme Cloud Portfolio Expansion** (acme-cloud-expansion)
 Client: Acme Cloud Services | Vision: strategic-options | Language: en
 
-| Phase | Status | Iterations | Files | Plugin Projects |
-|-------|--------|------------|-------|-----------------|
-| 0-Scope | complete | 0 | 1 | key question framed |
-| 1-Discover | complete | 0 | 12 | research: acme-landscape, tips: b2b-ict/acme, portfolio: acme-cloud |
-| 2-Define | in-progress | 0 | 3 | claims: verified 8/12 assumptions |
-| 3-Develop | pending | 0 | 0 | — |
-| 4-Deliver | pending | 0 | 0 | — |
+| Phase | Status | Files | Plugin Projects |
+|-------|--------|-------|-----------------|
+| 0-Scope | complete | 1 | key question framed |
+| 1-Discover | complete | 12 | research: acme-landscape, tips: b2b-ict/acme, portfolio: acme-cloud |
+| 2-Define | in-progress | 3 | claims: verified 8/12 assumptions |
+| 3-Develop | pending | 0 | — |
+| 4-Deliver | pending | 0 | — |
 
 After the table:
 


### PR DESCRIPTION
Closes #652.

## Summary
- Drop the `Iterations` column from the Step-4 status-dashboard template in `consulting-resume/SKILL.md` so the template matches the Example section's table, which already omits it.
- The column was always `0` on first pass (engagement-init.sh seeds `iteration_count=0`) and decorative — the load-bearing iteration surface is the Step-6 re-entry prose, which is unchanged.
- Bump cogni-consulting `0.0.17` → `0.0.18` in `plugin.json` and mirror in root `marketplace.json` per repo convention.

## Scope decisions
- **In scope:** the template/example drift in `consulting-resume/SKILL.md` (template at line 77, Example at line 119) and the version bump. Direction (drop the column rather than add it to the Example) follows the issue and triage as the lower-risk alignment.
- **Out of scope / nothing deferred:** the issue is a single acceptance criterion (one consistency fix); there is no separable remainder. `engagement-status.sh` already passes `phase_state` through verbatim and is unaffected.

## Plan record
https://github.com/cogni-work/insight-wave/issues/652#issuecomment-4680963285

## Test plan
- [x] `consulting-resume/SKILL.md` Step-4 template header now reads `| Phase | Status | Files | Plugin Projects |` and matches the Example table header exactly.
- [x] The separator row and all five data rows no longer carry the `Iterations` / `| 0 |` cell; column counts are consistent across header, separator, and data rows.
- [x] Step-6 iteration re-entry prose is unchanged — iteration context is still surfaced there.
- [x] `cogni-consulting/.claude-plugin/plugin.json` version is `0.0.18` and the `marketplace.json` cogni-consulting entry mirrors it.
- [x] `grep -c "Iterations" consulting-resume/SKILL.md` returns 0; check-skill-names + breadcrumb guards pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)