### PR TITLE
feat(cogni-consult): guarded dt_stage stage-advance helper with per-stage logging

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -35,7 +35,7 @@
     {
       "name": "cogni-consult",
       "source": "./cogni-consult",
-      "version": "0.1.18",
+      "version": "0.1.19",
       "maturity": "preview",
       "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
       "keywords": [

--- a/cogni-consult/.claude-plugin/plugin.json
+++ b/cogni-consult/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-consult",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-consult/scripts/dt-stage-advance.sh
+++ b/cogni-consult/scripts/dt-stage-advance.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# Guarded, logged dt_stage advance for one cogni-consult deliverable.
+#
+# Validates a design-thinking stage transition before applying it: the target
+# must be a member of the empathize->define->ideate->prototype->test set, and
+# the move must be permitted — a single-step forward advance, an idempotent
+# same-stage re-set, or a re-entry to any earlier stage (the loop may iterate).
+# A forward jump that skips a stage is rejected. On a permitted move it writes
+# dt_stage into the deliverable's field.json via an idempotent read-modify-write
+# and appends a per-stage move entry to .metadata/stage-log.json (created if
+# absent). Degrades gracefully on a legacy field.json whose deliverable carries
+# no dt_stage: the prior stage is unknown, so any valid target is accepted and
+# the move is logged with from=null.
+#
+# Per-stage moves live in a dedicated stage log, NOT the execution log — the
+# execution log records state transitions only (pending/in-progress/complete).
+#
+# Usage: bash dt-stage-advance.sh <engagement-dir> <field-slug> <deliverable-slug> <target-stage>
+# Output: JSON {"success": bool, "data": {...}, "error": "string"}
+
+set -euo pipefail
+
+ENGAGEMENT_DIR="${1:?Usage: bash dt-stage-advance.sh <engagement-dir> <field-slug> <deliverable-slug> <target-stage>}"
+FIELD_SLUG="${2:?Usage: bash dt-stage-advance.sh <engagement-dir> <field-slug> <deliverable-slug> <target-stage>}"
+DELIVERABLE_SLUG="${3:?Usage: bash dt-stage-advance.sh <engagement-dir> <field-slug> <deliverable-slug> <target-stage>}"
+TARGET_STAGE="${4:?Usage: bash dt-stage-advance.sh <engagement-dir> <field-slug> <deliverable-slug> <target-stage>}"
+
+ENGAGEMENT_DIR="$ENGAGEMENT_DIR" FIELD_SLUG="$FIELD_SLUG" \
+DELIVERABLE_SLUG="$DELIVERABLE_SLUG" TARGET_STAGE="$TARGET_STAGE" python3 - <<'PY'
+import json, os, datetime
+
+STAGES = ["empathize", "define", "ideate", "prototype", "test"]
+
+engagement_dir = os.environ["ENGAGEMENT_DIR"]
+field_slug = os.environ["FIELD_SLUG"]
+deliverable_slug = os.environ["DELIVERABLE_SLUG"]
+target = os.environ["TARGET_STAGE"]
+
+
+def fail(error, **data):
+    print(json.dumps({"success": False, "data": data, "error": error}))
+    raise SystemExit(0)
+
+
+# 1. Target must be a valid stage name (rejects typos like "prototype").
+if target not in STAGES:
+    fail(f"invalid target stage '{target}' (expected one of: {', '.join(STAGES)})",
+         target=target)
+
+field_path = os.path.join(engagement_dir, "action-fields", field_slug, "field.json")
+
+# 2. Read the field manifest (single source of truth for dt_stage).
+try:
+    with open(field_path) as f:
+        field = json.load(f)
+except FileNotFoundError:
+    fail(f"field manifest not found: {field_path}", path=field_path)
+except (json.JSONDecodeError, OSError) as exc:
+    fail(f"unreadable field manifest: {field_path}: {exc}", path=field_path)
+
+deliverables = field.get("deliverables")
+if not isinstance(deliverables, list):
+    fail(f"malformed field manifest: deliverables must be a list ({field_path})",
+         path=field_path)
+
+# 3. Locate the deliverable entry by slug.
+entry = next((d for d in deliverables
+             if isinstance(d, dict) and d.get("slug") == deliverable_slug), None)
+if entry is None:
+    fail(f"deliverable '{deliverable_slug}' not found in field '{field_slug}'",
+         path=field_path, deliverable=deliverable_slug)
+
+# 4. Validate the transition. A legacy entry with no dt_stage has an unknown
+#    prior stage — accept any valid target and log from=null.
+current = entry.get("dt_stage")
+if current is not None and current not in STAGES:
+    # An already-corrupt stored value: don't trust it for ordering. Treat as
+    # unknown so the guarded write can repair it to a valid target.
+    current = None
+
+if current is None:
+    pass  # graceful degradation: prior stage unknown, any valid target allowed
+else:
+    ci, ti = STAGES.index(current), STAGES.index(target)
+    if ti > ci + 1:
+        fail(f"illegal stage jump '{current}' -> '{target}': forward moves must "
+             f"advance one stage at a time (skips a stage)",
+             current=current, target=target)
+    # ti == ci (idempotent re-set), ti == ci + 1 (single-step forward), and
+    # ti < ci (re-entry to an earlier stage, loop iteration) are all permitted.
+
+# 5. Apply via idempotent read-modify-write — preserve every other field.
+entry["dt_stage"] = target
+tmp_path = field_path + ".tmp"
+with open(tmp_path, "w") as f:
+    json.dump(field, f, indent=2, ensure_ascii=False)
+    f.write("\n")
+os.replace(tmp_path, field_path)
+
+# 6. Append the per-stage move to the dedicated stage log (create if absent).
+meta_dir = os.path.join(engagement_dir, ".metadata")
+os.makedirs(meta_dir, exist_ok=True)
+stage_log_path = os.path.join(meta_dir, "stage-log.json")
+try:
+    with open(stage_log_path) as f:
+        stage_log = json.load(f)
+    if not isinstance(stage_log, dict) or not isinstance(stage_log.get("moves"), list):
+        stage_log = {"moves": []}
+except FileNotFoundError:
+    stage_log = {"moves": []}
+except (json.JSONDecodeError, OSError):
+    stage_log = {"moves": []}
+
+move = {
+    "action_field": field_slug,
+    "deliverable": deliverable_slug,
+    "from": current,
+    "to": target,
+    "timestamp": datetime.datetime.now(datetime.timezone.utc)
+        .replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+    "triggered_by": "consult-design-thinking",
+}
+stage_log["moves"].append(move)
+with open(stage_log_path, "w") as f:
+    json.dump(stage_log, f, indent=2, ensure_ascii=False)
+    f.write("\n")
+
+print(json.dumps({
+    "success": True,
+    "data": {
+        "action_field": field_slug,
+        "deliverable": deliverable_slug,
+        "from": current,
+        "to": target,
+        "path": field_path,
+        "stage_log": stage_log_path,
+    },
+    "error": "",
+}))
+PY

--- a/cogni-consult/scripts/dt-stage-advance.sh
+++ b/cogni-consult/scripts/dt-stage-advance.sh
@@ -42,7 +42,7 @@ def fail(error, **data):
     raise SystemExit(0)
 
 
-# 1. Target must be a valid stage name (rejects typos like "prototype").
+# 1. Target must be a valid stage name (rejects a misspelled or unknown stage).
 if target not in STAGES:
     fail(f"invalid target stage '{target}' (expected one of: {', '.join(STAGES)})",
          target=target)

--- a/cogni-consult/skills/consult-design-thinking/SKILL.md
+++ b/cogni-consult/skills/consult-design-thinking/SKILL.md
@@ -93,7 +93,10 @@ A single-step forward advance, an idempotent same-stage re-set, and a re-entry
 to any earlier stage (the loop may iterate) are all permitted; a forward jump
 that skips a stage is refused with `success: false`. The helper degrades
 gracefully on a legacy `field.json` whose deliverable has no `dt_stage` (it logs
-the move with `from: null`). Should the helper be absent (an older install),
+the move with `from: null`). On a `success: false` (a refused jump, a missing
+deliverable, an unreadable manifest) do not proceed past the boundary — surface
+the error and resolve it before retrying, since an unwritten `dt_stage` leaves
+the loop state inconsistent. Should the helper be absent (an older install),
 fall back to a free-text `Edit` of `field.json` setting `dt_stage` directly.
 Where a stage below says "advance `dt_stage` → `"X"`", run this helper with
 `<target-stage>` `X`.

--- a/cogni-consult/skills/consult-design-thinking/SKILL.md
+++ b/cogni-consult/skills/consult-design-thinking/SKILL.md
@@ -74,10 +74,29 @@ auto-walk mode, skip the pauses and proceed directly through each gate. The
 gates only add confirmation seams and reasoning narration around the existing
 writes; they never change what gets written or who owns it.
 
-When the guarded `dt_stage` stage-advance helper is present in the plugin,
-interactive mode routes each `dt_stage` transition through it for per-stage
-transition logging; when it is absent (as today), it degrades to the free-text
-`Edit` of `field.json` used throughout the stages below.
+### Advancing the stage
+
+Every `dt_stage` boundary below — in both auto-walk and interactive mode — moves
+the stage through the guarded helper rather than a free-text `Edit` of
+`field.json`. The helper validates the transition (rejects an unknown stage name
+and a forward jump that skips a stage), writes `dt_stage` via an idempotent
+read-modify-write, and appends a per-stage move to `.metadata/stage-log.json` so
+the loop's iterations leave a trail (the execution log keeps recording *state*
+transitions only, never per-stage moves):
+
+```bash
+bash $CLAUDE_PLUGIN_ROOT/scripts/dt-stage-advance.sh \
+    <engagement-dir> <field-slug> <deliverable-slug> <target-stage>
+```
+
+A single-step forward advance, an idempotent same-stage re-set, and a re-entry
+to any earlier stage (the loop may iterate) are all permitted; a forward jump
+that skips a stage is refused with `success: false`. The helper degrades
+gracefully on a legacy `field.json` whose deliverable has no `dt_stage` (it logs
+the move with `from: null`). Should the helper be absent (an older install),
+fall back to a free-text `Edit` of `field.json` setting `dt_stage` directly.
+Where a stage below says "advance `dt_stage` → `"X"`", run this helper with
+`<target-stage>` `X`.
 
 ### 1. Prerequisite Gate
 
