### PR TITLE
cogni-consult: surface chosen_framework across the read surfaces

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -35,7 +35,7 @@
     {
       "name": "cogni-consult",
       "source": "./cogni-consult",
-      "version": "0.1.14",
+      "version": "0.1.15",
       "maturity": "preview",
       "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
       "keywords": [

--- a/cogni-consult/.claude-plugin/plugin.json
+++ b/cogni-consult/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-consult",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-consult/skills/consult-action-fields/SKILL.md
+++ b/cogni-consult/skills/consult-action-fields/SKILL.md
@@ -91,9 +91,10 @@ priority), deliverables in manifest order:
 ```
 
 `Framework` shows the deliverable's stored `chosen_framework` read-only — a
-registry slug, `<slugA> + <slugB>` for a `combo:` pairing, or `—` when none is
-stored (legacy deliverables, or one created before a framework was chosen). It
-is surfaced exactly as stored; never inferred or chosen here.
+registry slug verbatim, or for a `combo:<slugA>+<slugB>` pairing the two slugs
+joined as `<slugA> + <slugB>` (the stored `combo:` prefix dropped for display),
+or `—` when none is stored (legacy deliverables, or one created before a
+framework was chosen). The value is never inferred or chosen here.
 
 Close the dashboard with the **next-deliverable recommendation**. Check for
 stale deliverables first: any deliverable carrying `lineage_status.status:

--- a/cogni-consult/skills/consult-action-fields/SKILL.md
+++ b/cogni-consult/skills/consult-action-fields/SKILL.md
@@ -82,13 +82,18 @@ Present one table, fields in `action_fields[]` order (that order is the WBS
 priority), deliverables in manifest order:
 
 ```
-| Action field | Deliverable | State | DT stage | Route | Persona review |
-|---|---|---|---|---|---|
-| market-evidence | market-sizing | complete | test | consult-design-thinking | complete |
-| market-evidence | competitor-landscape | in-progress | ideate | consult-design-thinking | pending |
-| portfolio-fit | — (no deliverables planned) | | | | |
-| go-to-market | ⚠ unreadable field.json (see warnings) | | | | |
+| Action field | Deliverable | State | DT stage | Framework | Route | Persona review |
+|---|---|---|---|---|---|---|
+| market-evidence | market-sizing | complete | test | pyramid-principle | consult-design-thinking | complete |
+| market-evidence | competitor-landscape | in-progress | ideate | — | consult-design-thinking | pending |
+| portfolio-fit | — (no deliverables planned) | | | | | |
+| go-to-market | ⚠ unreadable field.json (see warnings) | | | | | |
 ```
+
+`Framework` shows the deliverable's stored `chosen_framework` read-only — a
+registry slug, `<slugA> + <slugB>` for a `combo:` pairing, or `—` when none is
+stored (legacy deliverables, or one created before a framework was chosen). It
+is surfaced exactly as stored; never inferred or chosen here.
 
 Close the dashboard with the **next-deliverable recommendation**. Check for
 stale deliverables first: any deliverable carrying `lineage_status.status:

--- a/cogni-consult/skills/consult-dashboard/scripts/generate-dashboard.py
+++ b/cogni-consult/skills/consult-dashboard/scripts/generate-dashboard.py
@@ -358,6 +358,20 @@ def dt_indicator(stage):
     return f'<span class="dt-track">{"".join(dots)}</span><span class="dt-label">{label}</span>'
 
 
+def framework_cell(cf):
+    """Read-only display of the deliverable's stored chosen_framework: a
+    registry slug, a 'combo:<a>+<b>' pairing, or null/absent. Absence renders
+    as a dash so legacy deliverables display cleanly — never inferred here."""
+    if not cf:
+        return '<span class="deliv-fw-empty" title="No framework chosen">—</span>'
+    if isinstance(cf, str) and cf.startswith("combo:"):
+        parts = [p.strip() for p in cf[len("combo:"):].split("+") if p.strip()]
+        text = " + ".join(parts) if parts else cf
+    else:
+        text = cf
+    return f'<span class="fw-chip" title="Structuring framework">{esc(text)}</span>'
+
+
 def render_field_card(field):
     delivs = field["deliverables"]
     rows = []
@@ -382,6 +396,7 @@ def render_field_card(field):
             f'<div class="deliv-title">{esc(d.get("title") or d.get("slug"))}{dep_hint}</div>'
             f'<div class="deliv-state">{badge(st, STATE_ROLE.get(st, "muted"))}{stale_badge}</div>'
             f'<div class="deliv-dt">{dt_indicator(d.get("dt_stage"))}</div>'
+            f'<div class="deliv-framework">{framework_cell(d.get("chosen_framework"))}</div>'
             f'<div class="deliv-review">persona {badge(review, REVIEW_ROLE.get(review, "muted"))}</div>'
             '</div>'
         )
@@ -523,12 +538,15 @@ header.hero .hero-meta {{ margin-top: 1rem; display: flex; flex-wrap: wrap; gap:
 .field-research {{ font-size: .78rem; color: var(--text-muted); }}
 .field-framing {{ font-size: .88rem; color: var(--text-muted); margin: .5rem 0 .75rem; }}
 .deliv-list {{ display: flex; flex-direction: column; gap: .4rem; margin-top: .5rem; }}
-.deliv-row {{ display: grid; grid-template-columns: minmax(0,2.2fr) auto minmax(0,1.6fr) auto; gap: .75rem; align-items: center; background: var(--surface); border-radius: 8px; padding: .55rem .75rem; }}
+.deliv-row {{ display: grid; grid-template-columns: minmax(0,2.2fr) auto minmax(0,1.6fr) auto auto; gap: .75rem; align-items: center; background: var(--surface); border-radius: 8px; padding: .55rem .75rem; }}
 .deliv-title {{ font-size: .92rem; font-weight: 500; }}
 .deliv-deps {{ font-size: .72rem; color: var(--text-muted); margin-top: .2rem; display: flex; flex-wrap: wrap; align-items: center; gap: .25rem; }}
 .dep-chip {{ background: var(--surface2); border: 1px solid var(--border); border-radius: 999px; padding: .02rem .4rem; font-family: var(--font-mono); font-size: .68rem; }}
 .deliv-state {{ display: flex; align-items: center; gap: .35rem; flex-wrap: wrap; }}
 .stale-mark {{ display: inline-flex; }}
+.deliv-framework {{ display: flex; align-items: center; justify-content: flex-end; }}
+.fw-chip {{ background: var(--surface2); border: 1px solid var(--border); border-radius: 999px; padding: .04rem .5rem; font-family: var(--font-mono); font-size: .68rem; color: var(--text-muted); white-space: nowrap; }}
+.deliv-fw-empty {{ font-size: .72rem; color: var(--text-muted); }}
 .deliv-review {{ font-size: .76rem; color: var(--text-muted); text-align: right; }}
 .deliv-empty {{ font-size: .85rem; color: var(--text-muted); font-style: italic; padding: .5rem 0; }}
 .card.refresh {{ border-color: var(--yellow); }}

--- a/cogni-consult/skills/consult-resume/SKILL.md
+++ b/cogni-consult/skills/consult-resume/SKILL.md
@@ -78,8 +78,9 @@ Key question: <key_question>
 first non-complete deliverable with its `dt_stage` and stored
 `chosen_framework` in parentheses (`<stage> · <framework>`), or the
 first whose `persona_review` is still open when everything else is done.
-The framework is surfaced read-only exactly as stored — a registry slug,
-`<slugA> + <slugB>` for a `combo:` pairing, or `—` when none is stored
+The framework is surfaced read-only — a registry slug verbatim, or for a
+`combo:<slugA>+<slugB>` pairing the two slugs joined as `<slugA> + <slugB>`
+(the stored `combo:` prefix dropped for display), or `—` when none is stored
 (legacy deliverables); it is never inferred here.
 Keep it to this one table — the deep WBS view (planning deliverable sets,
 splitting fields) belongs to `consult-action-fields`, not here.

--- a/cogni-consult/skills/consult-resume/SKILL.md
+++ b/cogni-consult/skills/consult-resume/SKILL.md
@@ -70,13 +70,17 @@ Key question: <key_question>
 | Action Field | Status | Deliverables | Next Deliverable |
 |--------------|--------|--------------|------------------|
 | market-evidence | complete | 2/2 complete | — |
-| portfolio-fit | in-progress | 1/3 complete | competitor-map (ideate) |
-| go-to-market | pending | 0/2 started | channel-strategy (empathize) |
+| portfolio-fit | in-progress | 1/3 complete | competitor-map (ideate · pyramid-principle) |
+| go-to-market | pending | 0/2 started | channel-strategy (empathize · —) |
 ```
 
 `Deliverables` counts `complete` over total; `Next Deliverable` names the
-first non-complete deliverable with its `dt_stage` in parentheses, or the
+first non-complete deliverable with its `dt_stage` and stored
+`chosen_framework` in parentheses (`<stage> · <framework>`), or the
 first whose `persona_review` is still open when everything else is done.
+The framework is surfaced read-only exactly as stored — a registry slug,
+`<slugA> + <slugB>` for a `combo:` pairing, or `—` when none is stored
+(legacy deliverables); it is never inferred here.
 Keep it to this one table — the deep WBS view (planning deliverable sets,
 splitting fields) belongs to `consult-action-fields`, not here.
 

--- a/cogni-consult/tests/test_generate_dashboard.sh
+++ b/cogni-consult/tests/test_generate_dashboard.sh
@@ -164,6 +164,25 @@ assert_html_has   "3c stale badge survives"   "$HTML3" '>stale</span>'
 # ...but the Refresh-order section is omitted entirely (graceful degradation).
 assert_html_lacks "3d no refresh section"     "$HTML3" "Refresh order"
 
+# --- Fixture 4: chosen_framework surfaced read-only in deliverable rows ------------
+# A slug, a combo, and an absent value — the framework cell renders each exactly as
+# stored, with absence shown as a dash (legacy deliverables display cleanly).
+D4="$TMPROOT/framework"
+seed_engagement "$D4" '[
+  {"slug": "market-sizing", "title": "Market sizing", "state": "complete", "dt_stage": "test", "persona_review": "complete",
+   "chosen_framework": "pyramid-principle"},
+  {"slug": "options-brief", "title": "Options brief", "state": "in-progress", "dt_stage": "ideate", "persona_review": "pending",
+   "chosen_framework": "combo:scqa+pyramid-principle"},
+  {"slug": "legacy-note", "title": "Legacy note", "state": "complete", "dt_stage": "test", "persona_review": "complete"}
+]'
+OUT4="$(run "$D4")"
+HTML4="$D4/output/dashboard.html"
+assert_json "4a framework success"        "$OUT4" "d['success'] is True"
+assert_html_has "4b slug chip rendered"   "$HTML4" '<span class="fw-chip" title="Structuring framework">pyramid-principle</span>'
+assert_html_has "4c combo split rendered" "$HTML4" '<span class="fw-chip" title="Structuring framework">scqa + pyramid-principle</span>'
+# The legacy deliverable with no chosen_framework renders the empty-cell dash.
+assert_html_has "4d absent renders dash"  "$HTML4" '<span class="deliv-fw-empty" title="No framework chosen">'
+
 # --- Summary ----------------------------------------------------------------------
 if [ "$failures" -eq 0 ]; then
   echo "All generate-dashboard.py read-side tests passed."


