### PR TITLE
cogni-knowledge: ingest envelopes carry sub_question_refs for compose coverage

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -326,7 +326,7 @@
     {
       "name": "cogni-knowledge",
       "source": "./cogni-knowledge",
-      "version": "0.1.136",
+      "version": "0.1.137",
       "maturity": "preview",
       "description": "Wiki-first research that compounds. Binds each run to a cogni-wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`. The shallow `knowledge-query` rung is read-only by default and can optionally file its answer back as an un-verified synthesis page via `--file-back`.",
       "keywords": [

--- a/cogni-knowledge/.claude-plugin/plugin.json
+++ b/cogni-knowledge/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-knowledge",
-  "version": "0.1.136",
+  "version": "0.1.137",
   "description": "Wiki-first research that compounds. Binds each run to a cogni-wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`. The shallow `knowledge-query` rung is read-only by default and can optionally file its answer back as an un-verified synthesis page via `--file-back`.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-knowledge/agents/source-ingester.md
+++ b/cogni-knowledge/agents/source-ingester.md
@@ -181,12 +181,15 @@ Write a JSON envelope to `BATCH_OUTPUT_PATH`:
   "wiki_path": "<absolute path to the new page>",
   "title": "<resolved title>",
   "claims_extracted": 12,
+  "sub_question_refs": ["sq-01", "sq-03"],
   "summary": "<one crisp, self-contained sentence describing what the page is about>",
   "publisher": "europa.eu",
   "fetched_at": "<entry.fetched_at>",
   "cost_estimate": {"input_words": 5400, "output_words": 1100, "estimated_usd": 0.024}
 }
 ```
+
+`sub_question_refs` echoes the dispatched `SUB_QUESTION_REFS` input back as a list — split the comma-separated value on `,` and trim each `sq-NN` id (the same input already parsed for `sub_question_refs[0]`/`THEME_LABEL` resolution). The field is load-bearing downstream: the orchestrator merges it onto this source's `ingest-manifest.json::ingested[]` entry, which the compose-time coverage reader filters on per sub-question — an envelope without it would make this source invisible to every sub-question's coverage. No new input, no network.
 
 For the skip cases (cache miss / unavailable / empty body / invalid slug / invalid page type / slug collision / integrity mismatch):
 

--- a/cogni-knowledge/skills/knowledge-ingest/SKILL.md
+++ b/cogni-knowledge/skills/knowledge-ingest/SKILL.md
@@ -145,6 +145,7 @@ For each batch:
 
 4. After all ingesters in this batch return, merge the per-source batch JSONs into `ingest-manifest.json`:
    - For each batch JSON file: on `ok: true` append to `ingested[]`; on `ok: false` / skipped append to `skipped[]` with the `reason`.
+   - **Populate `sub_question_refs` on every `ingested[]` entry.** Prefer the envelope's own `sub_question_refs` when present; when absent (an older agent or a partial envelope), backfill from the Step 0 URL → `sub_question_refs[]` map (the `candidates.json` read kept around for Step 4). This field is load-bearing: `knowledge-compose`'s `coverage_report` filters `ingested[]` on it per sub-question, so an entry without it makes its source invisible to every sub-question's coverage — never append an `ingested[]` entry that lacks it.
    - Dedup within each array by URL (covers cross-run re-merges — same URL ingested twice keeps the later entry).
    - **Single atomic write per batch**, not per source. Use the shared helper rather than reinventing the mkstemp+os.replace dance. Pass paths via env vars so apostrophes / spaces in project paths cannot break the Python literal:
      ```
@@ -158,7 +159,9 @@ For each batch:
      from _knowledge_lib import atomic_write
      manifest_path = Path(os.environ["MANIFEST_PATH"])
      manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
-     # ... append batch entries to manifest["ingested"] / manifest["skipped"], dedup by URL ...
+     # ... append batch entries to manifest["ingested"] / manifest["skipped"], dedup by URL;
+     #     set entry["sub_question_refs"] on every ingested entry (envelope value,
+     #     else the Step 0 URL -> sub_question_refs[] map from candidates.json) ...
      atomic_write(manifest_path, manifest)
      '
      ```


### PR DESCRIPTION
Closes #686.

## Summary
- `source-ingester` Phase 4 `ok:true` batch envelope now echoes back `sub_question_refs` (the comma-separated `SUB_QUESTION_REFS` it already receives at dispatch, parsed to a `sq-NN` list) so the field travels with the source it describes.
- `knowledge-ingest` Step 3.4 merge contract is made explicit: each `ingested[]` entry is populated with `sub_question_refs` — from the envelope when present, falling back to the orchestrator's Step 0 URL → `sub_question_refs[]` map (built from `candidates.json`) as a deterministic backstop. The orchestrator no longer hand-backfills from the dispatch table.
- `coverage_report()` in `scripts/_knowledge_lib.py` is intentionally unchanged — it is correct when the field is present; this PR closes the upstream schema gap that left it empty. The `--source wiki` path already populates `ingested[].sub_question_refs` (`wiki-source-manifest.py`), so this aligns the web path to the same already-consumed contract.
- Bumped `cogni-knowledge` patch version in `plugin.json` (0.1.136 → 0.1.137) and mirrored it in root `marketplace.json`.

## Scope decisions
- **Included:** the additive envelope field, the explicit merge-with-backstop contract, and the version bump — the complete fix for the issue's acceptance criterion (compose `coverage_report` sees correct available sources after a per-SKILL.md ingest run).
- **Not changed:** `coverage_report()` reader logic (correct-when-present); `wiki-source-manifest.py` (the `--source wiki` path already writes `sub_question_refs` correctly); `fetch-manifest.json` (it does not and should not carry the field — the join comes from `candidates.json`). No `ingested[]` JSON-schema block exists in SKILL.md or `references/inverted-pipeline.md` to update. No issue/PR refs added to SKILL.md or the agent file (rationale stated semantically). Nothing deferred.

## Test plan
- [x] `agents/source-ingester.md` Phase 4 `ok:true` envelope lists `sub_question_refs`, derived by parsing the `SUB_QUESTION_REFS` dispatch input — no new input, no network.
- [x] `skills/knowledge-ingest/SKILL.md` Step 3.4 merge explicitly sets `sub_question_refs` on each `ingested[]` entry (envelope value, else the Step 0 candidates map).
- [x] No `#NNN` issue/PR refs in the agent/SKILL edits (`scripts/check-breadcrumbs.py`: 0 new violations).
- [x] `tests/test_ingest_contract.sh` + `tests/test_skill_contracts.sh` pass.
- [x] `plugin.json` and `marketplace.json` both carry 0.1.137.
- [ ] Live: run knowledge-ingest then knowledge-compose on a base and verify `coverage_report` reports non-zero available sources (manual bake-in; the schema gap is closed deterministically by the merge contract).

Plan record: https://github.com/cogni-work/insight-wave/issues/686#issuecomment-4690890651

🤖 Generated with [Claude Code](https://claude.com/claude-code)