### PR TITLE
cogni-consult: surface Strategy Advisor output-style hint at session start

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -35,7 +35,7 @@
     {
       "name": "cogni-consult",
       "source": "./cogni-consult",
-      "version": "0.1.9",
+      "version": "0.1.10",
       "maturity": "preview",
       "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
       "keywords": [

--- a/cogni-consult/.claude-plugin/plugin.json
+++ b/cogni-consult/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-consult",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-consult/skills/consult-resume/SKILL.md
+++ b/cogni-consult/skills/consult-resume/SKILL.md
@@ -90,6 +90,8 @@ delegating to the `consult-dashboard-refresher` agent with
 stays read-only — the agent runs the read-only generator; it never edits
 engagement state.
 
+> **Strategy Advisor voice** — this plugin ships an executive-advisor output style (answer-first, MECE options). Enable it from the `/config` output-style picker; it's opt-in and fixed at session start, so set it now or `/clear` after.
+
 ### 5. Recommend the Next Action
 
 Branch on the derived state, first match wins, and say *why*:

--- a/cogni-consult/skills/consult-resume/SKILL.md
+++ b/cogni-consult/skills/consult-resume/SKILL.md
@@ -90,7 +90,7 @@ delegating to the `consult-dashboard-refresher` agent with
 stays read-only — the agent runs the read-only generator; it never edits
 engagement state.
 
-> **Strategy Advisor voice** — this plugin ships an executive-advisor output style (answer-first, MECE options). Enable it from the `/config` output-style picker; it's opt-in and fixed at session start, so set it now or `/clear` after.
+> **Strategy Advisor voice** — this plugin ships the Strategy Advisor output style (answer-first, MECE options). Enable it from the `/config` output-style picker; it's opt-in and fixed at session start, so set it now or `/clear` after.
 
 ### 5. Recommend the Next Action
 

--- a/cogni-consult/skills/consult-setup/SKILL.md
+++ b/cogni-consult/skills/consult-setup/SKILL.md
@@ -94,7 +94,7 @@ The wrapper delegates to the cogni-workspace discovery helper with the cogni-con
 
 Close by confirming what exists (engagement directory, bound knowledge base, registry entry) and recommend `consult-scope` as the next step — the SMART key question and five scoping dimensions anchor the engagement before any action field is derived. When the user wants to continue immediately, dispatch `Skill("cogni-consult:consult-scope")` in the same session; otherwise stop here and report that the engagement is ready for scoping.
 
-> **Strategy Advisor voice** — point the consultant at the executive-advisor output style this plugin ships (answer-first, MECE options). Enable it from the `/config` output-style picker; it's opt-in and fixed at session start, so set it before scoping begins.
+> **Strategy Advisor voice** — point the consultant at the Strategy Advisor output style this plugin ships (answer-first, MECE options). Enable it from the `/config` output-style picker; it's opt-in and fixed at session start, so set it before scoping begins.
 
 ## Important Notes
 

--- a/cogni-consult/skills/consult-setup/SKILL.md
+++ b/cogni-consult/skills/consult-setup/SKILL.md
@@ -94,6 +94,8 @@ The wrapper delegates to the cogni-workspace discovery helper with the cogni-con
 
 Close by confirming what exists (engagement directory, bound knowledge base, registry entry) and recommend `consult-scope` as the next step — the SMART key question and five scoping dimensions anchor the engagement before any action field is derived. When the user wants to continue immediately, dispatch `Skill("cogni-consult:consult-scope")` in the same session; otherwise stop here and report that the engagement is ready for scoping.
 
+> **Strategy Advisor voice** — point the consultant at the executive-advisor output style this plugin ships (answer-first, MECE options). Enable it from the `/config` output-style picker; it's opt-in and fixed at session start, so set it before scoping begins.
+
 ## Important Notes
 
 - **State ownership**: `consult-project.json` holds only the `scope` workflow state. Deliverable state lives exclusively in each field's `field.json` — setup never touches it (no fields exist yet). See `$CLAUDE_PLUGIN_ROOT/references/data-model.md`.


### PR DESCRIPTION
Closes #796.

## Summary
- Add a deemphasized one-line pointer to the **Strategy Advisor** output style in `consult-resume` (re-entry is a fresh session start — the actionable moment), placed after the dashboard paragraph and before the next-action recommendation so it does not crowd the WBS dashboard.
- Mention the output style once at engagement creation in `consult-setup`, so first-run users learn it exists.
- Both hints are **unconditional** static prose — no runtime active-style detection (a skill cannot reliably read the live `outputStyle`), per the issue's design constraint. Each covers how to enable via `/config` → output styles plus the session-start / `/clear` caveat.
- Patch bump cogni-consult `0.1.9` → `0.1.10` in plugin.json and mirrored in marketplace.json.

## Scope decisions
- Full scope: all four acceptance criteria are met by two SKILL.md prose insertions plus the mirrored version bump. Nothing deferred.
- `consult-resume` gets a single deemphasized line (not a heavy section), as the re-entry view is already dense with the WBS dashboard and next-action routing.
- No tests touched: the only test (`tests/test_deliverable_graph.sh`) covers the Python deliverable-graph engine, not SKILL.md prose (re-run, still green).
- Pointer emoji dropped during the skill-quality review to match the plugin's plain bold-lead callout style.

## Test plan
- [ ] `consult-resume/SKILL.md` contains exactly one deemphasized line pointing to the Strategy Advisor output style, between the dashboard paragraph and the `### 5. Recommend the Next Action` heading; names `/config` → output styles and the fixed-at-session-start (set now or `/clear`) caveat.
- [ ] `consult-setup/SKILL.md` mentions the Strategy Advisor output style once near `### 6. Recommend the Next Step`, before `## Important Notes`.
- [ ] Neither hint attempts to detect whether the style is currently active.
- [ ] `cogni-consult/.claude-plugin/plugin.json` version is `0.1.10`.
- [ ] The `cogni-consult` entry in `.claude-plugin/marketplace.json` mirrors `0.1.10`.