@@ -117,7 +136,8 @@ that language; technical terms, slugs, and file names stay English.
 ### 2. Open the Loop
 
 If the deliverable's `state` is `pending`: one `Edit` of `field.json` sets it
-to `"in-progress"` and `dt_stage` to `"empathize"`, and one `Edit` of
+to `"in-progress"`, advance `dt_stage` → `"empathize"` via the helper (see
+*Advancing the stage* above), and one `Edit` of
 `.metadata/execution-log.json` appends to its `transitions[]` array the entry
 `{"action_field": "<field-slug>", "deliverable": "<deliverable-slug>",
 "from": "pending", "to": "in-progress", "timestamp": "<ISO>",
@@ -129,10 +149,11 @@ If the deliverable is already `in-progress`, resume at its current `dt_stage`
 
 If the deliverable is `complete` and the consultant wants rework ("continue
 the deliverable", a revision request), confirm the re-entry first, then one
-`Edit` of `field.json` sets `state` back to `"in-progress"` with `dt_stage`
-at the stage the rework needs (often `define` or `ideate`), and one `Edit` of
-`.metadata/execution-log.json` appends the `complete` → `in-progress`
-transition to `transitions[]`.
+`Edit` of `field.json` sets `state` back to `"in-progress"`, advance `dt_stage`
+to the stage the rework needs (often `define` or `ideate`) via the helper (see
+*Advancing the stage* above — a re-entry to an earlier stage is permitted), and
+one `Edit` of `.metadata/execution-log.json` appends the `complete` →
+`in-progress` transition to `transitions[]`.
 
 Because the deliverable's content is about to change, flag its downstream
 dependents stale now — before the rework begins — so the consultant sees the
@@ -177,7 +198,8 @@ finalized synthesis to `action-fields/<field-slug>/research/<topic-slug>.md`
 so this deliverable — and later ones — find it at a stable path. Evidence
 comes from the knowledge base, never from raw web search.
 
-Close the stage with one `Edit` of `field.json`: `dt_stage` → `"define"`.
+Close the stage by advancing `dt_stage` → `"define"` via the helper (see
+*Advancing the stage* above).
 
 ### 4. Define
 
@@ -206,7 +228,7 @@ then write.
 Append the locked spec to `.metadata/decision-log.json`'s `decisions[]` array as a decision
 (`{"id": "d-NNN", "action_field": ..., "deliverable": ..., "decision":
 "<locked problem framing>", "rationale": ..., "evidence_refs": [...],
-"timestamp": ...}`). Then `Edit` `field.json`: `dt_stage` → `"ideate"`.
+"timestamp": ...}`). Then advance `dt_stage` → `"ideate"` via the helper.
 
 ### 5. Ideate
 
