### PR TITLE
cogni-consult: producing skills declare deps + trigger staleness cascade

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -35,7 +35,7 @@
     {
       "name": "cogni-consult",
       "source": "./cogni-consult",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "maturity": "preview",
       "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
       "keywords": [

--- a/cogni-consult/.claude-plugin/plugin.json
+++ b/cogni-consult/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-consult",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-consult/skills/consult-action-fields/SKILL.md
+++ b/cogni-consult/skills/consult-action-fields/SKILL.md
@@ -125,10 +125,7 @@ field's `field.json` once, appending all agreed entries, each shaped:
   "state": "pending",
   "dt_stage": "empathize",
   "producing_route": "consult-design-thinking",
-  "persona_review": "pending",
-  "depends_on": [
-    { "action_field": "<upstream-field-slug>", "deliverable": "<upstream-deliverable-slug>" }
-  ]
+  "persona_review": "pending"
 }
 ```
 
@@ -139,15 +136,26 @@ artifact). `persona_review` tracks the acting-persona challenge pass:
 `pending` → `in-progress` → `complete`. Both fields are manifest metadata —
 recommend the route, never dispatch it from here.
 
-When a deliverable being planned builds on earlier work (e.g. "this
-proposition assumes the market-sizing is done"), elicit the upstream WBS
-coordinates from the consultant — which action-field slug and deliverable
-slug each dependency points at — and record them as a `depends_on[]` array
-of `{action_field, deliverable}` objects on the dependent entry. Edges may
-cross fields. `depends_on[]` is optional: omit it (or leave it `[]`) when the
-deliverable has no upstream dependency. This is the only place dependencies
-are declared — the inverse ("what does this block?") is derived at read time,
-never stored. Full edge schema:
+Most deliverables have no upstream dependency — the entry above is the
+default shape, so leave it as is. Only when a deliverable being planned
+builds on earlier work (e.g. "this proposition assumes the market-sizing is
+done") elicit the upstream WBS coordinates from the consultant — which
+action-field slug and deliverable slug each dependency points at — and add a
+`depends_on[]` array of `{action_field, deliverable}` objects to that
+dependent entry:
+
+```json
+  "depends_on": [
+    { "action_field": "market-evidence", "deliverable": "market-sizing" }
+  ]
+```
+
+Edges may cross fields. Never write placeholder or empty-string coordinates —
+omit `depends_on[]` entirely when there is no real dependency (an empty/`[]`
+array is also fine), since `validate` rejects a coordinate that names no
+existing deliverable as a dangling reference. This is the only place
+dependencies are declared — the inverse ("what does this block?") is derived
+at read time, never stored. Full edge schema:
 `$CLAUDE_PLUGIN_ROOT/references/dependency-model.md`.
 
 Whenever this session added or changed any `depends_on[]` entry, run the
@@ -202,13 +210,17 @@ Field-set changes touch two places, always both, in this order:
 A split or merge changes the owning action-field slug of every entry it
 moves, so any `depends_on` coordinate elsewhere in the engagement that
 pointed at a moved deliverable now references a field that no longer owns it
-— a dangling reference. After reconciling the directory tree, repoint each
-such `depends_on` entry to the moved deliverable's new `{action_field}`, then
-re-run the validator so the reshape leaves no dangling edges:
+— a dangling reference. After reconciling the directory tree, run the
+validator to enumerate exactly which coordinates broke — each entry in
+`data.dangling[]` names the dependent and the now-orphaned coordinate:
 
 ```bash
 python3 $CLAUDE_PLUGIN_ROOT/scripts/deliverable-graph.py <engagement-dir> validate
 ```
+
+Repoint each dangling `depends_on` entry to the moved deliverable's new
+`{action_field}`, then re-run `validate` to confirm the reshape leaves no
+dangling edges.
 
 Never overwrite an existing `field.json` — it is the single source of truth
 for that field's deliverable states.

--- a/cogni-consult/skills/consult-action-fields/SKILL.md
+++ b/cogni-consult/skills/consult-action-fields/SKILL.md
@@ -125,7 +125,10 @@ field's `field.json` once, appending all agreed entries, each shaped:
   "state": "pending",
   "dt_stage": "empathize",
   "producing_route": "consult-design-thinking",
-  "persona_review": "pending"
+  "persona_review": "pending",
+  "depends_on": [
+    { "action_field": "<upstream-field-slug>", "deliverable": "<upstream-deliverable-slug>" }
+  ]
 }
 ```
 
@@ -135,6 +138,30 @@ consultant names one (e.g. a direct `cogni-visual` export of an existing
 artifact). `persona_review` tracks the acting-persona challenge pass:
 `pending` → `in-progress` → `complete`. Both fields are manifest metadata —
 recommend the route, never dispatch it from here.
+
+When a deliverable being planned builds on earlier work (e.g. "this
+proposition assumes the market-sizing is done"), elicit the upstream WBS
+coordinates from the consultant — which action-field slug and deliverable
+slug each dependency points at — and record them as a `depends_on[]` array
+of `{action_field, deliverable}` objects on the dependent entry. Edges may
+cross fields. `depends_on[]` is optional: omit it (or leave it `[]`) when the
+deliverable has no upstream dependency. This is the only place dependencies
+are declared — the inverse ("what does this block?") is derived at read time,
+never stored. Full edge schema:
+`$CLAUDE_PLUGIN_ROOT/references/dependency-model.md`.
+
+Whenever this session added or changed any `depends_on[]` entry, run the
+dependency validator before considering the field planned — cycles and
+dangling references are hard errors that must block planning:
+
+```bash
+python3 $CLAUDE_PLUGIN_ROOT/scripts/deliverable-graph.py <engagement-dir> validate
+```
+
+On `"success": false`, surface the `error` string together with `data.cycles`
+and `data.dangling`, and ask the consultant to correct the dependency
+declarations. Do not close the session with an unresolved `validate` failure
+when dependencies were declared this session.
 
 When planning surfaces a research-heavy deliverable, note that its evidence
 will run through the engagement's bound knowledge base per
@@ -171,6 +198,17 @@ Field-set changes touch two places, always both, in this order:
      guard from `consult-scope` — leave the field's directory and
      `field.json` in place and note the removal in the summary; deleting
      deliverable history is the consultant's call, not the skill's.
+
+A split or merge changes the owning action-field slug of every entry it
+moves, so any `depends_on` coordinate elsewhere in the engagement that
+pointed at a moved deliverable now references a field that no longer owns it
+— a dangling reference. After reconciling the directory tree, repoint each
+such `depends_on` entry to the moved deliverable's new `{action_field}`, then
+re-run the validator so the reshape leaves no dangling edges:
+
+```bash
+python3 $CLAUDE_PLUGIN_ROOT/scripts/deliverable-graph.py <engagement-dir> validate
+```
 
 Never overwrite an existing `field.json` — it is the single source of truth
 for that field's deliverable states.

--- a/cogni-consult/skills/consult-design-thinking/SKILL.md
+++ b/cogni-consult/skills/consult-design-thinking/SKILL.md
@@ -253,9 +253,10 @@ to see before picking the next deliverable.
 
   Run it on the deliverable whose artifact cites the corrected source; the
   flagged dependents' `lineage_status.trigger` reads `claims_correction` so
-  the reason stays traceable. There is no automated cogni-claims callback into
-  cogni-consult — this is a consultant-initiated step when a correction is
-  noticed.
+  the reason stays traceable. A `"success": false` (node not found, bad dir)
+  is non-blocking here too — surface the error and continue. There is no
+  automated cogni-claims callback into cogni-consult — this is a
+  consultant-initiated step when a correction is noticed.
 - **Loop, not gate**: stages may re-enter earlier stages; `state` stays
   `in-progress` until the test stage passes. Log state transitions (not
   per-stage moves) in the execution log.

--- a/cogni-consult/skills/consult-design-thinking/SKILL.md
+++ b/cogni-consult/skills/consult-design-thinking/SKILL.md
@@ -82,6 +82,19 @@ at the stage the rework needs (often `define` or `ideate`), and one `Edit` of
 `.metadata/execution-log.json` appends the `complete` → `in-progress`
 transition to `transitions[]`.
 
+Because the deliverable's content is about to change, flag its downstream
+dependents stale now — before the rework begins — so the consultant sees the
+blast radius up front:
+
+```bash
+python3 $CLAUDE_PLUGIN_ROOT/scripts/deliverable-graph.py <engagement-dir> \
+    cascade-stale <field-slug>/<deliverable-slug> --trigger deliverable_update
+```
+
+Surface `data.newly_flagged` (the deliverables now marked stale). A
+`"success": false` (node not found, bad dir) is non-blocking — surface the
+error and proceed with the rework.
+
 ### 3. Empathize
 
 Read `$CLAUDE_PLUGIN_ROOT/references/methods/empathy-mapping.md` and run it
@@ -177,7 +190,19 @@ acting-persona pass will deepen once personas exist.
 If the draft survives (consultant accepts): one `Edit` of `field.json` sets
 `state` → `"complete"` (keep `dt_stage` at `"test"`), and one `Edit` of
 `.metadata/execution-log.json` appends the `in-progress` → `complete`
-transition to `transitions[]`. If it does not survive, loop back — set `dt_stage` to the stage
+transition to `transitions[]`. Then run the dependency cascade so every
+downstream deliverable that listed this one in its `depends_on[]` is flagged
+stale:
+
+```bash
+python3 $CLAUDE_PLUGIN_ROOT/scripts/deliverable-graph.py <engagement-dir> \
+    cascade-stale <field-slug>/<deliverable-slug> --trigger deliverable_update
+```
+
+Surface `data.newly_flagged` in the session summary so the consultant knows
+which deliverables now need revisiting. A `"success": false` (node not found,
+bad dir) is non-blocking — the completion stands; surface the error and
+continue. If it does not survive, loop back — set `dt_stage` to the stage
 the revision needs (often `define` or `ideate`) and continue; `state` stays
 `in-progress`.
 
@@ -216,6 +241,21 @@ to see before picking the next deliverable.
   (`$CLAUDE_PLUGIN_ROOT/references/research-routing.md`), never raw web
   search; every evidence-backed claim in the artifact carries the
   `sources[]` lineage triple so corrections can cascade.
+- **Claims-correction cascade**: when the consultant surfaces a cogni-claims
+  correction that reaches a deliverable through its `sources[]` lineage (a
+  cited claim was deviated and resolved upstream), flag that deliverable's
+  downstream dependents stale so the corrected ground propagates:
+
+  ```bash
+  python3 $CLAUDE_PLUGIN_ROOT/scripts/deliverable-graph.py <engagement-dir> \
+      cascade-stale <field-slug>/<deliverable-slug> --trigger claims_correction
+  ```
+
+  Run it on the deliverable whose artifact cites the corrected source; the
+  flagged dependents' `lineage_status.trigger` reads `claims_correction` so
+  the reason stays traceable. There is no automated cogni-claims callback into
+  cogni-consult — this is a consultant-initiated step when a correction is
+  noticed.
 - **Loop, not gate**: stages may re-enter earlier stages; `state` stays
   `in-progress` until the test stage passes. Log state transitions (not
   per-stage moves) in the execution log.


### PR DESCRIPTION
Closes #787.

With the edge schema and `deliverable-graph.py` foundation merged, the producing skills now actually populate the graph and trigger the staleness cascade, so the read side has lineage to render.

## Summary
- **consult-action-fields** Step 4: planned deliverable entries now carry a `depends_on[]` array of `{action_field, deliverable}` WBS coordinates (placed after `persona_review`, matching the data-model.md / dependency-model.md schema); planning runs `python3 $CLAUDE_PLUGIN_ROOT/scripts/deliverable-graph.py <engagement-dir> validate` as a hard gate (surfacing `data.cycles` / `data.dangling` on failure) before the field is considered planned.
- **consult-action-fields** Step 5: when a split/merge moves deliverable entries between fields (renaming their `action_field`), repoint every `depends_on` coordinate elsewhere that referenced a moved node, then re-run `validate` — so cross-field edges don't dangle after the WBS reshapes.
- **consult-design-thinking** Step 7: after a deliverable's `state` advances to `complete`, fire `cascade-stale <field>/<deliverable> --trigger deliverable_update` and surface `data.newly_flagged`.
- **consult-design-thinking** Step 2: before a `complete`→`in-progress` rework re-entry, fire the same `deliverable_update` cascade so dependents are flagged stale ahead of the rework.
- **consult-design-thinking** Important Notes: a consultant-driven claims-correction bullet — when an upstream cogni-claims source correction reaches a deliverable via its `sources[]` lineage, run `cascade-stale <field>/<deliverable> --trigger claims_correction` (cogni-claims has no automated inbound path into cogni-consult).
- Bump plugin.json + marketplace.json `0.1.6` → `0.1.7`.

## Scope decisions
- All three acceptance criteria ship together: additive prose against two SKILL.md files, sharing the cogni-consult version line and the same engine. Splitting would create version-line collisions for no review benefit.
- The claims path is a consultant-action bullet rather than an automated cogni-claims callback — no inbound cogni-claims→cogni-consult path exists, and inventing one is out of scope.
- No new scripts or schema changes: `deliverable-graph.py` already provides `validate` and `cascade-stale`.
- The read side (surfacing `lineage_status` stale flags in dashboard/resume) is the sibling phase-1 issue in this epic, tracked separately — this PR populates and flags the graph.

## Test plan
- [x] `cogni-workspace/scripts/check-skill-names.sh` passes.
- [x] `scripts/check-breadcrumbs.py` (Maintainer-breadcrumb guard) passes — no new refs.
- [x] `cogni-consult/tests/test_deliverable_graph.sh` still passes (engine unchanged, 10/10).
- [x] plugin.json and marketplace.json both read `0.1.7` for cogni-consult.