### PR TITLE
cogni-knowledge: perspectives.md When (v1) log-derived timeline

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -327,7 +327,7 @@
     {
       "name": "cogni-knowledge",
       "source": "./cogni-knowledge",
-      "version": "0.1.142",
+      "version": "0.1.143",
       "maturity": "preview",
       "description": "Wiki-first research that compounds. Binds each run to a cogni-wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`. The shallow `knowledge-query` rung is read-only by default and can optionally file its answer back as an un-verified synthesis page via `--file-back`.",
       "keywords": [

--- a/cogni-knowledge/.claude-plugin/plugin.json
+++ b/cogni-knowledge/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-knowledge",
-  "version": "0.1.142",
+  "version": "0.1.143",
   "description": "Wiki-first research that compounds. Binds each run to a cogni-wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`. The shallow `knowledge-query` rung is read-only by default and can optionally file its answer back as an un-verified synthesis page via `--file-back`.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-knowledge/references/perspectives-shape-decision.md
+++ b/cogni-knowledge/references/perspectives-shape-decision.md
@@ -63,7 +63,9 @@ is a deterministic projection of it.
 renderer discipline `sub_index.py` / `root_index.py` / `concepts_index.py` hold:
 
 - It lays down a fixed set of `## <Facet>` sections (Who / What / Why / When /
-  Where / How) and, under each, a count-link line for that facet's backing types.
+  Where / How) and, under each, a count-link line for that facet's backing types
+  (the **When** facet is the one exception — it renders a log-derived timeline
+  body instead of a count-link; see §4).
 - The counts come from `sub_index.theme_counts` — the **same** theme-assignment
   code that decides which pages each type's sub-index lists — summed across
   themes for the cross-base total. So `People (n)` on the overlay can never drift
@@ -81,7 +83,7 @@ The Tier-1 facet→type mapping:
 | **Who** | people + entities | the named subjects |
 | **What** | concepts + sources | the definitions and the primary evidence |
 | **Why** | questions + syntheses | the inquiry drivers and the conclusions |
-| **When** | *(none yet)* | a timeline facet — awaits temporal frontmatter |
+| **When** | `wiki/log.md` | a log-derived timeline (v1; grouped by month) |
 | **Where** | *(none yet)* | a geographic facet — awaits geo/market frontmatter |
 | **How** | *(none yet)* | its former backing types were retired (see §4) |
 
@@ -100,9 +102,29 @@ Ownership is enforced by two nested sentinels, the same posture
   fills those spans; Tier 1 ships the deterministic defaults, leaving the spans
   ready for narration without changing the renderer contract.
 
-### 4. Honest-empty When / Where / How
+### 4. When (v1) — log-derived timeline
 
-Three facets render **honestly empty** at Tier 1 — a `## <Facet>` heading, an
+The **When** facet renders a deterministic timeline of how the base grew,
+derived from data that **already exists** — no new ingest-time capture. The v1
+source is the append-only control log (`wiki/log.md`, resolved meta-first via
+`_knowledge_lib.log_path` so the curated-layout `wiki/meta/log.md` is found
+too): each `## [YYYY-MM-DD] <op> | <details>` operation heading is parsed,
+grouped by month (`YYYY-MM`, newest first), and rendered as one row per month
+with the operation count and the distinct operation types. The parse is stable
+because the log is append-only; the render is byte-identical on an unchanged
+wiki, the same contract every other facet holds. An absent / empty / unreadable
+log renders an honest `_(no timeline yet)_` line — When **never fabricates** a
+timeline.
+
+Per-page `created:`/`updated:` frontmatter is available as a corroborating
+signal (`frontmatter_scalar`) but the v1 timeline derives from the log alone —
+the purpose-built, richer source — to avoid over-engineering. **Claim-level
+event-date extraction is explicitly deferred to When v2** (it is fuzzy and would
+couple the deterministic renderer to claim-text NLP); see Out of scope below.
+
+### 5. Honest-empty Where / How
+
+Two facets still render **honestly empty** at Tier 1 — a `## <Facet>` heading, an
 engine-owned lead-in explaining why, and a `_(no pages in this facet yet)_` line:
 
 - **How** has no backing types *by decision*. Its former candidates — the
@@ -110,10 +132,9 @@ engine-owned lead-in explaining why, and a `_(no pages in this facet yet)_` line
   as dead vocabulary (zero pages across the production wikis, actively
   discouraged by the distiller). Rather than re-project a cut type, How renders
   empty and awaits a future process/method page type.
-- **When** and **Where** await new frontmatter. They are the deliberate Tier-2
-  follow-ups: When needs a temporal section driven by date/event frontmatter, and
-  Where needs `geo:`/`market:` frontmatter captured at ingest. Tier 1 gives each a
-  stable, honest slot so those children are additive, not structural.
+- **Where** awaits new frontmatter — the deliberate sibling follow-up: it needs
+  `geo:`/`market:` frontmatter captured at ingest plus a Where render. Tier 1
+  gives it a stable, honest slot so that child is additive, not structural.
 
 Honest-empty is a feature, not a gap: the overlay is *complete* (all six facets
 present) and *truthful* (it never fabricates a projection for a facet with no
@@ -122,7 +143,9 @@ will fill.
 
 ## Out of scope (Tier 1)
 
-- The **When** timeline section (temporal frontmatter + render) — its own child.
+- **When v2** — claim-level event-date extraction (temporal dates mined from
+  claim text). Deferred from When v1: it is fuzzy and would couple the
+  deterministic renderer to claim-text NLP. The v1 log-derived timeline ships here.
 - The **Where** geographic section (`geo:`/`market:` frontmatter at ingest +
   render) — its own child.
 - A **facet narrator** agent that authors the `PERSPECTIVES-FACET` lead-ins from

--- a/cogni-knowledge/scripts/perspectives_index.py
+++ b/cogni-knowledge/scripts/perspectives_index.py
@@ -29,7 +29,7 @@ The mapping:
   Who   → people + entities      (named subjects)
   What  → concepts + sources     (definitions + primary evidence)
   Why   → questions + syntheses  (inquiry drivers + conclusions)
-  When  → (none yet)             honest-empty — awaits temporal frontmatter
+  When  → wiki/log.md             log-derived timeline (v1; grouped by month)
   Where → (none yet)             honest-empty — awaits geo/market frontmatter
   How   → (none yet)             honest-empty — its former backing types
                                  (the cross-source `summary` + run-level
@@ -68,6 +68,7 @@ Output is a `{"success": bool, "data": {...}, "error": "..."}` JSON envelope
 from __future__ import annotations
 
 import argparse
+import re
 import sys
 from pathlib import Path
 from typing import Optional
@@ -76,6 +77,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 from _knowledge_lib import (  # noqa: E402
     atomic_write_text,
     extract_machine_block,
+    log_path,
 )
 from sub_index import (  # noqa: E402
     REGISTRY,
@@ -107,8 +109,8 @@ FACET_DISPLAY = (
      "_The inquiry — the research questions driving the base and the syntheses that "
      "answer them._"),
     ("when", "When", [],
-     "_The timeline. No backing page type yet — this facet awaits temporal "
-     "frontmatter on pages._"),
+     "_The timeline — how this base grew, derived from its append-only activity "
+     "log. Claim-level event dates are a future (v2) extension._"),
     ("where", "Where", [],
      "_The geography. No backing page type yet — this facet awaits geo/market "
      "frontmatter on pages._"),
@@ -152,6 +154,55 @@ def _type_total(tname: str, wiki_root: Path) -> int:
     return sum(theme_counts(REGISTRY[tname], wiki_root).values())
 
 
+# A `wiki/log.md` activity heading: `## [YYYY-MM-DD] <op> | <details>`. The op
+# token is the first word after the date; details (after `|`) are ignored for the
+# v1 timeline. Anchored at line start so prose and the `# Log` H1 never match.
+_WHEN_LOG_RE = re.compile(r"^##\s*\[(\d{4})-(\d{2})-\d{2}\]\s+(\S+)")
+WHEN_INTRO = "_Activity timeline from the base's append-only log (newest month first)._"
+WHEN_EMPTY_LINE = "_(no timeline yet)_"
+
+
+def _build_when_timeline(wiki_root: Path) -> "list[str]":
+    """The When-facet body: a deterministic, byte-stable timeline grouped by
+    month (`YYYY-MM`, newest first) from the append-only `wiki/log.md` operation
+    headings. Resolves the log via `_knowledge_lib.log_path` (meta-first /
+    legacy-flat — never hardcoded). An absent / empty / unreadable log, or a log
+    with no dated operation headings, renders the honest no-timeline line — never
+    a fabricated timeline.
+
+    v1 derives only from the activity log (the purpose-built, already-existing
+    signal); claim-level event-date extraction is the v2 extension."""
+    try:
+        text = log_path(wiki_root).read_text(encoding="utf-8")
+    except OSError:
+        return [WHEN_EMPTY_LINE]
+
+    # month "YYYY-MM" -> {"total": int, "ops": set(op)}. A dict preserves nothing
+    # order-wise we rely on; we sort the keys at render time for determinism.
+    months: "dict[str, dict]" = {}
+    for line in text.splitlines():
+        m = _WHEN_LOG_RE.match(line)
+        if not m:
+            continue
+        ym = f"{m.group(1)}-{m.group(2)}"
+        op = m.group(3)
+        bucket = months.setdefault(ym, {"total": 0, "ops": set()})
+        bucket["total"] += 1
+        bucket["ops"].add(op)
+
+    if not months:
+        return [WHEN_EMPTY_LINE]
+
+    out = [WHEN_INTRO, ""]
+    for ym in sorted(months, reverse=True):
+        bucket = months[ym]
+        n = bucket["total"]
+        noun = "operation" if n == 1 else "operations"
+        ops = " · ".join(sorted(bucket["ops"]))
+        out.append(f"- **{ym}** — {n} {noun} ({ops})")
+    return out
+
+
 def _build_perspectives(wiki_root: Path, existing_text: str) -> str:
     """Assemble the full proposed `wiki/perspectives.md` overlay text."""
     parts: list = [PAGE_H1, ""]
@@ -169,6 +220,13 @@ def _build_perspectives(wiki_root: Path, existing_text: str) -> str:
         inner = carried if carried is not None else default_leadin
         parts.append(_render_span(_facet_span_name(slug), inner))
         parts.append("")
+
+        if slug == "when":
+            # The When facet has a custom, log-derived timeline body (v1) instead
+            # of the count-link / honest-empty path the type-backed facets use.
+            parts.extend(_build_when_timeline(wiki_root))
+            parts.append("")
+            continue
 
         links = []
         for tname in type_names:

--- a/cogni-knowledge/tests/test_perspectives_index.sh
+++ b/cogni-knowledge/tests/test_perspectives_index.sh
@@ -102,6 +102,18 @@ sources: ["wiki://x/src-a"]
 ---
 body'
 
+# Append-only activity log (legacy-flat path) — the When (v1) timeline source.
+# Two months of dated `## [YYYY-MM-DD] <op> | …` operation headings.
+mk "$WIKI/wiki/log.md" '# Log
+
+Append-only record of every wiki operation. Never rewritten.
+
+## [2026-05-20] setup | wiki initialized
+## [2026-06-01] ingest | project=X sources=57 claims=512
+## [2026-06-01] compose | project=X draft=v1
+## [2026-06-02] verify | project=X round=1
+## [2026-06-02] finalize | project=X'
+
 PAGE="$WIKI/wiki/perspectives.md"
 
 # --- 1. render creates the page, envelope changed:true -----------------------
@@ -143,10 +155,33 @@ grep -q '\[People (1)\](people/index.md)' "$PAGE" \
   || { red "FAIL: a backed-facet count-link is missing/incorrect"; errors=$((errors+1)); }
 
 # --- 5. empty facets render the honest-empty line ----------------------------
+# When is no longer empty (it carries the log-derived timeline); only Where + How
+# render the honest-empty page line.
 EMPTY_COUNT="$(grep -c '_(no pages in this facet yet)_' "$PAGE" || true)"
-[ "$EMPTY_COUNT" -eq 3 ] \
-  && green "PASS: When/Where/How render the honest-empty line (3 occurrences)" \
-  || { red "FAIL: expected 3 honest-empty lines, got $EMPTY_COUNT"; errors=$((errors+1)); }
+[ "$EMPTY_COUNT" -eq 2 ] \
+  && green "PASS: Where/How render the honest-empty line (2 occurrences)" \
+  || { red "FAIL: expected 2 honest-empty lines, got $EMPTY_COUNT"; errors=$((errors+1)); }
+
+# --- 5b. When (v1) renders a deterministic log-derived timeline ---------------
+# The When facet derives a month-grouped timeline (newest first) from wiki/log.md.
+WHEN_BLOCK="$(sed -n '/^## When$/,/^## Where$/p' "$PAGE")"
+echo "$WHEN_BLOCK" | grep -q 'Activity timeline from the base' \
+  && green "PASS: When facet renders the timeline intro" \
+  || { red "FAIL: When timeline intro missing"; errors=$((errors+1)); }
+echo "$WHEN_BLOCK" | grep -q -- '- \*\*2026-06\*\* — 4 operations (compose · finalize · ingest · verify)' \
+  && green "PASS: When timeline groups 2026-06 by month with sorted op counts" \
+  || { red "FAIL: 2026-06 timeline row missing/incorrect"; errors=$((errors+1)); }
+echo "$WHEN_BLOCK" | grep -q -- '- \*\*2026-05\*\* — 1 operation (setup)' \
+  && green "PASS: When timeline groups 2026-05 (singular 'operation')" \
+  || { red "FAIL: 2026-05 timeline row missing/incorrect"; errors=$((errors+1)); }
+# Newest-first ordering: 2026-06 row must precede the 2026-05 row.
+echo "$WHEN_BLOCK" | grep -nE '2026-0[56]' | head -1 | grep -q '2026-06' \
+  && green "PASS: When timeline is newest-month-first" \
+  || { red "FAIL: When timeline ordering is not newest-first"; errors=$((errors+1)); }
+# The When facet does NOT render the honest-empty page line (it has a timeline).
+echo "$WHEN_BLOCK" | grep -q '_(no pages in this facet yet)_' \
+  && { red "FAIL: When facet wrongly rendered the honest-empty page line"; errors=$((errors+1)); } \
+  || green "PASS: When facet does not render the honest-empty page line"
 
 # --- 6. byte-idempotent re-render --------------------------------------------
 BEFORE="$(cat "$PAGE")"
@@ -196,6 +231,28 @@ echo "$OUT4" | grep -q '"subcommand": "stage"' \
 [ "$LIVE_BEFORE" = "$(cat "$PAGE")" ] \
   && green "PASS: stage left the live page untouched" \
   || { red "FAIL: stage mutated the live page"; errors=$((errors+1)); }
+
+# --- 10. When (v1) honest no-timeline fallback (absent log) -------------------
+# A wiki with no log.md must render the honest fallback, never a fabricated
+# timeline. Use a fresh fixture so the main fixture's log.md is untouched.
+NOLOG="$(mktemp -d)"
+mkdir -p "$NOLOG/.cogni-wiki" "$NOLOG/wiki/concepts"
+mk "$NOLOG/wiki/concepts/c1.md" '---
+id: c1
+type: concept
+title: C1
+theme_label: Scope
+---
+body'
+python3 "$PERSP_SCRIPT" render --wiki-root "$NOLOG" --wiki-scripts-dir "$WSD" >/dev/null
+NOLOG_WHEN="$(sed -n '/^## When$/,/^## Where$/p' "$NOLOG/wiki/perspectives.md")"
+echo "$NOLOG_WHEN" | grep -q '_(no timeline yet)_' \
+  && green "PASS: When facet renders the honest no-timeline fallback when log.md is absent" \
+  || { red "FAIL: missing no-timeline fallback for an absent log.md"; errors=$((errors+1)); }
+echo "$NOLOG_WHEN" | grep -q 'Activity timeline from the base' \
+  && { red "FAIL: When fabricated a timeline intro with no log.md"; errors=$((errors+1)); } \
+  || green "PASS: When does not fabricate a timeline when log.md is absent"
+rm -rf "$NOLOG" 2>/dev/null || true
 
 if [ "$errors" -eq 0 ]; then
   green "All perspectives_index.py tests passed."


### PR DESCRIPTION
Closes #680.

## Summary
The **When** facet of the 5W1H overlay (epic #682 phase 3): replace the honest-empty `when` facet with a deterministic, **log-derived timeline (v1)** — derived from data that already exists, zero new ingest-time capture.

- **`scripts/perspectives_index.py`** — special-case the `when` facet in `_build_perspectives` to render a timeline body (after the carried `MACHINE-OWNED:PERSPECTIVES-FACET:when` lead-in span) instead of the count-link/honest-empty path. Resolves the log via the existing `_knowledge_lib.log_path(wiki_root)` resolver (meta-first `wiki/meta/log.md` / legacy-flat `wiki/log.md` — never hardcoded), parses `## [YYYY-MM-DD] <op> | <details>` operation headings, groups by month (`YYYY-MM`, newest first) with the per-month operation count + sorted distinct op types. An absent / empty / unreadable log renders an honest `_(no timeline yet)_` line — **never a fabricated timeline**. Byte-idempotent, stdlib-only, JSON envelope unchanged.
- **`references/perspectives-shape-decision.md`** — moved When out of honest-empty/out-of-scope into a new "When (v1) — log-derived timeline" section (data sources + the claim-level-event-date **v2** deferral); Where/How stay honest-empty.
- **`tests/test_perspectives_index.sh`** — honest-empty count 3 → 2 (Where + How); added When-timeline assertions (month grouping, newest-first ordering, singular/plural noun, no honest-empty line) + an absent-log honest-fallback sub-test. **23/23 pass.**
- Bump `0.1.142 → 0.1.143`.

## Scope
- No new wiring — `perspectives_index.py` is already dispatched by `knowledge-finalize` (sub-step 3.8), the `knowledge-index` rebuild loop, and the root-portal link (all from the merged renderer child #679).
- The **Where** facet is the separate sibling #681 (not deferred from here).
- **When v2** (claim-level event-date extraction) is out of scope by the issue's own framing — recorded in the decision doc. It is fuzzy and would couple the deterministic renderer to claim-text NLP.

## Open questions
- **When v2 tracking (non-blocking):** the v2 claim-level-event-date extension is recorded as a decision-doc note rather than filed as a GitHub issue (avoiding issue-spam). A reviewer who wants it tracked as an issue can say so here.

## Test plan
- [x] `cogni-knowledge/tests/test_perspectives_index.sh` — 23/23 (timeline render + month grouping + newest-first + honest fallback + byte-idempotence + carry-forward + human-page + stage).
- [x] Full suite 68/69 (the one failure, `test_refresh_resweep_contract`, is pre-existing on `main`); `test_vendored_engine_parity.sh` green.
- [x] No `#NNN` issue refs in the script/test; breadcrumb guard 0 violations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)