### PR TITLE
cogni-consult: restructure 'Why this exists' to canonical 3-column problem table

### DIFF
--- a/cogni-consult/README.md
+++ b/cogni-consult/README.md
@@ -10,12 +10,12 @@ Consulting engagement orchestrator for [Claude Code](https://claude.com/claude-c
 
 ## Why this exists
 
-| Without cogni-consult | With cogni-consult |
-|---|---|
-| Engagement work is organized by fixed process phases, so deliverables wait on phase gates even when they could move | Action fields are the WBS — each deliverable progresses on its own clock inside its field |
-| One design-thinking pass for the whole engagement flattens every deliverable into the same rhythm | Every deliverable runs its own empathize→define→ideate→prototype→test loop, proportionate to its shape |
-| Stakeholder perspectives live in a slide nobody reads | Acting personas (shipped defaults: consulting partner, project manager) challenge each deliverable in their own voice before it counts as done |
-| Research is a throwaway per-question web search | One cogni-knowledge base bound at setup compounds across all deliverables — later research builds on earlier syntheses |
+| Problem | What happens | Impact |
+|---|---|---|
+| Engagement work is organized by fixed process phases | Deliverables wait on phase gates even when they could move on their own | Ready work stalls behind unrelated deliverables; the engagement runs at the speed of its slowest phase |
+| One design-thinking pass covers the whole engagement | Every deliverable is flattened into the same rhythm regardless of its shape | Simple deliverables are over-processed and complex ones under-explored |
+| Stakeholder perspectives live in a slide nobody reads | Deliverables ship without being challenged in the buyer's or PM's voice | Blind spots surface late — in front of the client, not before |
+| Research is a throwaway per-question web search | Each question starts from zero and earlier findings evaporate | Effort is repeated and later deliverables can't build on earlier syntheses |
 
 ## What it is
 


### PR DESCRIPTION
## Summary
Resolves the `/doc-audit` Check 7 (Power Messaging) **WEAK** finding for cogni-consult: the `## Why this exists` table used a 2-column *Without / With* layout, but the canonical README convention is a 3-column **Problem / What happens / Impact** problem table.

- Restructured the four rows into Problem / What happens / Impact, sharpening the consequence + business-cost articulation.
- No content lost: the former "With cogni-consult" solution column is already covered in `## What it is` (action-fields-as-WBS, design-thinking-per-deliverable, knowledge-base-as-research-spine).

Docs-only change — no version bump (README prose, not a skill/agent/structure change).

## Audit context
From the full-repo `/doc-audit all` run. Two cogni-* plugins were flagged for review:
- **cogni-consult** — messaging WEAK (this PR).
- **cogni-knowledge** — Check 13 flagged a "missing Released maturity callout" for v1.0.3. **This is a false positive, no change made:** the authoritative `maturity-model.md` doc-generate behavior table (and the project README convention) specify **Released → No callout** (callouts are for Incubating / Preview / Archived only). The discrepancy is in doc-audit's Check 13 wording (managed-service repo), not in cogni-knowledge.

## Test plan
- Re-run `/doc-audit cogni-consult` → Check 7 (Messaging) should read OK (3-column Problem/What-happens/Impact table with 4 rows).
- `git diff` touches only `cogni-consult/README.md` (6 insertions / 6 deletions).