### PR TITLE
cogni-consult: gap-check decision-log entries use contract kind + discrete fields

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -35,7 +35,7 @@
     {
       "name": "cogni-consult",
       "source": "./cogni-consult",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "maturity": "preview",
       "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
       "keywords": [

--- a/cogni-consult/.claude-plugin/plugin.json
+++ b/cogni-consult/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-consult",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-consult/skills/consult-design-thinking/SKILL.md
+++ b/cogni-consult/skills/consult-design-thinking/SKILL.md
@@ -95,8 +95,17 @@ contract for every research run in the engagement. Start with the gap-check
 rung: dispatch `Skill("cogni-knowledge:knowledge-query")` with
 `--knowledge-slug <plugin_refs.knowledge_base>` for the deliverable's topic.
 Record each gap-check per the Gap-Check Recording contract in the Research
-Routing Rule — one `decisions[]` entry in `.metadata/decision-log.json`
-carrying the verbatim question.
+Routing Rule — append one entry to `.metadata/decision-log.json`'s
+`decisions[]` array tagged `"kind": "gap-check"`, carrying the **verbatim**
+question plus the coverage outcome as discrete keys (never fold the verdict
+or overlap scores into a prose `decision` string):
+`{"id": "gc-NNN", "kind": "gap-check", "action_field": ..., "deliverable":
+..., "question": "<verbatim --question>", "theme_label": <label-or-null>,
+"verdict": "covered"|"partial"|"uncovered", "top_hit": "<page-slug>"|null,
+"top_score": <score>|null, "timestamp": ...}`. Use `kind` (not `type`) and
+emit `verdict`/`top_hit`/`top_score` as their own keys — no `decision`
+prose, no `evidence_refs` — so gap-checks stay filterable and the routing
+decision replays programmatically.
 When the base has no coverage, escalate to the full inverted pipeline (or
 the `--source wiki` re-run on a populated base) per the rule, and copy the
 finalized synthesis to `action-fields/<field-slug>/research/<topic-slug>.md`

--- a/cogni-consult/skills/consult-design-thinking/SKILL.md
+++ b/cogni-consult/skills/consult-design-thinking/SKILL.md
@@ -99,7 +99,7 @@ Routing Rule — append one entry to `.metadata/decision-log.json`'s
 `decisions[]` array tagged `"kind": "gap-check"`, carrying the **verbatim**
 question plus the coverage outcome as discrete keys (never fold the verdict
 or overlap scores into a prose `decision` string):
-`{"id": "gc-NNN", "kind": "gap-check", "action_field": ..., "deliverable":
+`{"id": "d-NNN", "kind": "gap-check", "action_field": ..., "deliverable":
 ..., "question": "<verbatim --question>", "theme_label": <label-or-null>,
 "verdict": "covered"|"partial"|"uncovered", "top_hit": "<page-slug>"|null,
 "top_score": <score>|null, "timestamp": ...}`. Use `kind` (not `type`) and


### PR DESCRIPTION
Closes #784.

## Summary
- Inline a concrete gap-check `decisions[]` entry template into the Empathize stage of `consult-design-thinking`, mirroring how the Define stage inlines its decision template.
- The template shows all contract-required fields — `id`, `kind` (`"gap-check"`), `action_field`, `deliverable`, `question` (verbatim), `theme_label`, `verdict` (covered/partial/uncovered), `top_hit`, `top_score`, `timestamp` — with NO `type`, NO prose `decision`, NO `evidence_refs`.
- Bump cogni-consult 0.1.4 → 0.1.5 in `plugin.json` and the repo-root `marketplace.json` (CLAUDE.md convention after a skill change).

## Root cause
The Empathize stage referenced the Gap-Check Recording contract by pointer only ("carrying the verbatim question"), with no inlined field template. At write time the LLM fell back to the nearby Define-stage decision template (which uses `decision`/`rationale`/`evidence_refs` and no `kind`), producing `"type": "gap-check"` + prose. Inlining the field template removes that failure mode.

## Scope decisions
- In scope: only the writer (`skills/consult-design-thinking/SKILL.md`, Empathize stage) plus the mandated version bump.
- Deliberately untouched: `references/research-routing.md` (lines 47-61) and `references/data-model.md` (line 169) — both already canonical and correct; the author preference is to fix the implementation, not loosen the reference.
- No consumer changes: no script/agent/skill reads `decisions[]` back and branches on `kind`/`verdict`/`top_hit`/`top_score`; the decision-log is a human-readable audit trail.

## Test plan
- [x] Inlined template field-by-field matches the contract in `references/research-routing.md` lines 47-61 and the example in `references/data-model.md` line 169.
- [x] Edited SKILL.md contains no `type`/`evidence_refs`/prose `decision` for gap-checks.
- [x] `plugin.json` and repo-root `marketplace.json` both read `0.1.5`.
- [x] `references/research-routing.md` and `references/data-model.md` unchanged.
- [x] Breadcrumb guard clean (0 new violations); JSON manifests parse.