### PR TITLE
cogni-knowledge: resolve-wiki-scripts.sh no longer aborts on unset CLAUDE_PLUGIN_ROOT

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -326,7 +326,7 @@
     {
       "name": "cogni-knowledge",
       "source": "./cogni-knowledge",
-      "version": "0.1.137",
+      "version": "0.1.138",
       "maturity": "preview",
       "description": "Wiki-first research that compounds. Binds each run to a cogni-wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`. The shallow `knowledge-query` rung is read-only by default and can optionally file its answer back as an un-verified synthesis page via `--file-back`.",
       "keywords": [

--- a/cogni-knowledge/.claude-plugin/plugin.json
+++ b/cogni-knowledge/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-knowledge",
-  "version": "0.1.137",
+  "version": "0.1.138",
   "description": "Wiki-first research that compounds. Binds each run to a cogni-wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`. The shallow `knowledge-query` rung is read-only by default and can optionally file its answer back as an un-verified synthesis page via `--file-back`.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-knowledge/scripts/resolve-wiki-scripts.sh
+++ b/cogni-knowledge/scripts/resolve-wiki-scripts.sh
@@ -5,11 +5,18 @@
 # (_knowledge_lib.resolve_wiki_scripts) stays a separate copy by necessity —
 # standalone Python scripts cannot source a shell snippet.
 #
-# Usage (inside a SKILL.md shell block, with CLAUDE_PLUGIN_ROOT in the env):
+# Usage (inside a SKILL.md shell block; CLAUDE_PLUGIN_ROOT preferred but optional —
+# when unset, the plugin root is derived from this script's own sourced location):
 #   . "${CLAUDE_PLUGIN_ROOT}/scripts/resolve-wiki-scripts.sh"
 #   WIKI_INGEST_SCRIPTS=$(resolve_wiki_scripts wiki-ingest backlink_audit.py) || abort "..."
 #
 # bash 3.2 + stdlib only.
+
+# Captured at SOURCE time, not function-run time: BASH_SOURCE[0] carries the
+# sourced file path under bash; under zsh (FUNCTION_ARGZERO default) $0 carries
+# it here at the top level but would be the *function name* inside the function
+# body, so capturing later would derive a garbage root.
+_RESOLVE_WIKI_SCRIPTS_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")/.." 2>/dev/null && pwd)"
 
 resolve_wiki_scripts() {  # $1 = skill name, e.g. wiki-ingest / wiki-lint / wiki-health
   local skill="$1"
@@ -18,16 +25,22 @@ resolve_wiki_scripts() {  # $1 = skill name, e.g. wiki-ingest / wiki-lint / wiki
   # probes below are the fallback (keeps both plugins installable until archive).
   local ep="${2:-}"   # $2 = optional entry-point script; when set, a probe branch
                       # wins only if "<dir>/$ep" is a file (a partial vendor falls through)
-  local vend="${CLAUDE_PLUGIN_ROOT}/scripts/vendor/cogni-wiki/skills/${skill}/scripts"
+  # Plugin root: prefer CLAUDE_PLUGIN_ROOT, fall back to the root derived from
+  # this script's own sourced location (nested-skill Bash blocks don't inherit
+  # the env var). Without the guard, the cache glob below expands against an
+  # empty prefix and zsh aborts fatally on the no-match (`no matches found`);
+  # bash merely degrades to not-found.
+  local _cpr="${CLAUDE_PLUGIN_ROOT:-$_RESOLVE_WIKI_SCRIPTS_ROOT}"
+  local vend="${_cpr}/scripts/vendor/cogni-wiki/skills/${skill}/scripts"
   test -d "$vend" && { [ -z "$ep" ] || [ -f "$vend/$ep" ]; } && { echo "$vend"; return 0; }
-  local sib="${CLAUDE_PLUGIN_ROOT}/../cogni-wiki/skills/${skill}/scripts"
+  local sib="${_cpr}/../cogni-wiki/skills/${skill}/scripts"
   test -d "$sib" && { [ -z "$ep" ] || [ -f "$sib/$ep" ]; } && { echo "$sib"; return 0; }
   # pick the NEWEST cached version, not the lexically-first. Consider ONLY
   # numeric version dirs — sort -V ranks a non-numeric name (main/latest/a
   # branch checkout) ABOVE every real version, so a stray dir would otherwise
   # win. sort -V handles multi-digit segments (0.0.9 < 0.0.16 < 0.0.46).
   local newest ver
-  newest=$(for d in "${CLAUDE_PLUGIN_ROOT}/../../cogni-wiki/"*/skills/"${skill}"/scripts; do
+  newest=$(for d in "${_cpr}/../../cogni-wiki/"*/skills/"${skill}"/scripts; do
     [ -d "$d" ] || continue
     { [ -z "$ep" ] || [ -f "$d/$ep" ]; } || continue
     ver=${d%/skills/${skill}/scripts}; ver=${ver##*/}

--- a/cogni-knowledge/tests/test_resolve_wiki_scripts.sh
+++ b/cogni-knowledge/tests/test_resolve_wiki_scripts.sh
@@ -207,6 +207,49 @@ else
   green "PASS: no dir carrying the entry-point -> resolver returns non-zero"
 fi
 
+# -----------------------------------------------------------------------------
+# Part 4: unset CLAUDE_PLUGIN_ROOT — the resolver derives the plugin root from
+#         its own sourced location instead of expanding a glob rooted at an
+#         empty prefix (which zsh aborts on with `no matches found`). The
+#         snippet must be sourced BY FILE PATH here: a `bash -c` inlined body
+#         (Parts 2-3) has an empty BASH_SOURCE, which would mask the fallback.
+# -----------------------------------------------------------------------------
+
+UNSET_ROOT="$WORK/cache/cogni-knowledge/0.1.1"
+mkdir -p "$UNSET_ROOT/scripts"
+cp "$RESOLVER_SNIPPET" "$UNSET_ROOT/scripts/resolve-wiki-scripts.sh"
+
+# Case 7: bash, CLAUDE_PLUGIN_ROOT unset -> source-location root, newest cache wins.
+if OUT=$(env -u CLAUDE_PLUGIN_ROOT bash -c ". '$UNSET_ROOT/scripts/resolve-wiki-scripts.sh'; resolve_wiki_scripts wiki-ingest"); then
+  case "$OUT" in
+    */cogni-wiki/0.0.45/skills/wiki-ingest/scripts)
+      green "PASS: unset CLAUDE_PLUGIN_ROOT derives the root from the script's own location" ;;
+    *)
+      red "FAIL: unset-env fallback resolved the wrong dir"
+      red "  got: $OUT"; errors=$((errors + 1)) ;;
+  esac
+else
+  red "FAIL: resolver returned non-zero with CLAUDE_PLUGIN_ROOT unset (fallback did not engage)"; errors=$((errors + 1))
+fi
+
+# Case 8: same shape under zsh — the originally-reported failure environment
+# (zsh aborts a sourced block on an unmatched glob). Runs only where zsh exists.
+if command -v zsh >/dev/null 2>&1; then
+  if OUT=$(env -u CLAUDE_PLUGIN_ROOT zsh -c ". '$UNSET_ROOT/scripts/resolve-wiki-scripts.sh'; resolve_wiki_scripts wiki-ingest" 2>&1); then
+    case "$OUT" in
+      */cogni-wiki/0.0.45/skills/wiki-ingest/scripts)
+        green "PASS: zsh + unset CLAUDE_PLUGIN_ROOT resolves without aborting" ;;
+      *)
+        red "FAIL: zsh unset-env run produced unexpected output"
+        red "  got: $OUT"; errors=$((errors + 1)) ;;
+    esac
+  else
+    red "FAIL: zsh aborted with CLAUDE_PLUGIN_ROOT unset (the reported bug): $OUT"; errors=$((errors + 1))
+  fi
+else
+  green "PASS: zsh not available on this host — zsh case skipped (bash case 7 covers the fallback)"
+fi
+
 if [ $errors -gt 0 ]; then
   red "$errors case(s) failed."
   exit 1


### PR DESCRIPTION
Closes #687.

## Summary
- `resolve_wiki_scripts()` now derives the plugin root from the resolver's own sourced location when `CLAUDE_PLUGIN_ROOT` is not inherited (nested-skill Bash blocks, plain operator shells): a top-level `_RESOLVE_WIKI_SCRIPTS_ROOT` capture (`BASH_SOURCE[0]` under bash, `$0` under zsh) feeds `local _cpr="${CLAUDE_PLUGIN_ROOT:-$_RESOLVE_WIKI_SCRIPTS_ROOT}"`, and all three probe sites (vendored / sibling / newest-version cache glob) use `${_cpr}`.
- The capture happens at **source time**, not function-run time — under zsh (`FUNCTION_ARGZERO` default) `$0` inside the function would be the function name, deriving a garbage root and leaving the zsh `no matches found` abort in place.
- Resolution order (vendored → sibling → newest version-sorted cache) is byte-identical; all 13 consuming skills are unchanged — the fix is internal to the resolver.
- Two new behavioral test cases: Case 7 sources the snippet **by file path** (so `BASH_SOURCE` populates; the existing `bash -c` harness inlines the body where it is empty) with `CLAUDE_PLUGIN_ROOT` unset; Case 8 repeats the shape under zsh — the originally-reported failure environment — guarded on zsh availability.
- Bump `plugin.json` 0.1.137 → 0.1.138, mirrored in `marketplace.json`.

## Scope decisions
- **Included:** the resolver guard, the source-time capture, two regression cases, the version bump — the complete fix.
- **Deferred:** nothing. The Python peer (`_knowledge_lib.resolve_wiki_scripts`) already derives its root from `__file__` and is immune; no cross-plugin copies of the shell snippet exist.

## Test plan
- [x] `bash cogni-knowledge/tests/test_resolve_wiki_scripts.sh` — all 17 cases pass (incl. new Cases 7+8; Case 8 ran live under zsh on this macOS host and confirms no `no matches found` abort).
- [x] Existing Cases 1–6 (version sort, sibling, absent, entry-point probes) stay green.
- [x] bash 3.2 compatible (no arrays beyond `BASH_SOURCE[0]` read, no bashisms in the POSIX-ish function body).
- [x] `python3 scripts/check-breadcrumbs.py` — 0 new violations.
- [x] `tests/test_skill_contracts.sh` passes; `plugin.json` + `marketplace.json` both at 0.1.138.

Plan record: https://github.com/cogni-work/insight-wave/issues/687#issuecomment-4691079424

🤖 Generated with [Claude Code](https://claude.com/claude-code)