### PR TITLE
cogni-consult: deliverable dependency-graph foundation (schema + engine + tests)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -35,7 +35,7 @@
     {
       "name": "cogni-consult",
       "source": "./cogni-consult",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "maturity": "preview",
       "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
       "keywords": [

--- a/cogni-consult/.claude-plugin/plugin.json
+++ b/cogni-consult/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-consult",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-consult/CLAUDE.md
+++ b/cogni-consult/CLAUDE.md
@@ -13,6 +13,8 @@ cogni-consult/
 ├── README.md                      Plugin documentation
 ├── references/
 │   ├── data-model.md              Engagement structure + entity schemas
+│   ├── dependency-model.md        Deliverable dependency graph: edge schema,
+│   │                              validation, cascade + topological refresh
 │   ├── deliverable-types.md       Deliverable-type catalog (field-type affinity)
 │   ├── evaluation-criteria.md     Six criteria from the replacement evaluation,
 │   │                              each with a concrete pass signal
@@ -32,6 +34,8 @@ cogni-consult/
 ├── scripts/
 │   ├── engagement-init.sh         Create engagement directory skeleton
 │   ├── engagement-status.sh       Read consult-project.json state → JSON
+│   ├── deliverable-graph.py       Deliverable dependency-graph engine: validate /
+│   │                              trace / impact / refresh-order / cascade-stale
 │   ├── discover-projects.sh       Thin wrapper over the cogni-workspace discovery helper
 │   └── _discover_extractor.py     Per-engagement field extractor for the wrapper
 └── skills/
@@ -80,6 +84,7 @@ Full schemas: `references/data-model.md`.
 |--------|---------|
 | `engagement-init.sh` | Create the engagement directory skeleton + consult-project.json |
 | `engagement-status.sh` | Read consult-project.json + derive field/deliverable rollups from `field.json` files → JSON |
+| `deliverable-graph.py` | Deliverable dependency-graph engine over all `field.json` files: `validate` (cycles + dangling refs), `trace` (upstream lineage), `impact` (downstream blast radius), `refresh-order` (topological layering of stale deliverables), `cascade-stale` (flag downstream `lineage_status` via idempotent RMW). Full model: `references/dependency-model.md` |
 | `discover-projects.sh` | Thin wrapper delegating to `cogni-workspace/scripts/discover-plugin-projects.sh` (registry: `$HOME/.claude/cogni-consult-projects.json`) |
 | `_discover_extractor.py` | Per-engagement JSON field extractor consumed by the discovery wrapper (reads the flat consult-project.json schema) |
 

--- a/cogni-consult/references/data-model.md
+++ b/cogni-consult/references/data-model.md
@@ -51,6 +51,16 @@ root `updated` date — it is not logged in `.metadata/execution-log.json`, whos
 entries are addressed by `action_field` + `deliverable` (no field exists yet at
 scope time).
 
+The deliverable dependency graph extends the same discipline. A deliverable's
+`depends_on[]` edges are stored on the dependent, but `blocks[]` (the inverse) is
+**derived at read time** by inverting `depends_on` across all `field.json` — never
+stored, so the two directions cannot drift. The one exception is `lineage_status`:
+staleness records a *past upstream-change event* that current state cannot
+reconstruct, so it **is** stored. Even then the contract is **flag-not-rewrite** —
+`scripts/deliverable-graph.py cascade-stale` only raises the flag on dependents; it
+never rewrites a deliverable's `state` or artifact. Reworking a stale deliverable is
+human work. Full model: `references/dependency-model.md`.
+
 ## Entity Schemas
 
 ### consult-project.json (Engagement Root)
@@ -113,7 +123,11 @@ and their states.
       "state": "in-progress",
       "dt_stage": "ideate",
       "producing_route": "consult-design-thinking",
-      "persona_review": "pending"
+      "persona_review": "pending",
+      "depends_on": [
+        { "action_field": "market-evidence", "deliverable": "market-sizing" }
+      ],
+      "lineage_status": null
     }
   ]
 }
@@ -134,6 +148,21 @@ advance `persona_review` but never create it on an entry that lacks it —
 when absent, persona `work_log` entries (and the artifact's challenge
 section) are the challenge record. `engagement-status.sh` passes both fields
 through unchanged (its rollup reads only `state`).
+
+`depends_on[]` (optional, default absent/empty) declares this deliverable's
+dependencies as an array of `{action_field, deliverable}` WBS-coordinate objects,
+declared **on the dependent**. Edges may cross fields. The inverse — `blocks[]`,
+"what this deliverable blocks" — is **not stored**; it is derived at read time by
+inverting `depends_on` across every `field.json` (see State Ownership). `lineage_status`
+(optional, `null` when current) is the one stored staleness flag —
+`{status:"stale", reason, flagged_at, trigger}`, orthogonal to `state`: a `complete`
+deliverable can also be `stale`, meaning an upstream change may have invalidated its
+ground while the artifact and DT stage stay intact until a human reworks (or clears)
+it. The graph engine `scripts/deliverable-graph.py` reads these fields (validate /
+trace / impact / refresh-order) and `cascade-stale` writes `lineage_status` on
+dependents via read-modify-write — flag-and-recommend only, never auto-rewriting a
+deliverable. Full edge schema, cycle/dangling rules, and cascade + topological-refresh
+semantics: `references/dependency-model.md`.
 
 ### Deliverable artifacts ({deliverable-slug}.md)
 

