### PR TITLE
cogni-consult: de-route the removed cogni-consulting plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -35,7 +35,7 @@
     {
       "name": "cogni-consult",
       "source": "./cogni-consult",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "maturity": "preview",
       "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
       "keywords": [

--- a/cogni-consult/.claude-plugin/plugin.json
+++ b/cogni-consult/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-consult",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-consult/references/data-model.md
+++ b/cogni-consult/references/data-model.md
@@ -3,7 +3,7 @@
 Action fields are the work-breakdown-structure (WBS) containers of an engagement:
 every deliverable lives inside exactly one action field, and progress is tracked
 per deliverable — not per global phase. This is the core structural difference
-from cogni-consulting's fixed phase folders.
+from the legacy phase-folder model.
 
 ## Engagement Structure
 
@@ -162,8 +162,7 @@ updated: 2026-06-11
 ### .metadata/ logs
 
 All three logs address work by the same structured coordinates —
-`action_field` + `deliverable` (the WBS replacement for cogni-consulting's
-`phase` key):
+`action_field` + `deliverable` (the WBS replacement for the legacy `phase` key):
 
 - **execution-log.json** — workflow-state transitions: `{"transitions": [{"action_field": "...", "deliverable": "...", "from": "pending", "to": "in-progress", "timestamp": "...", "triggered_by": "<skill>"}]}`
 - **method-log.json** — methods proposed/selected per deliverable: `{"methods": [{"action_field": "...", "deliverable": "...", "proposed": [...], "selected": [...], "rationale": "..."}]}`
@@ -175,7 +174,7 @@ Personas in cogni-consult are **acting** personas: the plugin speaks and
 challenges as them during deliverable work (the shipped defaults are a
 consulting partner and a project manager, copied from packaged templates in
 `references/personas/`; engagements add client-side stakeholders). The schema
-extends cogni-consulting's design-for persona shape with a `role` and `voice`
+extends the legacy design-for persona shape with a `role` and `voice`
 plus optional `capabilities[]` (what the persona can decide/access — grounds
 what its challenge can credibly demand) and `wants[]` (desired outcomes —
 distinct from `needs[]`, which are unmet requirements); the append-only trail

--- a/cogni-consult/references/deliverable-types.md
+++ b/cogni-consult/references/deliverable-types.md
@@ -9,8 +9,8 @@ Action fields are the WBS containers of an engagement; each field holds the
 deliverables that answer its framing. This catalog lists the deliverable types
 available when planning a field's deliverable set, with the **field-type
 affinity** that suggests where each type naturally belongs. It adapts
-cogni-consulting's deliverable catalog: where that plugin keys deliverables to
-Double Diamond phases, cogni-consult keys them to the *kind of action field*
+a deliverable-type catalog: where a Double Diamond model keys deliverables to
+phases, cogni-consult keys them to the *kind of action field*
 they serve — there are no phases here.
 
 ## Field Types

--- a/cogni-consult/scripts/_discover_extractor.py
+++ b/cogni-consult/scripts/_discover_extractor.py
@@ -4,7 +4,7 @@ Loaded by cogni-workspace/scripts/discover-plugin-projects.sh. Must define
 ``extract(project_dir: str) -> dict`` returning the per-engagement JSON envelope.
 
 cogni-consult's consult-project.json is FLAT (slug/name/language/key_question/
-workflow_state/plugin_refs/updated at top level) — unlike cogni-consulting's
+workflow_state/plugin_refs/updated at top level) — unlike a legacy
 nested engagement{}/phases{} schema. There are no phases here: the engagement's
 shape is its action fields, so the envelope carries the scope state and the
 ordered action-field list instead of a phase map.

--- a/cogni-consult/skills/consult-action-fields/SKILL.md
+++ b/cogni-consult/skills/consult-action-fields/SKILL.md
@@ -10,10 +10,9 @@ description: |
   "add an action field", "split this field", "merge two action fields",
   or when consult-scope hands off a freshly scoped engagement. Double
   Diamond phase phrasing ("discover phase", "deliver phase status")