### PR DESCRIPTION
Closes #801.

## Summary
Surface the stored `chosen_framework` read-only wherever deliverables are listed, so the consultant sees it at a glance without opening `field.json`.

- **HTML dashboard** (`generate-dashboard.py`): new `framework_cell()` helper renders a registry slug, a `combo:<a>+<b>` pairing as `a + b`, or `—` when none is stored. Added a `deliv-framework` cell to each deliverable row, extended the `.deliv-row` grid 4→5 columns, and added `.fw-chip` / `.deliv-fw-empty` styling.
- **WBS text table** (`consult-action-fields`): the per-deliverable table gains a `Framework` column.
- **Resume table** (`consult-resume`): the per-field `Next Deliverable` cell now reads `<stage> · <framework>`.

Strictly read-only surfacing — no selection or mutation happens here. A `null`/absent framework renders as a dash so legacy deliverables display cleanly.

## Scope decisions
- In: the three read surfaces named by the issue + version bump + a regression test.
- Out: no `engagement-status.sh` change — the dashboard renderer reads deliverable dicts directly from `field.json`, so `chosen_framework` is already available (the issue's "passed through by engagement-status.sh" assumption was incorrect; corrected in the triage/plan record).
- Combo and null handling are explicit so display is deterministic.

## Test plan
- [x] `generate-dashboard.py` compiles; `framework_cell` smoke test (null/slug/combo/empty).
- [x] Full dashboard test suite 20/20 — 16 prior + 4 new (`Fixture 4`: slug chip, combo split, absent→dash).
- [x] plugin.json + marketplace.json both read `0.1.15`; breadcrumb guard clean.