--- a/cogni-consult/references/dependency-model.md
+++ b/cogni-consult/references/dependency-model.md
@@ -1,0 +1,159 @@
+# cogni-consult Deliverable Dependency Model Reference
+
+Deliverables in an engagement are not islands. A market-sizing deliverable feeds
+the proposition that sizes the opportunity; a competitor landscape feeds the
+go-to-market play. When an upstream deliverable changes, its dependents may no
+longer rest on current ground. This reference defines how those dependencies are
+declared, validated, and propagated — the foundation the write side and read side
+both consume.
+
+The engine is `scripts/deliverable-graph.py` (stdlib python3, `{success, data, error}`
+JSON envelope, engagement directory as its first positional argument). It is
+read-mostly: every subcommand except `cascade-stale` is pure read; `cascade-stale`
+performs the single write this model allows — flagging dependents stale, never
+rewriting them.
+
+## Edge schema
+
+A dependency is declared on the **dependent**, inside its `field.json` deliverable
+entry, as a `depends_on[]` array of WBS-coordinate objects:
+
+```json
+{
+  "slug": "go-to-market-play",
+  "title": "Go-to-market play",
+  "state": "pending",
+  "dt_stage": "empathize",
+  "producing_route": "consult-design-thinking",
+  "persona_review": "pending",
+  "depends_on": [
+    { "action_field": "market-evidence", "deliverable": "market-sizing" },
+    { "action_field": "market-evidence", "deliverable": "competitor-landscape" }
+  ]
+}
+```
+
+Each entry is an object with exactly two string fields:
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `action_field` | Yes | The action-field slug that owns the upstream deliverable |
+| `deliverable` | Yes | The upstream deliverable's slug within that field |
+
+`depends_on[]` may be omitted or empty (the default — no dependencies). Edges may
+cross field boundaries: a deliverable in `go-to-market` can depend on one in
+`market-evidence`. The pair `{action_field, deliverable}` is the **WBS coordinate**
+of the upstream node; its canonical string form (used in tooling output and the CLI
+shorthand below) is `<action_field>/<deliverable>`.
+
+### `blocks[]` is derived, never stored
+
+The inverse relation — "what does this deliverable block?" — is **not** written to
+`field.json`. It is derived at read time by inverting `depends_on` across every
+field's `field.json`. This is the same single-source-of-truth discipline the data
+model applies to field/engagement completion (see `references/data-model.md`,
+*State Ownership*): storing both directions would double the write surface and make
+drift between the two copies possible. `deliverable-graph.py impact` computes the
+inverse on demand.
+
+### CLI coordinate shorthand
+
+The stored schema is the object form. On the command line, the WBS coordinate is
+passed in the `<action_field>/<deliverable>` **slash shorthand** and parsed into the
+object form internally:
+
+```bash
+python3 scripts/deliverable-graph.py <engagement-dir> trace go-to-market/go-to-market-play
+```
+
+## `lineage_status` — the stored staleness flag
+
+Independently of `state`, each deliverable carries an optional `lineage_status`:
+
+```json
+"lineage_status": {
+  "status": "stale",
+  "reason": "upstream deliverable market-evidence/market-sizing changed (trigger: deliverable_update)",
+  "flagged_at": "2026-06-15T15:30:00Z",
+  "trigger": "deliverable_update"
+}
+```
+
+| Field | Description |
+|-------|-------------|
+| `status` | Currently always `"stale"` when present; `null` (or the field absent) means current |
+| `reason` | Human-readable explanation naming the upstream coordinate and the trigger |
+| `flagged_at` | ISO-8601 UTC timestamp of when the flag was raised |
+| `trigger` | `"deliverable_update"` (an upstream deliverable was reworked) or `"claims_correction"` (a cogni-claims correction cascaded in) |
+
+`lineage_status` is **orthogonal to `state`**: a deliverable can be `complete` and
+`stale` at the same time. That is the point — the completed artifact and its DT
+stage stay intact (a human did real work to produce them), but the flag records that
+an upstream change may have invalidated the ground beneath it. Re-working the
+deliverable (or a deliberate human "still current" decision) clears `lineage_status`
+back to `null`.
+
+This is why `lineage_status` **is stored** while `blocks[]` is derived: staleness is
+a fact about a past event (an upstream change at a point in time) that cannot be
+recomputed from current state alone, so it must be persisted.
+
+## Validation rules (hard errors)
+
+`deliverable-graph.py validate` walks every `field.json` and fails (`success:false`)
+on either of two structural defects:
+
+- **Cycles.** A `depends_on` chain that loops back on itself (`A → B → A`) has no
+  valid refresh order and signals a modeling error. Reported as the offending node
+  sequence.
+- **Dangling references.** A `depends_on` entry whose `{action_field, deliverable}`
+  names a deliverable that does not exist in any `field.json`. Reported as the
+  `from → to` pair.
+
+A clean graph returns `success:true` with the node and edge counts. Validation is
+the gate the write side runs before accepting a newly declared edge.
+
+## Cascade semantics
+
+When an upstream deliverable changes, `cascade-stale` propagates the staleness to
+everything downstream of it:
+
+```bash
+python3 scripts/deliverable-graph.py <engagement-dir> cascade-stale \
+    market-evidence/market-sizing --trigger deliverable_update
+```
+
+- The **transitive downstream set** is computed by following the derived `blocks`
+  relation from the named coordinate. The named (upstream) deliverable is itself
+  **not** flagged — it is the fresh one; its dependents are.
+- Each downstream deliverable's `lineage_status` is set via **read-modify-write**:
+  the field's `field.json` is read, only the matching deliverable entries are
+  updated, every sibling field (`slug`, `title`, `state`, `dt_stage`,
+  `producing_route`, `persona_review`, …) is preserved, and the file is written
+  back.
+- The write is **idempotent.** A deliverable already carrying `status:"stale"` is
+  left untouched (its original `flagged_at` survives), so re-running `cascade-stale`
+  produces no new write and no churn. Only not-yet-stale dependents are flagged.
+
+## Topological refresh semantics
+
+`deliverable-graph.py refresh-order` takes the set of currently-stale deliverables
+and groups them into **refresh layers** so they are reworked upstream-first:
+
+- Layer 0 = stale deliverables with no stale dependency.
+- Layer N = stale deliverables whose stale dependencies all sit in layers < N.
+
+Refreshing layer by layer guarantees an upstream stale deliverable is reworked
+before any stale deliverable that depends on it — there is no point refreshing a
+dependent against an upstream that is itself about to change. A cycle among stale
+deliverables makes layering undefined and is surfaced as an error.
+
+## The flag-not-rewrite contract
+
+This model **surfaces refresh candidates; it never auto-rewrites a deliverable.**
+`cascade-stale` writes only the `lineage_status` flag — it never touches a
+deliverable's `state`, `dt_stage`, or markdown artifact, and it never regenerates
+content. Deciding whether (and how) to rework a stale deliverable is human work,
+routed through the normal design-thinking loop. This mirrors cogni-knowledge's
+`knowledge-refresh`, which flags syntheses for re-synthesis rather than silently
+overwriting them. Non-destructive by design: the worst a wrong cascade can do is
+raise a flag a human then clears.

