### PR TITLE
cogni-consult: framework-guided Define + Prototype in design-thinking

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -35,7 +35,7 @@
     {
       "name": "cogni-consult",
       "source": "./cogni-consult",
-      "version": "0.1.13",
+      "version": "0.1.14",
       "maturity": "preview",
       "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
       "keywords": [

--- a/cogni-consult/.claude-plugin/plugin.json
+++ b/cogni-consult/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-consult",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-consult/skills/consult-design-thinking/SKILL.md
+++ b/cogni-consult/skills/consult-design-thinking/SKILL.md
@@ -40,8 +40,9 @@ hand — no extra read is needed. When it is non-`null`, resolve its one-line
 resolve both and apply them together) and carry that signature into the
 **Define** and **Prototype** stages below: it shapes how the problem is framed
 and how the artifact body is organized. The registry is thin by design — it
-pins the signature and the stable key; supply the framework's depth at runtime
-(follow the registry `slug` cell's link where one exists).
+pins the signature and the stable key; supply the framework's depth at runtime:
+where the registry `slug` cell links to a first-party page, follow it for the
+framework's substance; otherwise supply that substance from your own knowledge.
 
 When `chosen_framework` is `null` — a legacy deliverable created before a
 framework was chosen, or a deliberate no-framework choice — run those stages
@@ -160,7 +161,9 @@ how you organize the problem and the approach — e.g. a `mece-issue-tree`
 signature decomposes the problem into mutually-exclusive, collectively-
 exhaustive branches before drafting, while a `pyramid-principle` signature
 pushes you to lead with the answer and group the supporting arguments beneath
-it. When `chosen_framework` is `null`, frame the spec as you would by default.
+it. For a `combo:` choice, let the first signature frame the problem and the
+second the approach. When `chosen_framework` is `null`, frame the spec as you
+would by default.
 When sharpening the spec surfaces an evidence gap (an assumption the
 consultant cannot ground),
 route the research per

--- a/cogni-consult/skills/consult-design-thinking/SKILL.md
+++ b/cogni-consult/skills/consult-design-thinking/SKILL.md
@@ -25,6 +25,29 @@ machine. The stage methods live in `$CLAUDE_PLUGIN_ROOT/references/methods/`
 owns the conversation flow, the artifact, and the state writes. Schemas:
 `$CLAUDE_PLUGIN_ROOT/references/data-model.md`.
 
+## The framework lens
+
+Each deliverable's `field.json` entry carries `chosen_framework` — the
+structuring framework its argument takes, set once at creation and read-only
+thereafter (schema in `$CLAUDE_PLUGIN_ROOT/references/data-model.md`). Its
+value is one of: a stable `slug` from
+`$CLAUDE_PLUGIN_ROOT/references/frameworks-registry.md` (e.g.
+`pyramid-principle`), a `"combo:<slugA>+<slugB>"` pairing of two, or `null`.
+
+The Prerequisite Gate (step 1) already reads `field.json`, so the value is in
+hand — no extra read is needed. When it is non-`null`, resolve its one-line
+**Structure signature** from the registry's framework table (for a `combo:`,
+resolve both and apply them together) and carry that signature into the
+**Define** and **Prototype** stages below: it shapes how the problem is framed
+and how the artifact body is organized. The registry is thin by design — it
+pins the signature and the stable key; supply the framework's depth at runtime
+(follow the registry `slug` cell's link where one exists).
+
+When `chosen_framework` is `null` — a legacy deliverable created before a
+framework was chosen, or a deliberate no-framework choice — run those stages
+exactly as written below, with no framework structuring. The framework only
+adds shape when present; it never blocks production when absent.
+
 ## Workflow
 
 ### 1. Prerequisite Gate
@@ -131,8 +154,15 @@ Close the stage with one `Edit` of `field.json`: `dt_stage` → `"define"`.
 
 Read `$CLAUDE_PLUGIN_ROOT/references/methods/hmw-synthesis.md` and sharpen
 the deliverable's problem spec from the empathize outputs plus the field's
-`framing`. Lock 1-3 HMW questions with the consultant. When sharpening the
-spec surfaces an evidence gap (an assumption the consultant cannot ground),
+`framing`. Lock 1-3 HMW questions with the consultant. When a framework lens
+is in play (see *The framework lens* above), let its Structure signature frame
+how you organize the problem and the approach — e.g. a `mece-issue-tree`
+signature decomposes the problem into mutually-exclusive, collectively-
+exhaustive branches before drafting, while a `pyramid-principle` signature
+pushes you to lead with the answer and group the supporting arguments beneath
+it. When `chosen_framework` is `null`, frame the spec as you would by default.
+When sharpening the spec surfaces an evidence gap (an assumption the
+consultant cannot ground),
 route the research per
 `$CLAUDE_PLUGIN_ROOT/references/research-routing.md` before locking — a
 spec built on an unverified assumption fails at the test stage anyway.
@@ -165,9 +195,16 @@ and `updated`. State is intentionally absent from the frontmatter — it lives
 in `field.json` only.
 
 Structure the body from the loop's outputs: the problem (define), options
-considered (ideate), the chosen approach, and the content itself. Every
-evidence-backed claim carries a `sources[]` entry. Then `Edit` `field.json`:
-`dt_stage` → `"test"`.
+considered (ideate), the chosen approach, and the content itself. When a
+framework lens is in play (see *The framework lens* above), organize the
+artifact body to its Structure signature rather than that default outline —
+e.g. `pyramid-principle` → lead with the answer, then MECE-grouped supporting
+arguments; `scqa` → Situation → Complication → Question → Answer;
+`journey-process` → sequential stages along the path. For a `combo:` choice,
+apply both signatures together (typically one frames the opening, the other
+the body). When `chosen_framework` is `null`, use the default outline above.
+Every evidence-backed claim carries a `sources[]` entry. Then `Edit`
+`field.json`: `dt_stage` → `"test"`.
 
 ### 7. Test
 


### PR DESCRIPTION
Closes #800.

## Summary
- Add a shared `## The framework lens` note to `consult-design-thinking` on reading `chosen_framework` from the deliverable's `field.json` entry (already in hand after the Prerequisite Gate) and resolving its one-line Structure signature from `references/frameworks-registry.md` — handling the three stored shapes: a registry slug, a `combo:<slugA>+<slugB>` pair, or `null`.
- `### 4. Define`: use the framework's signature to frame how the problem and approach are organized when a framework is stored.
- `### 6. Prototype`: structure the artifact body per the framework (e.g. Pyramid → answer-first with MECE-grouped support; SCQA → Situation/Complication/Question/Answer; journey-process → sequential stages).
- Graceful fallback: when `chosen_framework` is `null` (legacy deliverables), both stages behave exactly as today — the framework only adds structure when present, never blocks production when absent.
- Bump cogni-consult `0.1.13` → `0.1.14` in plugin.json and mirror in marketplace.json.

## Scope decisions
- In: the two stages named by the issue (Define for framing, Prototype for body structure) plus one shared brief note; version bumps.
- Out: no script change — `engagement-status.sh` already passes the deliverable field through verbatim, and Step 1 already reads `field.json`, so `chosen_framework` reaches the stages without new plumbing. Other DT stages (Empathize/Ideate/Test) are unchanged.
- Combo and null handling are specified inline so the behavior is deterministic; the model supplies framework depth at runtime per the registry's thin-by-design contract.

## Test plan
- [ ] Deliverable with `chosen_framework: "pyramid-principle"` → Define frames answer-first; Prototype structures the body answer-first with MECE-grouped support.
- [ ] `chosen_framework: "scqa"` → Prototype orders the body Situation → Complication → Question → Answer.
- [ ] `chosen_framework: "combo:scqa+pyramid-principle"` → both signatures resolved and applied without error.
- [ ] Legacy deliverable with `chosen_framework: null` (or absent) → Define and Prototype behave exactly as before.
- [ ] SKILL.md carries no issue/PR refs (breadcrumb guard passes); plugin.json and marketplace.json both read `0.1.14`.