### PR TITLE
cogni-consult: framework selection at deliverable creation

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -35,7 +35,7 @@
     {
       "name": "cogni-consult",
       "source": "./cogni-consult",
-      "version": "0.1.12",
+      "version": "0.1.13",
       "maturity": "preview",
       "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
       "keywords": [

--- a/cogni-consult/.claude-plugin/plugin.json
+++ b/cogni-consult/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-consult",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-consult/skills/consult-action-fields/SKILL.md
+++ b/cogni-consult/skills/consult-action-fields/SKILL.md
@@ -154,11 +154,12 @@ entry, choose its `chosen_framework` — the shape the deliverable's argument wi
 take. Read `$CLAUDE_PLUGIN_ROOT/references/frameworks-registry.md` (once per
 session — it covers every deliverable), then for each deliverable being planned:
 
-1. **Shortlist the top-5.** Combine the registry's deliverable-type and
-   field-type **affinity** columns with your own judgment of the field's
-   `framing` and the engagement's key question (from `scope/` /
-   `consult-project.json`) to rank the applicable frameworks, and take the five
-   strongest.
+1. **Shortlist the top-5.** For each deliverable being planned, rank the
+   applicable frameworks and take the five strongest — this top-5 is per
+   deliverable, not the `1-3 deliverables` count from the start of this step.
+   Rank by combining the registry's deliverable-type and field-type
+   **affinity** columns with your own judgment of the field's `framing` and the
+   engagement's key question (from `scope/` / `consult-project.json`).
 2. **Present each candidate** with its one-line structure signature from the
    registry's `Structure signature` column, so the consultant sees what each
    shape commits the deliverable to.
@@ -202,7 +203,9 @@ is written once at creation and read-only thereafter. On a re-run over a
 deliverable whose entry already carries a non-null `chosen_framework`, surface the
 existing choice and require explicit reconfirmation from the consultant before
 changing it — never overwrite it silently, and append no new decision-log entry
-unless the consultant explicitly chooses to change it.
+unless the consultant explicitly chooses to change it. When the consultant does
+change it, append a fresh `framework-selection` entry (the decision-log is
+append-only) so both the prior choice and the change stay on the trail.
 
 Most deliverables have no upstream dependency — the entry above is the
 default shape, so leave it as is. Only when a deliverable being planned

--- a/cogni-consult/skills/consult-action-fields/SKILL.md
+++ b/cogni-consult/skills/consult-action-fields/SKILL.md
@@ -135,6 +135,7 @@ field's `field.json` once, appending all agreed entries, each shaped:
   "state": "pending",
   "dt_stage": "empathize",
   "producing_route": "consult-design-thinking",
+  "chosen_framework": null,
   "persona_review": "pending"
 }
 ```
@@ -144,7 +145,64 @@ default `consult-design-thinking`; use another route only when the
 consultant names one (e.g. a direct `cogni-visual` export of an existing
 artifact). `persona_review` tracks the acting-persona challenge pass:
 `pending` → `in-progress` → `complete`. Both fields are manifest metadata —
-recommend the route, never dispatch it from here.
+recommend the route, never dispatch it from here. `chosen_framework` records
+the deliverable's structuring framework and is selected per the sub-step below
+(default `null` until chosen).
+
+**Select the structuring framework for each deliverable.** Before writing each
+entry, choose its `chosen_framework` — the shape the deliverable's argument will
+take. Read `$CLAUDE_PLUGIN_ROOT/references/frameworks-registry.md` (once per
+session — it covers every deliverable), then for each deliverable being planned:
+
+1. **Shortlist the top-5.** Combine the registry's deliverable-type and
+   field-type **affinity** columns with your own judgment of the field's
+   `framing` and the engagement's key question (from `scope/` /
+   `consult-project.json`) to rank the applicable frameworks, and take the five
+   strongest.
+2. **Present each candidate** with its one-line structure signature from the
+   registry's `Structure signature` column, so the consultant sees what each
+   shape commits the deliverable to.
+3. **Recommend in the consulting-partner's voice.** Act as the
+   `consulting-partner` persona
+   (`$CLAUDE_PLUGIN_ROOT/references/personas/consulting-partner.json`) — the
+   advisor who knows which frameworks fit which problem shape — and recommend one
+   framework, or a combination of two, **with an explicit rationale** tying the
+   choice to the field's so-what. A combination is stored as
+   `combo:<slugA>+<slugB>`.
+4. **Confirm with the consultant** before storing — the recommendation is a
+   starting point, not a constraint; the consultant may pick any registry slug,
+   or name a new structure (give it a clear kebab-case slug like any other).
+5. **Store the choice.** Set `chosen_framework` on the deliverable's `field.json`
+   entry to the chosen registry slug, the `combo:<slugA>+<slugB>` string, or
+   `null` if the consultant defers, and append a `framework-selection` entry to
+   the engagement's `.metadata/decision-log.json` `decisions[]` array (the same
+   array that already holds gap-check entries), discriminated by
+   `"kind": "framework-selection"`:
+
+```json
+{
+  "id": "<next decision id>",
+  "kind": "framework-selection",
+  "action_field": "<field-slug>",
+  "deliverable": "<deliverable-slug>",
+  "candidates_presented": ["pyramid-principle", "scqa", "..."],
+  "chosen": "pyramid-principle",
+  "is_combination": false,
+  "rationale": "<why this framework fits the field's so-what>",
+  "timestamp": "<ISO timestamp>"
+}
+```
+
+`candidates_presented[]` is the top-5 slugs you shortlisted, `chosen` mirrors the
+value written to `chosen_framework`, and `is_combination` is `true` only when
+`chosen` is a `combo:` string.
+
+**Idempotency — never silently overwrite a chosen framework.** `chosen_framework`
+is written once at creation and read-only thereafter. On a re-run over a
+deliverable whose entry already carries a non-null `chosen_framework`, surface the
+existing choice and require explicit reconfirmation from the consultant before
+changing it — never overwrite it silently, and append no new decision-log entry
+unless the consultant explicitly chooses to change it.
 
 Most deliverables have no upstream dependency — the entry above is the
 default shape, so leave it as is. Only when a deliverable being planned


### PR DESCRIPTION
Closes #799.

## Summary
- Add a framework-selection sub-step to `consult-action-fields` `### 4. Plan a Field's Deliverable Set`: for each new deliverable, derive the top-5 applicable frameworks by combining `references/frameworks-registry.md` affinity with LLM judgment over the field framing and the engagement's key question.
- Present each candidate with its one-line structure signature pulled from the registry.
- Have the consulting-partner persona (`references/personas/consulting-partner.json`) recommend one framework or a `combo:<slugA>+<slugB>` combination, WITH rationale, then confirm the choice with the consultant.
- Persist the choice: write `chosen_framework` (a registry slug, a `combo:` string, or null) on the field.json deliverable entry and append a `framework-selection` entry to `.metadata/decision-log.json` with `candidates_presented[]`, `chosen`, `is_combination`, and `rationale`.
- Idempotency guard: on re-run, never silently overwrite an existing non-null `chosen_framework` — surface it and require explicit reconfirmation before changing it.
- Add `chosen_framework` to the documented default deliverable-entry JSON shape in section 4.
- Bump cogni-consult 0.1.12 → 0.1.13 in plugin.json and marketplace.json.

