### PR TITLE
cogni-consult: opt-in consult-publish skill (deliverable → Claude Design brief)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -35,7 +35,7 @@
     {
       "name": "cogni-consult",
       "source": "./cogni-consult",
-      "version": "0.1.22",
+      "version": "0.1.23",
       "maturity": "preview",
       "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
       "keywords": [

--- a/cogni-consult/.claude-plugin/plugin.json
+++ b/cogni-consult/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-consult",
-  "version": "0.1.22",
+  "version": "0.1.23",
   "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-consult/references/data-model.md
+++ b/cogni-consult/references/data-model.md
@@ -177,6 +177,22 @@ dependents via read-modify-write — flag-and-recommend only, never auto-rewriti
 deliverable. Full edge schema, cycle/dangling rules, and cascade + topological-refresh
 semantics: `references/dependency-model.md`.
 
+`publish[]` (optional, default absent/empty) records the deliverable's publish
+lineage — one entry per format the consultant has published it to via
+`consult-publish`. Each entry is
+`{format, brief_path, route_steps, source_deliverable, published_at}`, where
+`format` ∈ `{slides, web-poster, report, infographic}` and `brief_path` is a
+**path reference** to the produced brief (the consult-native outline for
+slides/web-poster, or the route's output path for the visual formats) — brief
+content is never copied into `field.json`, mirroring the source-lineage
+discipline so an upstream correction stays visible downstream without
+duplication. `route_steps[]` records the dispatch chain actually run. The array
+**appends** per published format, so publishing a deliverable to a second format
+never overwrites the first. Like the other optional deliverable fields it needs
+no script change to reach read surfaces — `engagement-status.sh` passes it
+through verbatim. The routing each format resolves to is the canonical contract
+in `references/publish-routing.md`.
+
 ### Deliverable artifacts ({deliverable-slug}.md)
 
 Obsidian-browsable markdown with YAML frontmatter. State is intentionally

--- a/cogni-consult/skills/consult-design-thinking/SKILL.md
+++ b/cogni-consult/skills/consult-design-thinking/SKILL.md
@@ -339,6 +339,14 @@ to set one up. This is a lightweight snapshot — the dashboard reflects the
 engagement state at this checkpoint, which is exactly what the consultant wants
 to see before picking the next deliverable.
 
+**Publishing is elected, not automatic.** When this session moved the
+deliverable to `complete`, the consultant *may* now turn it into a
+presentation-ready brief for Claude Design with `/cogni-consult:consult-publish`
+(slides, web-poster, report, or infographic). Mention it as an available next
+step only — never auto-fire it from this loop. Publishing is a deliberate
+consultant judgment call about which deliverables are presentation-worthy and
+which format fits; the design-thinking loop ends at `complete`.
+
 ## Important Notes
 
 - **State ownership**: deliverable `state` and `dt_stage` live only in the

--- a/cogni-consult/skills/consult-publish/SKILL.md
+++ b/cogni-consult/skills/consult-publish/SKILL.md
@@ -70,67 +70,51 @@ lineage entry (step 5), so a second format never overwrites the first.
 
 ### 3. Optional voice polish
 
-Before building the brief, the deliverable (or, for slides/web-poster, the
-outline once drafted) may be polished with `cogni-copywriting:copywriter`. This
-is optional and graceful-degrading.
+The brief text may be polished with `cogni-copywriting:copywriter` before
+handoff. This is optional and graceful-degrading — **if `cogni-copywriting` is
+not installed, skip it with a one-line note**; the route still produces a valid
+brief.
 
-```
-Skill: cogni-copywriting:copywriter
-  FILE_PATH=<absolute path to the deliverable or outline .md>
-  --scope=tone
-  AUDIENCE=mixed
-```
+The polish target depends on the route, so its timing differs:
 
-Use `--scope=tone` for a light pass that preserves structure, `--scope=compress`
-to tighten for an executive audience, or `--scope=full` for a Pyramid/BLUF
-restructuring before a client-facing presentation. **If `cogni-copywriting` is
-not installed, skip this step with a one-line note** — the route still produces
-a valid brief.
+- **`report` / `infographic`** — polish the **deliverable** here, in step 3,
+  before the visual route post-processes it.
+- **`slides` / `web-poster`** — polish the **drafted outline** instead, after
+  step 4 builds it (there is no separate brief text until then).
+
+The dispatch invocation and the `--scope` options (`tone` / `compress` / `full`)
+are the canonical ones in `$CLAUDE_PLUGIN_ROOT/references/publish-routing.md` —
+see its "Optional Voice Polish" section rather than restating them here.
 
 ### 4. Build the brief by route
 
-Resolve the elected format to its route per `publish-routing.md`:
+Resolve the elected format to its route per `publish-routing.md` — the reference
+holds the exact dispatch block and per-route options; the mapping below is the
+execution summary, so read the reference for each route before dispatching:
 
-- **`slides` / `web-poster` → consult-native outline brief.** Consult
-  deliverables are framework-shaped (Pyramid / SCQA / MECE), not arc-shaped, so
-  this path does **not** dispatch `cogni-visual:story-to-slides` /
-  `story-to-web` and does **not** re-narrate through `cogni-narrative` —
-  arc-ifying a framework-shaped deliverable weakens its executive register.
-  Instead, derive the outline directly from the deliverable's own structure: an
-  ordered list of `{section_title, section_body}` entries, citations preserved.
-  - The Pyramid answer / governing thought becomes the opening (title slide or
-    hero section).
-  - Each MECE group / SCQA movement becomes one section entry, in the
-    deliverable's own order.
-  - Supporting evidence and citations are carried into the corresponding
-    section body — never dropped.
-  Write the outline alongside the deliverable at
-  `action-fields/<field-slug>/publish/<deliverable-slug>-outline.md`. This plain
-  title-and-description outline is exactly what Claude Design's presentation
-  generator consumes.
+| Elected format | Route | Brief output path |
+|---|---|---|
+| `slides` / `web-poster` | consult-native outline brief (built here, not dispatched) | `action-fields/<field-slug>/publish/<deliverable-slug>-outline.md` |
+| `report` | `cogni-visual:enrich-report` | `action-fields/<field-slug>/output/<deliverable-slug>-enriched.html` (default) |
+| `infographic` | `cogni-visual:story-to-infographic` | `infographic-brief.md` (auto-rendered) |
 
-- **`report` → `cogni-visual:enrich-report`.** A finished markdown deliverable
-  needs no arc; `enrich-report` post-processes it into a themed visual report.
+**Building the consult-native outline (`slides` / `web-poster`).** This is the
+one route the skill builds itself rather than dispatching. Consult deliverables
+are framework-shaped (Pyramid / SCQA / MECE), not arc-shaped, so this path does
+**not** dispatch `cogni-visual:story-to-slides` / `story-to-web` and does **not**
+re-narrate through `cogni-narrative` — arc-ifying a framework-shaped deliverable
+weakens its executive register. Derive the outline directly from the
+deliverable's own structure: an ordered list of `{section_title, section_body}`
+entries with citations preserved — Pyramid answer / governing thought → the
+opening, each MECE group / SCQA movement → one section in the deliverable's own
+order, supporting evidence carried into the matching section body (never
+dropped). The plain title-and-description outline is exactly what Claude
+Design's presentation generator consumes.
 
-  ```
-  Skill: cogni-visual:enrich-report
-    source_path: action-fields/<field-slug>/<deliverable-slug>.md
-  ```
-
-  `source_path` is the only required input; the enriched output lands by default
-  at `action-fields/<field-slug>/output/<deliverable-slug>-enriched.html`.
-
-- **`infographic` → `cogni-visual:story-to-infographic`.** Distils a single-page
-  infographic from the deliverable's prose.
-
-  ```
-  Skill: cogni-visual:story-to-infographic
-    source_path: action-fields/<field-slug>/<deliverable-slug>.md
-  ```
-
-  It emits an `infographic-brief.md` and auto-renders it. Pass a `style_preset`
-  (`editorial`, `data-viz`, `economist`, `corporate`, …) when the consultant has
-  a house look in mind.
+**The `report` and `infographic` routes** dispatch the named cogni-visual skill;
+the exact dispatch block, required inputs, and style options (e.g.
+`story-to-infographic`'s `style_preset`) live in `publish-routing.md` — follow
+it rather than restating them here, so the skill and the reference cannot drift.
 
 **Graceful degradation.** When `cogni-visual` is not installed, the `report`
 and `infographic` routes cannot run — skip the dispatch with a one-line note

--- a/cogni-consult/skills/consult-publish/SKILL.md
+++ b/cogni-consult/skills/consult-publish/SKILL.md
@@ -1,0 +1,200 @@
+---
+name: consult-publish
+description: |
+  This skill should be used when a consultant elects to turn a completed
+  cogni-consult deliverable into presentation-ready documentation — a brief the
+  consultant hands to Claude Design to render. Trigger on: "publish this
+  deliverable", "turn <deliverable> into slides", "make a poster/web page from
+  <deliverable>", "build a report from <deliverable>", "make an infographic
+  from <deliverable>", "present this deliverable", "render-ready brief", or
+  "hand this to Claude Design". Runs only when the named deliverable's
+  `state` is `complete`. It is consultant-elected: invoke it explicitly — it is
+  never auto-fired from the design-thinking loop.
+allowed-tools: Read, Write, Edit, Bash, Skill
+---
+
+# Publish a Deliverable
+
+Turn one completed deliverable into a **brief** — the clean handoff the
+consultant takes to Claude Design (claude.ai/design) to render in their own
+design system. This skill produces the brief and records its path; it never
+renders and never owns brand. Rendering and brand application live in Claude
+Design, by design.
+
+The routing — which format becomes which brief, built by which route — is the
+canonical contract in `$CLAUDE_PLUGIN_ROOT/references/publish-routing.md`. This
+skill **executes** that contract rather than restating it, so the routing
+cannot drift between the reference and the skill. Read the reference before
+building any brief; the per-format detail below is an execution summary, not a
+second source of truth.
+
+## When this runs
+
+Publishing is a consultant judgment call — which deliverables are
+presentation-worthy, and which format fits each. So this skill is **elected,
+not automatic**:
+
+- It runs only when the consultant invokes it explicitly on a named deliverable.
+- It runs only when that deliverable's `state` is `complete` in its field's
+  `field.json` (a deliverable still in its design-thinking loop is not ready to
+  present).
+- It is **never** wired into the `consult-design-thinking` empathize→test loop
+  as a post-test callback. The loop ends at `state: complete`; publishing is a
+  separate, later, deliberate step.
+
+## Workflow
+
+### 1. Locate the engagement and the deliverable
+
+Resolve the engagement root (the directory holding `consult-project.json`) and
+read the named action field's `action-fields/<field-slug>/field.json`. Find the
+deliverable entry by its `slug`.
+
+**Gate on completeness.** If the deliverable's `state` is not `complete`, stop
+and tell the consultant the deliverable must finish its design-thinking loop
+(and ideally its persona challenge) before it can be published — name the
+current `state` and `dt_stage`. Do not publish an unfinished deliverable.
+
+The deliverable artifact is at `action-fields/<field-slug>/<deliverable-slug>.md`.
+Read it — its framework structure is what the brief is built from.
+
+### 2. Elect the format
+
+The four target formats are `slides`, `web-poster`, `report`, and
+`infographic`. The choice is the consultant's and is not fixed per deliverable
+type. The deliverable artifact's frontmatter may record a format preference
+(`deliverable-types.md` records it at production time); read it and offer it as
+the default, but let the consultant confirm or override. A deliverable may be
+published to more than one format — each published format appends its own
+lineage entry (step 5), so a second format never overwrites the first.
+
+### 3. Optional voice polish
+
+Before building the brief, the deliverable (or, for slides/web-poster, the
+outline once drafted) may be polished with `cogni-copywriting:copywriter`. This
+is optional and graceful-degrading.
+
+```
+Skill: cogni-copywriting:copywriter
+  FILE_PATH=<absolute path to the deliverable or outline .md>
+  --scope=tone
+  AUDIENCE=mixed
+```
+
+Use `--scope=tone` for a light pass that preserves structure, `--scope=compress`
+to tighten for an executive audience, or `--scope=full` for a Pyramid/BLUF
+restructuring before a client-facing presentation. **If `cogni-copywriting` is
+not installed, skip this step with a one-line note** — the route still produces
+a valid brief.
+
+### 4. Build the brief by route
+
+Resolve the elected format to its route per `publish-routing.md`:
+
+- **`slides` / `web-poster` → consult-native outline brief.** Consult
+  deliverables are framework-shaped (Pyramid / SCQA / MECE), not arc-shaped, so
+  this path does **not** dispatch `cogni-visual:story-to-slides` /
+  `story-to-web` and does **not** re-narrate through `cogni-narrative` —
+  arc-ifying a framework-shaped deliverable weakens its executive register.
+  Instead, derive the outline directly from the deliverable's own structure: an
+  ordered list of `{section_title, section_body}` entries, citations preserved.
+  - The Pyramid answer / governing thought becomes the opening (title slide or
+    hero section).
+  - Each MECE group / SCQA movement becomes one section entry, in the
+    deliverable's own order.
+  - Supporting evidence and citations are carried into the corresponding
+    section body — never dropped.
+  Write the outline alongside the deliverable at
+  `action-fields/<field-slug>/publish/<deliverable-slug>-outline.md`. This plain
+  title-and-description outline is exactly what Claude Design's presentation
+  generator consumes.
+
+- **`report` → `cogni-visual:enrich-report`.** A finished markdown deliverable
+  needs no arc; `enrich-report` post-processes it into a themed visual report.
+
+  ```
+  Skill: cogni-visual:enrich-report
+    source_path: action-fields/<field-slug>/<deliverable-slug>.md
+  ```
+
+  `source_path` is the only required input; the enriched output lands by default
+  at `action-fields/<field-slug>/output/<deliverable-slug>-enriched.html`.
+
+- **`infographic` → `cogni-visual:story-to-infographic`.** Distils a single-page
+  infographic from the deliverable's prose.
+
+  ```
+  Skill: cogni-visual:story-to-infographic
+    source_path: action-fields/<field-slug>/<deliverable-slug>.md
+  ```
+
+  It emits an `infographic-brief.md` and auto-renders it. Pass a `style_preset`
+  (`editorial`, `data-viz`, `economist`, `corporate`, …) when the consultant has
+  a house look in mind.
+
+**Graceful degradation.** When `cogni-visual` is not installed, the `report`
+and `infographic` routes cannot run — skip the dispatch with a one-line note
+naming the absent plugin, and offer the consult-native outline brief instead so
+the consultant still leaves with a usable artifact. Never fail the run because a
+downstream plugin is missing.
+
+### 5. Record the publish lineage in field.json
+
+Store the brief as a **path reference plus lineage** on the deliverable entry —
+never copy brief content into consult state. Mirroring the source-lineage
+contract, the deliverable and its downstream brief are linked by path, so an
+upstream correction stays visible downstream without duplication.
+
+Add (append) one entry to the deliverable's `publish` array in
+`action-fields/<field-slug>/field.json` via a direct `Edit` — the field.json
+seam needs no script (`engagement-status.sh` passes every deliverable field
+through verbatim). Shape:
+
+```json
+"publish": [
+  {
+    "format": "slides",
+    "brief_path": "action-fields/<field-slug>/publish/<deliverable-slug>-outline.md",
+    "route_steps": ["consult-native-outline", "copywriter:tone"],
+    "source_deliverable": "<deliverable-slug>",
+    "published_at": "<ISO-8601 timestamp>"
+  }
+]
+```
+
+`brief_path` is the route's output path (the outline for slides/web-poster, or
+the enriched/infographic output path for the visual routes). `route_steps`
+records the dispatch chain actually run (including a skipped polish, noted as
+such). Because `publish` is an array, publishing a second format **appends** a
+new entry rather than overwriting the first.
+
+### 6. Print the Claude Design handoff
+
+End by pointing the consultant at the handoff: the brief's path **is** the
+handoff. Print the brief path and the one-line instruction — hand the brief to
+Claude Design (claude.ai/design) to render it in your design system. cogni-consult
+stops at the brief; Claude Design renders and applies brand.
+
+If multiple formats were produced in this session, list each brief path.
+
+## Important Notes
+
+- **Elected, never automatic.** This skill runs only on explicit consultant
+  invocation against a `complete` deliverable. It must never be auto-fired from
+  the `consult-design-thinking` loop or any other skill's close step — those may
+  *point* to it, but the consultant elects it.
+- **Path reference, not content copy.** The brief is stored as a `brief_path` in
+  `field.json`; brief content is never duplicated into consult state. The link
+  is the path, so corrections cascade without drift.
+- **The plugin's responsibility ends at the brief.** Rendering and brand
+  application happen in Claude Design. This skill produces no rendered artifact
+  and owns no theme.
+- **Graceful degradation.** When `cogni-visual` is absent, the report and
+  infographic routes are skipped (offer the consult-native outline instead);
+  when `cogni-copywriting` is absent, the polish step is skipped. Either way the
+  run still produces a valid brief — a missing downstream plugin degrades the
+  output, it never fails the run.
+- **Framework-shaped, not arc-shaped.** The slides/web-poster route builds the
+  outline directly from the deliverable's framework (Pyramid/MECE/SCQA). It does
+  not arc-ify and does not dispatch the arc-optimized cogni-visual story skills —
+  that is a deliberate quality choice, not an omission.

--- a/cogni-consult/skills/consult-resume/SKILL.md
+++ b/cogni-consult/skills/consult-resume/SKILL.md
@@ -134,7 +134,11 @@ Branch on the derived state, first match wins, and say *why*:
   it names a different skill).
 - **Everything is `complete`** → say so — the engagement is complete by
   derivation — and offer `consult-action-fields` to extend the WBS if the
-  consultant wants to add fields or deliverables.
+  consultant wants to add fields or deliverables. A `complete` deliverable can
+  also be published with `/cogni-consult:consult-publish` — turn it into a
+  presentation-ready brief (slides, web-poster, report, or infographic) for
+  Claude Design. Surface this only as an offer when the consultant elects it,
+  not as a standing menu item or an automatic next step.
 
 Three further offers surface only when the consultant's request or a deliverable's
 state calls for them — not as standing menu items:


### PR DESCRIPTION
Closes #824.

Adds `consult-publish`, an opt-in skill that turns a completed cogni-consult deliverable into a clean **brief** the consultant hands to Claude Design (claude.ai/design) to render in their own design system. The skill executes the already-merged `publish-routing.md` contract rather than re-deriving routing.

## Summary
- New skill `cogni-consult/skills/consult-publish/SKILL.md`: reads `action-fields/<field-slug>/<deliverable-slug>.md`, resolves the consultant-elected format against `references/publish-routing.md`, and builds the brief.
  - **slides / web-poster** → consult-native outline brief built directly from the deliverable's framework structure (Pyramid governing thought → opening; MECE groups / SCQA movements → one section each; citations preserved), written to `action-fields/<field-slug>/publish/<deliverable-slug>-outline.md`. No arc-ify hop, no `story-to-slides` / `story-to-web` / `cogni-narrative` dispatch.
  - **report** → `cogni-visual:enrich-report`; **infographic** → `cogni-visual:story-to-infographic`. Neither needs an arc.
  - Optional voice polish via `cogni-copywriting:copywriter --scope=tone`, graceful-degrading.
- Stores a **path reference** plus lineage (format, brief_path, route_steps, source_deliverable, published_at) in the deliverable's new `publish[]` array in `field.json` via the existing Edit seam — brief content is never copied into consult state.
- Covers all four formats and supports producing multiple formats per deliverable (append to `publish[]`).
- Consultant-elected: runs only when the deliverable `state == "complete"`, and is never wired as an automatic post-test callback inside the design-thinking loop.
- Degrades gracefully: when `cogni-visual` is absent, skip the format route and produce the consult-native outline brief only; when `cogni-copywriting` is absent, skip the polish — the route still produces a valid brief.
- Documents the `publish[]` key in `references/data-model.md`.
- Discoverability pointers (elected, not auto): a one-line pointer in `consult-resume`'s "everything complete" branch and in `consult-design-thinking`'s "Close the Session" step.
- Version: `cogni-consult` 0.1.22 → 0.1.23 in `plugin.json` and mirrored in `marketplace.json`.

## Scope decisions
- **In:** the full skill (all four formats + multi-format), the `publish[]` field.json seam + its data-model doc, both discoverability pointers, version bumps. This is the whole issue → `Closes #824`.
- **Out (by design, not deferred):** README sections are cogni-docs auto-generated surfaces — regenerated by `doc-generate`, not hand-edited here. No new routing reference is authored: `publish-routing.md` already exists on main. Rendering and brand stay out of plugin scope — the skill stops at the brief path.

## Test plan
- [x] Skill frontmatter validates (`name`, multiline `description`, `allowed-tools`); passes `check-skill-names.sh`.
- [x] SKILL.md references the routing contract via `$CLAUDE_PLUGIN_ROOT/references/publish-routing.md` and does not restate the routing table.
- [x] SKILL.md body carries no issue/PR/version breadcrumbs (`check-breadcrumbs.py` clean).
- [x] SKILL.md states the state==complete guard and the never-auto-fire rule explicitly.
- [x] SKILL.md states both graceful-degradation fallbacks (cogni-visual absent, cogni-copywriting absent) in prose.
- [x] `references/data-model.md` documents the `publish[]` array shape.
- [x] `consult-resume` and `consult-design-thinking` each carry a one-line elected pointer.
- [x] `plugin.json` and `marketplace.json` both read `0.1.23`.

Part of epic #827 (phase 1).