### PR TITLE
cogni-consult: consult-resume re-entry skill (discovery + dashboard + routing)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -349,7 +349,7 @@
     {
       "name": "cogni-consult",
       "source": "./cogni-consult",
-      "version": "0.0.7",
+      "version": "0.0.8",
       "maturity": "incubating",
       "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work, and cogni-knowledge is the central research tool across all skills.",
       "keywords": [

--- a/cogni-consult/.claude-plugin/plugin.json
+++ b/cogni-consult/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-consult",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work, and cogni-knowledge is the central research tool across all skills.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-consult/CLAUDE.md
+++ b/cogni-consult/CLAUDE.md
@@ -38,11 +38,11 @@ cogni-consult/
     │                              manifests + next-deliverable recommendation
     ├── consult-design-thinking/SKILL.md  Per-deliverable DT loop (empathize→define
     │                              →ideate→prototype→test) + artifact + state writes
-    └── consult-personas/SKILL.md  Acting personas: define from scope, enrich,
-                                   act-as challenge against deliverables
+    ├── consult-personas/SKILL.md  Acting personas: define from scope, enrich,
+    │                              act-as challenge against deliverables
+    └── consult-resume/SKILL.md    Engagement re-entry point: discovery + WBS
+                                   dashboard + workflow-state next-action routing
 ```
-
-Later work: consult-resume skill.
 
 ## Design Principles
 

--- a/cogni-consult/scripts/engagement-status.sh
+++ b/cogni-consult/scripts/engagement-status.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Read a cogni-consult engagement's consult-project.json and derive the WBS
-# field/deliverable rollup. Primary consumer: the consult-action-fields skill.
+# field/deliverable rollup. Consumers: the consult-action-fields and
+# consult-resume skills.
 # Usage: bash engagement-status.sh <engagement-dir>
 # Output: JSON {"success": bool, "data": {...}, "error": "string"}
 

--- a/cogni-consult/skills/consult-resume/SKILL.md
+++ b/cogni-consult/skills/consult-resume/SKILL.md
@@ -60,7 +60,7 @@ problem for the consultant to see, not to paper over).
 Lead with the key question, then one table row per action field:
 
 ```
-Engagement: <name> (<slug>) — updated <date>
+Engagement: <name> (<slug>) — scope config updated <date>
 Key question: <key_question>
 
 | Action Field | Status | Deliverables | Next Deliverable |
@@ -83,9 +83,12 @@ Branch on the derived state, first match wins, and say *why*:
 - **`scope_state` is not `complete`** → the WBS doesn't exist yet; recommend
   `consult-scope` ("scope not done — let's frame the key question and derive
   the action fields").
-- **A field has an empty `deliverables[]`** → the WBS has an unplanned
-  container; recommend `consult-action-fields` to plan that field's
-  deliverable set.
+- **A field's `state` is `unreadable`** → its manifest is broken, not
+  unplanned; the surfaced warning *is* the recommendation — fix or inspect
+  that `field.json` before any routing.
+- **A field has an empty `deliverables[]`** (and is not `unreadable`) → the
+  WBS has an unplanned container; recommend `consult-action-fields` to plan
+  that field's deliverable set.
 - **A deliverable is `in-progress`** → resume it where it stands; recommend
   `consult-design-thinking` naming the field, the deliverable, and its
   `dt_stage` ("competitor-map is mid-ideate — pick the loop back up there").

--- a/cogni-consult/skills/consult-resume/SKILL.md
+++ b/cogni-consult/skills/consult-resume/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: consult-resume
+description: |
+  This skill should be used when the user wants to resume, continue, or check
+  the status of a cogni-consult engagement across sessions. Trigger on:
+  "continue the engagement", "resume the engagement", "engagement status",
+  "where was I with the engagement", "what's next for the engagement", "show
+  engagement progress", "consult resume", or ANY session start that references
+  an existing cogni-consult engagement — even if the user doesn't say "resume"
+  explicitly. Route Double Diamond phrasing ("resume diamond", "diamond
+  status", phase talk like "continue discover") to
+  cogni-consulting:consulting-resume instead — cogni-consult engagements have
+  no phases; progress lives in the action-fields WBS.
+allowed-tools: Read, Bash, Skill
+---
+
+# Engagement Re-entry
+
+Re-enter a cogni-consult engagement: discover what exists, show progress
+against the action-fields WBS (fields × deliverables × status), and route to
+the most valuable next action. This skill is a read-only orienter — it never
+edits engagement state; every write belongs to the skill it routes to.
+
+## Workflow
+
+### 1. Discover Engagements
+
+```bash
+bash $CLAUDE_PLUGIN_ROOT/scripts/discover-projects.sh --json
+```
+
+When discovery returns **zero engagements**, there is nothing to resume:
+recommend scaffolding one and dispatch `Skill("cogni-consult:consult-setup")`,
+then stop — setup owns scaffolding and the knowledge-base binding.
+
+### 2. Select the Engagement
+
+- **One engagement** → select it silently.
+- **Multiple** → list them (name, slug, `scope_state`, `updated`) and ask
+  which to resume — unless the user already named one; then fuzzy-match on
+  name or slug and confirm only when the match is ambiguous.
+
+When `language` is set on the selected engagement, hold the conversation in
+that language; technical terms, slugs, and file names stay English.
+
+### 3. Read the Engagement Status
+
+```bash
+bash $CLAUDE_PLUGIN_ROOT/scripts/engagement-status.sh <engagement-path>
+```
+
+`<engagement-path>` is the `path` field from discovery. The script derives
+the rollups at read time: `scope_state`, and per field its `state` plus each
+deliverable's `state`, `dt_stage`, `producing_route`, and `persona_review`.
+Surface any `warnings[]` verbatim (an `unreadable` field manifest is a
+problem for the consultant to see, not to paper over).
+
+### 4. Present the Dashboard
+
+Lead with the key question, then one table row per action field:
+
+```
+Engagement: <name> (<slug>) — updated <date>
+Key question: <key_question>
+
+| Action Field | Status | Deliverables | Next Deliverable |
+|--------------|--------|--------------|------------------|
+| market-evidence | complete | 2/2 complete | — |
+| portfolio-fit | in-progress | 1/3 complete | competitor-map (ideate) |
+| go-to-market | pending | 0/2 started | channel-strategy (empathize) |
+```
+
+`Deliverables` counts `complete` over total; `Next Deliverable` names the
+first non-complete deliverable with its `dt_stage` in parentheses, or the
+first whose `persona_review` is still open when everything else is done.
+Keep it to this one table — the deep WBS view (planning deliverable sets,
+splitting fields) belongs to `consult-action-fields`, not here.
+
+### 5. Recommend the Next Action
+
+Branch on the derived state, first match wins, and say *why*:
+
+- **`scope_state` is not `complete`** → the WBS doesn't exist yet; recommend
+  `consult-scope` ("scope not done — let's frame the key question and derive
+  the action fields").
+- **A field has an empty `deliverables[]`** → the WBS has an unplanned
+  container; recommend `consult-action-fields` to plan that field's
+  deliverable set.
+- **A deliverable is `in-progress`** → resume it where it stands; recommend
+  `consult-design-thinking` naming the field, the deliverable, and its
+  `dt_stage` ("competitor-map is mid-ideate — pick the loop back up there").
+- **A deliverable is `complete` but its `persona_review` is `pending` or
+  `in-progress`** → the acting-persona challenge hasn't closed; recommend
+  `consult-personas` to run (or finish) the challenge pass.
+- **A deliverable is `pending`** → start the next one; recommend
+  `consult-design-thinking` (or the deliverable's own `producing_route` when
+  it names a different skill).
+- **Everything is `complete`** → say so — the engagement is complete by
+  derivation — and offer `consult-action-fields` to extend the WBS if the
+  consultant wants to add fields or deliverables.
+
+Recommend one action, not a menu. On the consultant's confirmation, dispatch
+the named skill via `Skill(...)` with the engagement path as the in-session
+handoff (the target skills skip rediscovery on handoff).
+
+## Important Notes
+
+- **Read-only**: this skill never writes `consult-project.json`,
+  `field.json`, personas, or logs — state writes belong to the routed
+  skills. See `$CLAUDE_PLUGIN_ROOT/references/data-model.md` for ownership.
+- **Derived, not stored**: field and engagement completion are computed at
+  read time by `engagement-status.sh`; never trust a stale summary over a
+  fresh script run.
+- **One recommendation**: the dashboard orients, the recommendation commits —
+  a single next action with its reason beats a list of options.

--- a/cogni-consult/skills/consult-resume/SKILL.md
+++ b/cogni-consult/skills/consult-resume/SKILL.md
@@ -36,7 +36,8 @@ then stop — setup owns scaffolding and the knowledge-base binding.
 ### 2. Select the Engagement
 
 - **One engagement** → select it silently.
-- **Multiple** → list them (name, slug, `scope_state`, `updated`) and ask
+- **Multiple** → list them (name, slug, `scope_state`, scope config
+  `updated`) and ask
   which to resume — unless the user already named one; then fuzzy-match on
   name or slug and confirm only when the match is ambiguous.
 

--- a/cogni-consult/skills/consult-setup/SKILL.md
+++ b/cogni-consult/skills/consult-setup/SKILL.md
@@ -15,7 +15,7 @@ allowed-tools: Read, Write, Edit, Bash, Glob, Grep, Skill
 
 Initialize a cogni-consult engagement: frame the desired outcome with the consultant, scaffold the action-fields-WBS directory structure, bind the one cogni-knowledge base the whole engagement compounds research into, and register the engagement for cross-session discovery. This is the entry point — without it, no later skill has a project to write to.
 
-Setup deliberately stays light: it captures the outcome and the research spine, nothing more. The SMART key question, the five scoping dimensions, and the 3-6 action fields are `consult-scope`'s job; personas ship with `consult-personas`; deliverables emerge inside action fields. If an engagement already exists for this client/topic, do not create a duplicate — redirect to `consult-resume` once that skill ships; until then, point the user at the existing engagement directory.
+Setup deliberately stays light: it captures the outcome and the research spine, nothing more. The SMART key question, the five scoping dimensions, and the 3-6 action fields are `consult-scope`'s job; personas ship with `consult-personas`; deliverables emerge inside action fields. If an engagement already exists for this client/topic, do not create a duplicate — dispatch `Skill("cogni-consult:consult-resume")` to re-enter it.
 
 ## Workflow
 
@@ -43,7 +43,7 @@ Run the init script from the workspace root:
 bash $CLAUDE_PLUGIN_ROOT/scripts/engagement-init.sh "<engagement-slug>" "<engagement-name>"
 ```
 
-The script creates `cogni-consult/<slug>/{scope,action-fields,personas,.metadata}/`, writes the three `.metadata/` logs, and writes `consult-project.json` last (its existence is the idempotency key). On `"success": false` with `"engagement already initialized"`, stop and point at the existing engagement (via `consult-resume` once it ships) — never overwrite.
+The script creates `cogni-consult/<slug>/{scope,action-fields,personas,.metadata}/`, writes the three `.metadata/` logs, and writes `consult-project.json` last (its existence is the idempotency key). On `"success": false` with `"engagement already initialized"`, stop and route to the existing engagement via `consult-resume` — never overwrite.
 
 Then enrich `consult-project.json` with `Edit` — never rewrite the file (the `created`/`updated` timestamps the script set must survive):
 


### PR DESCRIPTION
Closes #660.

## Summary
- Add `skills/consult-resume/SKILL.md` — the cross-session re-entry point for cogni-consult engagements, following the `cogni-dev:audit-resume` convention: **C1** discovery via the existing `scripts/discover-projects.sh --json` with a no-projects fallback dispatching `consult-setup`; **C2** workflow-state-driven next-action recommendations (first-match-wins branching on `scope_state`, deliverable `state`/`dt_stage`/`persona_review`); **C3** references every non-setup/non-resume skill (consult-scope, consult-action-fields, consult-design-thinking, consult-personas).
- Dashboard is action fields × deliverables × status, fed by `scripts/engagement-status.sh` (derived rollups, warnings surfaced). The deep WBS view stays delegated to `consult-action-fields` — the resume is a read-only orienter that never writes engagement state.
- Description disambiguates from `cogni-consulting:consulting-resume` (Double Diamond phrasing routes there).
- Update `CLAUDE.md`: consult-resume added to the skills tree as the re-entry point; "Later work: consult-resume skill." line removed.
- Bump cogni-consult 0.0.7 → 0.0.8 in `plugin.json` and root `marketplace.json`.

## Scope decisions
- **In:** the new skill, the CLAUDE.md tree update, paired version bumps — one indivisible deliverable.
- **Out:** surfacing `research/` syntheses (per `references/research-routing.md`) in the resume dashboard — outside this issue's fields × deliverables × status contract; worth a follow-up only if real multi-session usage shows the dashboard going blind to research artifacts. README build-out is tracked by its own downstream issue.

## Plan record
https://github.com/cogni-work/insight-wave/issues/660#issuecomment-4684920868

## Test plan
- [x] `check-skill-names.sh` passes (`consult-resume` carries the domain prefix)
- [x] Maintainer-breadcrumb guard passes (no #NNN/version/milestone refs in SKILL.md)
- [x] skill-quality-reviewer: pass (C1/C2/C3 all confirmed, 116-line body, read-only posture)
- [x] Both manifests parse and show 0.0.8
- [x] CLAUDE.md tree renders consult-resume; "Later work" line gone
- [x] Script invocations match the forms the five existing skills use (`discover-projects.sh --json`, `engagement-status.sh <path>`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)