@@ -221,8 +243,8 @@ a full workshop), and confirm it with the consultant before writing.
 
 Append the method selection to `.metadata/method-log.json`'s `methods[]` array
 (`{"action_field": ..., "deliverable": ..., "proposed": [...], "selected":
-[...], "rationale": ...}`). Then `Edit` `field.json`: `dt_stage` →
-`"prototype"`.
+[...], "rationale": ...}`). Then advance `dt_stage` → `"prototype"` via the
+helper.
 
 ### 6. Prototype
 
@@ -248,8 +270,8 @@ arguments; `scqa` → Situation → Complication → Question → Answer;
 `journey-process` → sequential stages along the path. For a `combo:` choice,
 apply both signatures together (typically one frames the opening, the other
 the body). When `chosen_framework` is `null`, use the default outline above.
-Every evidence-backed claim carries a `sources[]` entry. Then `Edit`
-`field.json`: `dt_stage` → `"test"`.
+Every evidence-backed claim carries a `sources[]` entry. Then advance
+`dt_stage` → `"test"` via the helper.
 
 ### 7. Test
 
@@ -288,9 +310,9 @@ python3 $CLAUDE_PLUGIN_ROOT/scripts/deliverable-graph.py <engagement-dir> \
 Surface `data.newly_flagged` in the session summary so the consultant knows
 which deliverables now need revisiting. A `"success": false` (node not found,
 bad dir) is non-blocking — the completion stands; surface the error and
-continue. If it does not survive, loop back — set `dt_stage` to the stage
-the revision needs (often `define` or `ideate`) and continue; `state` stays
-`in-progress`.
+continue. If it does not survive, loop back — advance `dt_stage` to the stage
+the revision needs (often `define` or `ideate`) via the helper (a re-entry to
+an earlier stage is permitted) and continue; `state` stays `in-progress`.
 
 ### 8. Close the Session
 
@@ -344,5 +366,7 @@ to see before picking the next deliverable.
   automated cogni-claims callback into cogni-consult — this is a
   consultant-initiated step when a correction is noticed.
 - **Loop, not gate**: stages may re-enter earlier stages; `state` stays
-  `in-progress` until the test stage passes. Log state transitions (not
-  per-stage moves) in the execution log.
+  `in-progress` until the test stage passes. State transitions go in the
+  execution log; per-stage `dt_stage` moves are logged separately to
+  `.metadata/stage-log.json` by the stage-advance helper (see *Advancing the
+  stage*) — the two logs never mix.

--- a/cogni-consult/tests/test_dt_stage_advance.sh
+++ b/cogni-consult/tests/test_dt_stage_advance.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# Regression test for cogni-consult/scripts/dt-stage-advance.sh — the guarded,
+# logged dt_stage stage-advance helper.
+#
+# Fixtures are heredoc'd inline — no committed JSON blobs to maintain. Each
+# fixture builds a minimal field.json under a temp engagement dir, runs the
+# helper, and asserts on the resulting JSON output plus the on-disk state.
+#
+# Coverage:
+#   1  forward-step        single-step advance empathize->define (success, logged)
+#   2  invalid-stage       unknown target stage name rejected (success:false)
+#   3  forward-skip        empathize->ideate skips a stage (success:false)
+#   4  re-entry            test->define backward loop re-entry allowed (success)
+#   5  idempotent          define->define same-stage re-set allowed (success)
+#   6  legacy-no-dt-stage  entry without dt_stage -> from=null, target applied
+#   7  deliverable-missing unknown deliverable slug (success:false)
+#   8  field-missing       no field.json at path (success:false)
+#   9  stage-log-created   stage-log.json created with the move appended
+#
+# Usage: bash cogni-consult/tests/test_dt_stage_advance.sh
+# Exits non-zero on any assertion failure.
+
+# `set -u` only — `set -e` would abort on the first failing assertion and defeat
+# the per-fixture failure counter below.
+set -u
+
+TESTS_DIR="$(cd "$(dirname "$0")" && pwd)"
+PLUGIN_DIR="$(cd "$TESTS_DIR/.." && pwd)"
+SCRIPT="$PLUGIN_DIR/scripts/dt-stage-advance.sh"
+
+if [ ! -f "$SCRIPT" ]; then
+  echo "FAIL: dt-stage-advance.sh not found at $SCRIPT" >&2
+  exit 1
+fi
+
+TMPROOT="$(mktemp -d)"
+trap 'rm -rf "$TMPROOT"' EXIT
+
+failures=0
+pass() { printf 'OK   %s\n' "$1"; }
+fail() { printf 'FAIL %s: %s\n' "$1" "$2" >&2; failures=$((failures + 1)); }
+
+# Build a minimal engagement with one field manifest. Args: <dir> <dt_stage-json-snippet>
+# The snippet is spliced as the deliverable's dt_stage line (or empty to omit it).
+make_field() {
+  local dir="$1" dt_line="$2"
+  mkdir -p "$dir/action-fields/market-evidence"
+  cat > "$dir/action-fields/market-evidence/field.json" <<EOF
+{
+  "slug": "market-evidence",
+  "title": "Market Evidence",
+  "deliverables": [
+    {
+      "slug": "market-sizing",
+      "title": "Market sizing",
+      "state": "in-progress"${dt_line}
+    }
+  ]
+}
+EOF
+}
+
+assert_json() {  # <label> <json> <python-bool-expr over `d`>
+  local label="$1" json="$2" expr="$3"
+  if printf '%s' "$json" | python3 -c "import json,sys; d=json.load(sys.stdin); sys.exit(0 if ($expr) else 1)" 2>/dev/null; then
+    pass "$label"
+  else
+    fail "$label" "assertion failed: $expr -- got: $json"
+  fi
+}
+
+# --- 1. forward-step: empathize -> define ---
+D="$TMPROOT/t1"; make_field "$D" ',
+      "dt_stage": "empathize"'
+OUT="$(bash "$SCRIPT" "$D" market-evidence market-sizing define)"
+assert_json "1 forward-step result" "$OUT" "d['success'] is True and d['data']['from']=='empathize' and d['data']['to']=='define'"
+STORED="$(python3 -c "import json;print(json.load(open('$D/action-fields/market-evidence/field.json'))['deliverables'][0]['dt_stage'])")"
+[ "$STORED" = "define" ] && pass "1 forward-step persisted" || fail "1 forward-step persisted" "field.json dt_stage=$STORED"
+
+# --- 2. invalid-stage ---
+D="$TMPROOT/t2"; make_field "$D" ',
+      "dt_stage": "empathize"'
+OUT="$(bash "$SCRIPT" "$D" market-evidence market-sizing prototpye)"
+assert_json "2 invalid-stage rejected" "$OUT" "d['success'] is False and 'invalid target stage' in d['error']"
+
+# --- 3. forward-skip: empathize -> ideate ---
+D="$TMPROOT/t3"; make_field "$D" ',
+      "dt_stage": "empathize"'
+OUT="$(bash "$SCRIPT" "$D" market-evidence market-sizing ideate)"
+assert_json "3 forward-skip rejected" "$OUT" "d['success'] is False and 'illegal stage jump' in d['error']"
+
+# --- 4. re-entry: test -> define ---
+D="$TMPROOT/t4"; make_field "$D" ',
+      "dt_stage": "test"'
+OUT="$(bash "$SCRIPT" "$D" market-evidence market-sizing define)"
+assert_json "4 re-entry allowed" "$OUT" "d['success'] is True and d['data']['from']=='test' and d['data']['to']=='define'"
+
+# --- 5. idempotent: define -> define ---
+D="$TMPROOT/t5"; make_field "$D" ',
+      "dt_stage": "define"'
+OUT="$(bash "$SCRIPT" "$D" market-evidence market-sizing define)"
+assert_json "5 idempotent allowed" "$OUT" "d['success'] is True and d['data']['to']=='define'"
+
+# --- 6. legacy entry without dt_stage ---
+D="$TMPROOT/t6"; make_field "$D" ''
+OUT="$(bash "$SCRIPT" "$D" market-evidence market-sizing empathize)"
+assert_json "6 legacy from=null" "$OUT" "d['success'] is True and d['data']['from'] is None and d['data']['to']=='empathize'"
+
+# --- 7. deliverable missing ---
+D="$TMPROOT/t7"; make_field "$D" ',
+      "dt_stage": "empathize"'
+OUT="$(bash "$SCRIPT" "$D" market-evidence nonexistent define)"
+assert_json "7 deliverable-missing rejected" "$OUT" "d['success'] is False and 'not found' in d['error']"
+
+# --- 8. field manifest missing ---
+D="$TMPROOT/t8"; mkdir -p "$D"
+OUT="$(bash "$SCRIPT" "$D" market-evidence market-sizing define)"
+assert_json "8 field-missing rejected" "$OUT" "d['success'] is False and 'not found' in d['error']"
+
+# --- 9. stage-log created + move appended ---
+D="$TMPROOT/t9"; make_field "$D" ',
+      "dt_stage": "empathize"'
+bash "$SCRIPT" "$D" market-evidence market-sizing define >/dev/null
+if [ -f "$D/.metadata/stage-log.json" ]; then
+  LOG_OK="$(python3 -c "
+import json
+m=json.load(open('$D/.metadata/stage-log.json'))['moves']
+e=m[-1]
+print('ok' if (len(m)==1 and e['from']=='empathize' and e['to']=='define' and e['action_field']=='market-evidence' and e['deliverable']=='market-sizing' and e['triggered_by']=='consult-design-thinking' and e['timestamp'].endswith('Z')) else 'bad')
+")"
+  [ "$LOG_OK" = "ok" ] && pass "9 stage-log created+appended" || fail "9 stage-log created+appended" "move entry malformed"
+else
+  fail "9 stage-log created+appended" "stage-log.json not created"
+fi
+
+echo ""
+if [ "$failures" -eq 0 ]; then
+  echo "All dt-stage-advance tests passed."
+  exit 0
+else
+  echo "$failures dt-stage-advance test(s) failed." >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Adds a guarded, logged `dt_stage` stage-advance helper for cogni-consult deliverables and wires the design-thinking loop through it.

`dt_stage` was previously hand-Edited as free text at every stage boundary in `consult-design-thinking/SKILL.md` (steps 2–7), with no guard — easy to corrupt mid-loop (typo a stage name, skip a stage). Only state-level transitions were logged; per-stage moves left no trail.

## What changed

- **NEW `scripts/dt-stage-advance.sh`** — stdlib bash+python3 helper modeled on `engagement-init.sh` (`{success,data,error}`). Validates a transition before applying it:
  - rejects an unknown stage name (typo guard) and a **forward jump that skips a stage**;
  - permits a single-step forward advance, an idempotent same-stage re-set, and a **re-entry to any earlier stage** (the loop may iterate);
  - writes `dt_stage` via an idempotent read-modify-write that preserves every other field;
  - appends a per-stage move to a **dedicated `.metadata/stage-log.json`** (created if absent) — the execution log keeps recording *state* transitions only, per the skill's "Loop, not gate" contract;
  - **degrades gracefully** on a legacy `field.json` whose deliverable carries no `dt_stage` (logs the move with `from: null`).
- **MODIFY `skills/consult-design-thinking/SKILL.md`** — a new *Advancing the stage* subsection defines the canonical helper call; every stage boundary (open-loop empathize, define/ideate/prototype/test closes, rework re-entry, test-stage loop-back) now routes through the helper in both auto-walk and interactive mode, with a free-text `Edit` fallback when the helper is absent.
- **NEW `tests/test_dt_stage_advance.sh`** — 10-assertion regression suite (mirrors `test_deliverable_graph.sh` style): forward-step, invalid-stage, forward-skip, re-entry, idempotent, legacy-no-dt_stage, deliverable-missing, field-missing, stage-log creation.
- **Version bump** cogni-consult 0.1.18 → 0.1.19 (`plugin.json` + `marketplace.json`).

## Testing

- `bash cogni-consult/tests/test_dt_stage_advance.sh` → all 10 pass.
- `bash cogni-consult/tests/test_deliverable_graph.sh` → no regression.
- Breadcrumb guard clean (0 violations); JSON validity confirmed.

Closes #814

Part of epic #815 (phase 1).