### PR TITLE
cogni-consult: persist chosen_framework on deliverables + decision-log kind

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -35,7 +35,7 @@
     {
       "name": "cogni-consult",
       "source": "./cogni-consult",
-      "version": "0.1.11",
+      "version": "0.1.12",
       "maturity": "preview",
       "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
       "keywords": [

--- a/cogni-consult/.claude-plugin/plugin.json
+++ b/cogni-consult/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-consult",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-consult/references/data-model.md
+++ b/cogni-consult/references/data-model.md
@@ -115,6 +115,7 @@ and their states.
       "state": "complete",
       "dt_stage": "test",
       "producing_route": "consult-design-thinking",
+      "chosen_framework": "pyramid-principle",
       "persona_review": "complete"
     },
     {
@@ -123,6 +124,7 @@ and their states.
       "state": "in-progress",
       "dt_stage": "ideate",
       "producing_route": "consult-design-thinking",
+      "chosen_framework": null,
       "persona_review": "pending",
       "depends_on": [
         { "action_field": "market-evidence", "deliverable": "market-sizing" }
@@ -148,6 +150,17 @@ advance `persona_review` but never create it on an entry that lacks it —
 when absent, persona `work_log` entries (and the artifact's challenge
 section) are the challenge record. `engagement-status.sh` passes both fields
 through unchanged (its rollup reads only `state`).
+
+`chosen_framework` (optional, default `null`) records the structuring framework
+the deliverable's argument takes — a stable `slug` from
+`references/frameworks-registry.md` (e.g. `pyramid-principle`),
+`"combo:<slugA>+<slugB>"` for a recommended combination of two, or `null` when
+no framework has been chosen yet. It is written once at deliverable creation
+(its selection recorded in the decision-log as a `framework-selection` entry,
+below) and read-only thereafter. Like `producing_route` and `persona_review`,
+it needs no script change to reach read surfaces: `engagement-status.sh` passes
+every deliverable field through verbatim (its rollup reads only `state`), so the
+stored slug is visible to every consumer that reads the deliverable entry.
 
 `depends_on[]` (optional, default absent/empty) declares this deliverable's
 dependencies as an array of `{action_field, deliverable}` WBS-coordinate objects,
@@ -195,7 +208,7 @@ All three logs address work by the same structured coordinates —
 
 - **execution-log.json** — workflow-state transitions: `{"transitions": [{"action_field": "...", "deliverable": "...", "from": "pending", "to": "in-progress", "timestamp": "...", "triggered_by": "<skill>"}]}`
 - **method-log.json** — methods proposed/selected per deliverable: `{"methods": [{"action_field": "...", "deliverable": "...", "proposed": [...], "selected": [...], "rationale": "..."}]}`
-- **decision-log.json** — key decisions with rationale and evidence refs: `{"decisions": [{"id": "d-001", "action_field": "...", "deliverable": "...", "decision": "...", "rationale": "...", "evidence_refs": [...], "timestamp": "..."}]}`. Gap-check entries share the same array, discriminated by `"kind": "gap-check"`: `{"id": "d-002", "kind": "gap-check", "action_field": "...", "deliverable": "...", "question": "<verbatim --question>", "theme_label": null, "verdict": "covered", "top_hit": "<page-slug>", "top_score": 0.36, "timestamp": "..."}` (recording contract: `references/research-routing.md`, Gap-Check Recording)
+- **decision-log.json** — key decisions with rationale and evidence refs: `{"decisions": [{"id": "d-001", "action_field": "...", "deliverable": "...", "decision": "...", "rationale": "...", "evidence_refs": [...], "timestamp": "..."}]}`. Gap-check entries share the same array, discriminated by `"kind": "gap-check"`: `{"id": "d-002", "kind": "gap-check", "action_field": "...", "deliverable": "...", "question": "<verbatim --question>", "theme_label": null, "verdict": "covered", "top_hit": "<page-slug>", "top_score": 0.36, "timestamp": "..."}` (recording contract: `references/research-routing.md`, Gap-Check Recording). Framework-selection entries likewise share the array, discriminated by `"kind": "framework-selection"`: `{"id": "d-003", "kind": "framework-selection", "action_field": "...", "deliverable": "...", "candidates_presented": ["pyramid-principle", "scqa", "..."], "chosen": "pyramid-principle", "is_combination": false, "rationale": "...", "timestamp": "..."}` — `candidates_presented[]` is the top-5 framework slugs shown at deliverable creation, `chosen` is the value stored in the deliverable's `chosen_framework` (a registry slug, a `"combo:<slugA>+<slugB>"` string, or `null`), and `is_combination` is `true` when `chosen` is a combo.
 
 ### personas/{slug}.json (Acting Stakeholder Personas)
 


### PR DESCRIPTION
Closes #798.

## Summary
- Add a `chosen_framework` field to the field.json deliverable-entry schema in `references/data-model.md`, sitting parallel to `producing_route`. Value = a `frameworks-registry.md` slug (e.g. `pyramid-principle`), `"combo:<slugA>+<slugB>"` for a recommended combination, or `null` when no framework is chosen yet.
- Demonstrate both cases in the JSON example: market-sizing gets `"chosen_framework": "pyramid-principle"`; competitor-landscape gets `"chosen_framework": null`.
- Add a prose paragraph defining `chosen_framework` (written at deliverable creation, read-only thereafter) and confirming it reaches read surfaces via the existing verbatim passthrough — `engagement-status.sh` passes it through unchanged, no script behavior change.
- Add a new `"framework-selection"` decision-log entry kind, mirroring the existing discriminated `"gap-check"` pattern: it shares the same `decisions[]` array and carries `id`, `kind`, `action_field`, `deliverable`, `candidates_presented[]` (top-5 slugs shown), `chosen` (the stored value), `is_combination` (bool), `rationale`, `timestamp`.
- Bump cogni-consult `0.1.11` → `0.1.12` in plugin.json and mirror in marketplace.json.

## Scope decisions
- **In scope:** the data model only — `references/data-model.md` plus version bumps. Phase-1 foundation of epic #802; the foundation #799 builds on.
- **Out of scope (deliberately deferred to downstream epic children, NOT dropped):** the write-at-creation behavior in `consult-action-fields` belongs to #799 (which this issue Blocks); the read-surface wiring in `consult-resume` belongs to #801. Pulling either into this PR would collide with those children. No script behavior change is required here — `engagement-status.sh` already passes every deliverable field through verbatim.
- `references/frameworks-registry.md` already exists (shipped by #797), so it is referenced, not created.

## Test plan
- [x] `references/data-model.md` JSON example parses; both `deliverables[]` entries carry `chosen_framework` after `producing_route` (market-sizing → `"pyramid-principle"`, competitor-landscape → `null`).
- [x] New prose paragraph defines the three legal value forms and the verbatim-passthrough / no-script-change guarantee.
- [x] decision-log bullet documents the `"framework-selection"` kind with all discrete fields, in the gap-check inline-JSON style.
- [x] plugin.json `0.1.12` and the cogni-consult marketplace.json entry mirror `0.1.12`.
- [x] No edits outside `references/data-model.md` + the two manifests; `consult-action-fields/SKILL.md` and `consult-resume/SKILL.md` untouched.