--- a/cogni-consult/scripts/deliverable-graph.py
+++ b/cogni-consult/scripts/deliverable-graph.py
@@ -1,0 +1,442 @@
+#!/usr/bin/env python3
+"""Deliverable dependency-graph engine for a cogni-consult engagement.
+
+Usage:
+  python3 deliverable-graph.py <engagement-dir> validate
+  python3 deliverable-graph.py <engagement-dir> trace <action_field>/<deliverable>
+  python3 deliverable-graph.py <engagement-dir> impact <action_field>/<deliverable>
+  python3 deliverable-graph.py <engagement-dir> refresh-order
+  python3 deliverable-graph.py <engagement-dir> cascade-stale <action_field>/<deliverable> \
+      --trigger deliverable_update|claims_correction
+
+Returns JSON on stdout: {"success": bool, "data": {...}, "error": "string"}
+
+Data model (references/data-model.md, references/dependency-model.md):
+  Each action-fields/<slug>/field.json carries deliverables[]. A deliverable may
+  declare depends_on[] — an array of {action_field, deliverable} WBS-coordinate
+  objects, declared on the DEPENDENT. blocks[] is NOT stored; it is derived here
+  at read time by inverting depends_on across every field.json (State-Ownership
+  principle). lineage_status IS stored on the deliverable
+  (null | {status:"stale", reason, flagged_at, trigger}); cascade-stale writes it
+  via read-modify-write preserving sibling fields, and is idempotent. The engine
+  surfaces refresh candidates — it never rewrites a deliverable's state or artifact
+  (flag-not-rewrite contract; mirrors cogni-knowledge knowledge-refresh).
+
+Edges run dependent -> dependency (D -> U when D depends_on U); upstream = follow
+depends_on, downstream = follow the inverted (blocks) relation. Stdlib only.
+"""
+
+import argparse
+import json
+import os
+import sys
+from datetime import datetime, timezone
+
+VALID_TRIGGERS = ("deliverable_update", "claims_correction")
+
+
+def node_key(action_field, deliverable):
+    """Canonical WBS-coordinate key for a deliverable node."""
+    return f"{action_field}/{deliverable}"
+
+
+def parse_coordinate(raw):
+    """Parse the CLI '<action_field>/<deliverable>' slash shorthand into a pair.
+
+    Raises ValueError on a malformed coordinate. The stored edge schema is the
+    object form {action_field, deliverable}; this is only the CLI shorthand.
+    """
+    if raw is None or "/" not in raw:
+        raise ValueError(
+            f"coordinate must be '<action_field>/<deliverable>', got: {raw!r}"
+        )
+    action_field, _, deliverable = raw.partition("/")
+    action_field, deliverable = action_field.strip(), deliverable.strip()
+    if not action_field or not deliverable:
+        raise ValueError(
+            f"coordinate must be '<action_field>/<deliverable>', got: {raw!r}"
+        )
+    return action_field, deliverable
+
+
+def load_graph(engagement_dir):
+    """Build the deliverable graph from consult-project.json + every field.json.
+
+    Returns a dict with:
+      nodes: {key -> {action_field, deliverable, state, lineage_status,
+                      depends_on(list of keys), field_path, field_slug}}
+      depends_on: {key -> [upstream_key, ...]}   (dependent -> dependencies)
+      blocks: {key -> [downstream_key, ...]}      (derived inverse)
+      dangling: [{from, to}, ...]                 (depends_on refs to missing nodes)
+    Raises ValueError with a user-facing message on an unreadable/malformed root.
+    """
+    proj_path = os.path.join(engagement_dir, "consult-project.json")
+    try:
+        with open(proj_path) as f:
+            project = json.load(f)
+    except (json.JSONDecodeError, OSError) as exc:
+        raise ValueError(f"unreadable engagement file {proj_path}: {exc}")
+
+    field_slugs = project.get("action_fields") or []
+    if not isinstance(field_slugs, list) or not all(
+        isinstance(s, str) for s in field_slugs
+    ):
+        raise ValueError(
+            "malformed engagement file: action_fields must be a list of strings"
+        )
+
+    nodes = {}
+    # First pass: collect every node so depends_on refs can be checked for danglers.
+    for slug in field_slugs:
+        fpath = os.path.join(engagement_dir, "action-fields", slug, "field.json")
+        try:
+            with open(fpath) as f:
+                fjson = json.load(f)
+        except FileNotFoundError:
+            continue
+        except (json.JSONDecodeError, OSError) as exc:
+            raise ValueError(f"unreadable field file {fpath}: {exc}")
+
+        for deliv in fjson.get("deliverables") or []:
+            dslug = deliv.get("slug")
+            if not dslug:
+                continue
+            key = node_key(slug, dslug)
+            raw_depends = deliv.get("depends_on") or []
+            depends_keys = []
+            for ref in raw_depends:
+                if not isinstance(ref, dict):
+                    raise ValueError(
+                        f"{key}: depends_on entries must be "
+                        f"{{action_field, deliverable}} objects, got: {ref!r}"
+                    )
+                up_af = ref.get("action_field")
+                up_d = ref.get("deliverable")
+                if not up_af or not up_d:
+                    raise ValueError(
+                        f"{key}: depends_on entry missing action_field/deliverable: {ref!r}"
+                    )
+                depends_keys.append(node_key(up_af, up_d))
+            nodes[key] = {
+                "action_field": slug,
+                "deliverable": dslug,
+                "state": deliv.get("state", "pending"),
+                "lineage_status": deliv.get("lineage_status"),
+                "depends_on": depends_keys,
+                "field_path": fpath,
+                "field_slug": slug,
+            }
+
+    # Second pass: build edge maps + collect dangling refs.
+    depends_on = {}
+    blocks = {key: [] for key in nodes}
+    dangling = []
+    for key, node in nodes.items():
+        valid_ups = []
+        for up_key in node["depends_on"]:
+            if up_key in nodes:
+                valid_ups.append(up_key)
+                blocks[up_key].append(key)
+            else:
+                dangling.append({"from": key, "to": up_key})
+        depends_on[key] = valid_ups
+
+    return {
+        "nodes": nodes,
+        "depends_on": depends_on,
+        "blocks": blocks,
+        "dangling": dangling,
+    }
+
+
+def find_cycles(depends_on):
+    """Return a list of cycles (each a list of node keys) in the dependent->dependency graph."""
+    WHITE, GREY, BLACK = 0, 1, 2
+    color = {k: WHITE for k in depends_on}
+    cycles = []
+    stack = []
+
+    def visit(key):
+        color[key] = GREY
+        stack.append(key)
+        for up in depends_on.get(key, []):
+            if color.get(up, WHITE) == GREY:
+                # Back-edge: extract the cycle from the current stack.
+                idx = stack.index(up)
+                cycles.append(stack[idx:] + [up])
+            elif color.get(up, WHITE) == WHITE:
+                visit(up)
+        stack.pop()
+        color[key] = BLACK
+
+    for key in depends_on:
+        if color[key] == WHITE:
+            visit(key)
+    return cycles
+
+
+def transitive(seed_key, adjacency):
+    """Return the ordered transitive closure reachable from seed_key (excludes seed)."""
+    seen = []
+    seen_set = set()
+    frontier = list(adjacency.get(seed_key, []))
+    while frontier:
+        cur = frontier.pop(0)
+        if cur in seen_set:
+            continue
+        seen_set.add(cur)
+        seen.append(cur)
+        frontier.extend(adjacency.get(cur, []))
+    return seen
+
+
+def cmd_validate(graph):
+    """Detect cycles + dangling depends_on refs across all field.json (hard errors)."""
+    cycles = find_cycles(graph["depends_on"])
+    dangling = graph["dangling"]
+    if cycles or dangling:
+        parts = []
+        if cycles:
+            parts.append(
+                "cycle(s): " + "; ".join(" -> ".join(c) for c in cycles)
+            )
+        if dangling:
+            parts.append(
+                "dangling depends_on ref(s): "
+                + ", ".join(f"{d['from']} -> {d['to']}" for d in dangling)
+            )
+        return {
+            "success": False,
+            "data": {
+                "node_count": len(graph["nodes"]),
+                "cycles": cycles,
+                "dangling": dangling,
+            },
+            "error": "; ".join(parts),
+        }
+    edge_count = sum(len(v) for v in graph["depends_on"].values())
+    return {
+        "success": True,
+        "data": {
+            "node_count": len(graph["nodes"]),
+            "edge_count": edge_count,
+            "cycles": [],
+            "dangling": [],
+        },
+        "error": "",
+    }
+
+
+def _require_node(graph, key):
+    if key not in graph["nodes"]:
+        raise ValueError(f"deliverable not found: {key}")
+
+
+def cmd_trace(graph, key):
+    """Upstream lineage — the transitive set this deliverable depends on."""
+    _require_node(graph, key)
+    upstream = transitive(key, graph["depends_on"])
+    return {
+        "success": True,
+        "data": {
+            "target": key,
+            "direct_depends_on": graph["depends_on"].get(key, []),
+            "upstream": upstream,
+            "upstream_count": len(upstream),
+        },
+        "error": "",
+    }
+
+
+def cmd_impact(graph, key):
+    """Downstream blast radius — the transitive set that depends on this deliverable."""
+    _require_node(graph, key)
+    downstream = transitive(key, graph["blocks"])
+    return {
+        "success": True,
+        "data": {
+            "target": key,
+            "direct_blocks": graph["blocks"].get(key, []),
+            "downstream": downstream,
+            "downstream_count": len(downstream),
+        },
+        "error": "",
+    }
+
+
+def _is_stale(node):
+    ls = node.get("lineage_status")
+    return isinstance(ls, dict) and ls.get("status") == "stale"
+
+
+def cmd_refresh_order(graph):
+    """Topologically layer the currently-stale deliverables (upstream first).
+
+    A stale node's layer is 1 + max(layer of its stale dependencies), or 0 when it
+    has no stale dependency. Refreshing layer by layer guarantees an upstream stale
+    deliverable is reworked before its stale dependents.
+    """
+    stale_keys = [k for k, n in graph["nodes"].items() if _is_stale(n)]
+    stale_set = set(stale_keys)
+    # Edges restricted to the stale sub-graph.
+    stale_depends = {
+        k: [u for u in graph["depends_on"].get(k, []) if u in stale_set]
+        for k in stale_keys
+    }
+
+    # If the stale sub-graph has a cycle, layering is undefined — surface it.
+    cycles = find_cycles(stale_depends)
+    if cycles:
+        return {
+            "success": False,
+            "data": {"stale": stale_keys, "cycles": cycles},
+            "error": "cycle(s) among stale deliverables: "
+            + "; ".join(" -> ".join(c) for c in cycles),
+        }
+
+    layer = {}
+
+    def compute(k, trail):
+        if k in layer:
+            return layer[k]
+        ups = stale_depends.get(k, [])
+        layer[k] = 0 if not ups else 1 + max(compute(u, trail + [k]) for u in ups)
+        return layer[k]
+
+    for k in stale_keys:
+        compute(k, [])
+
+    max_layer = max(layer.values()) if layer else -1
+    layers = [
+        sorted(k for k in stale_keys if layer[k] == i) for i in range(max_layer + 1)
+    ]
+    order = [k for lyr in layers for k in lyr]
+    return {
+        "success": True,
+        "data": {
+            "stale_count": len(stale_keys),
+            "layers": layers,
+            "order": order,
+        },
+        "error": "",
+    }
+
+
+def cmd_cascade_stale(graph, key, trigger):
+    """Flag the transitive downstream set of `key` as stale via idempotent RMW.
+
+    The updated deliverable (`key`) itself is NOT flagged — it is fresh; its
+    dependents are. Writes lineage_status={status:"stale", reason, flagged_at,
+    trigger} to each downstream deliverable's field.json, preserving every sibling
+    field. Idempotent: a deliverable already carrying status:"stale" is left
+    untouched (its original flagged_at survives), so re-running yields no new write.
+    """
+    _require_node(graph, key)
+    if trigger not in VALID_TRIGGERS:
+        raise ValueError(
+            f"--trigger must be one of {VALID_TRIGGERS}, got: {trigger!r}"
+        )
+
+    downstream = transitive(key, graph["blocks"])
+    reason = f"upstream deliverable {key} changed (trigger: {trigger})"
+    flagged_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    # Group target downstream keys by the field.json file that holds them, so each
+    # field file is read-modified-written exactly once.
+    by_file = {}
+    for dkey in downstream:
+        node = graph["nodes"][dkey]
+        by_file.setdefault(node["field_path"], []).append(node["deliverable"])
+
+    newly_flagged = []
+    already_stale = []
+    for fpath, deliv_slugs in by_file.items():
+        with open(fpath) as f:
+            fjson = json.load(f)
+        targets = set(deliv_slugs)
+        changed = False
+        for deliv in fjson.get("deliverables") or []:
+            if deliv.get("slug") not in targets:
+                continue
+            dkey = node_key(fjson.get("slug") or "", deliv.get("slug"))
+            existing = deliv.get("lineage_status")
+            if isinstance(existing, dict) and existing.get("status") == "stale":
+                already_stale.append(dkey)
+                continue
+            deliv["lineage_status"] = {
+                "status": "stale",
+                "reason": reason,
+                "flagged_at": flagged_at,
+                "trigger": trigger,
+            }
+            newly_flagged.append(dkey)
+            changed = True
+        if changed:
+            with open(fpath, "w") as f:
+                json.dump(fjson, f, indent=2, ensure_ascii=False)
+                f.write("\n")
+
+    return {
+        "success": True,
+        "data": {
+            "trigger": key,
+            "trigger_event": trigger,
+            "downstream_count": len(downstream),
+            "newly_flagged": sorted(newly_flagged),
+            "already_stale": sorted(already_stale),
+            "flagged_at": flagged_at,
+        },
+        "error": "",
+    }
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description="Deliverable dependency-graph engine for a cogni-consult engagement."
+    )
+    ap.add_argument("engagement_dir")
+    sub = ap.add_subparsers(dest="command", required=True)
+    sub.add_parser("validate")
+    p_trace = sub.add_parser("trace")
+    p_trace.add_argument("coordinate")
+    p_impact = sub.add_parser("impact")
+    p_impact.add_argument("coordinate")
+    sub.add_parser("refresh-order")
+    p_cascade = sub.add_parser("cascade-stale")
+    p_cascade.add_argument("coordinate")
+    p_cascade.add_argument(
+        "--trigger", required=True, choices=list(VALID_TRIGGERS)
+    )
+    args = ap.parse_args()
+
+    engagement_dir = os.path.abspath(args.engagement_dir)
+    try:
+        if not os.path.isdir(engagement_dir):
+            raise ValueError(f"engagement directory not found: {engagement_dir}")
+        graph = load_graph(engagement_dir)
+
+        if args.command == "validate":
+            result = cmd_validate(graph)
+        elif args.command == "trace":
+            af, d = parse_coordinate(args.coordinate)
+            result = cmd_trace(graph, node_key(af, d))
+        elif args.command == "impact":
+            af, d = parse_coordinate(args.coordinate)
+            result = cmd_impact(graph, node_key(af, d))
+        elif args.command == "refresh-order":
+            result = cmd_refresh_order(graph)
+        elif args.command == "cascade-stale":
+            af, d = parse_coordinate(args.coordinate)
+            result = cmd_cascade_stale(graph, node_key(af, d), args.trigger)
+        else:  # pragma: no cover — argparse already enforces the choice set
+            raise ValueError(f"unknown command: {args.command}")
+    except (ValueError, OSError, json.JSONDecodeError) as exc:
+        print(json.dumps({"success": False, "data": {}, "error": str(exc)}, ensure_ascii=False))
+        return 0
+
+    print(json.dumps(result, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/cogni-consult/tests/test_deliverable_graph.sh
+++ b/cogni-consult/tests/test_deliverable_graph.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+# Regression test for cogni-consult/scripts/deliverable-graph.py — the deliverable
+# dependency-graph engine (edge schema, validation, cascade, topological refresh).
+#
+# Fixtures are heredoc'd inline — no committed JSON blobs to maintain. Each fixture
+# builds a minimal engagement (consult-project.json + action-fields/<slug>/field.json)
+# in a temp directory, runs a subcommand, and asserts on the resulting JSON.
+#
+# Coverage:
+#   1  validate-clean        valid cross-field depends_on graph (success:true)
+#   2  validate-cycle        A->B->A cycle detected as a hard error (success:false)
+#   3  validate-dangling     depends_on ref to a missing deliverable (success:false)
+#   4  trace-upstream        transitive upstream lineage of a deliverable
+#   5  impact-downstream     transitive downstream blast radius of a deliverable
+#   6  cascade-stale         flags downstream lineage_status=stale via RMW, preserves siblings
+#   7  cascade-idempotent    a second cascade-stale produces no new writes
+#   8  refresh-order         currently-stale deliverables grouped into topological layers
+#
+# Usage: bash cogni-consult/tests/test_deliverable_graph.sh
+# Exits non-zero on any assertion failure.
+
+# `set -u` only — `set -e` would abort on the first failing assertion and defeat
+# the per-fixture failure counter below.
+set -u
+
+TESTS_DIR="$(cd "$(dirname "$0")" && pwd)"
+PLUGIN_DIR="$(cd "$TESTS_DIR/.." && pwd)"
+SCRIPT="$PLUGIN_DIR/scripts/deliverable-graph.py"
+
+if [ ! -f "$SCRIPT" ]; then
+  echo "FAIL: deliverable-graph.py not found at $SCRIPT" >&2
+  exit 1
+fi
+
+TMPROOT="$(mktemp -d)"
+trap 'rm -rf "$TMPROOT"' EXIT
+
+failures=0
+pass() { printf 'OK   %s\n' "$1"; }
+fail() { printf 'FAIL %s: %s\n' "$1" "$2" >&2; failures=$((failures + 1)); }
+
+run() { python3 "$SCRIPT" "$@"; }
+
+# assert_json <label> <json> <python-bool-expr over variable d (the parsed dict)>
+assert_json() {
+  local label="$1" js="$2" expr="$3"
+  local verdict
+  verdict="$(printf '%s' "$js" | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+print('PASS' if ($expr) else 'FAIL')
+" 2>/dev/null)"
+  if [ "$verdict" = "PASS" ]; then
+    pass "$label"
+  else
+    fail "$label" "assertion failed over: $js"
+  fi
+}
+
+# Build a three-deliverable chain spanning two fields:
+#   market-evidence/market-sizing  (root, no deps)
+#     <- portfolio-fit/portfolio-screen   (depends on market-sizing)
+#        <- go-to-market/gtm-play          (depends on portfolio-screen)
+seed_chain() {
+  local dir="$1"
+  mkdir -p "$dir/action-fields/market-evidence" \
+           "$dir/action-fields/portfolio-fit" \
+           "$dir/action-fields/go-to-market"
+  cat > "$dir/consult-project.json" <<'EOF'
+{
+  "slug": "acme",
+  "name": "Acme Engagement",
+  "key_question": "How?",
+  "action_fields": ["market-evidence", "portfolio-fit", "go-to-market"],
+  "workflow_state": {"scope": "complete"},
+  "created": "2026-06-15",
+  "updated": "2026-06-15"
+}
+EOF
+  cat > "$dir/action-fields/market-evidence/field.json" <<'EOF'
+{
+  "slug": "market-evidence",
+  "title": "Market Evidence",
+  "deliverables": [
+    {"slug": "market-sizing", "title": "Market sizing", "state": "complete", "dt_stage": "test", "producing_route": "consult-design-thinking", "persona_review": "complete"}
+  ]
+}
+EOF
+  cat > "$dir/action-fields/portfolio-fit/field.json" <<'EOF'
+{
+  "slug": "portfolio-fit",
+  "title": "Portfolio Fit",
+  "deliverables": [
+    {"slug": "portfolio-screen", "title": "Portfolio screen", "state": "complete", "dt_stage": "test", "producing_route": "consult-design-thinking", "persona_review": "complete",
+     "depends_on": [{"action_field": "market-evidence", "deliverable": "market-sizing"}]}
+  ]
+}
+EOF
+  cat > "$dir/action-fields/go-to-market/field.json" <<'EOF'
+{
+  "slug": "go-to-market",
+  "title": "Go To Market",
+  "deliverables": [
+    {"slug": "gtm-play", "title": "GTM play", "state": "in-progress", "dt_stage": "ideate", "producing_route": "consult-design-thinking", "persona_review": "pending",
+     "depends_on": [{"action_field": "portfolio-fit", "deliverable": "portfolio-screen"}]}
+  ]
+}
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# 1  validate-clean
+# ---------------------------------------------------------------------------
+D1="$TMPROOT/clean"; seed_chain "$D1"
+OUT="$(run "$D1" validate)"
+assert_json "validate-clean" "$OUT" \
+  "d['success'] is True and d['data']['node_count'] == 3 and d['data']['edge_count'] == 2 and not d['data']['cycles'] and not d['data']['dangling']"
+
+# ---------------------------------------------------------------------------
+# 2  validate-cycle  (market-sizing now depends on gtm-play -> A->B->C->A)
+# ---------------------------------------------------------------------------
+D2="$TMPROOT/cycle"; seed_chain "$D2"
+cat > "$D2/action-fields/market-evidence/field.json" <<'EOF'
+{
+  "slug": "market-evidence",
+  "title": "Market Evidence",
+  "deliverables": [
+    {"slug": "market-sizing", "title": "Market sizing", "state": "complete",
+     "depends_on": [{"action_field": "go-to-market", "deliverable": "gtm-play"}]}
+  ]
+}
+EOF
+OUT="$(run "$D2" validate)"
+assert_json "validate-cycle" "$OUT" \
+  "d['success'] is False and len(d['data']['cycles']) >= 1 and 'cycle' in d['error']"
+
+# ---------------------------------------------------------------------------
+# 3  validate-dangling  (gtm-play depends on a non-existent deliverable)
+# ---------------------------------------------------------------------------
+D3="$TMPROOT/dangling"; seed_chain "$D3"
+cat > "$D3/action-fields/go-to-market/field.json" <<'EOF'
+{
+  "slug": "go-to-market",
+  "title": "Go To Market",
+  "deliverables": [
+    {"slug": "gtm-play", "title": "GTM play", "state": "in-progress",
+     "depends_on": [{"action_field": "portfolio-fit", "deliverable": "does-not-exist"}]}
+  ]
+}
+EOF
+OUT="$(run "$D3" validate)"
+assert_json "validate-dangling" "$OUT" \
+  "d['success'] is False and len(d['data']['dangling']) == 1 and d['data']['dangling'][0]['to'] == 'portfolio-fit/does-not-exist'"
+
+# ---------------------------------------------------------------------------
+# 4  trace-upstream  (gtm-play -> portfolio-screen -> market-sizing)
+# ---------------------------------------------------------------------------
+OUT="$(run "$D1" trace go-to-market/gtm-play)"
+assert_json "trace-upstream" "$OUT" \
+  "d['success'] is True and set(d['data']['upstream']) == {'portfolio-fit/portfolio-screen', 'market-evidence/market-sizing'} and d['data']['upstream_count'] == 2"
+
+# ---------------------------------------------------------------------------
+# 5  impact-downstream  (market-sizing blocks portfolio-screen + gtm-play)
+# ---------------------------------------------------------------------------
+OUT="$(run "$D1" impact market-evidence/market-sizing)"
+assert_json "impact-downstream" "$OUT" \
+  "d['success'] is True and set(d['data']['downstream']) == {'portfolio-fit/portfolio-screen', 'go-to-market/gtm-play'} and d['data']['downstream_count'] == 2"
+
+# trace on a missing node is a graceful error
+OUT="$(run "$D1" trace market-evidence/nope)"
+assert_json "trace-missing-node" "$OUT" \
+  "d['success'] is False and 'not found' in d['error']"
+
+# ---------------------------------------------------------------------------
+# 6  cascade-stale  (market-sizing changed -> flag downstream, preserve siblings)
+# ---------------------------------------------------------------------------
+D6="$TMPROOT/cascade"; seed_chain "$D6"
+OUT="$(run "$D6" cascade-stale market-evidence/market-sizing --trigger deliverable_update)"
+assert_json "cascade-stale-result" "$OUT" \
+  "d['success'] is True and set(d['data']['newly_flagged']) == {'portfolio-fit/portfolio-screen', 'go-to-market/gtm-play'} and d['data']['already_stale'] == []"
+
+# the upstream (changed) deliverable itself is NOT flagged
+assert_json "cascade-upstream-not-flagged" \
+  "$(python3 -c "import json; print(json.dumps(json.load(open('$D6/action-fields/market-evidence/field.json'))))")" \
+  "d['deliverables'][0].get('lineage_status') is None"
+
+# a flagged downstream deliverable keeps its sibling fields + gains lineage_status
+assert_json "cascade-preserves-siblings" \
+  "$(python3 -c "import json; print(json.dumps(json.load(open('$D6/action-fields/portfolio-fit/field.json'))['deliverables'][0]))")" \
+  "d['state'] == 'complete' and d['dt_stage'] == 'test' and d['persona_review'] == 'complete' and d['lineage_status']['status'] == 'stale' and d['lineage_status']['trigger'] == 'deliverable_update' and 'market-evidence/market-sizing' in d['lineage_status']['reason']"
+
+# ---------------------------------------------------------------------------
+# 7  cascade-idempotent  (re-running flags nothing new)
+# ---------------------------------------------------------------------------
+OUT="$(run "$D6" cascade-stale market-evidence/market-sizing --trigger deliverable_update)"
+assert_json "cascade-idempotent" "$OUT" \
+  "d['success'] is True and d['data']['newly_flagged'] == [] and set(d['data']['already_stale']) == {'portfolio-fit/portfolio-screen', 'go-to-market/gtm-play'}"
+
+# ---------------------------------------------------------------------------
+# 8  refresh-order  (after the cascade, the two stale deliverables layer
+#     portfolio-screen (layer 0) before gtm-play (layer 1))
+# ---------------------------------------------------------------------------
+OUT="$(run "$D6" refresh-order)"
+assert_json "refresh-order" "$OUT" \
+  "d['success'] is True and d['data']['stale_count'] == 2 and d['data']['layers'][0] == ['portfolio-fit/portfolio-screen'] and d['data']['layers'][1] == ['go-to-market/gtm-play'] and d['data']['order'] == ['portfolio-fit/portfolio-screen', 'go-to-market/gtm-play']"
+
+# ---------------------------------------------------------------------------
+echo
+if [ "$failures" -eq 0 ]; then
+  echo "All deliverable-graph tests passed."
+  exit 0
+else
+  echo "$failures deliverable-graph test(s) failed." >&2
+  exit 1
+fi


### PR DESCRIPTION
Closes #786.

Phase 1 foundation for the cogni-consult deliverable dependency graph (epic #789). Lays the edge schema, the reference doc, and the stdlib graph engine that the write side (#787) and read side (#788) both consume.

## Summary
- Extend `references/data-model.md`: add `depends_on[]` (array of `{action_field, deliverable}` WBS-coordinate objects, declared on the DEPENDENT) and the stored `lineage_status` field (`null | {status:"stale", reason, flagged_at, trigger}`, orthogonal to `state`) to the deliverable entry; document `blocks[]` as derived-at-read-time by inverting `depends_on` (extends the State-Ownership principle) and the flag-not-rewrite contract.
- New `references/dependency-model.md`: edge schema, WBS-coordinate ref format + CLI slash shorthand, cycle + dangling-ref hard-error rules, cascade semantics, topological-refresh semantics, and the surface-candidates-never-auto-rewrite contract.
- New stdlib `scripts/deliverable-graph.py` (python3, no pip, `{success,data,error}` envelope, engagement-dir positional): subcommands `validate`, `trace <af/deliverable>`, `impact <af/deliverable>`, `refresh-order`, `cascade-stale <af/deliverable> --trigger deliverable_update|claims_correction` (idempotent RMW write of `lineage_status` on the downstream set, preserving sibling fields).
- New `tests/test_deliverable_graph.sh`: fixture-based stdlib test (11 assertions) covering validate-clean, cycle detection, dangling-ref detection, trace, impact, cascade-stale (incl. sibling preservation + upstream-not-flagged), idempotency, and refresh-order topological layering.
- Bump cogni-consult `plugin.json` 0.1.5 → 0.1.6, mirrored in root `marketplace.json`.

## Scope decisions
- Full scope in one reviewable PR; nothing deferred.
- `lineage_status` IS stored (written by `cascade-stale`); `blocks[]` is derived at read time by inverting `depends_on` — kept distinct per the data model's State-Ownership principle.
- `depends_on[]` entries are objects `{action_field, deliverable}`; the CLI shorthand `af/deliverable` is parsed into that object form (stored schema stays object form).
- Cascade is flag-and-recommend only (writes `lineage_status=stale`), never auto-rewrites a deliverable's artifact or `state` — mirrors cogni-knowledge knowledge-refresh.
- Version base was 0.1.5 on origin/main (the issue body's "0.1.4 -> 0.1.5" was stale; a prior PR already landed 0.1.5), so the bump target is 0.1.6.

## Test plan
- [x] `bash cogni-consult/tests/test_deliverable_graph.sh` exits 0 (11/11 assertions pass).
- [x] `python3 cogni-consult/scripts/deliverable-graph.py <fixture> validate` returns success on a clean graph and `success:false` with cycle/dangling errors on bad fixtures.
- [x] `cascade-stale` writes `lineage_status.status="stale"` to downstream deliverables while preserving `slug/title/state/dt_stage/producing_route/persona_review`; second run is idempotent.
- [x] `refresh-order` returns topologically layered stale deliverables (upstream layer before dependent layer).
- [x] `plugin.json` and root `marketplace.json` both read 0.1.6.

Plan record: https://github.com/cogni-work/insight-wave/issues/786#issuecomment-4709421265