-  signals a legacy engagement of the archived cogni-consulting plugin —
-  route that to cogni-consulting:consulting-resume; new consulting work
-  lives in cogni-consult (this skill owns its WBS and deliverable
-  management).
+  refers to a legacy engagement model no longer in the ecosystem; new
+  consulting work lives in cogni-consult (this skill owns its WBS and
+  deliverable management).
 allowed-tools: Read, Write, Edit, Bash, Skill
 ---
 

--- a/cogni-consult/skills/consult-design-thinking/SKILL.md
+++ b/cogni-consult/skills/consult-design-thinking/SKILL.md
@@ -8,8 +8,8 @@ description: |
   <deliverable>", "produce the <deliverable> deliverable", "start the DT loop",
   "draft the deliverable", "continue the deliverable", or when a WBS
   dashboard recommendation hands off the next unstarted deliverable. Global
-  phase phrasing ("discover phase", "develop phase", "diamond") signals a
-  legacy engagement of the archived cogni-consulting plugin — do not run
+  phase phrasing ("discover phase", "develop phase", "diamond") refers to a
+  legacy engagement model no longer in the ecosystem — do not run
   this loop against legacy engagement directories; cogni-consult has no
   engagement-level phases; design thinking runs per deliverable.
 allowed-tools: Read, Write, Edit, Bash, Skill

--- a/cogni-consult/skills/consult-personas/SKILL.md
+++ b/cogni-consult/skills/consult-personas/SKILL.md
@@ -10,7 +10,7 @@ description: |
   review", "what would the partner say", or when a design-thinking test stage
   requests a persona challenge. Design-for persona phrasing tied to Double
   Diamond phases ("discover personas", "persona for the define phase")
-  belongs to legacy engagements of the archived cogni-consulting plugin —
+  belongs to a legacy engagement model no longer in the ecosystem —
   cogni-consult personas act and challenge, they are not phase artifacts.
 allowed-tools: Read, Write, Edit, Bash, Skill
 ---

--- a/cogni-consult/skills/consult-resume/SKILL.md
+++ b/cogni-consult/skills/consult-resume/SKILL.md
@@ -8,9 +8,8 @@ description: |
   engagement progress", "consult resume", or ANY session start that references
   an existing cogni-consult engagement — even if the user doesn't say "resume"
   explicitly. Double Diamond phrasing ("resume diamond", "diamond status",
-  phase talk like "continue discover") signals a legacy engagement of the
-  archived cogni-consulting plugin — route that to
-  cogni-consulting:consulting-resume; cogni-consult engagements have no
+  phase talk like "continue discover") refers to a legacy engagement model no
+  longer in the ecosystem; cogni-consult engagements have no
   phases; progress lives in the action-fields WBS.
 allowed-tools: Read, Bash, Skill
 ---
