### PR TITLE
cogni-consult: canonical structuring-frameworks registry reference

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -35,7 +35,7 @@
     {
       "name": "cogni-consult",
       "source": "./cogni-consult",
-      "version": "0.1.10",
+      "version": "0.1.11",
       "maturity": "preview",
       "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
       "keywords": [

--- a/cogni-consult/.claude-plugin/plugin.json
+++ b/cogni-consult/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-consult",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-consult/references/frameworks-registry.md
+++ b/cogni-consult/references/frameworks-registry.md
@@ -1,0 +1,56 @@
+---
+name: frameworks-registry
+description: Canonical thin registry of consulting structuring frameworks — stable slug, terse structure signature, when-to-use, and deliverable-/field-type affinity. The key for deterministic framework selection at deliverable creation, not a teaching catalog.
+---
+
+# Frameworks Registry
+
+When a deliverable is created, the consultant picks a **structuring framework**
+— the shape the deliverable's argument takes. This registry pins each framework
+to a stable `slug` so the stored choice on a deliverable is a deterministic key
+rather than free text, alongside a one-line structure signature, a one-line
+when-to-use, and its affinity to the deliverable types and field types in
+[deliverable-types.md](deliverable-types.md).
+
+It is deliberately **thin, not a teaching catalog**: the model supplies each
+framework's depth at runtime, and where a framework already has a first-party
+page elsewhere in the ecosystem the `slug` cell links to it instead of
+duplicating. The registry only stabilises the key and the affinity so top-N
+selection is reproducible.
+
+## Framework Catalog
+
+| Slug | Structure signature | When to use | Deliverable-type affinity | Field-type affinity |
+|---|---|---|---|---|
+| [`pyramid-principle`](../../cogni-copywriting/skills/copywriter/references/02-messaging-frameworks/pyramid-framework.md) | Answer first, then MECE-grouped supporting arguments | Structuring any recommendation top-down for leadership | Executive Summary, Strategic Options Brief, Business Case | `strategy`, `execution` |
+| `mece-issue-tree` | Mutually-exclusive, collectively-exhaustive decomposition tree | Breaking a problem into non-overlapping, complete branches | Strategic Options Brief, Canvas Stress-Test Report | `analysis`, `strategy` |
+| `hypothesis-driven` | Lead hypothesis → test against evidence → confirm or revise | Focusing research on a falsifiable claim before boiling the ocean | Market Assessment, Lean Canvas | `evidence`, `analysis` |
+| [`scqa`](../../cogni-copywriting/skills/copywriter/references/02-messaging-frameworks/scqa-framework.md) | Situation → Complication → Question → Answer | Framing a problem narrative that sets up a recommendation | Executive Summary, Solution Brief | `strategy` |
+| [`bluf`](../../cogni-copywriting/skills/copywriter/references/02-messaging-frameworks/bluf-framework.md) | Bottom line up front, supporting detail after | Time-poor leadership reads and fast decisions | Executive Summary, Decision Board | `strategy`, `execution` |
+| [`inverted-pyramid`](../../cogni-copywriting/skills/copywriter/references/02-messaging-frameworks/inverted-pyramid-framework.md) | Most important first, descending detail | Skimmable, news-style briefs and summaries | Executive Summary, Market Assessment | `evidence`, `strategy` |
+| `2x2-matrix` | Two decision axes → four positioned quadrants | Positioning options or scenarios on the two dimensions that matter | Scenario Matrix, Portfolio Snapshot, Decision Board | `analysis`, `strategy` |
+| `options-trade-off` | Options × weighted criteria → ranked comparison | Comparing alternatives against explicit decision criteria | Strategic Options Brief, Decision Board | `strategy` |
+| [`scenario-planning`](../../cogni-narrative/skills/narrative/references/story-arc/arc-registry.md) | Signals → scenarios → strategies → decisions | Planning under deep uncertainty with multiple plausible futures | Scenario Matrix, Transformation Roadmap | `analysis`, `strategy` |
+| `journey-process` | Sequential stages or steps along a path | Mapping a process, customer journey, or phased rollout | Action Roadmap, Action Plan, Transformation Roadmap | `execution` |
+| [`fab`](../../cogni-copywriting/skills/copywriter/references/02-messaging-frameworks/fab-framework.md) | Feature → Advantage → Benefit | Translating capabilities into buyer-facing value | Solution Brief, Lean Canvas | `strategy` |
+| [`psb`](../../cogni-copywriting/skills/copywriter/references/02-messaging-frameworks/psb-framework.md) | Problem → Solution → Benefit | Pitching a solution against a stated need | Solution Brief, Business Case | `strategy` |
+| [`star`](../../cogni-copywriting/skills/copywriter/references/02-messaging-frameworks/star-framework.md) | Situation → Task → Action → Result | Evidence narratives, case examples, and track-record proof | Claim Verification Log, Canvas Stress-Test Report | `evidence`, `analysis` |
+
+## Using the Registry
+
+When recommending a framework at deliverable creation (consumed by
+deliverable-selection logic, tracked under the engagement's framework choice):
+
+1. Read the deliverable's type and its field's type, then shortlist frameworks
+   whose **deliverable-type affinity** or **field-type affinity** matches.
+2. Recommend from the shortlist and store the chosen framework's `slug` as the
+   stable key — never the display name or free text.
+3. Where the `slug` cell links to a first-party page, follow it for the
+   framework's depth; the registry intentionally does not restate it.
+4. Affinity is a starting recommendation, not a constraint — the consultant can
+   pick any framework, and engagement-specific structures outside this registry
+   are normal. Give a new structure a clear kebab-case `slug` like any other.
+
+The registry pins *which* structuring shape and its stable key; the model
+supplies the framework's substance at runtime, and `deliverable-types.md` owns
+*what* deliverable to produce per field.


### PR DESCRIPTION
Closes #797.

## Summary
- Adds `cogni-consult/references/frameworks-registry.md` — a thin canonical table of 13 consulting structuring frameworks (Pyramid Principle, MECE issue tree, hypothesis-driven, SCQA, BLUF, inverted pyramid, 2×2 matrix, options/trade-off, scenario planning, journey/process, FAB, PSB, STAR).
- Each row pins a stable `slug`, a one-line structure signature, a one-line when-to-use, plus deliverable-type and field-type affinity drawn **verbatim** from the existing 16-type catalog in `references/deliverable-types.md` (validated: every affinity value is a real deliverable title / one of `evidence`/`analysis`/`strategy`/`execution`).
- Cross-links existing first-party framework pages instead of duplicating their depth — the 7 cogni-copywriting `02-messaging-frameworks/` pages (pyramid/scqa/bluf/inverted-pyramid/fab/psb/star) and cogni-narrative `arc-registry.md` (scenario-planning). The registry only pins the key; the model supplies framework depth at runtime.
- Bumps cogni-consult `0.1.10` → `0.1.11` (plugin.json + marketplace.json mirrored).

## Scope decisions
- **In:** the registry file, deterministic-selection intro prose, the affinity table reusing the catalog's exact vocabulary, cross-links, and the version bump.
- **Deliberately thin, not a teaching catalog** (per the issue): no prose framework explanations — the registry only stabilizes the stored selection key.
- **Out (separate issue):** consumption of this registry by selection logic is tracked by #799, which this issue blocks. Epic #802 phase-1 foundation. No selection-side code is in scope here.
- House style matched to `references/deliverable-types.md` (frontmatter shape, table format, closing `## Using the Registry` section).

## Test plan
- [x] `references/frameworks-registry.md` exists with `name:`/`description:` frontmatter (no `title:`/`version:`), an H1 `# Frameworks Registry`, and a closing `## Using the Registry` section.
- [x] Every deliverable-type affinity value is one of the 16 catalog titles; every field-type affinity value ∈ {`evidence`,`analysis`,`strategy`,`execution`} (validated programmatically).
- [x] pyramid/scqa/bluf/inverted-pyramid/fab/psb/star rows carry working `../../` relative cross-links to the cogni-copywriting pages; scenario-planning cross-links cogni-narrative `arc-registry.md` (all resolve to real files).
- [x] plugin.json and marketplace.json both read `0.1.11`.
- [x] `tests/test_deliverable_graph.sh` still passes.