### PR TITLE
relabel removed-plugin prose in scattered downstream skills (keep probes live)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -68,7 +68,7 @@
     {
       "name": "cogni-narrative",
       "source": "./cogni-narrative",
-      "version": "0.11.2",
+      "version": "0.11.3",
       "maturity": "preview",
       "description": "Story arc engine for insight-wave. Transforms structured research and portfolio output into executive narratives via 11 arc frameworks (Corporate Visions, JTBD Portfolio, Strategic Foresight, Trend Panorama, Smarter Service + 6) and 8 narrative techniques. Includes review scoring (0–100, A–F) and derivative formats (executive brief, talking points, one-pager). Bilingual EN/DE.",
       "keywords": [
@@ -90,7 +90,7 @@
     {
       "name": "cogni-copywriting",
       "source": "./cogni-copywriting",
-      "version": "0.6.1",
+      "version": "0.6.2",
       "maturity": "preview",
       "description": "Document polishing with messaging frameworks (BLUF, Pyramid, SCQA, STAR, PSB, FAB, Inverted Pyramid), parallel-persona stakeholder review, readability optimization, sales Power Positions, JSON field polishing (copy-json), arc audit against cogni-narrative, and translate-then-polish across DE/EN/FR/IT/PL/NL/ES via an EN/DE pivot. Arc-mode translation across all seven languages.",
       "keywords": [
@@ -174,7 +174,7 @@
     {
       "name": "cogni-visual",
       "source": "./cogni-visual",
-      "version": "0.16.24",
+      "version": "0.16.25",
       "maturity": "preview",
       "description": "Transform polished narratives and structured data into visual deliverables — presentation briefs, slide decks, scrollable web narratives, poster storyboards, single-page infographics, and visual assets. Supports Excalidraw, Pencil MCP, PPTX, and HTML rendering.",
       "keywords": [

--- a/cogni-copywriting/.claude-plugin/plugin.json
+++ b/cogni-copywriting/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-copywriting",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Document polishing with messaging frameworks (BLUF, Pyramid, SCQA, STAR, PSB, FAB, Inverted Pyramid), parallel-persona stakeholder review, readability optimization, sales Power Positions, JSON field polishing (copy-json), arc audit against cogni-narrative, and translate-then-polish across DE/EN/FR/IT/PL/NL/ES via an EN/DE pivot. Arc-mode translation across all seven languages.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-copywriting/skills/copywriter/SKILL.md
+++ b/cogni-copywriting/skills/copywriter/SKILL.md
@@ -384,7 +384,7 @@ All references are organized in progressive disclosure tiers. Start with `refere
 
 ## Cross-Plugin Next Steps
 
-When polishing a cogni-research report (detected by project directory containing `project-config.json` or `00-sub-questions/`), include this guidance after the quality metrics:
+When polishing a research report (detected by project directory containing `project-config.json` or `00-sub-questions/`), include this guidance after the quality metrics:
 
 > **Next: Visual pipeline**
 > 1. `/story-to-infographic` + `/render-infographic` — Infographic header (Pencil, 10-step validated)

--- a/cogni-narrative/.claude-plugin/plugin.json
+++ b/cogni-narrative/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-narrative",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "description": "Story arc engine for insight-wave. Transforms structured research and portfolio output into executive narratives via 11 arc frameworks (Corporate Visions, JTBD Portfolio, Strategic Foresight, Trend Panorama, Smarter Service + 6) and 8 narrative techniques. Includes review scoring (0–100, A–F) and derivative formats (executive brief, talking points, one-pager). Bilingual EN/DE.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-narrative/skills/narrative/SKILL.md
+++ b/cogni-narrative/skills/narrative/SKILL.md
@@ -28,7 +28,7 @@ Transform input markdown files into a structured executive narrative using one o
 | `--arc-id` | No | Explicit arc selection; overrides auto-detection |
 | `--language` | No | Output language: `en` (default) or `de`. Fallback chain: explicit parameter > project metadata > workspace preference (`.workspace-config.json`) > content detection > `en` |
 | `--output-path` | No | Output file path; defaults to `insight-summary.md` in source directory |
-| `--project-path` | No | Research/knowledge project root; enables arc inheritance from the project's `.metadata/` (`plan.json` for a cogni-knowledge project, or `project-config.json` for a legacy cogni-research project — Phase 1 step 8) and loading entity data beyond source path. When omitted, Phase 1 step 8 probes `<source-path>/..` and `<source-path>/../..` to auto-detect the project root |
+| `--project-path` | No | Research/knowledge project root; enables arc inheritance from the project's `.metadata/` (`plan.json` for a cogni-knowledge project, or `project-config.json` for an older project layout — Phase 1 step 8) and loading entity data beyond source path. When omitted, Phase 1 step 8 probes `<source-path>/..` and `<source-path>/../..` to auto-detect the project root |
 | `--research-question` | No | Original research question for narrative hook framing |
 | `--target-length` | No | Target total word count as a single number (e.g., `2500`). System applies +/-15% band to derive the acceptable range. Default: `1675` (yields ~1,424-1,926 words). Recommended: 800-4,000 — outside this range, arc rhetorical structure may not scale well |
 | `--content-map` | No | YAML map of content category keys to file/directory paths for additional context |
@@ -114,7 +114,7 @@ The quality of each phase depends on the previous one. In particular, Phases 3 a
 
 ### Phase 0.5: Citation Bridge (conditional)
 
-Source content from upstream research/knowledge tools (e.g., cogni-knowledge, or legacy cogni-research) may use `[Source: Publisher](URL)` inline citations. These need to be converted into per-source markdown files before Phase 1 can load them as citable references.
+Source content from upstream research/knowledge tools (e.g., cogni-knowledge) may use `[Source: Publisher](URL)` inline citations. These need to be converted into per-source markdown files before Phase 1 can load them as citable references.
 
 **Detection:** Scan the first 500 lines of the source content for the pattern `[Source: ...](...)`. If present, run the bridge. If not, skip to Phase 1.
 
@@ -149,7 +149,7 @@ After running the bridge, redirect `--source-path` to the `narrative-input/` dir
 5. If `--research-question` provided, store it for hook construction.
 6. Parse `--target-length` if provided (single integer). Compute the acceptable range: `total_lower = target * 0.85`, `total_upper = target * 1.15`. If omitted, default to `target = 1675` (range 1424-1926). Store `target_length`, `total_lower`, `total_upper`.
 7. Build a mental CONTENT_REGISTRY: list of loaded files with titles, word counts, key sections, category tags.
-8. **Resolve arc inheritance from a source research/knowledge project.** The upstream producer is a cogni-knowledge inverted-pipeline project (or a legacy cogni-research project). Probe up to three candidate roots in order — `--project-path` (when provided), then `<source-path>/..` (handles `--source-path <project>/output/`), then `<source-path>/../..` (handles `--source-path <project>/output/report.md`). For each candidate, read the story-arc id from either project-metadata file — `.metadata/plan.json` (cogni-knowledge inverted pipeline) or `.metadata/project-config.json` (legacy cogni-research). The first candidate+file yielding a non-empty `story_arc_id` wins; jq returns empty on a missing file, so no separate existence check is needed and a project that carries no arc (e.g. a cogni-knowledge wiki deposit) simply falls through:
+8. **Resolve arc inheritance from a source research/knowledge project.** The upstream producer is a cogni-knowledge inverted-pipeline project (or an older `project-config.json` project layout). Probe up to three candidate roots in order — `--project-path` (when provided), then `<source-path>/..` (handles `--source-path <project>/output/`), then `<source-path>/../..` (handles `--source-path <project>/output/report.md`). For each candidate, read the story-arc id from either project-metadata file — `.metadata/plan.json` (cogni-knowledge inverted pipeline) or `.metadata/project-config.json` (an older project layout). The first candidate+file yielding a non-empty `story_arc_id` wins; jq returns empty on a missing file, so no separate existence check is needed and a project that carries no arc (e.g. a cogni-knowledge wiki deposit) simply falls through:
 
    ```bash
    for CANDIDATE in "${PROJECT_PATH:+$PROJECT_PATH}" "${SOURCE_PATH}/.." "${SOURCE_PATH}/../.."; do
@@ -161,7 +161,7 @@ After running the bridge, redirect `--source-path` to the `narrative-input/` dir
    done
    ```
 
-   If `INHERITED_ARC` is set AND not `standard-research`, store as `inherited_arc_id` for Phase 2 and log: `Inheriting story_arc_id="<INHERITED_ARC>" from <PROJECT_ROOT>`. Otherwise skip silently. The probe is layout-agnostic — it reads whichever `.metadata/` project-metadata file is present, so it works against a cogni-knowledge project, a legacy cogni-research project, or a bare source path with no project root. Mirrors `cogni-visual:enrich-report` Phase 0's parent-of-source-path detection with a narrower scope (only the `.metadata/` project-metadata files are checked).
+   If `INHERITED_ARC` is set AND not `standard-research`, store as `inherited_arc_id` for Phase 2 and log: `Inheriting story_arc_id="<INHERITED_ARC>" from <PROJECT_ROOT>`. Otherwise skip silently. The probe is layout-agnostic — it reads whichever `.metadata/` project-metadata file is present, so it works against a cogni-knowledge project, an older `project-config.json` project layout, or a bare source path with no project root. Mirrors `cogni-visual:enrich-report` Phase 0's parent-of-source-path detection with a narrower scope (only the `.metadata/` project-metadata files are checked).
 
 **Before moving on,** make sure you can answer: How many files loaded? What are the 2-3 dominant themes? What is the approximate total word count? If you can't answer these, you haven't internalized the source material yet.
 

--- a/cogni-visual/.claude-plugin/plugin.json
+++ b/cogni-visual/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-visual",
-  "version": "0.16.24",
+  "version": "0.16.25",
   "description": "Transform polished narratives and structured data into visual deliverables \u2014 presentation briefs, slide decks, scrollable web narratives, poster storyboards, single-page infographics, and visual assets. Supports Excalidraw, Pencil MCP, PPTX, and HTML rendering.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-visual/skills/enrich-report/SKILL.md
+++ b/cogni-visual/skills/enrich-report/SKILL.md
@@ -15,7 +15,7 @@ description: >
   exportieren, Diagramme hinzufuegen). The key signal is that the user already
   has a finished report file and wants to make it visual or export it — this
   skill post-processes existing content, it never creates new reports from
-  scratch (that is cogni-research or cogni-trends), never creates slides (that
+  scratch (that is cogni-trends or an upstream research run), never creates slides (that
   is story-to-slides), and never rewrites prose (that is cogni-copywriting).
 ---
 
@@ -113,7 +113,7 @@ Each phase: verify the previous phase's output exists (entry gate), load the ref
 
 > Find the report, detect its type, set up theming.
 
-**If `source_path` provided:** use directly, then resolve `source_dir` to the **project root** — the directory that contains `cogni-visual/`, `output/`, and other project subdirectories. This matters because cogni-research and cogni-trends projects store the report inside `output/` but the visual artifacts (infographic, enrichment plan, design variables) live in `cogni-visual/` at the project root level, not inside `output/`.
+**If `source_path` provided:** use directly, then resolve `source_dir` to the **project root** — the directory that contains `cogni-visual/`, `output/`, and other project subdirectories. This matters because research and trends projects store the report inside `output/` but the visual artifacts (infographic, enrichment plan, design variables) live in `cogni-visual/` at the project root level, not inside `output/`.
 
 Resolution logic:
 1. Set `candidate = parent(source_path)` (e.g., `.../project-slug/output/`)
@@ -138,7 +138,7 @@ This ensures the skill finds pre-existing infographic artifacts regardless of wh
 | `generated_by: trend-report` in frontmatter | `trend-report` |
 | `total_themes:` + `total_claims:` in frontmatter | `trend-report` |
 | H2 "Investment Thesis" + "Value Chains" content | `trend-report` |
-| `project-config.json` with cogni-research fields in parent | `research-report` |
+| `project-config.json` with research-project fields in parent | `research-report` |
 | H2 "Introduction" + "Conclusion" + "References" | `research-report` |
 | Neither | `generic` |
 


### PR DESCRIPTION
Closes #752.

Three downstream skills describe a **live** `.metadata` back-compat probe using a "legacy cogni-research project" label. cogni-research was removed; the probe logic must keep working, so this rewords only the prose label.

## What changed (per-plugin patch bumps)
- **cogni-narrative/skills/narrative/SKILL.md** (0.11.2 → 0.11.3): reworded "legacy cogni-research project" → "an older `project-config.json` project layout" across the `--project-path` doc, the citation-bridge note, and the Phase-1 arc-inheritance probe. The probe still reads `.metadata/plan.json` (cogni-knowledge) **or** `.metadata/project-config.json` — logic unchanged.
- **cogni-visual/skills/enrich-report/SKILL.md** (0.16.24 → 0.16.25): reworded the frontmatter boundary clause and the Phase-0 `output/`-layout note off the cogni-research name; the detection-table row `project-config.json with research-project fields → research-report` keeps the probe.
- **cogni-copywriting/skills/copywriter/SKILL.md** (0.6.1 → 0.6.2): "polishing a cogni-research report" → "polishing a research report" (detection by `project-config.json` / `00-sub-questions/` unchanged).

## Q1 resolved
The two cogni-portfolio files named in the source intent (`agents/proposition-review-assessor.md`, `skills/features/SKILL.md`) carry **no** cogni-research / `.metadata` probe prose (grep-confirmed) — they only hold cogni-consulting example data, out of this issue's scope. cogni-portfolio is therefore **dropped from the bump set**; only narrative/visual/copywriting are touched.

## Kept intentionally
- The live `.metadata`/`project-config.json` back-compat probe **logic** in all three skills (only the prose label changed).
- A `cogni-visual` eval *trigger fixture* (`evals/trigger-eval.json`) that simulates a user saying "my cogni-research report is done…" — a realistic user utterance, not probe prose.

## Verification
- All three skills retain their `project-config.json` probe references (logic intact)
- No "legacy cogni-research project" label remains in the three SKILL.md
- `scripts/check-breadcrumbs.py` exit 0
- 3 plugin.json bumps each mirrored in marketplace.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)