### PR TITLE
feat(cogni-consult): infer unrecorded depends_on edges from sources[] artifact references

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -35,7 +35,7 @@
     {
       "name": "cogni-consult",
       "source": "./cogni-consult",
-      "version": "0.1.19",
+      "version": "0.1.20",
       "maturity": "preview",
       "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
       "keywords": [

--- a/cogni-consult/.claude-plugin/plugin.json
+++ b/cogni-consult/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-consult",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-consult/references/dependency-model.md
+++ b/cogni-consult/references/dependency-model.md
@@ -112,6 +112,40 @@ on either of two structural defects:
 A clean graph returns `success:true` with the node and edge counts. Validation is
 the gate the write side runs before accepting a newly declared edge.
 
+## Inferred edges (unrecorded dependencies from `sources[]`)
+
+A dependency can exist in fact without ever being declared: a deliverable's artifact
+may cite another deliverable's artifact through its frontmatter `sources[]` lineage
+triple (an `entity_ref` or a `file://` `source_url` carrying an
+`action-fields/<af>/<deliverable>` segment) while no `depends_on[]` edge was recorded.
+The declared graph then reports zero dependents for the cited deliverable, so a
+correction or rework never cascades to the deliverable that actually consumes it — a
+silent gap.
+
+`deliverable-graph.py` surfaces these as **inferred edges**. `load_graph` reads each
+deliverable's artifact frontmatter `sources[]`, resolves any entry that names a sibling
+deliverable, and records an inferred edge (`dependent → dependency`) whenever the
+resolved target is a real, distinct node **not** already in the dependent's
+`depends_on[]`. A self-referential `entity_ref` — the lineage triple naming the
+deliverable's own coordinate, as carried alongside an external `source_url` — resolves
+to the node itself and is skipped, so an external https source raises no edge.
+
+Inferred edges are **advisory**:
+
+- `validate` surfaces them in `inferred_edges[]` / `inferred_edge_count` plus a
+  human-readable `warnings[]` entry, and **stays `success:true`** — they never feed
+  cycle or dangling detection (those remain `depends_on`-only hard errors).
+- They are **never written** to `field.json`. Making an inferred edge authoritative is
+  an explicit author action: declare it in `depends_on[]`. This preserves the
+  flag-not-rewrite contract — the engine never mutates author-declared graph state from
+  a heuristic.
+- `impact` and `cascade-stale` accept `--include-inferred` to fold the inferred edges
+  into the blast radius (closing the silent-zero-dependents gap). Default is the
+  declared graph only, so existing callers are unaffected.
+
+Resolution degrades gracefully: a deliverable with no artifact `.md`, no frontmatter,
+no `sources[]`, or only external/unresolvable references contributes no inferred edge.
+
 ## Cascade semantics
 
 When an upstream deliverable changes, `cascade-stale` propagates the staleness to

--- a/cogni-consult/scripts/deliverable-graph.py
+++ b/cogni-consult/scripts/deliverable-graph.py
@@ -4,12 +4,20 @@
 Usage:
   python3 deliverable-graph.py <engagement-dir> validate
   python3 deliverable-graph.py <engagement-dir> trace <action_field>/<deliverable>
-  python3 deliverable-graph.py <engagement-dir> impact <action_field>/<deliverable>
+  python3 deliverable-graph.py <engagement-dir> impact <action_field>/<deliverable> \
+      [--include-inferred]
   python3 deliverable-graph.py <engagement-dir> refresh-order
   python3 deliverable-graph.py <engagement-dir> cascade-stale <action_field>/<deliverable> \
-      --trigger deliverable_update|claims_correction
+      --trigger deliverable_update|claims_correction [--include-inferred]
 
 Returns JSON on stdout: {"success": bool, "data": {...}, "error": "string"}
+
+Inferred edges: `validate` also surfaces *unrecorded* dependencies — edges a
+deliverable's artifact sources[] (frontmatter lineage triple) imply by referencing
+another deliverable's artifact, but which were never declared in depends_on[]. These
+are advisory (validate stays success:true; they never feed cycle/dangling detection
+and never mutate field.json). Pass --include-inferred to impact / cascade-stale to
+fold them into the blast radius, closing the silent-zero-dependents gap.
 
 Data model (references/data-model.md, references/dependency-model.md):
   Each action-fields/<slug>/field.json carries deliverables[]. A deliverable may
@@ -59,6 +67,158 @@ def parse_coordinate(raw):
     return action_field, deliverable
 
 
+def _strip_md_suffix(value):
+    return value[:-3] if value.endswith(".md") else value
+
+
+def _coord_from_path(raw):
+    """Extract an (action_field, deliverable) pair from an entity_ref / file path.
+
+    Recognizes any path carrying an `action-fields/<af>/<deliverable>` segment
+    (a `file://` scheme, deeper sub-paths, and a trailing `.md` are all tolerated).
+    Returns None when no such segment is present — the caller treats that as "this
+    source does not reference a sibling deliverable" (e.g. an external https URL).
+    """
+    if not isinstance(raw, str) or not raw:
+        return None
+    path = raw[len("file://"):] if raw.startswith("file://") else raw
+    parts = [p for p in path.replace("\\", "/").split("/") if p]
+    if "action-fields" not in parts:
+        return None
+    i = parts.index("action-fields")
+    if len(parts) < i + 3:
+        return None
+    action_field = parts[i + 1].strip()
+    deliverable = _strip_md_suffix(parts[i + 2].strip())
+    if not action_field or not deliverable:
+        return None
+    return action_field, deliverable
+
+
+def _maybe_kv(target, fragment):
+    """Record a 'source_url:'/'entity_ref:' fragment into target (others ignored)."""
+    for key in ("source_url", "entity_ref"):
+        prefix = key + ":"
+        if fragment.startswith(prefix):
+            val = fragment[len(prefix):].strip().strip('"').strip("'")
+            if val:
+                target[key] = val
+            return
+
+
+def _extract_frontmatter_sources(md_path):
+    """Best-effort stdlib parse of a deliverable artifact's frontmatter sources[].
+
+    Returns a list of {source_url?, entity_ref?} dicts. Degrades to [] on any
+    missing file, absent/unterminated frontmatter, or missing sources block —
+    edge inference is advisory and must never raise. The parser handles only the
+    constrained frontmatter shape documented in references/data-model.md (a
+    top-level `sources:` list of mappings); anything more exotic yields [].
+    """
+    try:
+        with open(md_path, encoding="utf-8") as f:
+            text = f.read()
+    except OSError:
+        return []
+    lines = text.splitlines()
+    if not lines or lines[0].strip() != "---":
+        return []
+    frontmatter = []
+    closed = False
+    for line in lines[1:]:
+        if line.strip() == "---":
+            closed = True
+            break
+        frontmatter.append(line)
+    if not closed:
+        return []  # unterminated frontmatter fence — not valid YAML frontmatter
+
+    sources = []
+    in_sources = False
+    sources_indent = 0
+    current = None
+    for line in frontmatter:
+        if not line.strip() or line.lstrip().startswith("#"):
+            continue
+        indent = len(line) - len(line.lstrip())
+        stripped = line.strip()
+        if not in_sources:
+            if indent == 0 and stripped.rstrip() == "sources:":
+                in_sources = True
+                sources_indent = indent
+            continue
+        # Inside the sources block. A dedent to a non-list-item line ends it.
+        if indent <= sources_indent and not stripped.startswith("- "):
+            break
+        if stripped.startswith("- "):
+            if current is not None:
+                sources.append(current)
+            current = {}
+            _maybe_kv(current, stripped[2:].strip())
+        elif current is not None:
+            _maybe_kv(current, stripped)
+    if current is not None:
+        sources.append(current)
+    return [s for s in sources if s]
+
+
+def _infer_source_edges(nodes, depends_on):
+    """Infer unrecorded dependency edges from each deliverable's sources[].
+
+    For every node, read its artifact markdown frontmatter sources[]; resolve each
+    entry to a sibling deliverable coordinate (via entity_ref or a file:// source_url
+    that carries an `action-fields/<af>/<deliverable>` segment). An edge is *inferred*
+    only when the resolved target is a real, distinct node NOT already declared in the
+    dependent's depends_on[]. Returns (inferred_edges, inferred_blocks):
+      inferred_edges: [{from, to}, ...]   (dependent -> dependency, like depends_on)
+      inferred_blocks: {key -> [downstream_key, ...]}  (inverse, for impact/cascade)
+    Pure read; never mutates field.json. A self-referential entity_ref (the lineage
+    triple naming the deliverable's own coordinate, as for an external source) resolves
+    to the node itself and is skipped, so an external https source raises no edge.
+    """
+    declared = {k: set(v) for k, v in depends_on.items()}
+    inferred_edges = []
+    inferred_blocks = {key: [] for key in nodes}
+    seen = set()
+    for key, node in nodes.items():
+        field_dir = os.path.dirname(node["field_path"])
+        md_path = os.path.join(field_dir, node["deliverable"] + ".md")
+        for entry in _extract_frontmatter_sources(md_path):
+            # Resolve both fields; pick the first that names a real, non-self node.
+            target = None
+            for field in ("entity_ref", "source_url"):
+                coord = _coord_from_path(entry.get(field))
+                if not coord:
+                    continue
+                cand = node_key(*coord)
+                if cand != key and cand in nodes:
+                    target = cand
+                    break
+            if target is None or target in declared.get(key, set()):
+                continue
+            edge_id = (key, target)
+            if edge_id in seen:
+                continue
+            seen.add(edge_id)
+            inferred_edges.append({"from": key, "to": target})
+            inferred_blocks[target].append(key)
+    return inferred_edges, inferred_blocks
+
+
+def _merge_adjacency(primary, extra):
+    """Union two adjacency maps, preserving order and de-duplicating per key."""
+    merged = {}
+    for key in set(primary) | set(extra):
+        seen = set()
+        combined = []
+        for nbr in list(primary.get(key, [])) + list(extra.get(key, [])):
+            if nbr not in seen:
+                seen.add(nbr)
+                combined.append(nbr)
+        merged[key] = combined
+    return merged
+
+
 def load_graph(engagement_dir):
     """Build the deliverable graph from consult-project.json + every field.json.
 
@@ -68,6 +228,8 @@ def load_graph(engagement_dir):
       depends_on: {key -> [upstream_key, ...]}   (dependent -> dependencies)
       blocks: {key -> [downstream_key, ...]}      (derived inverse)
       dangling: [{from, to}, ...]                 (depends_on refs to missing nodes)
+      inferred_edges: [{from, to}, ...]           (unrecorded deps from sources[])
+      inferred_blocks: {key -> [downstream_key, ...]}  (inverse of inferred_edges)
     Raises ValueError with a user-facing message on an unreadable/malformed root.
     """
     proj_path = os.path.join(engagement_dir, "consult-project.json")
@@ -141,11 +303,17 @@ def load_graph(engagement_dir):
                 dangling.append({"from": key, "to": up_key})
         depends_on[key] = valid_ups
 
+    # Third pass: infer unrecorded dependency edges from artifact sources[].
+    # Advisory only — never feeds cycle/dangling detection, never mutates state.
+    inferred_edges, inferred_blocks = _infer_source_edges(nodes, depends_on)
+
     return {
         "nodes": nodes,
         "depends_on": depends_on,
         "blocks": blocks,
         "dangling": dangling,
+        "inferred_edges": inferred_edges,
+        "inferred_blocks": inferred_blocks,
     }
 
 
@@ -215,6 +383,17 @@ def cmd_validate(graph):
             "error": "; ".join(parts),
         }
     edge_count = sum(len(v) for v in graph["depends_on"].values())
+    inferred = graph.get("inferred_edges", [])
+    warnings = []
+    if inferred:
+        warnings.append(
+            f"{len(inferred)} unrecorded dependency(ies) inferred from sources[] "
+            "not declared in depends_on[]: "
+            + ", ".join(f"{e['from']} -> {e['to']}" for e in inferred)
+            + ". Declare them in depends_on[] to make the edge authoritative, or pass "
+            "--include-inferred to impact/cascade-stale to fold them into the blast "
+            "radius (the graph never rewrites field.json on its own)."
+        )
     return {
         "success": True,
         "data": {
@@ -222,6 +401,9 @@ def cmd_validate(graph):
             "edge_count": edge_count,
             "cycles": [],
             "dangling": [],
+            "inferred_edges": inferred,
+            "inferred_edge_count": len(inferred),
+            "warnings": warnings,
         },
         "error": "",
     }
@@ -248,17 +430,26 @@ def cmd_trace(graph, key):
     }
 
 
