### PR TITLE
cogni-consult: surface deliverable publish state on dashboard + resume

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -35,7 +35,7 @@
     {
       "name": "cogni-consult",
       "source": "./cogni-consult",
-      "version": "0.1.23",
+      "version": "0.1.24",
       "maturity": "preview",
       "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
       "keywords": [

--- a/cogni-consult/.claude-plugin/plugin.json
+++ b/cogni-consult/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-consult",
-  "version": "0.1.23",
+  "version": "0.1.24",
   "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-consult/skills/consult-dashboard/SKILL.md
+++ b/cogni-consult/skills/consult-dashboard/SKILL.md
@@ -123,14 +123,19 @@ The generated HTML is a single self-contained page with these sections:
    with the current stage highlighted), and its persona-review status. A deliverable that an
    upstream change has invalidated (`lineage_status.status: "stale"`) carries a **stale badge**
    next to its state, and a deliverable with declared dependencies shows a **`⤴ depends on`**
-   hint listing the upstream deliverables to refresh first.
+   hint listing the upstream deliverables to refresh first. A deliverable that has been published
+   via `consult-publish` shows a **`📤` publish sub-row** — one chip per published format naming
+   the format, the brief path, and the publish date, with a **`→ render in Claude Design`** pointer
+   (hand the brief to claude.ai/design to render). An unpublished deliverable shows no sub-row.
 4. **Knowledge base** — the bound knowledge-base slug and the count of research synthesis files
    across scope and action fields.
 5. **Next action** — a single recommended next step derived from scope state and deliverable
    states. Stale deliverables take precedence: when any exist, the recommendation is to refresh
    them upstream-first (the layer-0 deliverable in the topological refresh order) before any
    pending or in-progress work; otherwise it falls through to finish scoping / continue an
-   in-progress deliverable / start the next one / assemble the output.
+   in-progress deliverable / start the next one / — once everything is complete — publish a
+   complete-but-unpublished deliverable with `consult-publish`, or (when all are published) hand
+   the briefs to Claude Design to render.
 6. **Refresh order** — appears when deliverables are stale: the stale set grouped into
    topological layers (layer 0 first — safe to refresh now, since nothing else stale depends on
    it; deeper layers become reliable once the layer above is refreshed). When nothing is stale it

--- a/cogni-consult/skills/consult-dashboard/SKILL.md
+++ b/cogni-consult/skills/consult-dashboard/SKILL.md
@@ -126,7 +126,7 @@ The generated HTML is a single self-contained page with these sections:
    hint listing the upstream deliverables to refresh first. A deliverable that has been published
    via `consult-publish` shows a **`📤` publish sub-row** — one chip per published format naming
    the format, the brief path, and the publish date, with a **`→ render in Claude Design`** pointer
-   (hand the brief to claude.ai/design to render). An unpublished deliverable shows no sub-row.
+   (hand the brief to Claude Design to render). An unpublished deliverable shows no sub-row.
 4. **Knowledge base** — the bound knowledge-base slug and the count of research synthesis files
    across scope and action fields.
 5. **Next action** — a single recommended next step derived from scope state and deliverable

--- a/cogni-consult/skills/consult-dashboard/scripts/generate-dashboard.py
+++ b/cogni-consult/skills/consult-dashboard/scripts/generate-dashboard.py
@@ -320,7 +320,20 @@ def next_action(eng, summary, refresh=None, deliv_index=None):
         if not f["deliverables"]:
             return f"Plan deliverables for {f['title']} (consult-action-fields)."
     if summary["engagement_state"] == "complete":
-        return "All deliverables complete — review with acting personas and assemble the engagement output."
+        unpublished = [
+            d
+            for f in eng["action_fields"]
+            for d in f["deliverables"]
+            if d.get("state") == "complete" and not (d.get("publish") or [])
+        ]
+        if unpublished:
+            first = unpublished[0]
+            title = first.get("title") or first.get("slug")
+            return (
+                f"All deliverables complete — publish “{title}” with consult-publish "
+                f"to produce a presentation-ready brief, then hand it to Claude Design to render."
+            )
+        return "All deliverables complete and published — hand the briefs to Claude Design (claude.ai/design) to render."
     return "Review the engagement status."
 
 
@@ -372,6 +385,32 @@ def framework_cell(cf):
     return f'<span class="fw-chip" title="Structuring framework">{esc(text)}</span>'
 
 
+def render_publish_row(publish_list):
+    """Read-only display of the deliverable's stored publish lineage — one chip
+    per format the consultant has published via consult-publish. Each chip names
+    the format, the brief path, and the publish date, with a static pointer to
+    hand the brief to Claude Design for rendering. Absent/empty publish[] renders
+    nothing, so unpublished deliverables look exactly as before."""
+    entries = [p for p in (publish_list or []) if isinstance(p, dict)]
+    if not entries:
+        return ""
+    chips = []
+    for p in entries:
+        fmt = p.get("format") or "—"
+        brief_path = p.get("brief_path") or ""
+        date = (p.get("published_at") or "")[:10]
+        path_html = (
+            f'<code class="publish-chip" title="Brief path (hand to Claude Design)">{esc(brief_path)}</code>'
+            if brief_path else ""
+        )
+        date_html = f'<span class="dt-label">{esc(date)}</span>' if date else ""
+        chips.append(
+            f'<span class="publish-entry">{badge(fmt, "info")}{path_html}{date_html}</span>'
+        )
+    pointer = '<span class="publish-cta" title="Hand this brief to claude.ai/design">→ render in Claude Design</span>'
+    return f'<div class="deliv-publish" title="Published briefs">📤 {"".join(chips)}{pointer}</div>'
+
+
 def render_field_card(field):
     delivs = field["deliverables"]
     rows = []
@@ -391,9 +430,10 @@ def render_field_card(field):
         if dep_labels:
             chips = "".join(f'<span class="dep-chip">{l}</span>' for l in dep_labels)
             dep_hint = f'<div class="deliv-deps" title="Depends on (refresh these first)">⤴ depends on {chips}</div>'
+        publish_row = render_publish_row(d.get("publish"))
         rows.append(
             '<div class="deliv-row">'
-            f'<div class="deliv-title">{esc(d.get("title") or d.get("slug"))}{dep_hint}</div>'
+            f'<div class="deliv-title">{esc(d.get("title") or d.get("slug"))}{dep_hint}{publish_row}</div>'
             f'<div class="deliv-state">{badge(st, STATE_ROLE.get(st, "muted"))}{stale_badge}</div>'
             f'<div class="deliv-dt">{dt_indicator(d.get("dt_stage"))}</div>'
             f'<div class="deliv-framework">{framework_cell(d.get("chosen_framework"))}</div>'
@@ -542,6 +582,10 @@ header.hero .hero-meta {{ margin-top: 1rem; display: flex; flex-wrap: wrap; gap:
 .deliv-title {{ font-size: .92rem; font-weight: 500; }}
 .deliv-deps {{ font-size: .72rem; color: var(--text-muted); margin-top: .2rem; display: flex; flex-wrap: wrap; align-items: center; gap: .25rem; }}
 .dep-chip {{ background: var(--surface2); border: 1px solid var(--border); border-radius: 999px; padding: .02rem .4rem; font-family: var(--font-mono); font-size: .68rem; }}
+.deliv-publish {{ font-size: .72rem; color: var(--text-muted); margin-top: .2rem; display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; }}
+.publish-entry {{ display: inline-flex; align-items: center; gap: .3rem; flex-wrap: wrap; }}
+.publish-chip {{ background: var(--surface2); border: 1px solid var(--border); border-radius: 6px; padding: .02rem .4rem; font-family: var(--font-mono); font-size: .68rem; color: var(--text-muted); }}
+.publish-cta {{ color: var(--accent); font-size: .7rem; white-space: nowrap; }}
 .deliv-state {{ display: flex; align-items: center; gap: .35rem; flex-wrap: wrap; }}
 .stale-mark {{ display: inline-flex; }}
 .deliv-framework {{ display: flex; align-items: center; justify-content: flex-end; }}

--- a/cogni-consult/skills/consult-resume/SKILL.md
+++ b/cogni-consult/skills/consult-resume/SKILL.md
@@ -134,15 +134,10 @@ Branch on the derived state, first match wins, and say *why*:
   it names a different skill).
 - **Everything is `complete`** → say so — the engagement is complete by
   derivation — and offer `consult-action-fields` to extend the WBS if the
-  consultant wants to add fields or deliverables. Then read each deliverable's
-  `publish[]` lineage and offer the matching next step: a `complete` deliverable
-  with absent/empty `publish[]` can be published with
-  `/cogni-consult:consult-publish` — turn it into a presentation-ready brief
-  (slides, web-poster, report, or infographic); a deliverable that already
-  carries `publish[]` entries is ready to render — name its `brief_path`(s) and
-  point the consultant to hand them to Claude Design (claude.ai/design). Surface
-  these only as offers when the consultant elects them, not as a standing menu
-  item or an automatic next step.
+  consultant wants to add fields or deliverables. Per-deliverable publish/render
+  next steps follow the publish offer below (read each `complete` deliverable's
+  `publish[]` and offer `consult-publish` or the Claude Design handoff) — surface
+  them only as elect-only offers, never as a standing menu item.
 
 Four further offers surface only when the consultant's request or a deliverable's
 state calls for them — not as standing menu items:

--- a/cogni-consult/skills/consult-resume/SKILL.md
+++ b/cogni-consult/skills/consult-resume/SKILL.md
@@ -134,13 +134,17 @@ Branch on the derived state, first match wins, and say *why*:
   it names a different skill).
 - **Everything is `complete`** → say so — the engagement is complete by
   derivation — and offer `consult-action-fields` to extend the WBS if the
-  consultant wants to add fields or deliverables. A `complete` deliverable can
-  also be published with `/cogni-consult:consult-publish` — turn it into a
-  presentation-ready brief (slides, web-poster, report, or infographic) for
-  Claude Design. Surface this only as an offer when the consultant elects it,
-  not as a standing menu item or an automatic next step.
+  consultant wants to add fields or deliverables. Then read each deliverable's
+  `publish[]` lineage and offer the matching next step: a `complete` deliverable
+  with absent/empty `publish[]` can be published with
+  `/cogni-consult:consult-publish` — turn it into a presentation-ready brief
+  (slides, web-poster, report, or infographic); a deliverable that already
+  carries `publish[]` entries is ready to render — name its `brief_path`(s) and
+  point the consultant to hand them to Claude Design (claude.ai/design). Surface
+  these only as offers when the consultant elects them, not as a standing menu
+  item or an automatic next step.
 
-Three further offers surface only when the consultant's request or a deliverable's
+Four further offers surface only when the consultant's request or a deliverable's
 state calls for them — not as standing menu items:
 
 - **The consultant names an already-`complete` deliverable to revisit or
@@ -171,6 +175,15 @@ state calls for them — not as standing menu items:
   acting on a finding is a separate `consult-design-thinking` rework. Surface
   this only when the conformance question is relevant to the next action, not
   as a standing audit of every complete deliverable.
+- **A `complete` deliverable (its `persona_review` closed) is unpublished, or
+  published but not yet rendered** → offer the publish / render next step from
+  its `publish[]` lineage, even before the whole engagement is complete: an
+  empty/absent `publish[]` → offer `/cogni-consult:consult-publish` to produce a
+  presentation-ready brief; a populated `publish[]` → name its `brief_path`(s)
+  and point the consultant to hand them to Claude Design (claude.ai/design) to
+  render. This is read-only over `publish[]` — `consult-publish` owns brief
+  production; resume only routes. Surface it only when the consultant elects it
+  or names that deliverable, never as a standing menu item.
 
 Recommend one action, not a menu. On the consultant's confirmation, dispatch
 the named skill via `Skill(...)` with the engagement path as the in-session


### PR DESCRIPTION
Closes #825.

## Summary
- Add a `render_publish_row(publish_list)` helper to `generate-dashboard.py` rendering a publish sub-row inside each `.deliv-row` (a `format` badge, the `brief_path` in a `<code class="publish-chip">`, the `published_at` date, and a static "→ render in Claude Design" pointer per published format); returns `""` when `publish[]` is absent/empty so unpublished deliverables look unchanged.
- Add `.deliv-publish` / `.publish-entry` / `.publish-chip` / `.publish-cta` CSS near the existing `.deliv-deps` rule.
- Teach `next_action()` to name a complete-but-unpublished deliverable and suggest `consult-publish` when the engagement is complete (and, when all are published, point to Claude Design), instead of the generic assemble-the-output line.
- Fold per-deliverable publish routing into the `consult-resume` step-5 waterfall: the "Everything is complete" bullet now reads each deliverable's `publish[]` and offers `consult-publish` (unpublished) or names the brief path + Claude Design handoff (published); plus a fourth elect-only "further offer" for a single complete deliverable that is unpublished or published-not-rendered.
- Document the new publish sub-row (§3) and update the Next-action fall-through description (§5) in `consult-dashboard` SKILL.md.
- Bump cogni-consult 0.1.23 → 0.1.24 in plugin.json and mirror in marketplace.json.

## Scope decisions
- Full read-only surfacing of `publish[]` across both surfaces (dashboard + resume) shipped together as one reviewable change — they read the same lineage and share the schema, so splitting would orphan half the surfacing.
- `consult-dashboard-refresher.md` is unchanged: it only re-runs the generator and opens the browser, so it picks up the new sub-row automatically (confirmed, no edit).
- No change to how briefs are produced (that is #824's surface); this child is read-only over the `publish[]` lineage.
- No script API/contract change — `publish[]` already flows through `load_engagement()` verbatim.

## Test plan
- [x] `generate-dashboard.py` renders the publish sub-row (format badge, brief path, date, Claude Design pointer) for a deliverable with `publish[]` entries — verified via fixture render.
- [x] A deliverable with absent/empty `publish[]` renders with no sub-row (verified: exactly 1 sub-row for 1 published deliverable in a 2-deliverable fixture).
- [x] A multi-format deliverable renders one chip per `publish[]` entry (slides + infographic both rendered).
- [x] `next_action()` names a complete-but-unpublished deliverable and suggests `consult-publish`; when all published, points to Claude Design (both branches unit-tested).
- [x] plugin.json and marketplace.json both show 0.1.24.
- [x] `scripts/check-breadcrumbs.py` passes (0 violations).