### PR TITLE
cogni-consult: canonical cogni-knowledge research-routing reference

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -349,7 +349,7 @@
     {
       "name": "cogni-consult",
       "source": "./cogni-consult",
-      "version": "0.0.6",
+      "version": "0.0.7",
       "maturity": "incubating",
       "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work, and cogni-knowledge is the central research tool across all skills.",
       "keywords": [

--- a/cogni-consult/.claude-plugin/plugin.json
+++ b/cogni-consult/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-consult",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work, and cogni-knowledge is the central research tool across all skills.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-consult/CLAUDE.md
+++ b/cogni-consult/CLAUDE.md
@@ -15,6 +15,8 @@ cogni-consult/
 │   ├── data-model.md              Engagement structure + entity schemas
 │   ├── deliverable-types.md       Deliverable-type catalog (field-type affinity)
 │   ├── persona-schema.md          Acting-persona schema + acting contract
+│   ├── research-routing.md        Canonical cogni-knowledge research rule (binding,
+│   │                              pipeline rungs, depth framing, storage contract)
 │   ├── personas/                  Packaged default advisors (consulting-partner,
 │   │                              project-manager)
 │   └── methods/
@@ -81,4 +83,5 @@ All scripts are stdlib-only (bash + python3, no pip dependencies).
 - `dt_stage` tracks the design-thinking stage per deliverable (`empathize`/`define`/`ideate`/`prototype`/`test`)
 - Entity outputs are Obsidian-browsable markdown with YAML frontmatter; state files are plain JSON
 - `language` field in consult-project.json controls communication language (technical terms stay English)
+- **Research routing**: every research run goes through the engagement's bound knowledge base per `references/research-routing.md` — the canonical rule all deliverable-producing skills point at (binding via `plugin_refs.knowledge_base`, pipeline rungs, depth framing, syntheses copied to `action-fields/<field-slug>/research/<topic-slug>.md`); raw WebSearch only for a single trivial fact-check
 - cogni-consulting remains untouched during the evaluation; the two plugins never share engagement directories

--- a/cogni-consult/references/data-model.md
+++ b/cogni-consult/references/data-model.md
@@ -15,12 +15,19 @@ cogni-consult/{engagement-slug}/
 │   ├── method-log.json                    # Methods proposed and selected per deliverable
 │   └── decision-log.json                  # Key decisions with rationale
 ├── scope/
-│   └── key-question.md                    # SMART key question + 5 scoping dimensions
-│                                          #   + derived action-field list (3-6 fields)
+│   ├── key-question.md                    # SMART key question + 5 scoping dimensions
+│   │                                      #   + derived action-field list (3-6 fields)
+│   └── research/
+│       └── {topic-slug}.md                # Scoping-stage research syntheses (see
+│                                          #   references/research-routing.md)
 ├── action-fields/
 │   └── {field-slug}/                      # One directory per WBS action field
 │       ├── field.json                     # Single source of truth for the field's deliverable states
-│       └── {deliverable-slug}.md          # Deliverable artifacts (markdown + YAML frontmatter)
+│       ├── {deliverable-slug}.md          # Deliverable artifacts (markdown + YAML frontmatter)
+│       └── research/
+│           └── {topic-slug}.md            # Research syntheses copied from the knowledge
+│                                          #   base after knowledge-finalize (see
+│                                          #   references/research-routing.md)
 └── personas/
     └── {persona-slug}.json                # Acting stakeholder personas (partner, PM, ...)
 ```
@@ -215,7 +222,7 @@ states — see State Ownership above.
 
 | Plugin | Direction | Contract |
 |--------|-----------|----------|
-| cogni-knowledge | Orchestrates | Binds one knowledge base per engagement (`plugin_refs.knowledge_base`); every deliverable's research runs through the inverted pipeline and compounds in the same base. Deliverable `sources[].kb_ref` points back at knowledge-base pages |
+| cogni-knowledge | Orchestrates | Binds one knowledge base per engagement (`plugin_refs.knowledge_base`); every deliverable's research runs through the inverted pipeline and compounds in the same base (canonical rule: `references/research-routing.md`). Finalized syntheses are copied to `action-fields/{field-slug}/research/{topic-slug}.md`; deliverable `sources[].kb_ref` points back at knowledge-base pages |
 | cogni-claims | Consumes | Deliverable `sources[]` carries the lineage triple (`source_url`, `entity_ref`, `propagated_at`) so claim corrections cascade to deliverables |
 | cogni-visual / document-skills | Orchestrates | Deliverable export (slides, docs) from action-field artifacts |
 

--- a/cogni-consult/references/research-routing.md
+++ b/cogni-consult/references/research-routing.md
@@ -1,0 +1,82 @@
+# Research Routing Rule
+
+When research is needed anywhere in a cogni-consult engagement — scoping
+evidence for a dimension, empathize/define inputs for a deliverable, or a
+consultant request to "look into X" — **always dispatch the cogni-knowledge
+inverted pipeline against the engagement's bound knowledge base**. Never use
+raw WebSearch for engagement research. cogni-knowledge deposits structured,
+citable syntheses into one base that **compounds across the whole
+engagement**: every deliverable's research builds on what earlier
+deliverables already established instead of dying as a throwaway per-session
+report, and deliverable artifacts cite the base via their `sources[]`
+`kb_ref` entries so claim corrections cascade.
+
+This file is the canonical rule. The deliverable-producing skills
+(`consult-scope`, `consult-design-thinking`, `consult-action-fields`) point
+here rather than restating the routing, so the contract cannot drift across
+skills.
+
+## One Base Per Engagement
+
+The base is bound once, at setup: `consult-setup` dispatches
+`cogni-knowledge:knowledge-setup` and records the slug in
+`consult-project.json` → `plugin_refs.knowledge_base`. Every later research
+run, in any skill, binds to that base by passing the same
+`--knowledge-slug <plugin_refs.knowledge_base>` — never a fresh slug, never
+a second base. If `plugin_refs.knowledge_base` is missing, route the
+consultant through `consult-setup` rather than improvising a binding.
+
+## Pipeline Rungs
+
+Pick the rung that matches what the base already holds:
+
+- **New topic** (the base has no coverage yet): run the full inverted
+  pipeline — `knowledge-plan` → `knowledge-curate` → `knowledge-fetch` →
+  `knowledge-ingest` → `knowledge-compose` → `knowledge-verify` →
+  `knowledge-finalize`.
+- **Re-run on a populated base** (the topic is already covered; the angle or
+  framing is new): `knowledge-plan` → `knowledge-compose --source wiki` →
+  `knowledge-verify` → `knowledge-finalize` — skips the web crawl and
+  composes from what the base already holds.
+- **Quick gap-check** (just need what the base already knows):
+  `cogni-knowledge:knowledge-query --knowledge-slug <slug> --question "..."`
+  — the shallow read rung, no web crawl, no new project. When the answer
+  shows a gap, escalate to one of the two rungs above rather than filling
+  the gap from model memory or ad-hoc search.
+
+## Depth Framing
+
+Frame the run's depth when dispatching `knowledge-plan`:
+
+- **Focused single-topic dive** → `--target-words 3000` with 3–4
+  sub-questions, `--prose-density standard`
+- **Broad multi-angle** → `--target-words 4000` with 5–7 sub-questions
+- **Exhaustive** (e.g. a market or transformation landscape) →
+  `--target-words 6000+` (or split into two plans),
+  `--prose-density executive`
+
+## Storage Contract
+
+After `knowledge-finalize`, copy the finalized synthesis
+`wiki/syntheses/<slug>.md` into the engagement's action-field directory so
+the producing deliverable finds it at a stable path:
+
+```
+action-fields/<field-slug>/research/<topic-slug>.md
+```
+
+One file per research topic, named by a descriptive kebab-case slug.
+Research requested during iteration re-entry lands in the same `research/`
+directory alongside the existing syntheses — a new run, not an overwrite.
+Deliverable artifacts reference these via `sources[]` entries whose `kb_ref`
+points back at the knowledge-base page, preserving the lineage triple for
+claim-correction cascades. Scoping-stage research (before action fields
+exist) lands in `scope/research/<topic-slug>.md` and moves nothing when the
+fields are derived — later deliverables cite it where it is.
+
+## The Only Exception
+
+A quick fact-check during conversation (confirming a date, a name, a number)
+is fine as a single WebSearch. Anything requiring multiple queries, or
+producing content that feeds an engagement artifact, must go through
+cogni-knowledge.

--- a/cogni-consult/skills/consult-action-fields/SKILL.md
+++ b/cogni-consult/skills/consult-action-fields/SKILL.md
@@ -125,6 +125,13 @@ artifact). `persona_review` tracks the acting-persona challenge pass:
 `pending` → `in-progress` → `complete`. Both fields are manifest metadata —
 recommend the route, never dispatch it from here.
 
+When planning surfaces a research-heavy deliverable, note that its evidence
+will run through the engagement's bound knowledge base per
+`$CLAUDE_PLUGIN_ROOT/references/research-routing.md`, with syntheses landing
+in this field's `research/` directory
+(`action-fields/<field-slug>/research/<topic-slug>.md`) — the producing
+route reads them from there.
+
 Removing or renaming a deliverable is also an `Edit` of `field.json` — but
 never silently drop an entry whose `state` is not `pending`; started work is
 the consultant's to discard.
@@ -176,3 +183,7 @@ markdown artifact lands under the field directory either way.
   survive; root `updated` changes only when `action_fields[]` itself does.
 - **Slug discipline**: `action_fields[]` holds kebab-case slug strings only —
   `engagement-status.sh` rejects non-string entries as malformed.
+- **Research routing**: deliverable research always runs through the
+  engagement's bound knowledge base per
+  `$CLAUDE_PLUGIN_ROOT/references/research-routing.md` — never raw web
+  search; this skill plans the work, the producing route runs the research.

--- a/cogni-consult/skills/consult-design-thinking/SKILL.md
+++ b/cogni-consult/skills/consult-design-thinking/SKILL.md
@@ -88,13 +88,16 @@ for the personas that matter to this deliverable (`personas/*.json`). When the
 directory is empty, say so and continue with the consultant's own stakeholder
 knowledge — persona files can be added later without redoing the loop.
 
-When the engagement has a bound knowledge base
-(`plugin_refs.knowledge_base`), recommend pulling existing synthesis first —
-dispatch `Skill("cogni-knowledge:knowledge-query")` with
+Research for this stage follows the Research Routing Rule in
+`$CLAUDE_PLUGIN_ROOT/references/research-routing.md` — the canonical
+contract for every research run in the engagement. Start with the gap-check
+rung: dispatch `Skill("cogni-knowledge:knowledge-query")` with
 `--knowledge-slug <plugin_refs.knowledge_base>` for the deliverable's topic.
-Evidence comes from the knowledge base, never from raw web search; when the
-base has no coverage, note the gap as a research need rather than
-improvising sources.
+When the base has no coverage, escalate to the full inverted pipeline (or
+the `--source wiki` re-run on a populated base) per the rule, and copy the
+finalized synthesis to `action-fields/<field-slug>/research/<topic-slug>.md`
+so this deliverable — and later ones — find it at a stable path. Evidence
+comes from the knowledge base, never from raw web search.
 
 Close the stage with one `Edit` of `field.json`: `dt_stage` → `"define"`.
 
@@ -102,7 +105,11 @@ Close the stage with one `Edit` of `field.json`: `dt_stage` → `"define"`.
 
 Read `$CLAUDE_PLUGIN_ROOT/references/methods/hmw-synthesis.md` and sharpen
 the deliverable's problem spec from the empathize outputs plus the field's
-`framing`. Lock 1-3 HMW questions with the consultant.
+`framing`. Lock 1-3 HMW questions with the consultant. When sharpening the
+spec surfaces an evidence gap (an assumption the consultant cannot ground),
+route the research per
+`$CLAUDE_PLUGIN_ROOT/references/research-routing.md` before locking — a
+spec built on an unverified assumption fails at the test stage anyway.
 
 Append the locked spec to `.metadata/decision-log.json`'s `decisions[]` array as a decision
 (`{"id": "d-NNN", "action_field": ..., "deliverable": ..., "decision":
@@ -179,9 +186,10 @@ the plugin, or by reading the field manifests directly).
   the root `consult-project.json` is never touched by deliverable work (its
   `updated` covers root-file changes only).
 - **Evidence discipline**: research goes through the engagement's bound
-  knowledge base (`cogni-knowledge:knowledge-query`), never raw web search;
-  every evidence-backed claim in the artifact carries the `sources[]`
-  lineage triple so corrections can cascade.
+  knowledge base per the Research Routing Rule
+  (`$CLAUDE_PLUGIN_ROOT/references/research-routing.md`), never raw web
+  search; every evidence-backed claim in the artifact carries the
+  `sources[]` lineage triple so corrections can cascade.
 - **Loop, not gate**: stages may re-enter earlier stages; `state` stays
   `in-progress` until the test stage passes. Log state transitions (not
   per-stage moves) in the execution log.

--- a/cogni-consult/skills/consult-scope/SKILL.md
+++ b/cogni-consult/skills/consult-scope/SKILL.md
@@ -44,6 +44,8 @@ Draft the key question collaboratively with the consultant following the method 
 
 Then walk the five dimensions (Strategic Context, Scope, Stakeholder, Constraints/Barriers, Success factors) as a guided conversation per the method reference, capturing concise structured notes per dimension.
 
+When a dimension needs evidence the consultant cannot supply from their own knowledge (market sizing for Strategic Context, regulatory constraints, competitor moves), route the research per `$CLAUDE_PLUGIN_ROOT/references/research-routing.md` — through the engagement's bound knowledge base, never raw web search. Scoping-stage syntheses land in `scope/research/<topic-slug>.md` per that rule's storage contract.
+
 ### 4. Derive the Action Fields (WBS Close)
 
 Close by naming 3-6 action fields per the method reference — each with a kebab-case slug, a title, and a one-line framing. Confirm the set with the consultant, then persist it in two writes:
@@ -75,3 +77,4 @@ Close by naming 3-6 action fields per the method reference — each with a kebab
 - **State ownership**: `consult-project.json` holds only the `scope` workflow state and the action-field slug list; everything per-field lives in that field's `field.json`. See `$CLAUDE_PLUGIN_ROOT/references/data-model.md`.
 - **One deliverable file**: scoping produces a single `scope/key-question.md` — key question, dimensions, and action-field list are one guided conversation and one artifact, not three files.
 - **Edit, never rewrite**: all `consult-project.json` changes go through `Edit` so setup-owned fields (`created`, `plugin_refs`, `language`) survive.
+- **Research routing**: any scoping research runs through the engagement's bound knowledge base per `$CLAUDE_PLUGIN_ROOT/references/research-routing.md` — the canonical rule shared by every cogni-consult skill.


### PR DESCRIPTION
Closes #659.

## Summary
- Add `cogni-consult/references/research-routing.md` as the single canonical research rule: one knowledge base bound per engagement (`plugin_refs.knowledge_base`), every research run passes `--knowledge-slug <that-slug>`, the full inverted pipeline for new topics (`knowledge-plan → knowledge-curate → knowledge-fetch → knowledge-ingest → knowledge-compose → knowledge-verify → knowledge-finalize`), the re-run path (`knowledge-plan → knowledge-compose --source wiki → knowledge-verify → knowledge-finalize`), the gap-check rung (`knowledge-query`), depth framing, and the storage contract (copy `wiki/syntheses/<slug>.md` into `action-fields/<field-slug>/research/<topic-slug>.md`; scoping-stage research into `scope/research/<topic-slug>.md`).
- Establish the `research/` storage convention in `references/data-model.md` (Engagement Structure tree + Cross-Plugin Integration cogni-knowledge row).
- Point `consult-design-thinking` (Empathize + Define + Important Notes), `consult-scope` (strategic-context evidence + Important Notes), and `consult-action-fields` (deliverable planning + Important Notes) at the canonical reference, replacing the knowledge-query-only ad-hoc wiring. Raw WebSearch allowed only for a single trivial fact-check.
- Add a Research Routing entry to `cogni-consult/CLAUDE.md` Key Conventions and list the new reference in the Architecture tree.
- Bump cogni-consult 0.0.6 → 0.0.7 in `plugin.json` and root `marketplace.json`.

## Scope decisions
- **In:** the canonical reference, the three skill pointers, the data-model storage convention, the CLAUDE.md convention, and version bumps — one cohesive increment, all within cogni-consult.
- **Out:** nothing deferred. README.md stays out of scope — it is still a stub with no research-routing mention, so there is no drift to fix here.
- The rule is canonical in `references/` (per the issue — unlike cogni-consulting where it lives inside consulting-discover); skills carry short pointers plus stage-specific notes so the prose can't drift across skills.

## Plan record
https://github.com/cogni-work/insight-wave/issues/659#issuecomment-4684651225

## Test plan
- [x] `references/research-routing.md` exists, prose-first, no `#NNN` issue refs (breadcrumb guard passed, 175 occurrences scanned)
- [x] All three skills reference `references/research-routing.md` (skill-quality-reviewer: 3× pass)
- [x] `references/data-model.md` tree shows `research/` under `action-fields/{field-slug}/` and `scope/`
- [x] CLAUDE.md Key Conventions has a Research Routing bullet
- [x] `plugin.json` and root `marketplace.json` both show cogni-consult `0.0.7`
- [x] `cogni-workspace/scripts/check-skill-names.sh` passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)