### PR TITLE
cogni-consult: full README + plugin-guide deep dive + ecosystem link

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -349,7 +349,7 @@
     {
       "name": "cogni-consult",
       "source": "./cogni-consult",
-      "version": "0.0.8",
+      "version": "0.0.9",
       "maturity": "incubating",
       "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work, and cogni-knowledge is the central research tool across all skills.",
       "keywords": [

--- a/cogni-consult/.claude-plugin/plugin.json
+++ b/cogni-consult/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-consult",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work, and cogni-knowledge is the central research tool across all skills.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-consult/CLAUDE.md
+++ b/cogni-consult/CLAUDE.md
@@ -10,7 +10,7 @@ cogni-consult is a consulting engagement orchestrator for the insight-wave ecosy
 cogni-consult/
 ├── .claude-plugin/plugin.json     Plugin manifest (v0.0.x, Incubating)
 ├── CLAUDE.md                      This developer guide
-├── README.md                      User documentation (stub; full README is planned work)
+├── README.md                      Plugin documentation
 ├── references/
 │   ├── data-model.md              Engagement structure + entity schemas
 │   ├── deliverable-types.md       Deliverable-type catalog (field-type affinity)

--- a/cogni-consult/README.md
+++ b/cogni-consult/README.md
@@ -2,11 +2,143 @@
 
 > **Incubating** (v0.0.x) — skills, data formats, and workflows may change at any time.
 
-> **insight-wave readiness (Claude Code desktop recommended)** — Claude Code desktop is the recommended interface for insight-wave today. Cowork is a secondary path and is not yet production-ready for insight-wave workflows because of context-window and Pencil-MCP fidelity gaps — see the [deployment guide](../docs/deployment-guide.md) for detail. This guidance will flip when those gaps close upstream.
+> **insight-wave readiness (Claude Code desktop)** — Claude Code desktop is the recommended interface for insight-wave today. Cowork is a secondary path and is not yet production-ready for insight-wave workflows because of context-window and Pencil-MCP fidelity gaps — see the [deployment guide](../docs/deployment-guide.md) for detail. This guidance will flip when those gaps close upstream.
 
-Consulting engagement orchestrator for Claude Code / Claude Cowork where **action fields are the work-breakdown-structure containers** for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.
+> **Start here.** Run `/cogni-consult:consult-resume` for engagement status and the next recommended action, or `/cogni-consult:consult-setup` to start a new engagement.
 
-This is the foundation scaffold. Skills, the full documentation set, and the evaluation against cogni-consulting are planned work — see `CLAUDE.md` for the developer guide and `references/data-model.md` for the engagement data model.
+Consulting engagement orchestrator for [Claude Code](https://claude.com/claude-code) / [Claude Cowork](https://claude.ai) where **action fields are the work-breakdown-structure containers** for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.
+
+## Why this exists
+
+| Without cogni-consult | With cogni-consult |
+|---|---|
+| Engagement work is organized by fixed process phases, so deliverables wait on phase gates even when they could move | Action fields are the WBS — each deliverable progresses on its own clock inside its field |
+| One design-thinking pass for the whole engagement flattens every deliverable into the same rhythm | Every deliverable runs its own empathize→define→ideate→prototype→test loop, proportionate to its shape |
+| Stakeholder perspectives live in a slide nobody reads | Acting personas (shipped defaults: consulting partner, project manager) challenge each deliverable in their own voice before it counts as done |
+| Research is a throwaway per-question web search | One cogni-knowledge base bound at setup compounds across all deliverables — later research builds on earlier syntheses |
+
+## What it is
+
+A consulting engagement orchestrator built on three structural bets:
+
+- **Action fields as WBS** — scoping derives 3-6 action fields from one SMART key question; every deliverable lives inside exactly one field, and progress is tracked per deliverable, not per global phase.
+- **Design thinking per deliverable** — each deliverable iterates its own loop; fields complete when their deliverables do, and the engagement is complete by derivation.
+- **Knowledge base as the research spine** — one cogni-knowledge base is bound once at setup (`plugin_refs.knowledge_base`); all research routes through it per the canonical Research Routing Rule and compounds across the engagement.
+
+It is an orchestrator, not a producer: it manages engagement state and dispatches content work to the plugins that own it. It is also the evaluation candidate alongside cogni-consulting (Double Diamond), which stays untouched during the comparison.
+
+## What it does
+
+1. **Scaffold an engagement** — directory skeleton, cogni-knowledge base binding, and cross-session registry (`consult-setup`)
+2. **Scope the engagement** — frame the SMART key question, work the five scoping dimensions, derive 3-6 action fields as the WBS (`consult-scope`)
+3. **Manage the WBS** — per-field deliverable manifests, a fields × deliverables dashboard, next-deliverable recommendations, add/split/merge fields (`consult-action-fields`)
+4. **Produce deliverables** — run the empathize→define→ideate→prototype→test loop on one deliverable at a time, with evidence from the bound knowledge base (`consult-design-thinking`)
+5. **Challenge with acting personas** — define stakeholder personas from the scope, enrich them with evidence, and have them push back on deliverables in their own voice (`consult-personas`)
+6. **Resume across sessions** — discover engagements, show WBS progress, and route to the most valuable next action (`consult-resume`)
+
+## What it means for you
+
+- **Research compounds instead of evaporating** — every deliverable's evidence lands in one refinable knowledge base, so the tenth deliverable starts smarter than the first
+- **Progress where the work actually is** — deliverable-level state means you always know what is mid-loop, what awaits persona review, and what to pick up next
+- **Built-in challenge before delivery** — acting personas surface the partner's and PM's objections while the artifact is still cheap to change
+- **A fair comparison** — the plugin exists to be evaluated against cogni-consulting on real engagements; the two never share engagement directories
+
+## Install
+
+- **5-minute walkthrough** — [From Install to Infographic](../docs/workflows/install-to-infographic.md)
+- **Full setup reference** — [Claude Code desktop](../docs/claude-code-desktop.md)
+- **Enterprise / compliance setup** — [Deployment guide](../docs/deployment-guide.md)
+
+This plugin is part of the [insight-wave ecosystem](../docs/ecosystem-overview.md).
+
+> **Note**: cogni-knowledge is the one required companion — the engagement binds a knowledge base at setup and every research run routes through it.
+
+## Quick start
+
+```
+/cogni-consult:consult-setup        # scaffold an engagement + bind the knowledge base
+/cogni-consult:consult-scope        # key question, five dimensions, action-field WBS
+/cogni-consult:consult-action-fields # plan deliverable sets, pick the next deliverable
+/cogni-consult:consult-design-thinking # run the DT loop on one deliverable
+/cogni-consult:consult-personas     # define/enrich personas, challenge a deliverable
+/cogni-consult:consult-resume       # re-enter: status dashboard + next action
+```
+
+Natural language works too: "start a consulting engagement for ACME's DACH cloud expansion", "scope the engagement", "work the competitor-map deliverable", "have the partner persona challenge the draft", "where was I with the engagement?".
+
+## Data model
+
+| Entity | Lives in | Owns |
+|---|---|---|
+| Engagement | `cogni-consult/{slug}/consult-project.json` | Key question, action-field slug list, `workflow_state.scope`, `plugin_refs.knowledge_base`, language |
+| Action field | `action-fields/{field-slug}/field.json` | The field's deliverable states — single source of truth (`state`, `dt_stage`, `producing_route`, `persona_review`) |
+| Deliverable artifact | `action-fields/{field-slug}/{deliverable-slug}.md` | Markdown + YAML frontmatter with `sources[]` lineage triples (`kb_ref` for knowledge-base claims) |
+| Research synthesis | `action-fields/{field-slug}/research/{topic-slug}.md` | Finalized cogni-knowledge syntheses copied per the Research Routing Rule |
+| Persona | `personas/{persona-slug}.json` | Acting stakeholder persona (role, core tension, empathy map, work log) |
+| Logs | `.metadata/` | Execution, method, and decision logs addressed by field + deliverable |
+
+Field and engagement completion are derived at read time — never stored. Full schemas: `references/data-model.md`.
+
+## How it works
+
+```
+consult-setup ──→ consult-scope ──→ consult-action-fields ──→ consult-design-thinking
+ (scaffold +        (key question +     (plan deliverable        (empathize→define→ideate
+  kb binding)        5 dimensions +      sets, pick next)          →prototype→test per
+                     3-6 action fields)        │                    deliverable)
+                                               │                         │
+                                               ▼                         ▼
+                                        consult-resume  ←──────  consult-personas
+                                        (re-entry: dashboard      (acting personas
+                                         + next action)            challenge the draft)
+
+cogni-knowledge (bound once at setup) ←── every research run, per references/research-routing.md
+```
+
+Research never goes to raw web search: the engagement's bound knowledge base serves quick gap-checks (`knowledge-query`), full inverted-pipeline runs for new topics, and `--source wiki` re-runs on covered topics — with finalized syntheses copied to the owning action field's `research/` directory.
+
+## Components
+
+| Component | Type | Description |
+|---|---|---|
+| `consult-setup` | Skill | Engagement entry point: scaffold, cogni-knowledge base binding, global registry |
+| `consult-scope` | Skill | SMART key question + five scoping dimensions + 3-6 action fields as the WBS |
+| `consult-action-fields` | Skill | WBS dashboard, per-field deliverable manifests, next-deliverable recommendation, add/split/merge |
+| `consult-design-thinking` | Skill | Per-deliverable design-thinking loop with artifact + state writes |
+| `consult-personas` | Skill | Acting personas: define from scope, enrich with evidence, act-as challenge against deliverables |
+| `consult-resume` | Skill | Cross-session re-entry: engagement discovery, WBS dashboard, workflow-state next-action routing |
+| `engagement-init.sh` | Script | Create the engagement directory skeleton + `consult-project.json` |
+| `engagement-status.sh` | Script | Derive field/deliverable rollups from `field.json` files → JSON |
+| `discover-projects.sh` | Script | Engagement discovery (delegates to the cogni-workspace helper) |
+
+## Architecture
+
+```
+cogni-consult/
+├── .claude-plugin/plugin.json     Plugin manifest (v0.0.x, Incubating)
+├── CLAUDE.md                      Developer guide
+├── README.md                      This file
+├── references/
+│   ├── data-model.md              Engagement structure + entity schemas
+│   ├── deliverable-types.md       Deliverable-type catalog (field-type affinity)
+│   ├── persona-schema.md          Acting-persona schema + acting contract
+│   ├── research-routing.md        Canonical cogni-knowledge research rule
+│   ├── personas/                  Packaged default advisors (partner, PM)
+│   └── methods/                   Stage methods (scope dimensions, empathy mapping,
+│                                  HMW synthesis, guided ideation)
+├── scripts/                       Engagement init/status/discovery (stdlib-only)
+└── skills/                        The six skills listed under Components
+```
+
+## Dependencies
+
+| Plugin | Required | Purpose |
+|--------|----------|---------|
+| cogni-knowledge | Yes | Bound once at setup (`plugin_refs.knowledge_base`) — the research spine every deliverable's evidence routes through |
+| cogni-workspace | No | Cross-session engagement discovery (`discover-projects.sh` delegates to its helper) |
+| cogni-visual / document-skills | No | Deliverable export (slides, documents) when a deliverable names an export route |
+
+cogni-consult is standalone as an orchestrator — it structures the engagement, the WBS, and the design-thinking loops on its own. cogni-knowledge is the one required integration: without it, deliverable research has no compounding base.
 
 ## License
 

--- a/docs/ecosystem-overview.md
+++ b/docs/ecosystem-overview.md
@@ -1,6 +1,6 @@
 # Ecosystem Overview
 
-insight-wave is a monorepo of 13 Claude Code plugins that cover the full consulting and B2B content pipeline: from raw research through strategy, content production, visual delivery, and website generation. This document describes how the plugins are organized, how data moves between them, and what infrastructure they share.
+insight-wave is a monorepo of 14 Claude Code plugins that cover the full consulting and B2B content pipeline: from raw research through strategy, content production, visual delivery, and website generation. This document describes how the plugins are organized, how data moves between them, and what infrastructure they share.
 
 For the canonical plugin descriptions, see the individual README files. For step-by-step workflows, see [docs/workflows/](workflows/).
 
@@ -8,7 +8,7 @@ For the canonical plugin descriptions, see the individual README files. For step
 
 ## Plugin Landscape
 
-The 13 plugins are grouped by the role they play in a typical engagement.
+The 14 plugins are grouped by the role they play in a typical engagement.
 
 ### Foundation
 
@@ -33,6 +33,7 @@ See [Research to Report workflow](workflows/research-to-report.md) for how resea
 |--------|-------------|
 | [cogni-portfolio](../cogni-portfolio/README.md) | Structures product and service messaging using the IS/DOES/MEANS framework. Features are market-independent (IS). Advantages (DOES) and benefits (MEANS) are market-specific. Includes TAM/SAM/SOM sizing, competitor analysis, Lean Canvas bootstrapping, and eight industry taxonomies. |
 | [cogni-consulting](../cogni-consulting/README.md) | Orchestrates engagements through the Double Diamond phases (Discover, Define, Develop, Deliver) by dispatching to research, trends, portfolio, and claims plugins at the right moment. Phase-gated, vision-first. |
+| [cogni-consult](../cogni-consult/README.md) | Incubating evaluation candidate alongside cogni-consulting: action fields as the work-breakdown structure, a design-thinking loop per deliverable, acting stakeholder personas, and one cogni-knowledge base per engagement as the compounding research spine. See the [deep dive](plugin-guide/cogni-consult.md). |
 
 See the [Double Diamond Engagement workflow](workflows/consulting-engagement.md) for how cogni-consulting coordinates the other plugins.
 

--- a/docs/plugin-guide/cogni-consult.md
+++ b/docs/plugin-guide/cogni-consult.md
@@ -1,0 +1,139 @@
+# cogni-consult
+
+Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable, each deliverable runs its own design-thinking loop, acting personas challenge the work, and one cogni-knowledge base per engagement is the research spine. For canonical positioning see the [README](../../cogni-consult/README.md).
+
+---
+
+## Overview
+
+cogni-consult structures a consulting engagement without fixed process phases. Scoping converges on one SMART key question and derives 3-6 **action fields** — thematic containers that together form the engagement's work-breakdown structure. Every deliverable lives inside exactly one field and walks its own **design-thinking loop** (empathize → define → ideate → prototype → test) at its own pace; a field is complete when its deliverables are, and the engagement is complete by derivation. Nothing waits on a phase gate.
+
+Two further mechanisms keep quality and evidence honest. **Acting personas** — stakeholder profiles such as the shipped consulting-partner and project-manager defaults — challenge each deliverable in their own voice at the test stage, so the partner's objections surface while the artifact is still cheap to change. And **one cogni-knowledge base per engagement**, bound at setup, is the only sanctioned research tool: every evidence run routes through it per the canonical Research Routing Rule, so the tenth deliverable's research builds on the first nine instead of starting cold.
+
+cogni-consult is the **evaluation candidate** alongside cogni-consulting (Double Diamond). The two plugins never share engagement directories, and cogni-consulting stays untouched while the comparison runs.
+
+---
+
+## Key Concepts
+
+| Term | Meaning |
+|---|---|
+| Key question | One SMART question the whole engagement answers; framed in scoping |
+| Scoping dimensions | Five guided lenses — Strategic Context, Scope, Stakeholder, Constraints/Barriers, Success factors |
+| Action field | A WBS container derived from the key question; owns a set of deliverables via its `field.json` manifest |
+| Deliverable | One artifact inside a field, produced by its own design-thinking loop; state is `pending` → `in-progress` → `complete` |
+| `dt_stage` | The deliverable's position in the loop: `empathize` / `define` / `ideate` / `prototype` / `test` |
+| Acting persona | A stakeholder profile that actively challenges deliverables in its own voice; tracked per deliverable via `persona_review` |
+| Knowledge base | The engagement's bound cogni-knowledge wiki (`plugin_refs.knowledge_base`); all research compounds there |
+
+### Engagement layout
+
+```
+cogni-consult/{engagement-slug}/
+├── consult-project.json        # config + scope state + plugin refs
+├── scope/key-question.md       # key question + dimensions + field list
+├── action-fields/{field-slug}/ # field.json + deliverable artifacts + research/
+├── personas/{persona-slug}.json
+└── .metadata/                  # execution / method / decision logs
+```
+
+State ownership is strict: deliverable state lives only in `field.json`; field and engagement completion are derived at read time, never stored.
+
+---
+
+## Getting Started
+
+Say something like:
+
+> "Start a consulting engagement for ACME's DACH cloud portfolio expansion."
+
+1. **`consult-setup`** scaffolds the engagement directory, binds a cogni-knowledge base (one per engagement), and registers the engagement for cross-session discovery.
+2. **`consult-scope`** frames the SMART key question, walks the five scoping dimensions, and derives 3-6 action fields — the WBS every later skill works inside.
+3. **`consult-action-fields`** plans each field's deliverable set and recommends the next deliverable to work.
+4. **`consult-design-thinking`** produces that deliverable through its loop, pulling evidence from the bound knowledge base.
+5. **`consult-personas`** lets the partner and PM personas challenge the draft before it counts as complete.
+6. In any later session, **`consult-resume`** shows the WBS dashboard and routes to the most valuable next action.
+
+---
+
+## Capabilities
+
+### `consult-setup` — engagement entry point
+
+Scaffolds `cogni-consult/{slug}/` via `engagement-init.sh`, captures the desired outcome and language, dispatches `cogni-knowledge:knowledge-setup` to bind the engagement's knowledge base (recorded in `plugin_refs.knowledge_base`), and registers the engagement in the global discovery registry. Idempotent: an already-initialized engagement routes to `consult-resume` instead of overwriting.
+
+### `consult-scope` — key question, dimensions, WBS
+
+The keystone conversation. Drafts the SMART key question collaboratively, walks Strategic Context, Scope, Stakeholder, Constraints/Barriers, and Success factors, then closes by naming 3-6 action fields (slug, title, one-line framing) persisted as `field.json` stubs. Produces one deliverable: `scope/key-question.md`. Dimension evidence the consultant cannot supply routes through the knowledge base per the Research Routing Rule, landing in `scope/research/`.
+
+### `consult-action-fields` — the WBS manager
+
+Renders the fields × deliverables dashboard from `engagement-status.sh`, plans a field's deliverable set from the deliverable-type catalog (1-3 per field, each with a `producing_route` and `persona_review` tracker), recommends the next deliverable, and handles add/split/merge of fields — always keeping each deliverable in exactly one field. It plans the work; the producing route runs it.
+
+### `consult-design-thinking` — the per-deliverable loop
+
+Walks one deliverable through empathize (persona empathy mapping + knowledge-base recall), define (HMW problem spec, locked as a logged decision), ideate (guided diverge→converge), prototype (the artifact, with `sources[]` lineage on every evidence-backed claim), and test (persona challenges + consultant acceptance). Stages may re-enter earlier stages; `state` stays `in-progress` until test passes. Evidence gaps escalate through the Research Routing Rule — never raw web search.
+
+### `consult-personas` — acting stakeholders
+
+Defines personas from the scope's Stakeholder dimension (or enriches the shipped partner/PM defaults with engagement evidence), and acts as a persona to challenge a deliverable in its voice — objections from its role, core tension, and empathy map, each dispositioned (accepted / revised / rejected with reason) and logged to the persona's `work_log`.
+
+### `consult-resume` — cross-session re-entry
+
+Discovers engagements (registry-backed, works from any directory), renders the action-fields × deliverables × status dashboard, surfaces manifest warnings, and recommends exactly one next action keyed on derived state — scope not done → `consult-scope`; unplanned field → `consult-action-fields`; deliverable mid-loop → `consult-design-thinking`; challenge pass open → `consult-personas`. Read-only: it never writes engagement state.
+
+---
+
+## Integration Points
+
+| Plugin | Direction | What flows |
+|---|---|---|
+| cogni-knowledge | Orchestrates (required) | One base bound at setup; all research runs through the inverted pipeline / `knowledge-query`; finalized syntheses copied to `action-fields/{field}/research/` |
+| cogni-workspace | Consumes | Cross-session engagement discovery via the shared registry helper |
+| cogni-claims | Consumes | Deliverable `sources[]` lineage triples let claim corrections cascade into artifacts |
+| cogni-visual / document-skills | Orchestrates (optional) | Deliverable export when a deliverable's `producing_route` names an export path |
+
+cogni-consult is standalone as a methodology orchestrator; cogni-knowledge is the one integration it requires to deliver its compounding-research promise.
+
+---
+
+## Common Workflows
+
+**1. New engagement, first deliverable**
+
+1. `consult-setup` → scaffold + bind knowledge base
+2. `consult-scope` → key question, dimensions, 3-6 fields
+3. `consult-action-fields` → plan the first field's deliverables, pick one
+4. `consult-design-thinking` → run the loop to a tested artifact
+
+**2. Multi-session continuation**
+
+1. `consult-resume` → dashboard + one recommended next action
+2. Confirm → the named skill picks up with the engagement path handed off in-session (no rediscovery)
+
+**3. Research-heavy deliverable**
+
+1. Empathize surfaces a coverage gap → `knowledge-query` confirms the base is silent
+2. Full inverted pipeline runs against the bound base (`--knowledge-slug` from `plugin_refs.knowledge_base`)
+3. Finalized synthesis copied to the field's `research/` directory; the artifact cites it via `sources[].kb_ref`
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| "There's no engagement yet" on every skill | Setup never ran, or the engagement isn't registered | Run `consult-setup`; for an existing directory, register it via the discovery script's `--register` |
+| A field shows `unreadable` in the dashboard | Corrupt or hand-edited `field.json` | Inspect and fix the manifest before routing — the surfaced warning names the file |
+| Research recommendations ignore earlier syntheses | Engagement bound to the wrong knowledge slug, or a second base was created | Check `plugin_refs.knowledge_base` in `consult-project.json`; one base per engagement, always |
+| Persona challenges feel generic | Personas not yet enriched with engagement evidence | Run `consult-personas` enrichment against the scope and knowledge base first |
+| Double Diamond phase language gets routed here | Wrong plugin — phases belong to cogni-consulting | Use `cogni-consulting:consulting-*` skills; the two plugins never share engagements |
+
+---
+
+## Extending This Plugin
+
+- **Deliverable types** — extend `references/deliverable-types.md` with new types and field-type affinities
+- **Personas** — add JSON personas under `references/personas/` (schema: `references/persona-schema.md`)
+- **Stage methods** — add or refine method references under `references/methods/`
+- **Research routing** — the canonical rule lives in `references/research-routing.md`; skills point at it, so extend it there, not per-skill


### PR DESCRIPTION
Closes #661.

## Summary
- Rewrite `cogni-consult/README.md` from the scaffold stub to the full 16-section IS/DOES/MEANS structure: Incubating maturity callout kept after the H1, readiness callout normalized to the canonical sibling wording, dual-interface intro ("Claude Code / Claude Cowork") kept, plus Why-this-exists problem table, IS/DOES/MEANS sections, Install/Quick-start blocks, Data model, How-it-works flow, Components table (6 skills + 3 scripts), Architecture tree, and a Dependencies table marking cogni-knowledge **Required: Yes** (bound at setup — the research spine).
- Finalize `cogni-consult/CLAUDE.md`: the Architecture tree no longer describes README.md as a planned-work stub.
- Add `docs/plugin-guide/cogni-consult.md` (~190 lines) mirroring the cogni-consulting guide shape: Overview, Key Concepts, Getting Started, Capabilities (one H3 per skill), Integration Points, Common Workflows, Troubleshooting, Extending.
- Link it from `docs/ecosystem-overview.md`: new cogni-consult row in Strategy and Portfolio (framed as the incubating evaluation candidate alongside cogni-consulting) and the prose plugin count corrected 13 → 14.
- Bump cogni-consult 0.0.8 → 0.0.9 in `plugin.json` and root `marketplace.json`.

## Scope decisions
- **Ecosystem-overview count:** corrected to **14** = the enumerated table rows after adding cogni-consult (the tables currently list 13 plugins). Writing the marketplace's 16 would contradict the visible rows, because cogni-knowledge and cogni-wiki rows are missing — pre-existing drift deliberately not fixed here (cogni-wiki's row depends on the pending archival decision; cogni-knowledge needs its own placement pass). Tracked as follow-up #673. Whether the prose count should instead track the marketplace total is part of that follow-up.
- **No new skills/agents/scripts** — pure documentation; maturity stays Incubating (0.0.x).

## Follow-up issues
- #673 — docs/ecosystem-overview.md: add cogni-knowledge row + reconcile plugin count with marketplace (cogni-wiki row pending archival decision)

## Plan record
https://github.com/cogni-work/insight-wave/issues/661#issuecomment-4685155658

## Test plan
- [x] README has all 16 sections in order (12 H2 sections + H1/callouts/footer); no #NNN refs (breadcrumb guard pass)
- [x] Components table lists all 6 skills matching SKILL.md frontmatter; Architecture tree mirrors CLAUDE.md
- [x] CLAUDE.md no longer says "stub; full README is planned work"
- [x] docs/plugin-guide/cogni-consult.md exists and is linked from ecosystem-overview.md
- [x] ecosystem-overview says "14" at both count occurrences and includes the cogni-consult row
- [x] Both manifests show 0.0.9

🤖 Generated with [Claude Code](https://claude.com/claude-code)