### PR TITLE
cogni-knowledge: knowledge-native SCHEMA.md seed + index truth-up

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -327,7 +327,7 @@
     {
       "name": "cogni-knowledge",
       "source": "./cogni-knowledge",
-      "version": "0.1.139",
+      "version": "0.1.140",
       "maturity": "preview",
       "description": "Wiki-first research that compounds. Binds each run to a cogni-wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`. The shallow `knowledge-query` rung is read-only by default and can optionally file its answer back as an un-verified synthesis page via `--file-back`.",
       "keywords": [

--- a/cogni-knowledge/.claude-plugin/plugin.json
+++ b/cogni-knowledge/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-knowledge",
-  "version": "0.1.139",
+  "version": "0.1.140",
   "description": "Wiki-first research that compounds. Binds each run to a cogni-wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`. The shallow `knowledge-query` rung is read-only by default and can optionally file its answer back as an un-verified synthesis page via `--file-back`.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-knowledge/skills/knowledge-index/SKILL.md
+++ b/cogni-knowledge/skills/knowledge-index/SKILL.md
@@ -171,8 +171,9 @@ else echo "generic"; fi
 End with a compact block: base title + wiki path, the mode that ran, per-type
 render results (or the migration actions), the schema version, and the
 SCHEMA.md truth-up outcome (`overwritten` / `already-current` /
-`no-SCHEMA-found → seeded`). For a migrate dry-run, the last line names the
-apply command so the user can execute the preview.
+`no-SCHEMA-found → seeded`, or `skipped — dry run` when 2c did not run). For a
+migrate dry-run, the last line names the apply command so the user can execute
+the preview.
 
 ## Edge cases
 

--- a/cogni-knowledge/skills/knowledge-index/SKILL.md
+++ b/cogni-knowledge/skills/knowledge-index/SKILL.md
@@ -10,7 +10,7 @@ Two related operations on a bound knowledge base, both delegating to the locked
 renderers (`sub_index.py`, `root_index.py`) so index-shaping logic lives in one
 place:
 
-- **Rebuild** — deterministically (re)render the seven per-type sub-indexes
+- **Rebuild** — deterministically (re)render the eight per-type sub-indexes
   (`wiki/<type>/index.md`) and the curated root MAP (`wiki/index.md`) from
   current wiki state. Useful after manual page edits, a crashed finalize, or
   any time the indexes look stale. Idempotent: an unchanged wiki re-renders
@@ -78,12 +78,12 @@ Requires `schema_version >= 0.0.8` — on an older base, say so and route to
 `--migrate` instead (a rebuild against a flat layout would render sub-indexes
 the old root never links to).
 
-Render the seven sub-indexes, then the root (the root's count-links read the
+Render the eight sub-indexes, then the root (the root's count-links read the
 same theme assignment the sub-indexes use, so order matters only for
 readability — both are idempotent):
 
 ```bash
-for t in concepts entities learnings questions sources summaries syntheses; do
+for t in concepts entities learnings people questions sources summaries syntheses; do
   python3 "${CLAUDE_PLUGIN_ROOT}/scripts/sub_index.py" render \
     --type "$t" --wiki-root "<wiki_path>" --wiki-scripts-dir "$WIKI_INGEST_SCRIPTS"
 done
@@ -140,10 +140,15 @@ re-running after an interruption is safe.
 After a rebuild render or a migrate `--apply` (never on a dry run), truth-up
 the base's self-describing contract. `SCHEMA.md` is not a locked shared-state
 file, so this is an orchestrator-side check-then-overwrite, not a
-`migrate-layout.py` phase:
+`migrate-layout.py` phase. Detect by the **positive provenance sentinel** the
+knowledge-native seed carries in its subtitle — never by grepping for the
+generic dir names, which the seed itself mentions in its intentionally-absent
+paragraph and would therefore self-match:
 
 ```bash
-grep -qE '(decisions/|meetings/)' "<wiki_path>/SCHEMA.md" 2>/dev/null && echo "generic" || echo "current"
+if [ ! -f "<wiki_path>/SCHEMA.md" ]; then echo "missing"
+elif grep -qF 'knowledge-native contract (seeded by cogni-knowledge)' "<wiki_path>/SCHEMA.md"; then echo "current"
+else echo "generic"; fi
 ```
 
 - **`generic`** — the base still carries the generic wiki-setup template
@@ -151,11 +156,15 @@ grep -qE '(decisions/|meetings/)' "<wiki_path>/SCHEMA.md" 2>/dev/null && echo "g
   writes, omitting `sources/`/`questions/`/`people/`): overwrite
   `<wiki_path>/SCHEMA.md` with the **knowledge-native seed defined in
   `knowledge-setup` Step 3.5 sub-step (b)** — read that heredoc block and
-  apply it with this base's title and today's date (single canonical copy;
-  never fork the seed text here, or the two sites drift and the migrate path
-  converges bases onto a stale schema).
-- **`current`** — the base is already knowledge-native: clean no-op.
-- **No `SCHEMA.md`** — report `no-SCHEMA-found` and seed it the same way.
+  apply it with this base's title (`binding.json` `knowledge_title`, read in
+  Step 1) and today's date (single canonical copy; never fork the seed text
+  here, or the two sites drift and the migrate path converges bases onto a
+  stale schema).
+- **`current`** — the base is already knowledge-native (a hand-extended
+  knowledge-native `SCHEMA.md` still carries the sentinel, so user additions
+  are never clobbered): clean no-op.
+- **`missing`** — report `no-SCHEMA-found` and seed it the same way as
+  `generic`.
 
 ### 3. Summary
 

--- a/cogni-knowledge/skills/knowledge-index/SKILL.md
+++ b/cogni-knowledge/skills/knowledge-index/SKILL.md
@@ -135,12 +135,35 @@ Report from the envelope: control files moved, the overview fold, the rendered
 indexes, and `schema_after: 0.0.8`. A second `--apply` is a clean no-op, so
 re-running after an interruption is safe.
 
+### 2c. SCHEMA.md truth-up (both modes, idempotent)
+
+After a rebuild render or a migrate `--apply` (never on a dry run), truth-up
+the base's self-describing contract. `SCHEMA.md` is not a locked shared-state
+file, so this is an orchestrator-side check-then-overwrite, not a
+`migrate-layout.py` phase:
+
+```bash
+grep -qE '(decisions/|meetings/)' "<wiki_path>/SCHEMA.md" 2>/dev/null && echo "generic" || echo "current"
+```
+
+- **`generic`** — the base still carries the generic wiki-setup template
+  (declaring `decisions/`/`meetings/`/`notes/` the knowledge pipeline never
+  writes, omitting `sources/`/`questions/`/`people/`): overwrite
+  `<wiki_path>/SCHEMA.md` with the **knowledge-native seed defined in
+  `knowledge-setup` Step 3.5 sub-step (b)** — read that heredoc block and
+  apply it with this base's title and today's date (single canonical copy;
+  never fork the seed text here, or the two sites drift and the migrate path
+  converges bases onto a stale schema).
+- **`current`** — the base is already knowledge-native: clean no-op.
+- **No `SCHEMA.md`** — report `no-SCHEMA-found` and seed it the same way.
+
 ### 3. Summary
 
 End with a compact block: base title + wiki path, the mode that ran, per-type
-render results (or the migration actions), and the schema version. For a
-migrate dry-run, the last line names the apply command so the user can execute
-the preview.
+render results (or the migration actions), the schema version, and the
+SCHEMA.md truth-up outcome (`overwritten` / `already-current` /
+`no-SCHEMA-found → seeded`). For a migrate dry-run, the last line names the
+apply command so the user can execute the preview.
 
 ## Edge cases
 

--- a/cogni-knowledge/skills/knowledge-setup/SKILL.md
+++ b/cogni-knowledge/skills/knowledge-setup/SKILL.md
@@ -205,7 +205,9 @@ heredoc delimiter (`<<'EOF'`) — they need no shell expansion, and quoting keep
 or executed. Substitute `<knowledge-title>` and today's date `YYYY-MM-DD`
 **textually** before running (the quoted delimiter means the shell will not expand
 a `$(date)` here — the log heredoc in (c) is the one place that stays unquoted
-precisely because it *does* rely on `$(date)`):
+precisely because it *does* rely on `$(date)`). The in-body `<knowledge-root>/`
+tree root in the SCHEMA.md seed stays **literal** — it is a generic placeholder
+in the deposited contract, not a substitution token:
 
 - **`wiki/index.md`** becomes the curated **portal front door** carrying the
   `MACHINE-OWNED:OVERVIEW-NARRATIVE` block **in its intro** (the narrative now
@@ -286,7 +288,9 @@ if cogni-knowledge is uninstalled or replaced.
     │   ├── learnings/        type: learning — run-level lessons
     │   ├── interviews/       type: interview — standalone interview deposits
     │   └── audits/           lint-YYYY-MM-DD.md / health-YYYY-MM-DD.md reports
-    └── .cogni-wiki/          Engine metadata (config.json, ingest queue)
+    ├── .cogni-wiki/          Engine metadata (config.json, ingest queue)
+    └── .cogni-knowledge/     Binding manifest + fetch cache (which research
+                              projects fed this base)
 
 The eight indexed types (concepts, entities, people, summaries, learnings,
 sources, questions, syntheses) each carry a machine-owned `index.md`

--- a/cogni-knowledge/skills/knowledge-setup/SKILL.md
+++ b/cogni-knowledge/skills/knowledge-setup/SKILL.md
@@ -202,12 +202,15 @@ heredocs (since this skill's `allowed-tools` carries no `Write` tool — the see
 mechanism is `cat > … <<'EOF'`, not a `Write` call). All bodies use a **quoted**
 heredoc delimiter (`<<'EOF'`) — they need no shell expansion, and quoting keeps a
 `<knowledge-title>` that happens to contain a `$` or backtick from being expanded
-or executed. Substitute `<knowledge-title>` and today's date `YYYY-MM-DD`
-**textually** before running (the quoted delimiter means the shell will not expand
-a `$(date)` here — the log heredoc in (c) is the one place that stays unquoted
-precisely because it *does* rely on `$(date)`). The in-body `<knowledge-root>/`
-tree root in the SCHEMA.md seed stays **literal** — it is a generic placeholder
-in the deposited contract, not a substitution token:
+or executed. Substitute `<knowledge-title>` and — on the `_Created:` subtitle
+line **only** — today's date `YYYY-MM-DD` **textually** before running (the
+quoted delimiter means the shell will not expand a `$(date)` here — the log
+heredoc in (c) is the one place that stays unquoted precisely because it *does*
+rely on `$(date)`). Never replace-all on `YYYY-MM-DD`: the SCHEMA.md seed's
+audits/ tree line carries `lint-YYYY-MM-DD.md` / `health-YYYY-MM-DD.md` as
+filename **patterns** that must stay literal. The in-body `<knowledge-root>/`
+tree root in the SCHEMA.md seed likewise stays **literal** — it is a generic
+placeholder in the deposited contract, not a substitution token:
 
 - **`wiki/index.md`** becomes the curated **portal front door** carrying the
   `MACHINE-OWNED:OVERVIEW-NARRATIVE` block **in its intro** (the narrative now
@@ -330,8 +333,11 @@ Every page's frontmatter `type:` MUST match the directory it lives in.
 - `[[page-slug]]` for wiki pages — slug-only, no path; slugs are globally
   unique and resolve to their per-type directory.
 - Standard markdown links for external URLs and `raw/` files.
-- A forward `[[link]]` implies a prose reverse link on the target page; lint
-  reports missing reverses (audit reports and synthesis citations exempt).
+- A forward `[[link]]` implies a prose reverse link on the target page
+  (rule `R1_bidirectional_wikilink` — lint reports missing reverses).
+  Two exemptions: synthesis-page `wiki://` citations need no reverse link
+  (`R2_synthesis_wiki_source`), and audit reports are terminal on both ends
+  (`R3_audit_report`). Lint findings cite these rule IDs.
 
 ## Golden rules
 

--- a/cogni-knowledge/skills/knowledge-setup/SKILL.md
+++ b/cogni-knowledge/skills/knowledge-setup/SKILL.md
@@ -196,9 +196,10 @@ done
 ```
 
 **(b) Seed the curated root files — `wiki/index.md` (curated MAP front door,
-overview narrative in its intro) and `wiki/overview.md` (stub).** Overwrite both `wiki-setup` seeds via Bash
+overview narrative in its intro), `wiki/overview.md` (stub), and the
+knowledge-native `SCHEMA.md`.** Overwrite all three `wiki-setup` seeds via Bash
 heredocs (since this skill's `allowed-tools` carries no `Write` tool — the seed
-mechanism is `cat > … <<'EOF'`, not a `Write` call). Both bodies use a **quoted**
+mechanism is `cat > … <<'EOF'`, not a `Write` call). All bodies use a **quoted**
 heredoc delimiter (`<<'EOF'`) — they need no shell expansion, and quoting keeps a
 `<knowledge-title>` that happens to contain a `$` or backtick from being expanded
 or executed. Substitute `<knowledge-title>` and today's date `YYYY-MM-DD`
@@ -222,6 +223,20 @@ precisely because it *does* rely on `$(date)`):
   `index.md`'s intro). It remains the home of the `## Recent syntheses` running
   list that `knowledge-finalize`'s `overview_update.py recent-bullet` appends —
   the only surface still written there.
+- **`SCHEMA.md`** (at the wiki ROOT, `<knowledge_root>/SCHEMA.md` — one level
+  above the `wiki/` page tree the two seeds above target; that is where
+  `wiki-setup` copies its generic template) is replaced with the
+  **knowledge-native contract**: the generic template declares directories the
+  knowledge pipeline never writes (`decisions/`, `meetings/`, `notes/`) while
+  omitting the knowledge-native surfaces (`sources/`, `questions/`, `people/`,
+  `interviews/`, `audits/`) — so without this overwrite every new base violates
+  its own self-describing contract. The seed's directory set is pinned to the
+  `sub_index.py` REGISTRY's eight indexed types plus the on-disk
+  `interviews/` / `audits/` / `wiki/meta/`, and it documents the
+  concept-vs-entity **instance-free test** (the same rule the
+  `concept-distiller` agent applies) so the contract is readable from inside
+  the base. This seed is also the canonical copy `knowledge-index`'s schema
+  truth-up applies to existing bases — change it here, never fork it there.
 
 ```
 cat > <knowledge_root>/wiki/index.md <<'EOF'
@@ -240,6 +255,86 @@ cat > <knowledge_root>/wiki/overview.md <<'EOF'
 # Overview
 
 _The overview narrative now lives in the curated map intro at [index.md](index.md). This page keeps the running `## Recent syntheses` list._
+EOF
+
+cat > <knowledge_root>/SCHEMA.md <<'EOF'
+# SCHEMA — <knowledge-title>
+
+_Created: YYYY-MM-DD · knowledge-native contract (seeded by cogni-knowledge)_
+
+This file is the contract for how this knowledge base is structured. It lives
+inside the base (not inside the plugin) so the base stays self-describing even
+if cogni-knowledge is uninstalled or replaced.
+
+## Directory layout
+
+    <knowledge-root>/
+    ├── SCHEMA.md             This file — conventions and contract
+    ├── raw/                  Immutable source documents (papers, transcripts, data)
+    ├── assets/               Attachments referenced from pages
+    ├── wiki/
+    │   ├── index.md          Curated MAP front door (overview narrative + theme map)
+    │   ├── overview.md       Stub — holds the running `## Recent syntheses` list
+    │   ├── meta/             Control files: log.md, context_brief.md, open_questions.md
+    │   ├── concepts/         type: concept — instance-free ideas, frameworks, mechanisms
+    │   ├── entities/         type: entity — named orgs, laws, products, programs
+    │   ├── people/           type: person — named humans (the Who facet)
+    │   ├── sources/          type: source — ingested bodies with pre-extracted claims
+    │   ├── questions/        type: question — research-question nodes with answer claims
+    │   ├── syntheses/        type: synthesis — finalized research deposits
+    │   ├── summaries/        type: summary — cross-source topical overviews
+    │   ├── learnings/        type: learning — run-level lessons
+    │   ├── interviews/       type: interview — standalone interview deposits
+    │   └── audits/           lint-YYYY-MM-DD.md / health-YYYY-MM-DD.md reports
+    └── .cogni-wiki/          Engine metadata (config.json, ingest queue)
+
+The eight indexed types (concepts, entities, people, summaries, learnings,
+sources, questions, syntheses) each carry a machine-owned `index.md`
+sub-index; `interviews/` and `audits/` are real on disk but not sub-indexed.
+The generic wiki directories this pipeline never writes (`decisions/`,
+`meetings/`, `notes/`, legacy flat `pages/`) are intentionally absent — one
+appearing here was hand-added and sits outside the pipeline contract.
+
+## Types — what goes where
+
+- **concept** — a reusable, instance-free idea: a framework, mechanism,
+  obligation, rule, regime, or discipline describable without naming one
+  specific instance. **A concept title MUST be instance-free.** Test: if the
+  title only makes sense as one organization's thing, it is an instance ⇒
+  `entity` (or `summary` for a cross-source program/theme), never `concept`.
+  The reusable idea behind an instance may still earn its own concept page.
+- **entity** — a named instance: an organization, law, product, program,
+  facility, team, service offering, or initiative — even one whose name
+  sounds abstract.
+- **person** — a named human (the Who facet); named humans live here, never
+  in `entities/`.
+- **source** — an ingested source body; its `pre_extracted_claims:`
+  frontmatter is what drafts cite and the verifier scores against.
+- **question** — one node per research sub-question; links its answering
+  sources and may carry citable `answer_claims:`.
+- **synthesis** — a finalized, verified research deposit (or filed-back query
+  answer); cites its wiki provenance.
+- **summary** — a cross-source topical overview no single concept or entity
+  captures.
+- **learning** — a run-level lesson.
+- **interview** — a standalone interview deposit.
+
+Every page's frontmatter `type:` MUST match the directory it lives in.
+
+## Linking
+
+- `[[page-slug]]` for wiki pages — slug-only, no path; slugs are globally
+  unique and resolve to their per-type directory.
+- Standard markdown links for external URLs and `raw/` files.
+- A forward `[[link]]` implies a prose reverse link on the target page; lint
+  reports missing reverses (audit reports and synthesis citations exempt).
+
+## Golden rules
+
+1. Claude writes the wiki; the user curates the raw sources.
+2. Every query reads the wiki — never answers from memory.
+3. Citations required — claims on pages trace to `raw/` files or URLs.
+4. Append-only log (`wiki/meta/log.md`) — recorded, never rewritten.
 EOF
 ```
 


### PR DESCRIPTION
Closes #677.

## Summary
- Seed a **knowledge-native `SCHEMA.md`** CK-side in `knowledge-setup` Step 3.5 sub-step (b) — a third quoted heredoc alongside the existing `wiki/index.md` / `wiki/overview.md` overwrites — so every new base self-describes its real surfaces: `sources/`, `questions/`, `people/`, `interviews/`, `audits/` plus the rest of the `sub_index.py` REGISTRY's 8 indexed types and `wiki/meta/`. The generic never-written dirs (`decisions/`, `meetings/`, `notes/`, legacy `pages/`) are declared intentionally absent instead of falsely declared present.
- Document the **concept-vs-entity instance-free test** (the concept-distiller rule) and `people/` (named humans, the Who facet) inside the seed, so the contract is readable from inside the base without the plugin installed.
- Add an idempotent **SCHEMA.md truth-up** to `knowledge-index` (new step 2c, both modes, never on dry run): grep for generic wiki-setup markers (`decisions/` / `meetings/`); on a hit overwrite with the canonical seed from `knowledge-setup` (pointer, never a forked copy — anti-drift); surface the outcome in the Step 3 summary.
- Bump `cogni-knowledge` 0.1.139 → 0.1.140 in `plugin.json` and `marketplace.json`.

All edits are CK-side: the live `cogni-wiki` plugin and the vendored engine tree are untouched (`test_vendored_engine_parity.sh`: 21/21 byte-identical), so this is not gated behind the cogni-wiki archival epic.

## Scope decisions
- **`summaries/` and `learnings/` declared as-is.** Their fate (keep / retire) is the separate phase-2 sibling child of this epic; this PR declares them truthfully and does not resolve that question.
- **Migration via the orchestrator, not `migrate-layout.py`.** `SCHEMA.md` is not a locked shared-state file; a grep-then-overwrite in the `knowledge-index` SKILL is the lighter surface and keeps the migrator's locked phase choreography untouched.
- **Single canonical seed copy.** The heredoc lives only in `knowledge-setup`; `knowledge-index` points at it by reference. Both sites carry the anti-drift rationale.
- **Deferred:** none — full scope.

## Review notes
- Pre-existing (not introduced by this change): `knowledge-setup/SKILL.md`'s body now sits ~548 lines, over the 500-line soft cap — the bulk is the pre-existing Step 3.5 seeding mechanics and curated-layout contract. The skill-quality reviewer flagged it `introduced_by_change: false`; offloading the seeding rationale to a `references/` file is a candidate follow-up, not blocking this PR.

## Test plan
- [x] `tests/test_setup_seed_contract.sh`, `test_knowledge_setup_probe.sh`, `test_skill_contracts.sh` pass
- [x] `tests/test_vendored_engine_parity.sh` passes (vendored tree untouched)
- [x] `scripts/check-breadcrumbs.py` + `check-skill-names.sh` pass; both manifests valid JSON at 0.1.140
- [x] Seed directory set matches `sub_index.py` REGISTRY's 8 indexed types + on-disk `interviews/`/`audits/`/`meta/`
- [ ] Manual: run `knowledge-setup` against a fresh dir and confirm the seeded `SCHEMA.md`; run `knowledge-index` against an existing generic-schema base and confirm the truth-up (then re-run → no-op)

Plan record: https://github.com/cogni-work/insight-wave/issues/677#issuecomment-4691669180

🤖 Generated with [Claude Code](https://claude.com/claude-code)