## Scope decisions
- In scope: SKILL.md prose for section 4 plus the documented entry shape, and the version bump. The dependency artifacts (frameworks-registry from the registry child, the `chosen_framework` field.json field and `framework-selection` decision-log discriminator from the data-model child) are already merged on `main`, so this wiring change consumes them — no schema or registry edits here.
- No script changes: `engagement-status.sh` passes every deliverable field through verbatim, and the decision-log append is a plain model-written JSON Edit, so no script touches `chosen_framework`.
- Full scope: the entire issue ships in this one PR; nothing deferred. The downstream issues this blocks (consume the stored choice / surface it across read surfaces) are tracked separately.

## Test plan
- [ ] In a consult engagement, run `consult-action-fields` and add a deliverable via `### 4. Plan a Field's Deliverable Set`; confirm the top-5 framework shortlist is presented, each with its registry structure signature.
- [ ] Confirm the consulting-partner persona recommends one framework OR a `combo:<slugA>+<slugB>` with an explicit rationale, and that the consultant is asked to confirm before storing.
- [ ] Verify the resulting field.json deliverable entry carries `chosen_framework` set to a registry slug / combo string / null.
- [ ] Verify `.metadata/decision-log.json` gained a `{"kind":"framework-selection", ...}` entry with `candidates_presented[]`, `chosen`, `is_combination`, and `rationale`.
- [ ] Re-run section 4 over the same deliverable with a non-null `chosen_framework`; confirm it is surfaced and explicit reconfirmation is required before any change (no silent overwrite).
- [ ] Confirm cogni-consult version reads 0.1.13 in both `.claude-plugin/plugin.json` and the marketplace.json entry.