### PR TITLE
cogni-knowledge: make the fetch-cache snippet-grounding contract explicit

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "cogni-knowledge",
       "source": "./cogni-knowledge",
-      "version": "1.0.11",
+      "version": "1.0.12",
       "maturity": "released",
       "description": "Wiki-first research that compounds. Binds each run to a wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`. The shallow `knowledge-query` rung is read-only by default and can optionally file its answer back as an un-verified synthesis page via `--file-back`.",
       "keywords": [

--- a/cogni-knowledge/.claude-plugin/plugin.json
+++ b/cogni-knowledge/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-knowledge",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "Wiki-first research that compounds. Binds each run to a wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`. The shallow `knowledge-query` rung is read-only by default and can optionally file its answer back as an un-verified synthesis page via `--file-back`.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-knowledge/agents/source-curator.md
+++ b/cogni-knowledge/agents/source-curator.md
@@ -229,7 +229,7 @@ If **no saved-file path is found** in the WebFetch output (the EUR-Lex case empi
 Otherwise, on a non-empty body:
 
 1. Write the fetched body to a temp file (use `mktemp`; remove on exit).
-2. Store it (same `fetch-cache.py store` invocation as the PDF branch above, `--fetch-method webfetch --status ok`).
+2. Store it (same `fetch-cache.py store` invocation as the PDF branch above, `--fetch-method webfetch --status ok`). The stored body is the WebFetch return value — a summarized extract, not the full HTML source; see `references/fetch-cache-design.md` §"Body fidelity and grounding contract" for what downstream grounding rests on.
 3. Attach `fetch.status: "ok"` with the returned `cache_key` + `content_hash`.
 
 On WebFetch failure (timeout, 4xx, 5xx, blocked, refusal) → proceed to Step 4. **Do not cobrowse** — that is Phase 3's opt-in job; you have no browser tools.

--- a/cogni-knowledge/references/fetch-cache-design.md
+++ b/cogni-knowledge/references/fetch-cache-design.md
@@ -21,7 +21,7 @@ One canonical cache per knowledge base, shared across all projects under that ba
   "content_hash": "sha256:<hex>",
   "fetch_method": "webfetch",
   "status": "ok",
-  "body": "<full text of the page, as fetched>",
+  "body": "<body as returned by WebFetch — a summarized/extracted representation, typically 300-1200 words, not the full HTML source>",
   "publisher": "europa.eu",
   "http_status": 200,
   "etag": "...",
@@ -34,6 +34,22 @@ One canonical cache per knowledge base, shared across all projects under that ba
 **`direct` — non-web sources.** `webfetch` and `cobrowse_interactive` are the two web-fetch outcomes (an automated `WebFetch`, or an interactive Claude-in-Chrome recovery). `direct` records a source whose bytes are already in hand and were never fetched over the network — a local file (`.docx`/`.html`/`.txt`), pasted text, a local PDF, or a local interview note. It is the honest provenance value for `knowledge-ingest-source`'s local-input path. A `direct` entry is always `status: ok` (the body exists by definition), so it never carries a `webfetch_*`/negative-cache `reason` — the negative-cache machinery is web-only.
 
 `status ∈ {ok, unavailable}`. An unavailable entry is recorded for negative caching — repeated fetches against a known-dead URL within the freshness window short-circuit to the cached `unavailable` verdict. `direct` entries are never `unavailable`.
+
+## Body fidelity and grounding contract
+
+The cached `body` for a `webfetch` entry is **the value WebFetch returns — a tool-generated extract of the page, not its full HTML source**. WebFetch summarizes and truncates: in practice an `ok` body is typically 300–1200 words, even when the underlying document is a 40+-page PDF or a long regulatory text. This is the deliberate, documented grounding contract, not a defect in the cache: `fetch-cache.py store` is a body-agnostic pass-through (it stores exactly the string it is handed), and `source-curator` (Phase 2) hands it the raw WebFetch return. The cache neither summarizes nor re-fetches.
+
+Everything downstream grounds on this extract:
+
+- **claim extraction** (`source-ingester` → `claim-extractor`, Phase 4) reads the cached body to populate `pre_extracted_claims:`;
+- **composition** (`wiki-composer`, Phase 5) cites those claims;
+- **verification** (`wiki-verifier`, Phase 6) scores citations against them.
+
+For the large majority of sources this is sufficient — WebFetch returns the page's primary informational content, and the wiki **compounds** claims across runs and across sources (see [`differentiation-thesis.md` §"The compounding loop"](differentiation-thesis.md)), so a single source's extract is rarely the whole evidentiary picture for a synthesis. The deliberate trade-off: a source ingested once contributes its extracted claims to the wiki for every future run, rather than being re-fetched in full each time.
+
+The documented limitation: for **high-authority `primary`-tier sources** — legal normative text, dense regulatory annexes, multi-page statutes — the WebFetch extract may omit sections, which bounds claim-extraction completeness and is a real (documented) correctness consideration: a claim extracted from an extract may miss nuance present only in the omitted full text.
+
+A **fuller-body capture path** — interactive cobrowse, or a dedicated full-text `fetch_method` — for `primary`-tier sources is the deferred alternative. It would add per-fetch cost and (for cobrowse) session interactivity, so whether the improved completeness on primary sources is worth that cost is a **maintainer cost/benefit decision**, not a silent default. This contract documents the current snippet-grounding behavior; it does not foreclose adding such a path later.
 
 ## Cache-key choice: URL, not content
 


### PR DESCRIPTION
Closes #839.

## Summary
- Corrects the misleading `"body": "<full text of the page, as fetched>"` schema comment in `references/fetch-cache-design.md` — the cached body is the WebFetch tool's returned value, a summarized/extracted representation (typically ~300–1200 words), not the full document text.
- Adds a new `## Body fidelity and grounding contract` subsection stating that (1) the cached body is the raw WebFetch return value — a tool-generated extract, not full HTML; (2) all downstream consumers (claim extraction in `source-ingester`, composition in `wiki-composer`, verification in `wiki-verifier`) ground on this extract; (3) for most sources WebFetch returns the page's primary informational content, which is sufficient; (4) for high-authority primary sources (legal normative text, dense regulatory annexes) the extract may omit sections, a documented correctness limitation that bounds claim-extraction completeness; (5) the fuller-body capture path is the deferred enhancement now tracked in #853.
- Cross-references `references/differentiation-thesis.md` §"The compounding loop" for why snippet-grounding is acceptable (the wiki compounds claims across runs).
- Adds one cross-reference line in `agents/source-curator.md` (Phase 4 non-PDF branch) pointing at the new grounding-contract section.
- Patch version bump 1.0.14 → 1.0.15 (docs-only changes still require a bump per CLAUDE.md), mirrored in `marketplace.json`.

## Scope decisions
- **In (option a):** documenting the snippet-grounding contract explicitly — the smallest defensible increment, which closes the "silent default" gap the issue identifies (the contract is now stated, not implicit).
- **No code change:** `fetch-cache.py cmd_store` is a body-agnostic pass-through (`body = args.body or ""`); WebFetch is the summarizer. The cache is not the cause, so no behavior changes.
- **Out (option b → #853):** adding a fuller-body capture path (cobrowse-interactive or full-text `fetch_method`) for `primary`-tier sources. Approved as future work and spun out to #853; documenting current behavior does not foreclose it.

## Test plan
- [x] `references/fetch-cache-design.md` no longer claims the body is "full text"; the schema comment describes it as a WebFetch summary/extract.
- [x] A new `## Body fidelity and grounding contract` subsection exists, names the three downstream consumers, states the primary-source completeness limitation, and points at option (b) as deferred (#853).
- [x] The subsection cross-references `references/differentiation-thesis.md` §"The compounding loop".
- [x] `agents/source-curator.md` carries one cross-reference line near its WebFetch-body store call.
- [x] `plugin.json` version and the `cogni-knowledge` marketplace.json entry are both 1.0.15 and match.
- [x] Breadcrumb guard clean (0 new violations); both manifests valid JSON.
- [x] No script, skill, or agent behavior changed (docs + version only).

## Deferred (planned)
Option (b) — the fuller-body capture path for high-authority `primary`-tier sources — is **approved as future work** and tracked in **#853**. This PR documents the current snippet-grounding contract (option a) and does not build the capture path; the documented limitation does not foreclose adding it later.