-def cmd_impact(graph, key):
-    """Downstream blast radius — the transitive set that depends on this deliverable."""
+def cmd_impact(graph, key, include_inferred=False):
+    """Downstream blast radius — the transitive set that depends on this deliverable.
+
+    With include_inferred=True the inferred (sources[]-derived) edges are folded into
+    the blocks adjacency so unrecorded dependents are counted; default is the declared
+    graph only, so existing callers see byte-identical behavior.
+    """
     _require_node(graph, key)
-    downstream = transitive(key, graph["blocks"])
+    blocks = graph["blocks"]
+    if include_inferred:
+        blocks = _merge_adjacency(graph["blocks"], graph.get("inferred_blocks", {}))
+    downstream = transitive(key, blocks)
     return {
         "success": True,
         "data": {
             "target": key,
-            "direct_blocks": graph["blocks"].get(key, []),
+            "direct_blocks": blocks.get(key, []),
             "downstream": downstream,
             "downstream_count": len(downstream),
+            "include_inferred": include_inferred,
         },
         "error": "",
     }
@@ -322,7 +513,7 @@ def cmd_refresh_order(graph):
     }
 
 
-def cmd_cascade_stale(graph, key, trigger):
+def cmd_cascade_stale(graph, key, trigger, include_inferred=False):
     """Flag the transitive downstream set of `key` as stale via idempotent RMW.
 
     The updated deliverable (`key`) itself is NOT flagged — it is fresh; its
@@ -330,6 +521,11 @@ def cmd_cascade_stale(graph, key, trigger):
     trigger} to each downstream deliverable's field.json, preserving every sibling
     field. Idempotent: a deliverable already carrying status:"stale" is left
     untouched (its original flagged_at survives), so re-running yields no new write.
+
+    With include_inferred=True, dependents reachable only through inferred
+    (sources[]-derived) edges are included in the blast radius — closing the
+    silent-zero-dependents gap when a real dependency was never declared in
+    depends_on[]. Default is the declared graph only (unchanged behavior).
     """
     _require_node(graph, key)
     if trigger not in VALID_TRIGGERS:
