### PR TITLE
cogni-website: retire stale cogni-research reference in website-setup

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -251,7 +251,7 @@
     {
       "name": "cogni-website",
       "source": "./cogni-website",
-      "version": "0.0.4",
+      "version": "0.0.5",
       "maturity": "incubating",
       "description": "Assembles multi-page customer websites from portfolio, marketing, trend, and research content produced by other insight-wave plugins — outputting a deployable static site with shared navigation, theming, and responsive HTML.",
       "keywords": [

--- a/cogni-website/.claude-plugin/plugin.json
+++ b/cogni-website/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-website",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Assembles multi-page customer websites from portfolio, marketing, trend, and research content produced by other insight-wave plugins \u2014 outputting a deployable static site with shared navigation, theming, and responsive HTML.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-website/libraries/page-templates.md
+++ b/cogni-website/libraries/page-templates.md
@@ -539,7 +539,7 @@ Showcases trend analysis from cogni-trends. The trend report is executive-ready 
 
 ## 10. Resources Page (`resources`)
 
-A library of research reports and whitepapers from cogni-research. Each report gets a card with title, abstract, date, and a link to the full report or download.
+A library of research syntheses and whitepapers from cogni-knowledge. Each report gets a card with title, abstract, date, and a link to the full report or download.
 
 ### Sections
 

--- a/cogni-website/skills/website-plan/SKILL.md
+++ b/cogni-website/skills/website-plan/SKILL.md
@@ -70,7 +70,7 @@ If `sources.trends_project` is set in website-project.json:
 
 #### Research Scan
 If `sources.research_projects` is non-empty in website-project.json:
-- For each research project, read the report output (`output/report.md` or latest `output/draft-v*.md`)
+- For each research project, read the research output (latest `output/draft-v*.md`)
 - Extract title, abstract/executive summary, date, topic
 - These feed the `resources` page type
 
@@ -92,7 +92,7 @@ Based on discovered content, propose a page list. Apply these rules:
 | `blog-post` | Per marketing article | Single marketing markdown file | — | One per article |
 | `case-studies` | Customer narratives exist AND `include_case_studies: true` (legacy — prefer `persona` / `capability`) | Per-customer narrative | — | Conditional |
 | `insights` | Trend report exists AND `include_insights: true` | `tips-trend-report.md` | — | Conditional |
-| `resources` | Research reports exist AND `include_resources: true` | Research `output/report.md` | — | Conditional |
+| `resources` | Research syntheses exist AND `include_resources: true` | Research `output/draft-v*.md` | — | Conditional |
 | `custom` | User requests ad-hoc pages | User-specified | — | Per user request |
 | `contact` | Always | Company details from project config | — | Always |
 | `legal-imprint` / `legal-privacy` / `legal-cookies` | Managed by `website-legal` skill | Legal templates | — | Footer-only — never proposed by `website-plan` directly |

--- a/cogni-website/skills/website-resume/SKILL.md
+++ b/cogni-website/skills/website-resume/SKILL.md
@@ -90,7 +90,7 @@ Re-run content discovery using the same globs as website-setup and compare again
 
 - **New entities**: e.g., a new product was added to portfolio, or new marketing articles published → suggest re-planning to include them
 - **Removed entities**: source files referenced in the plan no longer exist → warn about stale plan
-- **New upstream plugins**: glob for `**/tips-project.json` and `**/output/report.md` that were not present when the project was created (i.e., `sources.trends_project` or `sources.research_projects` is null/empty but projects now exist) → suggest re-running setup to discover new content sources
+- **New upstream plugins**: glob for `**/tips-project.json` and `**/output/draft-v*.md` that were not present when the project was created (i.e., `sources.trends_project` or `sources.research_projects` is null/empty but projects now exist) → suggest re-running setup to discover new content sources
 
 Present changes:
 

--- a/cogni-website/skills/website-setup/SKILL.md
+++ b/cogni-website/skills/website-setup/SKILL.md
@@ -2,7 +2,7 @@
 name: website-setup
 description: |
   This skill initializes a cogni-website project by discovering content sources from
-  cogni-portfolio, cogni-marketing, cogni-trends, and cogni-research, selecting a theme,
+  cogni-portfolio, cogni-marketing, cogni-trends, and cogni-knowledge, selecting a theme,
   and scaffolding the project directory. It should be triggered when the user mentions
   creating a website, starting a new website project, setting up a website, "build me a
   website", "company website", "customer website", "generate a website", "website setup",
@@ -22,7 +22,7 @@ A website project aggregates content from multiple insight-wave plugins into a m
 - **cogni-portfolio** (required) — products, features, propositions, solutions, customer narratives
 - **cogni-marketing** (optional) — blog posts, articles, whitepapers
 - **cogni-trends** (optional) — trend reports with investment themes for an insights page
-- **cogni-research** (optional) — research reports for a resources/whitepapers page
+- **cogni-knowledge** (optional) — research syntheses for a resources/whitepapers page
 
 Setup discovers what content is available across these plugins, validates minimum requirements, captures company details, selects a visual theme, and creates `website-project.json` — the configuration that all downstream skills depend on.
 
@@ -64,7 +64,7 @@ Scan the workspace for insight-wave plugin projects using recursive globs. This 
 - Trend reports contain executive-ready narrative content with inline citations — ideal for an Insights page
 
 #### Research Discovery (optional)
-- Glob for directories containing `**/output/draft-v*.md` or `**/output/report.md` (cogni-research output)
+- Glob for directories containing `**/output/draft-v*.md` (cogni-knowledge research output)
 - Count available research reports
 - Research reports serve as whitepapers/resources — high-value content for establishing authority
 


### PR DESCRIPTION
## Summary
Fully retires the removed/archived **cogni-research** plugin from cogni-website (surfaced by `/doc-audit` Check 4 on `website-setup`, then extended to sibling files flagged by the skill review). Retargeted to **cogni-knowledge** (the replacement, already in the README Dependencies table):

- **`website-setup/SKILL.md`** — optional-source intro list, the optional-source bullet (`research syntheses for a resources/whitepapers page`), and the output-discovery glob (dropped the dead `**/output/report.md`, kept cogni-knowledge's `**/output/draft-v*.md`).
- **`website-plan/SKILL.md`** — research-output read drops dead `output/report.md` (keeps `output/draft-v*.md`); the `resources` page-type content source → `output/draft-v*.md`.
- **`website-resume/SKILL.md`** — new-upstream detection globs `**/output/draft-v*.md` instead of the dead `**/output/report.md`.
- **`libraries/page-templates.md`** — resources-page description "from cogni-research" → "from cogni-knowledge".

Bumped **cogni-website 0.0.4 → 0.0.5** (plugin.json + marketplace.json mirror).

## Result
`grep -rn "cogni-research|output/report.md" cogni-website/{skills,libraries}` → 0. cogni-website no longer references the removed plugin anywhere; all research-content discovery points at cogni-knowledge's inverted-pipeline output.

## Test plan
- `/doc-audit cogni-website` → Dependencies OK.
- `git diff` touches only cogni-website skills/library + the two version mirrors.