@@ -31,9 +30,9 @@ bash $CLAUDE_PLUGIN_ROOT/scripts/discover-projects.sh --json
 ```
 
 When discovery returns **zero engagements**, there is nothing to resume here.
-If the user was working a phase-based (Double Diamond) engagement, that lives
-in the archived cogni-consulting plugin — point them to
-`cogni-consulting:consulting-resume` instead. Otherwise recommend scaffolding
+If the user was working a phase-based (Double Diamond) engagement, that engagement
+model is no longer part of the ecosystem — those engagements live in git history.
+Otherwise recommend scaffolding
 an engagement and dispatch `Skill("cogni-consult:consult-setup")`, then stop —
 setup owns scaffolding and the knowledge-base binding.
 

--- a/cogni-consult/skills/consult-scope/SKILL.md
+++ b/cogni-consult/skills/consult-scope/SKILL.md
@@ -7,9 +7,8 @@ description: |
   Trigger on: "scope the engagement", "consult scope", "frame the key question",
   "define action fields", "run scoping for the consult engagement", or when
   consult-setup hands off a freshly scaffolded engagement for scoping. Double
-  Diamond phrasing ("0-scope phase", "diamond scoping") signals a legacy
-  engagement of the archived cogni-consulting plugin — route that to
-  cogni-consulting:consulting-scope; all new scoping runs here.
+  Diamond phrasing ("0-scope phase", "diamond scoping") refers to a legacy
+  engagement model no longer in the ecosystem; all new scoping runs here.
 allowed-tools: Read, Write, Edit, Bash, Skill
 ---
 

--- a/cogni-consult/skills/consult-setup/SKILL.md
+++ b/cogni-consult/skills/consult-setup/SKILL.md
@@ -2,14 +2,13 @@
 name: consult-setup
 description: |
   This skill should be used when the user wants to start a new consulting
-  engagement — cogni-consult is the action-fields-WBS successor to the archived
-  cogni-consulting plugin, so new structured consulting work starts here. Trigger
+  engagement — cogni-consult is the action-fields-WBS engagement model, so new structured
+  consulting work starts here. Trigger
   on: "start a consult engagement", "new consulting engagement", "set up a
   consult project", "begin an action-fields engagement", or any request to start
-  structured consulting work. Only legacy Double Diamond requests route to the
-  archived plugin: resuming an existing engagement
-  (cogni-consulting:consulting-resume) or an explicit ask to start a new Double
-  Diamond engagement (cogni-consulting:consulting-setup).
+  structured consulting work. Legacy Double Diamond engagements are not handled
+  here — that earlier engagement model is no longer part of the ecosystem and its
+  engagements live in git history.
   Scaffolds the engagement directory, binds one cogni-knowledge base, and
   registers it globally.
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep, Skill
@@ -100,4 +99,4 @@ Close by confirming what exists (engagement directory, bound knowledge base, reg
 - **State ownership**: `consult-project.json` holds only the `scope` workflow state. Deliverable state lives exclusively in each field's `field.json` — setup never touches it (no fields exist yet). See `$CLAUDE_PLUGIN_ROOT/references/data-model.md`.
 - **One base per engagement**: never bind a second knowledge base; re-runs reuse `plugin_refs.knowledge_base`.
 - **Communication language**: when `language` is set, communicate in that language; technical terms, skill names, and CLI commands stay English.
-- **Legacy boundary**: engagements of the archived cogni-consulting plugin and cogni-consult engagements never share directories; legacy Double Diamond engagements stay where they are and are not migrated into cogni-consult structures.
+- **Legacy boundary**: legacy Double Diamond engagement directories are never shared with or migrated into cogni-consult structures; they remain where they are.


### PR DESCRIPTION
Closes #749.

The `cogni-consulting` plugin was removed from the ecosystem, but cogni-consult's skills still routed legacy Double Diamond requests to dead `cogni-consulting:consulting-*` skills. This drops those dead routes and reframes the disambiguation to present-state.

## What changed (patch bump 0.1.1 → 0.1.2)
- **6 SKILL.md** (consult-setup, consult-scope, consult-personas, consult-design-thinking, consult-action-fields, consult-resume): removed the dead `cogni-consulting:consulting-*` dispatch routes from frontmatter triggers and bodies; reframed Double Diamond phrasing as "a legacy engagement model no longer in the ecosystem" / "engagements live in git history" rather than routing to a removed plugin. The disambiguation intent (Double Diamond phrasing ≠ cogni-consult's action-fields model) is preserved.
- **references/data-model.md, references/deliverable-types.md, scripts/_discover_extractor.py**: light-touch reword of the predecessor-comparison prose to describe the present design without naming the removed plugin.
- **plugin.json 0.1.1 → 0.1.2**, mirrored in `.claude-plugin/marketplace.json`.

## Deliberately kept
- `references/evaluation-criteria.md` — an explicit historical record of the replacement evaluation; its purpose is the comparison, so it is left intact.

## Verification
- `grep -rn 'cogni-consulting:' cogni-consult/skills/` → 0 dead routes
- `scripts/check-breadcrumbs.py` exit 0 (no new `#NNN`/version-tag breadcrumbs in SKILL.md)
- `cogni-workspace/scripts/check-skill-names.sh` → OK
- plugin.json 0.1.2 mirrored in marketplace.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)