### PR TITLE
cogni-consult: stale-deliverable surfacing + topological refresh-order (read side)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -35,7 +35,7 @@
     {
       "name": "cogni-consult",
       "source": "./cogni-consult",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "maturity": "preview",
       "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
       "keywords": [

--- a/cogni-consult/.claude-plugin/plugin.json
+++ b/cogni-consult/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-consult",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-consult/skills/consult-action-fields/SKILL.md
+++ b/cogni-consult/skills/consult-action-fields/SKILL.md
@@ -90,16 +90,26 @@ priority), deliverables in manifest order:
 | go-to-market | ⚠ unreadable field.json (see warnings) | | | | |
 ```
 
-Close the dashboard with the **next-deliverable recommendation**: the first
-deliverable with `state: "pending"`, walking fields in `action_fields[]`
-order and deliverables in manifest order. When a field has an empty
-`deliverables[]`, recommend planning that field's set (step 4) instead —
-an empty container outranks a half-done one. Skip unreadable fields in
-this walk — the rollup reports them with an empty `deliverables[]` too,
-but the right response is surfacing their warning, not a planning
-recommendation that would `Edit` a malformed `field.json`. When every
-deliverable is `complete`, say so: the engagement is complete by
-derivation, there is nothing to store.
+Close the dashboard with the **next-deliverable recommendation**. Check for
+stale deliverables first: any deliverable carrying `lineage_status.status:
+"stale"` has been invalidated by an upstream change, and refreshing it outranks
+starting fresh pending work (new work built on a stale foundation is wasted).
+When stale deliverables exist, run `deliverable-graph.py <engagement-dir>
+refresh-order` and recommend refreshing them in **topological order — upstream
+before dependents**: the layer-0 deliverable(s) first (nothing else stale
+depends on them, so they are safe to refresh now), deeper layers only once the
+layer above is refreshed. Route to `knowledge-refresh`, then
+`consult-design-thinking` to re-run the deliverable's loop.
+
+Only when nothing is stale, fall through to the first deliverable with
+`state: "pending"`, walking fields in `action_fields[]` order and deliverables
+in manifest order. When a field has an empty `deliverables[]`, recommend
+planning that field's set (step 4) instead — an empty container outranks a
+half-done one. Skip unreadable fields in this walk — the rollup reports them
+with an empty `deliverables[]` too, but the right response is surfacing their
+warning, not a planning recommendation that would `Edit` a malformed
+`field.json`. When every deliverable is `complete` and current, say so: the
+engagement is complete by derivation, there is nothing to store.
 
 **Offer the visual dashboard.** This text table is the quick check; for a
 themed, browsable view of the same WBS — deliverable states, design-thinking

--- a/cogni-consult/skills/consult-dashboard/SKILL.md
+++ b/cogni-consult/skills/consult-dashboard/SKILL.md
@@ -120,12 +120,22 @@ The generated HTML is a single self-contained page with these sections:
 3. **Action fields — work breakdown** — one card per action field showing the field title,
    framing, derived state, and a `done/total` count; each deliverable row shows its title, a
    state badge, a five-step design-thinking indicator (empathize→define→ideate→prototype→test
-   with the current stage highlighted), and its persona-review status.
+   with the current stage highlighted), and its persona-review status. A deliverable that an
+   upstream change has invalidated (`lineage_status.status: "stale"`) carries a **stale badge**
+   next to its state, and a deliverable with declared dependencies shows a **`⤴ depends on`**
+   hint listing the upstream deliverables to refresh first.
 4. **Knowledge base** — the bound knowledge-base slug and the count of research synthesis files
    across scope and action fields.
 5. **Next action** — a single recommended next step derived from scope state and deliverable
-   states (finish scoping / continue an in-progress deliverable / start the next one / assemble
-   the output).
+   states. Stale deliverables take precedence: when any exist, the recommendation is to refresh
+   them upstream-first (the layer-0 deliverable in the topological refresh order) before any
+   pending or in-progress work; otherwise it falls through to finish scoping / continue an
+   in-progress deliverable / start the next one / assemble the output.
+6. **Refresh order** — appears when deliverables are stale: the stale set grouped into
+   topological layers (layer 0 first — safe to refresh now, since nothing else stale depends on
+   it; deeper layers become reliable once the layer above is refreshed). When nothing is stale it
+   shows a "current" note; when the dependency-graph engine is unavailable the section is omitted
+   entirely and the rest of the dashboard still renders (graceful degradation).
 
 A **Warnings** card appears only when a `field.json` is unreadable (surfaced, never conflated
 with "pending").

--- a/cogni-consult/skills/consult-dashboard/scripts/generate-dashboard.py
+++ b/cogni-consult/skills/consult-dashboard/scripts/generate-dashboard.py
@@ -19,6 +19,7 @@ import html
 import json
 import os
 import re
+import subprocess
 import sys
 from datetime import datetime, timezone
 
@@ -220,10 +221,93 @@ def compute_summary(eng):
     }
 
 
-def next_action(eng, summary):
-    """A single recommendation line, mirroring engagement-status signals."""
+# ---------------------------------------------------------------------------
+# Deliverable dependency / staleness surfacing — the read side of the
+# deliverable-graph engine. lineage_status.status == "stale" is the cascade flag
+# written by deliverable-graph.py cascade-stale; depends_on is the WBS edge set.
+# ---------------------------------------------------------------------------
+
+
+def _is_stale_deliv(d):
+    """A deliverable is stale when the cascade flagged its lineage_status."""
+    ls = d.get("lineage_status")
+    return isinstance(ls, dict) and ls.get("status") == "stale"
+
+
+def build_deliv_index(eng):
+    """Map each deliverable's WBS-coordinate key 'field_slug/deliv_slug' to its
+    display info, so the dependency edges and refresh-order layers (which speak in
+    keys) can render human titles."""
+    idx = {}
+    for f in eng["action_fields"]:
+        for d in f["deliverables"]:
+            slug = d.get("slug")
+            if not slug:
+                continue
+            ls = d.get("lineage_status") if isinstance(d.get("lineage_status"), dict) else {}
+            idx[f"{f['slug']}/{slug}"] = {
+                "title": d.get("title") or slug,
+                "field_title": f["title"],
+                "stale": ls.get("status") == "stale",
+                "reason": ls.get("reason") or "",
+            }
+    return idx
+
+
+def load_refresh_order(engagement_dir):
+    """Shell out to the deliverable-graph engine for the topological refresh order
+    of the currently-stale deliverables. Returns the data dict
+    ({stale_count, layers, order}) on success, or None when the engine is absent,
+    errors, times out, or reports a cycle — every failure degrades gracefully and
+    the dashboard still renders without the refresh view."""
+    script = os.path.join(
+        os.path.dirname(os.path.abspath(__file__)),
+        "..", "..", "..", "scripts", "deliverable-graph.py",
+    )
+    if not os.path.isfile(script):
+        return None
+    try:
+        proc = subprocess.run(
+            [sys.executable, script, engagement_dir, "refresh-order"],
+            capture_output=True, text=True, timeout=30,
+        )
+        payload = json.loads(proc.stdout)
+    except (OSError, ValueError, subprocess.SubprocessError):
+        return None
+    if not isinstance(payload, dict) or not payload.get("success"):
+        return None
+    data = payload.get("data")
+    return data if isinstance(data, dict) else None
+
+
+def next_action(eng, summary, refresh=None, deliv_index=None):
+    """A single recommendation line, mirroring engagement-status signals.
+
+    Stale deliverables take precedence over pending/in-progress work: an upstream
+    change has invalidated downstream artifacts, so the highest-value next step is
+    to refresh them — and to refresh them upstream-first (the layer-0 deliverable
+    in the topological refresh order), never a dependent before its dependency."""
     if eng["scope_state"] != "complete":
         return "Finish scoping the engagement (consult-scope) — define the SMART key question and action fields."
+    stale = [d for f in eng["action_fields"] for d in f["deliverables"] if _is_stale_deliv(d)]
+    if stale:
+        first_title = None
+        if refresh and refresh.get("layers"):
+            for layer in refresh["layers"]:
+                if layer:
+                    key0 = layer[0]
+                    info = (deliv_index or {}).get(key0)
+                    first_title = info["title"] if info else key0
+                    break
+        if not first_title:
+            first_title = stale[0].get("title") or stale[0].get("slug")
+        n = len(stale)
+        plural = "deliverable" if n == 1 else "deliverables"
+        return (
+            f"{n} {plural} went stale after an upstream change — refresh "
+            f"“{first_title}” first, then work down the refresh order (upstream "
+            f"before dependents; knowledge-refresh, then re-run its design-thinking loop)."
+        )
     for f in eng["action_fields"]:
         for d in f["deliverables"]:
             if d.get("state") == "in-progress":
@@ -282,10 +366,21 @@ def render_field_card(field):
     for d in delivs:
         st = d.get("state", "pending")
         review = d.get("persona_review", "pending")
+        ls = d.get("lineage_status") if isinstance(d.get("lineage_status"), dict) else {}
+        stale_badge = ""
+        if ls.get("status") == "stale":
+            reason = ls.get("reason") or "an upstream deliverable changed"
+            stale_badge = f'<span class="stale-mark" title="Stale — {esc(reason)}">{badge("stale", "danger")}</span>'
+        deps = d.get("depends_on") or []
+        dep_labels = [esc(ref.get("deliverable")) for ref in deps if isinstance(ref, dict) and ref.get("deliverable")]
+        dep_hint = ""
+        if dep_labels:
+            chips = "".join(f'<span class="dep-chip">{l}</span>' for l in dep_labels)
+            dep_hint = f'<div class="deliv-deps" title="Depends on (refresh these first)">⤴ depends on {chips}</div>'
         rows.append(
             '<div class="deliv-row">'
-            f'<div class="deliv-title">{esc(d.get("title") or d.get("slug"))}</div>'
-            f'<div class="deliv-state">{badge(st, STATE_ROLE.get(st, "muted"))}</div>'
+            f'<div class="deliv-title">{esc(d.get("title") or d.get("slug"))}{dep_hint}</div>'
+            f'<div class="deliv-state">{badge(st, STATE_ROLE.get(st, "muted"))}{stale_badge}</div>'
             f'<div class="deliv-dt">{dt_indicator(d.get("dt_stage"))}</div>'
             f'<div class="deliv-review">persona {badge(review, REVIEW_ROLE.get(review, "muted"))}</div>'
             '</div>'
@@ -309,7 +404,46 @@ def render_field_card(field):
     )
 
 
-def render_html(eng, summary, theme):
+def render_refresh_section(refresh, deliv_index):
+    """The 'Refresh order' card: stale deliverables grouped into topological layers,
+    layer 0 first (safe to refresh now). Returns '' when the engine is unavailable
+    (graceful degradation) and a 'current' note when nothing is stale."""
+    if refresh is None:
+        return ""
+    if not refresh.get("stale_count"):
+        return (
+            '<section class="card refresh">'
+            '<h2>Refresh order</h2>'
+            '<p class="refresh-note">✓ All deliverables are current — nothing stale to refresh.</p>'
+            '</section>'
+        )
+    layers = refresh.get("layers") or []
+    layer_html = []
+    for i, lyr in enumerate(layers):
+        chips = "".join(
+            f'<span class="refresh-chip" title="{esc((deliv_index or {}).get(k, {}).get("field_title", ""))}">'
+            f'{esc((deliv_index or {}).get(k, {}).get("title", k))}</span>'
+            for k in lyr
+        )
+        label = "refresh first" if i == 0 else f"after layer {i - 1}"
+        layer_html.append(
+            f'<div class="refresh-layer"><div class="refresh-layer-lbl">Layer {i} · {label}</div>'
+            f'<div class="refresh-chips">{chips}</div></div>'
+        )
+    n = refresh["stale_count"]
+    plural = "deliverable" if n == 1 else "deliverables"
+    return (
+        '<section class="card refresh">'
+        f'<h2>Refresh order — {n} stale {plural}</h2>'
+        '<p class="refresh-note">An upstream change marked these stale. Refresh upstream '
+        'before dependents: work top to bottom — each layer becomes reliable once the layer '
+        'above it has been refreshed.</p>'
+        f'{"".join(layer_html)}'
+        '</section>'
+    )
+
+
+def render_html(eng, summary, theme, refresh=None, deliv_index=None):
     colors = theme["colors"]
     status = theme["status"]
     fonts = theme["fonts"]
@@ -391,8 +525,19 @@ header.hero .hero-meta {{ margin-top: 1rem; display: flex; flex-wrap: wrap; gap:
 .deliv-list {{ display: flex; flex-direction: column; gap: .4rem; margin-top: .5rem; }}
 .deliv-row {{ display: grid; grid-template-columns: minmax(0,2.2fr) auto minmax(0,1.6fr) auto; gap: .75rem; align-items: center; background: var(--surface); border-radius: 8px; padding: .55rem .75rem; }}
 .deliv-title {{ font-size: .92rem; font-weight: 500; }}
+.deliv-deps {{ font-size: .72rem; color: var(--text-muted); margin-top: .2rem; display: flex; flex-wrap: wrap; align-items: center; gap: .25rem; }}
+.dep-chip {{ background: var(--surface2); border: 1px solid var(--border); border-radius: 999px; padding: .02rem .4rem; font-family: var(--font-mono); font-size: .68rem; }}
+.deliv-state {{ display: flex; align-items: center; gap: .35rem; flex-wrap: wrap; }}
+.stale-mark {{ display: inline-flex; }}
 .deliv-review {{ font-size: .76rem; color: var(--text-muted); text-align: right; }}
 .deliv-empty {{ font-size: .85rem; color: var(--text-muted); font-style: italic; padding: .5rem 0; }}
+.card.refresh {{ border-color: var(--yellow); }}
+.refresh-note {{ font-size: .85rem; color: var(--text-muted); margin-bottom: 1rem; max-width: 70ch; }}
+.refresh-layer {{ display: flex; flex-wrap: wrap; align-items: baseline; gap: .6rem; padding: .5rem 0; border-top: 1px dashed var(--border); }}
+.refresh-layer:first-of-type {{ border-top: none; }}
+.refresh-layer-lbl {{ font-size: .78rem; font-weight: 600; color: var(--accent-dark); min-width: 11rem; }}
+.refresh-chips {{ display: flex; flex-wrap: wrap; gap: .4rem; }}
+.refresh-chip {{ background: var(--surface2); border: 1px solid var(--border); border-radius: 999px; padding: .15rem .6rem; font-size: .8rem; }}
 .dt-track {{ display: inline-flex; gap: 3px; vertical-align: middle; }}
 .dt-dot {{ width: 9px; height: 9px; border-radius: 50%; background: var(--border); display: inline-block; }}
 .dt-dot.dt-done {{ background: var(--accent-muted); }}
@@ -443,8 +588,10 @@ footer {{ text-align: center; color: var(--text-muted); font-size: .78rem; margi
 
   <section class="card">
     <h2>Next action</h2>
-    <p class="next">{esc(next_action(eng, summary))}</p>
+    <p class="next">{esc(next_action(eng, summary, refresh, deliv_index))}</p>
   </section>
+
+  {render_refresh_section(refresh, deliv_index)}
 
   {warn_block}
 
@@ -468,12 +615,14 @@ def main():
             raise ValueError(f"engagement directory not found: {engagement_dir}")
         eng = load_engagement(engagement_dir)
         summary = compute_summary(eng)
+        deliv_index = build_deliv_index(eng)
+        refresh = load_refresh_order(engagement_dir)
         theme, dv_path = resolve_theme(args.design_variables, args.theme)
         out_dir = os.path.join(engagement_dir, "output")
         os.makedirs(out_dir, exist_ok=True)
         out_path = os.path.join(out_dir, "dashboard.html")
         with open(out_path, "w") as f:
-            f.write(render_html(eng, summary, theme))
+            f.write(render_html(eng, summary, theme, refresh, deliv_index))
     except (ValueError, OSError, json.JSONDecodeError) as exc:
         print(json.dumps({"success": False, "data": {}, "error": str(exc)}))
         return 1
@@ -486,6 +635,7 @@ def main():
             "design_variables": dv_path,
             "engagement_state": summary["engagement_state"],
             "completion_pct": summary["completion_pct"],
+            "stale_count": (refresh or {}).get("stale_count", 0),
         },
         "error": "",
     }))

--- a/cogni-consult/skills/consult-resume/SKILL.md
+++ b/cogni-consult/skills/consult-resume/SKILL.md
@@ -103,6 +103,17 @@ Branch on the derived state, first match wins, and say *why*:
 - **A field has an empty `deliverables[]`** (and is not `unreadable`) → the
   WBS has an unplanned container; recommend `consult-action-fields` to plan
   that field's deliverable set.
+- **Any deliverable carries `lineage_status.status: "stale"`** → an upstream
+  deliverable it depends on changed, so its artifact is out of date. Stale work
+  outranks both in-progress and pending work here: finishing fresh work on a
+  stale foundation wastes it, so refreshing comes first. Recommend refreshing
+  the stale set in **topological order — upstream before dependents**: run
+  `deliverable-graph.py <engagement-dir> refresh-order` and recommend the
+  layer-0 deliverable(s) first (they depend on nothing else that is stale, so
+  they are safe to refresh now); a deeper-layer deliverable is refreshed only
+  once the layer above it has been. Route to `knowledge-refresh` for the
+  research, then `consult-design-thinking` to re-run that deliverable's loop.
+  Never recommend refreshing a dependent before its upstream dependency.
 - **A deliverable is `in-progress`** → resume it where it stands; recommend
   `consult-design-thinking` naming the field, the deliverable, and its
   `dt_stage` ("competitor-map is mid-ideate — pick the loop back up there").

--- a/cogni-consult/tests/test_generate_dashboard.sh
+++ b/cogni-consult/tests/test_generate_dashboard.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+# Regression test for cogni-consult/skills/consult-dashboard/scripts/generate-dashboard.py
+# — the read side of the deliverable dependency-graph engine: stale badges, depends_on
+# hints, and the topological "Refresh order" section that shells out to
+# deliverable-graph.py refresh-order.
+#
+# Fixtures are heredoc'd inline — no committed JSON blobs to maintain. Each fixture
+# builds a minimal engagement (consult-project.json + action-fields/<slug>/field.json)
+# in a temp directory, runs the generator, and asserts on both the JSON stdout and the
+# generated output/dashboard.html.
+#
+# Coverage:
+#   1  no-stale           engagement with dependencies but nothing stale → no stale
+#                         badge, a "current" refresh note, depends_on hint rendered
+#   2  stale-layers       two stale deliverables in a dependency chain → stale badge +
+#                         a "Refresh order" section with two topological layers
+#   3  graceful-degrade   stale deliverables whose stale sub-graph has a cycle →
+#                         refresh-order errors, so the section is omitted, but the
+#                         dashboard still renders with stale badges (no hard failure)
+#
+# Usage: bash cogni-consult/tests/test_generate_dashboard.sh
+# Exits non-zero on any assertion failure.
+
+# `set -u` only — `set -e` would abort on the first failing assertion and defeat
+# the per-fixture failure counter below.
+set -u
+
+TESTS_DIR="$(cd "$(dirname "$0")" && pwd)"
+PLUGIN_DIR="$(cd "$TESTS_DIR/.." && pwd)"
+SCRIPT="$PLUGIN_DIR/skills/consult-dashboard/scripts/generate-dashboard.py"
+GRAPH="$PLUGIN_DIR/scripts/deliverable-graph.py"
+
+if [ ! -f "$SCRIPT" ]; then
+  echo "FAIL: generate-dashboard.py not found at $SCRIPT" >&2
+  exit 1
+fi
+if [ ! -f "$GRAPH" ]; then
+  echo "FAIL: deliverable-graph.py not found at $GRAPH (refresh-order dependency)" >&2
+  exit 1
+fi
+
+TMPROOT="$(mktemp -d)"
+trap 'rm -rf "$TMPROOT"' EXIT
+
+failures=0
+pass() { printf 'OK   %s\n' "$1"; }
+fail() { printf 'FAIL %s: %s\n' "$1" "$2" >&2; failures=$((failures + 1)); }
+
+run() { python3 "$SCRIPT" "$@"; }
+
+# assert_json <label> <json> <python-bool-expr over variable d (the parsed dict)>
+assert_json() {
+  local label="$1" js="$2" expr="$3"
+  local verdict
+  verdict="$(printf '%s' "$js" | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+print('PASS' if ($expr) else 'FAIL')
+" 2>/dev/null)"
+  if [ "$verdict" = "PASS" ]; then
+    pass "$label"
+  else
+    fail "$label" "assertion failed over: $js"
+  fi
+}
+
+# assert_html_has <label> <file> <needle>
+assert_html_has() {
+  local label="$1" file="$2" needle="$3"
+  if [ -f "$file" ] && grep -qF "$needle" "$file"; then
+    pass "$label"
+  else
+    fail "$label" "expected to find '$needle' in $file"
+  fi
+}
+
+# assert_html_lacks <label> <file> <needle>
+assert_html_lacks() {
+  local label="$1" file="$2" needle="$3"
+  if [ -f "$file" ] && grep -qF "$needle" "$file"; then
+    fail "$label" "did not expect '$needle' in $file"
+  else
+    pass "$label"
+  fi
+}
+
+# Build a single-field, two-deliverable engagement. The deliverable bodies are
+# substituted by the caller so each fixture controls state / lineage_status / edges.
+#   seed_engagement <dir> <deliverables-json>
+seed_engagement() {
+  local dir="$1" delivs="$2"
+  mkdir -p "$dir/action-fields/market-evidence"
+  cat > "$dir/consult-project.json" <<'EOF'
+{
+  "slug": "acme",
+  "name": "Acme Engagement",
+  "key_question": "How do we enter the market?",
+  "action_fields": ["market-evidence"],
+  "workflow_state": {"scope": "complete"}
+}
+EOF
+  cat > "$dir/action-fields/market-evidence/field.json" <<EOF
+{
+  "title": "Market evidence",
+  "framing": "Size the opportunity.",
+  "deliverables": $delivs
+}
+EOF
+}
+
+# --- Fixture 1: dependencies present, nothing stale ------------------------------
+D1="$TMPROOT/no-stale"
+seed_engagement "$D1" '[
+  {"slug": "market-sizing", "title": "Market sizing", "state": "complete", "dt_stage": "test", "persona_review": "complete"},
+  {"slug": "competitor-map", "title": "Competitor map", "state": "complete", "dt_stage": "test", "persona_review": "complete",
+   "depends_on": [{"action_field": "market-evidence", "deliverable": "market-sizing"}]}
+]'
+OUT1="$(run "$D1")"
+HTML1="$D1/output/dashboard.html"
+assert_json "1a no-stale success"        "$OUT1" "d['success'] is True"
+assert_json "1b no-stale stale_count==0" "$OUT1" "d['data']['stale_count'] == 0"
+assert_html_has   "1c depends_on hint rendered" "$HTML1" "depends on"
+assert_html_has   "1d current refresh note"     "$HTML1" "All deliverables are current"
+assert_html_lacks "1e no stale badge"           "$HTML1" '>stale</span>'
+
+# --- Fixture 2: two stale deliverables in a chain → two refresh layers ------------
+D2="$TMPROOT/stale-layers"
+seed_engagement "$D2" '[
+  {"slug": "market-sizing", "title": "Market sizing", "state": "complete", "dt_stage": "test", "persona_review": "complete",
+   "lineage_status": {"status": "stale", "reason": "source data updated"}},
+  {"slug": "competitor-map", "title": "Competitor map", "state": "complete", "dt_stage": "test", "persona_review": "complete",
+   "depends_on": [{"action_field": "market-evidence", "deliverable": "market-sizing"}],
+   "lineage_status": {"status": "stale", "reason": "upstream changed"}}
+]'
+OUT2="$(run "$D2")"
+HTML2="$D2/output/dashboard.html"
+assert_json "2a stale success"          "$OUT2" "d['success'] is True"
+assert_json "2b stale_count==2"         "$OUT2" "d['data']['stale_count'] == 2"
+assert_html_has "2c stale badge"        "$HTML2" '>stale</span>'
+assert_html_has "2d refresh section"    "$HTML2" "Refresh order"
+assert_html_has "2e refresh layer 0"    "$HTML2" "Layer 0"
+assert_html_has "2f refresh layer 1"    "$HTML2" "Layer 1"
+# next-action recommends refreshing first, ahead of pending/in-progress work
+assert_html_has "2g next-action stale"  "$HTML2" "went stale"
+
+# --- Fixture 3: stale sub-graph has a cycle → refresh-order errors → degrade -------
+D3="$TMPROOT/graceful"
+seed_engagement "$D3" '[
+  {"slug": "alpha", "title": "Alpha", "state": "complete", "dt_stage": "test", "persona_review": "complete",
+   "depends_on": [{"action_field": "market-evidence", "deliverable": "beta"}],
+   "lineage_status": {"status": "stale", "reason": "x"}},
+  {"slug": "beta", "title": "Beta", "state": "complete", "dt_stage": "test", "persona_review": "complete",
+   "depends_on": [{"action_field": "market-evidence", "deliverable": "alpha"}],
+   "lineage_status": {"status": "stale", "reason": "y"}}
+]'
+OUT3="$(run "$D3")"
+HTML3="$D3/output/dashboard.html"
+# Dashboard still generates even though refresh-order returns success:false on the cycle.
+assert_json "3a degrade success"          "$OUT3" "d['success'] is True"
+# refresh is None on a cycle, so stale_count falls back to 0 in the output envelope.
+assert_json "3b degrade stale_count==0"   "$OUT3" "d['data']['stale_count'] == 0"
+# Stale badges still render (they come from lineage_status directly, not refresh-order)...
+assert_html_has   "3c stale badge survives"   "$HTML3" '>stale</span>'
+# ...but the Refresh-order section is omitted entirely (graceful degradation).
+assert_html_lacks "3d no refresh section"     "$HTML3" "Refresh order"
+
+# --- Summary ----------------------------------------------------------------------
+if [ "$failures" -eq 0 ]; then
+  echo "All generate-dashboard.py read-side tests passed."
+  exit 0
+else
+  echo "$failures assertion(s) failed." >&2
+  exit 1
+fi


### PR DESCRIPTION
Closes #788.

## Summary
The deliverable dependency-graph foundation and producer wiring already landed; this delivers the **read side** so the staleness signal is visible and actionable.

- **Dashboard** (`generate-dashboard.py`): each deliverable row now shows a **stale badge** when `lineage_status.status == "stale"` (with the cascade reason as a tooltip) and a **`⤴ depends on`** hint listing its upstream deliverables. A new **Refresh order** section shells out to `deliverable-graph.py refresh-order` and renders the topological layers (layer 0 = upstream-most, safe to refresh now). Graceful degradation: a "current" note when nothing is stale, and the section is omitted entirely (dashboard still renders) when the engine is unavailable or the stale sub-graph has a cycle.
- **`next_action()`** gains a stale-first branch — when scoping is complete and stale deliverables exist, it recommends refreshing the layer-0 stale deliverable first, ahead of pending/in-progress work.
- **consult-resume** "Recommend the Next Action" waterfall and **consult-action-fields** next-deliverable recommendation both add a stale-first pass: refresh in topological order (upstream before dependents), per the portfolio-lineage Mode 5 pattern. Stated semantically (no breadcrumbs).
- **consult-dashboard SKILL.md** Dashboard Sections documents the stale badge, depends-on hint, stale-first Next-action precedence, and the new Refresh-order section.
- New **`tests/test_generate_dashboard.sh`** (3 fixtures): no-stale baseline, stale badge + two refresh layers, and graceful degradation on a stale-subgraph cycle.

## Scope
Full scope, nothing deferred — the last open child of the deliverable-dependency-graph epic. Read-side only: no schema or write-side changes (the engine and `lineage_status`/`depends_on` model were delivered by the foundation child).

## Version
Bumped cogni-consult **0.1.7 → 0.1.8** in `plugin.json` and the root `marketplace.json`. (The version base advanced from 0.1.6 → 0.1.7 when the producer/write-side child merged ahead of this branch — the version-line collision the issue anticipated — so this lands on 0.1.8.)

## Test plan
- [x] `bash cogni-consult/tests/test_generate_dashboard.sh` — 16/16 assertions pass
- [x] `bash cogni-consult/tests/test_deliverable_graph.sh` — engine unchanged, still passes
- [x] `python3 -m py_compile generate-dashboard.py`
- [x] Breadcrumb guard: 0 new breadcrumbs; `check-skill-names.sh` passes; plugin.json + marketplace.json valid JSON, both 0.1.8