### PR TITLE
insight-wave: retire stale cogni-research references in CONTRIBUTING / CLA / audit-report

### DIFF
--- a/CLA.md
+++ b/CLA.md
@@ -13,7 +13,6 @@ Thank you for your interest in contributing to insight-wave core plugins. This C
 - cogni-visual
 - cogni-help
 - cogni-marketing
-- cogni-research
 - cogni-sales
 
 This Agreement does **not** apply to third-party community plugins published on the insight-wave marketplace. See [MARKETPLACE_TERMS.md](MARKETPLACE_TERMS.md) for community plugin terms.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,6 @@ Core plugins are maintained by insight-wave and licensed under AGPL-3.0:
 - cogni-visual
 - cogni-help
 - cogni-marketing
-- cogni-research
 - cogni-sales
 
 ### CLA Requirement

--- a/docs/audit-report.md
+++ b/docs/audit-report.md
@@ -3,6 +3,8 @@
 Generated: 2026-04-15
 Repo: /Users/stephandehaas/GitHub/dev/insight-wave
 
+> **Note:** Historical drift snapshot from the date above. It predates the current 13-plugin ecosystem — cogni-research (this run's row removed), cogni-consulting, and cogni-wiki have since been retired/removed, and cogni-consult + cogni-knowledge were added. Run a fresh `doc-audit all` to regenerate against the live plugin set.
+
 ## Repository-Level
 
 | Check | Verdict | Detail |
@@ -22,7 +24,6 @@ Repo: /Users/stephandehaas/GitHub/dev/insight-wave
 | cogni-marketing | OK | OK | OK | OK | OK | OK | OK | OK | OK | OK | OK | OK | OK |
 | cogni-narrative | OK | OK | OK | OK | OK | OK | WEAK | OK | OK | OK | OK | OK | NEEDS UPDATE |
 | cogni-portfolio | OK | DRIFT | OK | OK | OK | OK | OK | OK | OK | OK | OK | OK | NEEDS UPDATE |
-| cogni-research | OK | OK | OK | OK | OK | OK | OK | DRIFT | OK | OK | OK | OK | NEEDS UPDATE |
 | cogni-sales | DRIFT | DRIFT | OK | OK | OK | OK | OK | OK | OK | OK | OK | OK | NEEDS UPDATE |
 | cogni-trends | OK | OK | OK | OK | OK | OK | OK | OK | OK | OK | OK | OK | OK |
 | cogni-visual | OK | DRIFT | OK | OK | OK | OK | OK | OK | OK | OK | OK | OK | NEEDS UPDATE |
@@ -58,11 +59,6 @@ Repo: /Users/stephandehaas/GitHub/dev/insight-wave
 
 ### Architecture Tree Drift
 - DRIFT: Wrong version annotation — README architecture tree says `(v0.9.3)` but `plugin.json` version is `0.9.4`
-
-## cogni-research
-
-### docs/
-- DRIFT: stale plugin guide — guide references "two skills" (`research-report`, `verify-report`) but current skill count is 4 (`research-resume` and `research-setup` added since guide was generated)
 
 ## cogni-sales
 
@@ -102,7 +98,6 @@ Per-plugin fixes (structural → messaging → docs), then repo-level:
 
 3. **Generate user docs:**
    - `/doc-hub cogni-help` (regenerate plugin guide — 5 → 7 skills)
-   - `/doc-hub cogni-research` (regenerate plugin guide — 2 → 4 skills)
    - `/doc-hub cogni-copywriting` (add a workflow guide covering the cogni-copywriting ↔ cogni-narrative connection, or extend `content-pipeline.md` to include cogni-narrative)
 
 Repository-level: all OK — no `/doc-readme-root`, `/doc-deploy refresh`, or `/doc-issues` remediation needed this run.


### PR DESCRIPTION
Closes #730.

## Summary
Retire stale references to the removed **cogni-research** plugin from the contributor / governance / audit docs now that it's been absorbed into cogni-knowledge and its directory removed.

- **`CONTRIBUTING.md`** — drop `cogni-research` from the core-plugins (CLA-required) list.
- **`CLA.md`** — drop `cogni-research` from the CLA scope list.
- **`docs/audit-report.md`** — drop the stale `cogni-research` per-plugin drift row, its `## cogni-research` section, and the `/doc-hub cogni-research` regenerate step. Added a short staleness note: this is a dated 2026-04-15 generated snapshot and a fresh `doc-audit all` is the source of truth for the live plugin set.

## Scope
- **In:** cogni-research references only (this issue's scope), across the three named files. No version bump (repo docs; the maintainer-breadcrumb guard does not apply to CONTRIBUTING/CLA). Part of epic #731 (child C); disjoint from siblings #728/#729.
- **Preserved:** accurate archival context elsewhere (e.g. `docs/plugin-guide/cogni-knowledge.md` legacy-chain note, `.alpha/` historical `dc:creator` tags) is untouched.
- **Deferred → #734:** investigation showed `docs/audit-report.md` is a globally-stale snapshot — it also references the removed **cogni-consulting** and **cogni-wiki** plugins and omits cogni-consult/cogni-knowledge, with summary counts tied to the old 14-plugin lineup. Reconciling it fully would require regenerating the report (and fabricating audit verdicts by hand is not honest), so that broader regeneration is tracked separately in #734. `CONTRIBUTING.md` still lists `cogni-consulting (archived — security patches only)` — left as-is (different removed plugin, out of this issue's scope; covered by the #734 reconciliation discussion).

## Test plan
- `grep -rn "cogni-research" CONTRIBUTING.md CLA.md docs/audit-report.md` returns only the intentional staleness note in audit-report.md (which states cogni-research was removed) — no "cogni-research is a current core plugin" framing remains.
- `docs/audit-report.md`'s `## cogni-research` section is gone; the section list now runs `## cogni-portfolio` → `## cogni-sales`.
- `git diff` touches only the three named files; no plugin.json/version change.