@@ -337,7 +533,10 @@ def cmd_cascade_stale(graph, key, trigger):
             f"--trigger must be one of {VALID_TRIGGERS}, got: {trigger!r}"
         )
 
-    downstream = transitive(key, graph["blocks"])
+    blocks = graph["blocks"]
+    if include_inferred:
+        blocks = _merge_adjacency(graph["blocks"], graph.get("inferred_blocks", {}))
+    downstream = transitive(key, blocks)
     reason = f"upstream deliverable {key} changed (trigger: {trigger})"
     flagged_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
@@ -385,6 +584,7 @@ def cmd_cascade_stale(graph, key, trigger):
             "newly_flagged": sorted(newly_flagged),
             "already_stale": sorted(already_stale),
             "flagged_at": flagged_at,
+            "include_inferred": include_inferred,
         },
         "error": "",
     }
@@ -401,11 +601,21 @@ def main():
     p_trace.add_argument("coordinate")
     p_impact = sub.add_parser("impact")
     p_impact.add_argument("coordinate")
+    p_impact.add_argument(
+        "--include-inferred",
+        action="store_true",
+        help="fold sources[]-inferred (unrecorded) edges into the blast radius",
+    )
     sub.add_parser("refresh-order")
     p_cascade = sub.add_parser("cascade-stale")
     p_cascade.add_argument("coordinate")
     p_cascade.add_argument(
         "--trigger", required=True, choices=list(VALID_TRIGGERS)
+    )
+    p_cascade.add_argument(
+        "--include-inferred",
+        action="store_true",
+        help="also flag dependents reachable only through sources[]-inferred edges",
     )
     args = ap.parse_args()
 
