### PR TITLE
cogni-knowledge: bash-3.2-safe case patterns in resolve-wiki-scripts.sh

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -326,7 +326,7 @@
     {
       "name": "cogni-knowledge",
       "source": "./cogni-knowledge",
-      "version": "0.1.138",
+      "version": "0.1.139",
       "maturity": "preview",
       "description": "Wiki-first research that compounds. Binds each run to a cogni-wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`. The shallow `knowledge-query` rung is read-only by default and can optionally file its answer back as an un-verified synthesis page via `--file-back`.",
       "keywords": [

--- a/cogni-knowledge/.claude-plugin/plugin.json
+++ b/cogni-knowledge/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-knowledge",
-  "version": "0.1.138",
+  "version": "0.1.139",
   "description": "Wiki-first research that compounds. Binds each run to a cogni-wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`. The shallow `knowledge-query` rung is read-only by default and can optionally file its answer back as an un-verified synthesis page via `--file-back`.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-knowledge/scripts/resolve-wiki-scripts.sh
+++ b/cogni-knowledge/scripts/resolve-wiki-scripts.sh
@@ -44,7 +44,10 @@ resolve_wiki_scripts() {  # $1 = skill name, e.g. wiki-ingest / wiki-lint / wiki
     [ -d "$d" ] || continue
     { [ -z "$ep" ] || [ -f "$d/$ep" ]; } || continue
     ver=${d%/skills/${skill}/scripts}; ver=${ver##*/}
-    case "$ver" in ''|*[!0-9.]*) continue ;; esac
+    # Leading-paren case patterns: the closing-paren-only form trips bash 3.2's
+    # case-inside-$(...) parser bug (the whole file then fails to source under
+    # the macOS system bash); the balanced form is parsed by every bash + zsh.
+    case "$ver" in ('') continue ;; (*[!0-9.]*) continue ;; esac
     printf '%s\n' "$d"
   done | sort -V | tail -1)
   [ -n "$newest" ] && { echo "$newest"; return 0; }

--- a/cogni-knowledge/tests/test_resolve_wiki_scripts.sh
+++ b/cogni-knowledge/tests/test_resolve_wiki_scripts.sh
@@ -232,6 +232,26 @@ else
   red "FAIL: resolver returned non-zero with CLAUDE_PLUGIN_ROOT unset (fallback did not engage)"; errors=$((errors + 1))
 fi
 
+# Case 7b: the snippet must parse + resolve under the SYSTEM bash (macOS ships
+# /bin/bash 3.2, whose parser rejects closing-paren-only case patterns inside
+# $(...) — the suite's plain `bash` resolves to a newer Homebrew bash, which
+# masked exactly that regression). Runs only where /bin/bash exists.
+if [ -x /bin/bash ]; then
+  if OUT=$(env -u CLAUDE_PLUGIN_ROOT /bin/bash -c ". '$UNSET_ROOT/scripts/resolve-wiki-scripts.sh'; resolve_wiki_scripts wiki-ingest" 2>&1); then
+    case "$OUT" in
+      */cogni-wiki/0.0.45/skills/wiki-ingest/scripts)
+        green "PASS: system /bin/bash (3.2 on macOS) parses and resolves the snippet" ;;
+      *)
+        red "FAIL: system /bin/bash run produced unexpected output"
+        red "  got: $OUT"; errors=$((errors + 1)) ;;
+    esac
+  else
+    red "FAIL: system /bin/bash could not source/resolve the snippet (3.2 parser regression?): $OUT"; errors=$((errors + 1))
+  fi
+else
+  green "PASS: /bin/bash not present on this host — system-bash case skipped"
+fi
+
 # Case 8: same shape under zsh — the originally-reported failure environment
 # (zsh aborts a sourced block on an unmatched glob). Runs only where zsh exists.
 if command -v zsh >/dev/null 2>&1; then


### PR DESCRIPTION
Closes #691.

## Summary
- Balance the version-filter case patterns with leading parens — `case "$ver" in ('') continue ;; (*[!0-9.]*) continue ;; esac` — so the snippet parses under bash 3.2's case-inside-`$(...)` parser (the macOS system `/bin/bash`). Semantics identical; the closing-paren-only form made the whole file fail to source (`resolve_wiki_scripts: command not found`), contradicting the file's own "bash 3.2 + stdlib only" header.
- New test Case 7b pins one invocation to `/bin/bash` (guarded on existence), closing the detection gap: the suite's plain `bash` resolves to Homebrew bash 5.x, which masked exactly this class of regression.
- Bump `plugin.json` 0.1.138 → 0.1.139, mirrored in `marketplace.json`.

## Test plan
- [x] Reproduced before the fix: `/bin/bash -c '. .../resolve-wiki-scripts.sh'` → `syntax error near unexpected token ';;'` at the case line (bash 3.2.57, arm64-apple-darwin25).
- [x] After the fix: `/bin/bash` sources the snippet cleanly and the new Case 7b resolves the newest cached version.
- [x] Full suite: all 18 cases pass (bash 5.x behavioral cases, unset-env Case 7, zsh Case 8, new system-bash Case 7b).
- [x] `scripts/check-breadcrumbs.py` — 0 new violations; versions mirrored at 0.1.139.

Plan record: https://github.com/cogni-work/insight-wave/issues/691#issuecomment-4691195687

🤖 Generated with [Claude Code](https://claude.com/claude-code)