### PR TITLE
cogni-knowledge: refresh-synthesis overwrites the right synthesis page

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "cogni-knowledge",
       "source": "./cogni-knowledge",
-      "version": "1.0.6",
+      "version": "1.0.7",
       "maturity": "released",
       "description": "Wiki-first research that compounds. Binds each run to a wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`. The shallow `knowledge-query` rung is read-only by default and can optionally file its answer back as an un-verified synthesis page via `--file-back`.",
       "keywords": [

--- a/cogni-knowledge/.claude-plugin/plugin.json
+++ b/cogni-knowledge/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-knowledge",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Wiki-first research that compounds. Binds each run to a wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`. The shallow `knowledge-query` rung is read-only by default and can optionally file its answer back as an un-verified synthesis page via `--file-back`.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-knowledge/skills/knowledge-refresh-synthesis/SKILL.md
+++ b/cogni-knowledge/skills/knowledge-refresh-synthesis/SKILL.md
@@ -235,8 +235,10 @@ push-mode does).
 
 **Do not clear the refresh candidate yourself** — `knowledge-finalize` already calls
 `knowledge-binding.py resolve-refresh-candidate --synthesis-slug <slug> [--cites <csv>]` during
-its binding-append step, which removes the `refresh_candidates[]` entry (and, via `--cites`,
-clears it even if the refreshed synthesis landed under a divergent slug). A second
+its binding-append step, which removes the `refresh_candidates[]` entry. Now that Step 6 passes
+the held `--synthesis-slug`, that deposit slug is deterministic and matches the candidate, so
+finalize clears by exact `synthesis_slug` match; the `--cites` citation-overlap clear remains a
+backstop for a hand-named or legacy candidate whose slug still diverges. Either way a second
 `resolve-refresh-candidate` call here would be a redundant double-clear — let finalize own it.
 
 On failure, capture `{failed_phase: "finalize", error}`, report, and stop.

--- a/cogni-knowledge/skills/knowledge-refresh-synthesis/SKILL.md
+++ b/cogni-knowledge/skills/knowledge-refresh-synthesis/SKILL.md
@@ -216,8 +216,17 @@ final summary. On failure, capture `{failed_phase: "verify", error}`, report, an
 
 ```
 Skill("cogni-knowledge:knowledge-finalize",
-      args="--knowledge-slug <knowledge_slug> --project-path <PROJECT_PATH> --knowledge-root <knowledge_root> --overwrite --no-portal-prompt --no-concepts-prompt")
+      args="--knowledge-slug <knowledge_slug> --project-path <PROJECT_PATH> --knowledge-root <knowledge_root> --synthesis-slug <SYNTHESIS_SLUG> --overwrite --no-portal-prompt --no-concepts-prompt")
 ```
+
+`--synthesis-slug <SYNTHESIS_SLUG>` is required — pass the slug held since Step 1, **not**
+finalize's default. Without it, `knowledge-finalize` re-derives the deposit slug from
+`slugify(plan.topic)`; when the existing synthesis slug diverges (it was originally finalized
+with a custom `--synthesis-slug`, or hand-named), that derived slug points at no existing page,
+so `--overwrite` never fires and finalize silently writes a **duplicate** synthesis instead of
+refreshing the real one — and the wrong slug also leaves the `refresh_candidates[]` entry
+uncleared. Passing the held slug makes the overwrite deterministic and the candidate-clear
+reliable.
 
 `--overwrite` is required — the synthesis page already exists, and finalize refuses to
 clobber it without the flag. `--no-portal-prompt` and `--no-concepts-prompt` keep the run


### PR DESCRIPTION
Closes #774.

## Summary
- `knowledge-refresh-synthesis` Step 6 now passes `--synthesis-slug <SYNTHESIS_SLUG>` to the `knowledge-finalize` dispatch, so finalize overwrites the existing synthesis page instead of deriving a fresh slug from `slugify(plan.topic)` and depositing a silent duplicate.
- The same flag lets finalize's Step 9 `resolve-refresh-candidate` clear the correct `refresh_candidates[]` entry, so the base keeps compounding.
- Added a short explanatory paragraph in Step 6 stating *why* the held slug must be passed (the failure mode), per the skill's explain-the-why voice.
- Bumps cogni-knowledge `plugin.json` 1.0.6 → 1.0.7 and mirrors it in `marketplace.json`.

## Scope decisions
- In scope: the one-token slug propagation + its why-paragraph + the mandated patch version bump. `SYNTHESIS_SLUG` is already resolved and held from Step 1, so no upstream wiring changes.
- Full scope, no deferred work. `knowledge-finalize` already accepts `--synthesis-slug` and its `--cites` candidate-clear path is already correct; only the slug propagation was missing.

## Test plan
- [ ] Step 6 of `cogni-knowledge/skills/knowledge-refresh-synthesis/SKILL.md` includes `--synthesis-slug <SYNTHESIS_SLUG>` in the finalize args.
- [ ] `plugin.json` and the `marketplace.json` cogni-knowledge entry both read `1.0.7`.
- [ ] A refresh whose synthesis slug diverges from `slugify(plan.topic)` overwrites the existing `wiki/syntheses/<SYNTHESIS_SLUG>.md` rather than creating a second page, and the matching `refresh_candidates[]` entry clears.

## Provenance
- Note: the version base shifted to 1.0.6 mid-run because PR #779 (fixing #775) merged concurrently; this PR bumps 1.0.6 → 1.0.7 off that base.