@@ -422,12 +632,14 @@ def main():
             result = cmd_trace(graph, node_key(af, d))
         elif args.command == "impact":
             af, d = parse_coordinate(args.coordinate)
-            result = cmd_impact(graph, node_key(af, d))
+            result = cmd_impact(graph, node_key(af, d), args.include_inferred)
         elif args.command == "refresh-order":
             result = cmd_refresh_order(graph)
         elif args.command == "cascade-stale":
             af, d = parse_coordinate(args.coordinate)
-            result = cmd_cascade_stale(graph, node_key(af, d), args.trigger)
+            result = cmd_cascade_stale(
+                graph, node_key(af, d), args.trigger, args.include_inferred
+            )
         else:  # pragma: no cover — argparse already enforces the choice set
             raise ValueError(f"unknown command: {args.command}")
     except (ValueError, OSError, json.JSONDecodeError) as exc:

--- a/cogni-consult/tests/test_deliverable_graph.sh
+++ b/cogni-consult/tests/test_deliverable_graph.sh
@@ -15,6 +15,12 @@
 #   6  cascade-stale         flags downstream lineage_status=stale via RMW, preserves siblings
 #   7  cascade-idempotent    a second cascade-stale produces no new writes
 #   8  refresh-order         currently-stale deliverables grouped into topological layers
