### PR TITLE
cogni-consult: optional presentation-intent layer on the slides outline brief

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -35,7 +35,7 @@
     {
       "name": "cogni-consult",
       "source": "./cogni-consult",
-      "version": "0.1.26",
+      "version": "0.1.27",
       "maturity": "preview",
       "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
       "keywords": [

--- a/cogni-consult/.claude-plugin/plugin.json
+++ b/cogni-consult/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-consult",
-  "version": "0.1.26",
+  "version": "0.1.27",
   "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-consult/references/publish-routing.md
+++ b/cogni-consult/references/publish-routing.md
@@ -67,6 +67,57 @@ The brief is a plain title-and-description outline — exactly what Claude Desig
 presentation generator consumes. Write it alongside the deliverable, e.g.
 `action-fields/<field-slug>/publish/<deliverable-slug>-outline.md`.
 
+#### Optional presentation-intent layer
+
+The `{section_title, section_body}` outline above optimizes for **narrative
+completeness** and is the only required shape — a brief with nothing more than
+those entries is valid and renders. But on its own it leaves the downstream
+renderer (Claude Design) to guess two things every deck needs settled up front:
+the **design register**, and **what belongs on the slide vs. in the talk-track**.
+That guessing turns into a clarify-then-build round before the deck can be built.
+
+To skip that round and let the deck build in one pass, the author **may** layer a
+thin **presentation-intent** annotation on top of the same content. It is
+**optional and additive** — omit any piece and the brief still renders; the
+narrative-completeness strength is never traded away. The author (not the
+renderer) owns the slide-vs-notes and emphasis decisions. The five pieces:
+
+1. **`design:` front-matter block** — a small block at the head of the brief
+   declaring the deck's design intent, so the renderer does not ask. Fields, all
+   optional with sensible defaults:
+   - `register` — the visual/tonal register (e.g. `quiet-executive`, `bold`).
+     Default: the deliverable's own register (executive/Pyramid).
+   - `dark_slides: [...]` — slide numbers to render dark, as rhythm anchors
+     (e.g. section breaks, the climax). Default: none.
+   - `speaker_notes` — the speaker-notes style (e.g. `full-script`,
+     `calm peer-to-peer`, `bullets`). Default: bullets.
+   - `imagery` — imagery direction (e.g. `none`, `type-only`, `photographic`).
+     Default: `none`.
+   - `variations` — how many design variations to generate. Default: 1.
+2. **Per-slide `slide_points` vs. `talk_track` split** — instead of one
+   `section_body` that blends wall copy with presenter rationale, split the entry
+   into `slide_points` (3–4 short on-slide lines, max) and `talk_track` (the
+   reasoning the presenter speaks). This moves the on-slide-vs-notes distillation
+   decision into the brief. When the split is omitted, `section_body` stands as
+   before — the renderer distills it.
+3. **Per-slide `type:` tag** — declares the intended visual treatment instead of
+   leaving the renderer to infer it (so a quote slide is not built as bullets).
+   One of: `cover`, `bluf`, `two-column`, `table`, `timeline`, `quote`, `metric`,
+   `roles`. Default: inferred from the section content, as today.
+4. **`key_figures:`** — a brief-level list promoting the hero numbers out of
+   prose (e.g. `~25 auditors`, `8–10 shortlist`, `240 min`, `≥80% return`,
+   `~30 backlog`) so the renderer can build big-number moments rather than
+   burying them in body text. Default: none (numbers stay inline).
+5. **Climax and TBD marks** — name the point slide for emphasis (e.g.
+   `climax: slide 11` — the asks), and flag genuine placeholders
+   (`tbd: ["CO-1…4 staffing", "confirm exact title"]`) so the renderer treats
+   them as open vs. settled copy. Default: none.
+
+**Keep, regardless of the layer:** the meta-instruction `note:` line (e.g.
+"render citations as footnotes / speaker notes") and the **"design is frozen"**
+framing — both proved useful in real handoffs; favor more of that over reasoning
+prose buried inside bullets.
+
 ### report → consult-native report-outline brief
 
 A report deliverable is already framework-shaped prose, so — exactly like the

--- a/cogni-consult/skills/consult-publish/SKILL.md
+++ b/cogni-consult/skills/consult-publish/SKILL.md
@@ -110,6 +110,15 @@ order, supporting evidence carried into the matching section body (never
 dropped). The plain title-and-description outline is exactly what Claude
 Design's presentation generator consumes.
 
+The author may additionally layer the **optional presentation-intent**
+annotation on this outline — a `design:` front-matter block, a per-slide
+`slide_points`/`talk_track` split, a per-slide `type:` tag, brief-level
+`key_figures:`, and climax/TBD marks — so the deck builds in one renderer pass
+instead of a clarify-then-build round. It is optional and additive: a brief
+without it still renders. Build it per the **Optional presentation-intent
+layer** subsection in `publish-routing.md` (the canonical schema) — do not
+restate the field shape here.
+
 **The `report` and `infographic` routes** are built here too, not dispatched —
 derive a consult-native brief directly from the deliverable's framework (a
 report-outline brief, or an infographic brief of headline + hero facts + MECE


### PR DESCRIPTION
Closes #834.

## Summary
- Extend the canonical `slides`/`web-poster` consult-native outline-brief contract in `references/publish-routing.md` with an **optional, additive** presentation-intent layer on top of the existing `{section_title, section_body}` content, so a deck builds in one Claude Design pass instead of a clarify-then-build round.
- The layer adds: a `design:` front-matter block (register, `dark_slides:` rhythm anchors, speaker-notes style, imagery, variations count); a per-slide split into `slide_points` (3–4 short on-slide lines) and `talk_track` (the reasoning); a per-slide `type:` tag (cover / bluf / two-column / table / timeline / quote / metric / roles); a `key_figures:` block promoting hero numbers out of prose; and explicit marks for the climax/point slide and real TBD placeholders vs. settled copy.
- Keep the existing `note:` meta-instruction line and the "design is frozen" framing — both proved useful in a real handoff.
- Sync `skills/consult-publish/SKILL.md` step 4 to **name** the optional layer and point at the reference, without restating the schema (preserves the single-source-of-truth contract).
- Bump `cogni-consult` 0.1.26 → 0.1.27 in `plugin.json` and mirror in `marketplace.json`.

## Scope decisions
- **In:** the brief-schema extension in its canonical reference, the execution-summary pointer sync in SKILL.md, and the version bump. The author (not the renderer) owns the slide-vs-notes distillation and emphasis decisions, per the issue.
- The layer is strictly **optional and additive**: the reference documents defaults and states explicitly that a brief omitting the layer is still valid and renders (narrative-completeness strength preserved).
- **Out** (verified no change needed): `references/data-model.md` publish[] lineage (records `brief_path`, never brief content), `deliverable-types.md` (format affinity, not brief schema), `engagement-status.sh` and all other scripts (none parse brief content), and README §4 (auto-generated). No tests/fixtures cover the brief shape.
- No decomposition: a single coherent extension of one schema, one reviewable PR.

## Test plan
- [x] `publish-routing.md` slides/web-poster section documents all five layer elements + retains the `note:`/"design is frozen" framing.
- [x] The reference states the layer is optional/additive and that a brief without it still renders (defaults documented).
- [x] `consult-publish/SKILL.md` step 4 names the optional layer and points back to `publish-routing.md`; does not restate the field schema.
- [x] `plugin.json` is `0.1.27` and the `marketplace.json` cogni-consult entry mirrors `0.1.27` (UTF-8 preserved, JSON valid).
- [x] `check-skill-names.sh` passes; breadcrumb guard passes (0 violations).

Complements the now-merged #832 (#833), which made the consult-native brief the standard handoff for every format; this makes that brief render-ready in one pass.

Plan record: https://github.com/cogni-work/insight-wave/issues/834#issuecomment-4720910565