+#   9  validate-inferred     unrecorded sources[]-derived edge surfaced, success stays true
+#  10  impact-default        declared graph only — inferred dependent not counted
+#  11  impact-include-inferred   --include-inferred folds the unrecorded dependent in
+#  12  cascade-default       status-quo silent-zero-dependents (no flag, flags nothing)
+#  13  cascade-include-inferred  --include-inferred flags the unrecorded dependent stale
+#  14  inferred-graceful     no artifact .md -> zero inferred edges, no warnings, success
 #
 # Usage: bash cogni-consult/tests/test_deliverable_graph.sh
 # Exits non-zero on any assertion failure.
@@ -203,6 +209,143 @@ assert_json "cascade-idempotent" "$OUT" \
 OUT="$(run "$D6" refresh-order)"
 assert_json "refresh-order" "$OUT" \
   "d['success'] is True and d['data']['stale_count'] == 2 and d['data']['layers'][0] == ['portfolio-fit/portfolio-screen'] and d['data']['layers'][1] == ['go-to-market/gtm-play'] and d['data']['order'] == ['portfolio-fit/portfolio-screen', 'go-to-market/gtm-play']"
+
+# ---------------------------------------------------------------------------
+# Inferred edges from artifact sources[] (unrecorded dependencies)
+# ---------------------------------------------------------------------------
+# canvas/canvas-build-spec's artifact sources[] references facilitation-flow's
+# artifact (via a file:// source_url) but declares NO depends_on; market/ext-note
+# cites only an external https source. So exactly one edge should be inferred:
+#   canvas/canvas-build-spec -> facilitation/facilitation-flow
+seed_sources() {
+  local dir="$1"
+  mkdir -p "$dir/action-fields/facilitation" \
+           "$dir/action-fields/canvas" \
+           "$dir/action-fields/market"
+  cat > "$dir/consult-project.json" <<'EOF'
+{
+  "slug": "acme",
+  "name": "Acme Engagement",
+  "key_question": "How?",
+  "action_fields": ["facilitation", "canvas", "market"],
+  "workflow_state": {"scope": "complete"},
+  "created": "2026-06-15",
+  "updated": "2026-06-15"
+}
+EOF
+  cat > "$dir/action-fields/facilitation/field.json" <<'EOF'
+{
+  "slug": "facilitation",
+  "title": "Facilitation",
+  "deliverables": [
+    {"slug": "facilitation-flow", "title": "Facilitation flow", "state": "complete", "dt_stage": "test", "producing_route": "consult-design-thinking", "persona_review": "complete"}
+  ]
+}
+EOF
+  cat > "$dir/action-fields/canvas/field.json" <<'EOF'
+{
+  "slug": "canvas",
+  "title": "Canvas",
+  "deliverables": [
+    {"slug": "canvas-build-spec", "title": "Canvas build spec", "state": "in-progress", "dt_stage": "prototype", "producing_route": "consult-design-thinking", "persona_review": "pending"}
+  ]
+}
+EOF
+  cat > "$dir/action-fields/market/field.json" <<'EOF'
+{
+  "slug": "market",
+  "title": "Market",
+  "deliverables": [
+    {"slug": "ext-note", "title": "External note", "state": "complete", "dt_stage": "test", "producing_route": "consult-design-thinking", "persona_review": "complete"}
+  ]
+}
+EOF
+  cat > "$dir/action-fields/facilitation/facilitation-flow.md" <<'EOF'
+---
+slug: facilitation-flow
+action_field: facilitation
+updated: 2026-06-11
+---
+
+# Facilitation flow
+EOF
+  # canvas-build-spec sources facilitation-flow via a file:// source_url; its
+  # entity_ref is its own coordinate (the lineage triple's self-identity), which
+  # must be skipped so the source_url is what resolves the cross-deliverable edge.
+  cat > "$dir/action-fields/canvas/canvas-build-spec.md" <<'EOF'
+---
+slug: canvas-build-spec
+action_field: canvas
+sources:
+  - source_url: file:///repo/cogni-consult/acme/action-fields/facilitation/facilitation-flow.md
+    entity_ref: cogni-consult/acme/action-fields/canvas/canvas-build-spec
+    propagated_at: 2026-06-11T09:00:00Z
+updated: 2026-06-11
+---
+
+# Canvas build spec
+EOF
+  # ext-note cites only an external source: entity_ref is self, source_url is https.
+  # Neither resolves to a sibling deliverable, so it must contribute no edge.
+  cat > "$dir/action-fields/market/ext-note.md" <<'EOF'
+---
+slug: ext-note
+action_field: market
+sources:
+  - source_url: https://www.destatis.de/some-figure
+    entity_ref: cogni-consult/acme/action-fields/market/ext-note
+    propagated_at: 2026-06-11T09:00:00Z
+    kb_ref: wiki/sources/destatis
+updated: 2026-06-11
+---
+
+# External note
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# 9  validate-inferred  (surfaces the one unrecorded edge, stays success:true)
+# ---------------------------------------------------------------------------
+D9="$TMPROOT/sources"; seed_sources "$D9"
+OUT="$(run "$D9" validate)"
+assert_json "validate-inferred" "$OUT" \
+  "d['success'] is True and d['data']['edge_count'] == 0 and d['data']['inferred_edge_count'] == 1 and d['data']['inferred_edges'] == [{'from': 'canvas/canvas-build-spec', 'to': 'facilitation/facilitation-flow'}] and len(d['data']['warnings']) == 1"
+
+# ---------------------------------------------------------------------------
+# 10  impact-default  (declared graph only: facilitation-flow blocks nothing)
+# ---------------------------------------------------------------------------
+OUT="$(run "$D9" impact facilitation/facilitation-flow)"
+assert_json "impact-default-no-inferred" "$OUT" \
+  "d['success'] is True and d['data']['downstream_count'] == 0 and d['data']['include_inferred'] is False"
+
+# ---------------------------------------------------------------------------
+# 11  impact-include-inferred  (folds in the unrecorded dependent)
+# ---------------------------------------------------------------------------
+OUT="$(run "$D9" impact facilitation/facilitation-flow --include-inferred)"
+assert_json "impact-include-inferred" "$OUT" \
+  "d['success'] is True and d['data']['downstream'] == ['canvas/canvas-build-spec'] and d['data']['downstream_count'] == 1 and d['data']['include_inferred'] is True"
+
+# ---------------------------------------------------------------------------
+# 12  cascade-default  (the silent-zero-dependents status quo: flags nothing)
+# ---------------------------------------------------------------------------
+OUT="$(run "$D9" cascade-stale facilitation/facilitation-flow --trigger deliverable_update)"
+assert_json "cascade-default-no-inferred" "$OUT" \
+  "d['success'] is True and d['data']['downstream_count'] == 0 and d['data']['newly_flagged'] == []"
+
+# ---------------------------------------------------------------------------
+# 13  cascade-include-inferred  (flags the unrecorded dependent stale)
+# ---------------------------------------------------------------------------
+OUT="$(run "$D9" cascade-stale facilitation/facilitation-flow --trigger deliverable_update --include-inferred)"
+assert_json "cascade-include-inferred" "$OUT" \
+  "d['success'] is True and d['data']['newly_flagged'] == ['canvas/canvas-build-spec'] and d['data']['include_inferred'] is True"
+
+# ---------------------------------------------------------------------------
+# 14  inferred-graceful  (no artifact .md anywhere -> zero inferred, success)
+# ---------------------------------------------------------------------------
+D14="$TMPROOT/graceful"; seed_chain "$D14"
+OUT="$(run "$D14" validate)"
+assert_json "inferred-graceful-no-artifacts" "$OUT" \
+  "d['success'] is True and d['data']['inferred_edge_count'] == 0 and d['data']['warnings'] == []"
 
 # ---------------------------------------------------------------------------
 echo


### PR DESCRIPTION
## Summary

Teaches `deliverable-graph.py` to detect **unrecorded dependencies** — edges a deliverable's artifact `sources[]` (frontmatter lineage triple) imply by referencing another deliverable's artifact, but which were never declared in `depends_on[]`. Previously the graph was built purely from declared `depends_on[]`, so such a reference produced a silent zero-dependents result and a correction/rework never cascaded to the deliverable that actually consumes the changed artifact.

## What changed

- **`scripts/deliverable-graph.py`**
  - `load_graph` now reads each deliverable's artifact frontmatter `sources[]` (a small, defensive stdlib parser — no pip), resolves any entry naming a sibling deliverable (`entity_ref` or a `file://` `source_url` carrying an `action-fields/<af>/<deliverable>` segment), and records **inferred edges** (`dependent → dependency`) for any not already in `depends_on[]`. A self-referential `entity_ref` (the lineage triple's own-coordinate identity, carried alongside an external `source_url`) resolves to the node itself and is skipped, so external https sources raise no edge.
  - `validate` surfaces `inferred_edges[]` / `inferred_edge_count` + a human-readable `warnings[]` entry and **stays `success:true`** — inferred edges are advisory, never feed cycle/dangling detection, and **never mutate `field.json`** (flag-not-rewrite contract preserved; making an edge authoritative stays an explicit `depends_on[]` declaration).
  - `impact` and `cascade-stale` gain `--include-inferred` to fold inferred edges into the blast radius, closing the silent-zero-dependents gap. **Default behavior is byte-identical** — existing callers unaffected.
  - Degrades gracefully: no artifact `.md`, no frontmatter, no `sources[]`, or external-only references → no inferred edge.
- **`tests/test_deliverable_graph.sh`** — 6 new cases (validate-inferred, impact default vs `--include-inferred`, cascade default vs `--include-inferred`, graceful no-artifacts). 17/17 pass.
- **`references/dependency-model.md`** — new "Inferred edges" section documenting the model and the `--include-inferred` flag.
- **Version bump** cogni-consult 0.1.19 → 0.1.20 (`plugin.json` + `marketplace.json`).

## Testing

- `bash cogni-consult/tests/test_deliverable_graph.sh` → all 17 pass (11 existing + 6 new; existing behavior unchanged).
- Breadcrumb guard clean (0 violations); JSON validity confirmed; stdlib-only, `{success,data,error}` contract preserved.

Closes #813

Part of epic #815 (phase 1, final child).