### PR TITLE
cogni-knowledge: skip dead prefilter under executive density + see finalize phase

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "cogni-knowledge",
       "source": "./cogni-knowledge",
-      "version": "1.0.11",
+      "version": "1.0.12",
       "maturity": "released",
       "description": "Wiki-first research that compounds. Binds each run to a wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`. The shallow `knowledge-query` rung is read-only by default and can optionally file its answer back as an un-verified synthesis page via `--file-back`.",
       "keywords": [

--- a/cogni-knowledge/.claude-plugin/plugin.json
+++ b/cogni-knowledge/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-knowledge",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "Wiki-first research that compounds. Binds each run to a wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`. The shallow `knowledge-query` rung is read-only by default and can optionally file its answer back as an un-verified synthesis page via `--file-back`.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-knowledge/scripts/pipeline-summary.py
+++ b/cogni-knowledge/scripts/pipeline-summary.py
@@ -48,9 +48,15 @@ BINDING_FILENAME = "binding.json"
 DEFAULT_FETCH_CACHE_MAX_AGE_DAYS = 30
 
 # Furthest-phase ordering. A phase is "reached" when its manifest is present.
-# `finalize` is not manifest-backed at the project level (it deposits to the
-# wiki + binding), so the deepest project-local phase is `verify`.
-_PHASE_ORDER = ["plan", "curate", "fetch", "ingest", "distill", "compose", "verify"]
+# `finalize` deposits to the wiki + binding rather than a `.metadata/` manifest,
+# so it is detected from two deterministic on-disk artifacts instead: a
+# `run-metrics.json` row with `phase == "finalize"` (the durable per-phase
+# ledger) OR a `binding.json::research_projects[]` entry whose `project_path`
+# matches this project — see `_finalize_reached`. Both must be added to
+# `_PHASE_ORDER` and the `cmd_project` `present{}` dict in lockstep: the
+# `phase_reached` loop indexes `present[phase]`, so a `_PHASE_ORDER` entry with
+# no matching `present` key would raise `KeyError`.
+_PHASE_ORDER = ["plan", "curate", "fetch", "ingest", "distill", "compose", "verify", "finalize"]
 _VERIFY_RE = re.compile(r"^verify-v(\d+)\.json$")
 
 
@@ -112,9 +118,55 @@ def _latest_verify(metadata: Path) -> tuple[int, dict] | None:
     return best
 
 
+def _finalize_reached(project_path: Path, knowledge_root: Path | None) -> bool:
+    """True when the project has been finalized (synthesis deposited).
+
+    Finalize leaves no `.metadata/` manifest, so it is detected from two
+    deterministic on-disk artifacts, OR'd so either alone suffices:
+
+    1. **run-metrics ledger** — `<project>/.metadata/run-metrics.json` carries a
+       `phases[]` row with `phase == "finalize"`. Self-contained (needs only
+       `project_path`), present on any run on the run-metrics-ledger line.
+    2. **binding deposit record** — the bound `binding.json::research_projects[]`
+       carries an entry whose `project_path` matches this project. The canonical
+       finalize artifact, independent of the run-metrics ledger (covers a
+       project finalized before the ledger landed). The binding sits at
+       `<knowledge_root>/.cogni-knowledge/binding.json`; `knowledge_root`
+       defaults to `project_path.parent` by the `<knowledge_root>/<slug>/`
+       layout convention when `--knowledge-root` is not supplied.
+
+    Both legs are fail-soft reads — a missing/unreadable ledger or binding
+    simply contributes `False`, never an exception.
+    """
+    ledger = _load_json(project_path / METADATA_DIRNAME / "run-metrics.json")
+    if ledger and isinstance(ledger.get("phases"), list):
+        if any(
+            isinstance(p, dict) and p.get("phase") == "finalize"
+            for p in ledger["phases"]
+        ):
+            return True
+
+    root = knowledge_root if knowledge_root is not None else project_path.parent
+    binding = _load_json(root / BINDING_DIRNAME / BINDING_FILENAME)
+    if binding and isinstance(binding.get("research_projects"), list):
+        target = str(project_path)
+        if any(
+            isinstance(p, dict) and p.get("project_path") == target
+            for p in binding["research_projects"]
+        ):
+            return True
+
+    return False
+
+
 def cmd_project(args: argparse.Namespace) -> int:
     project_path = Path(args.project_path).resolve()
     metadata = project_path / METADATA_DIRNAME
+    knowledge_root = (
+        Path(args.knowledge_root).resolve()
+        if getattr(args, "knowledge_root", None)
+        else None
+    )
 
     plan = _load_json(metadata / "plan.json")
     candidates = _load_json(metadata / "candidates.json")
@@ -136,6 +188,7 @@ def cmd_project(args: argparse.Namespace) -> int:
         "distill": distill is not None,
         "compose": citation is not None,
         "verify": verify is not None,
+        "finalize": _finalize_reached(project_path, knowledge_root),
     }
     phase_reached = "none"
     for phase in _PHASE_ORDER:
@@ -410,6 +463,13 @@ def main(argv: list[str]) -> int:
 
     p_project = sub.add_parser("project", help="Per-project inverted-pipeline state.")
     p_project.add_argument("--project-path", required=True)
+    p_project.add_argument(
+        "--knowledge-root",
+        default=None,
+        help="Knowledge-base root (dir holding .cogni-knowledge/binding.json) for the "
+             "finalize binding-deposit check. Defaults to the project-path parent by the "
+             "<knowledge_root>/<slug>/ layout convention.",
+    )
     p_project.set_defaults(func=cmd_project)
 
     p_cache = sub.add_parser("cache-health", help="Knowledge-base-global fetch-cache health.")

--- a/cogni-knowledge/scripts/verify-store.py
+++ b/cogni-knowledge/scripts/verify-store.py
@@ -238,6 +238,42 @@ def cmd_prefilter(args: argparse.Namespace) -> int:
         wanted = {tok for tok in (t.strip() for t in args.only_ids.split(",")) if tok}
         citations = [c for c in citations if c.get("id") in wanted]
 
+    # Executive-density bypass. The substring prefilter only ever marks a
+    # citation `verbatim` on a near-exact draft↔claim match; executive prose
+    # paraphrases sources by design (BLUF + Pyramid), so the prefilter measures
+    # a 0% hit rate on executive drafts — it still scans every citation, reads
+    # every cited wiki page, and routes 100% of citations to the LLM verifier,
+    # pure latency for zero shard reduction. Skip the scan: emit the same zeroed
+    # fragment the no-match path produces below and route every citation to
+    # `remaining_ids`. Fail-safe — the standard path would have produced the
+    # identical empty match set, just slower.
+    if args.prose_density == "executive":
+        all_ids = [c.get("id") for c in citations]
+        frag_path = out_dir / f"verify-shard-prefilter-v{draft_version}.json"
+        atomic_write(
+            frag_path,
+            {
+                "schema_version": SCHEMA_VERSION,
+                "draft_version": draft_version,
+                "revision_round": int(args.revision_round),
+                "verified": [],
+                "deviations": [],
+                "counts": {"verbatim": 0, "paraphrase": 0, "synthesis": 0,
+                           "unsupported": 0, "total": 0},
+            },
+        )
+        return _emit(
+            True,
+            data={
+                "fragment": str(frag_path),
+                "matched_ids": [],
+                "remaining_ids": all_ids,
+                "matched_count": 0,
+                "remaining_count": len(all_ids),
+                "skipped": "executive-density",
+            },
+        )
+
     # Read the current draft (NFC-normalized) so we can confirm the manifest's
     # draft_sentence is ACTUALLY in the draft before classifying — the same
     # staleness guard the wiki-verifier applies (`sentence_not_in_draft`). The
@@ -636,6 +672,13 @@ def main(argv: list[str]) -> int:
     )
     p_pre.add_argument("--only-ids", default=None, help="CSV of citation ids to restrict the scan to")
     p_pre.add_argument("--revision-round", type=int, default=0, help="Cosmetic; merge sets the canonical round")
+    p_pre.add_argument(
+        "--prose-density",
+        default="standard",
+        choices=["standard", "executive"],
+        help="When 'executive', skip the substring scan entirely (paraphrase-by-design, 0%% hit rate) "
+             "and route every citation to the LLM verifier — emits a zeroed fragment. Default 'standard'.",
+    )
     p_pre.set_defaults(func=cmd_prefilter)
 
     p_merge = sub.add_parser("merge", help="Merge per-shard verify fragments into verify-vN.json")

--- a/cogni-knowledge/skills/knowledge-verify/SKILL.md
+++ b/cogni-knowledge/skills/knowledge-verify/SKILL.md
@@ -105,8 +105,7 @@ Default `2`. If `--max-rounds` is passed:
 Read the run's prose density from `plan.json` (the same key `knowledge-compose` resolves) so the pre-filter can be skipped on an executive draft:
 
 ```
-KNOWLEDGE_SCRIPTS="${CLAUDE_PLUGIN_ROOT}/scripts" \
-PLAN_PATH="<project_path>/.metadata/plan.json" \
+PROSE_DENSITY=$(PLAN_PATH="<project_path>/.metadata/plan.json" \
 python3 -c '
 import json, os
 from pathlib import Path
@@ -117,10 +116,10 @@ try:
 except (OSError, ValueError):
     pass
 print(density if density in ("standard", "executive") else "standard")
-'
+')
 ```
 
-Capture the result as `PROSE_DENSITY` (default `standard` — a missing/unreadable `plan.json` or an unknown value falls back, never aborts). It is threaded into Step 3.1(a)'s pre-filter invocation. **Why it matters:** the substring pre-filter only marks a citation `verbatim` on a near-exact draft↔claim match, but `executive` prose paraphrases sources by design (BLUF + Pyramid) — so on an executive draft the pre-filter measures a 0% hit rate yet still scans every citation and reads every cited page. Passing `--prose-density executive` skips that dead-weight scan and routes every citation straight to the LLM verifier (identical verdict set, less latency).
+`PROSE_DENSITY` defaults to `standard` — a missing/unreadable `plan.json` or an unknown value falls back, never aborts. It is threaded into Step 3.1(a)'s pre-filter invocation. **Why it matters:** the substring pre-filter only marks a citation `verbatim` on a near-exact draft↔claim match, but `executive` prose paraphrases sources by design (BLUF + Pyramid) — so on an executive draft the pre-filter measures a 0% hit rate yet still scans every citation and reads every cited page. Passing `--prose-density executive` skips that dead-weight scan and routes every citation straight to the LLM verifier (identical verdict set, less latency).
 
 ### 1. Resolve current draft version N
 
@@ -214,7 +213,7 @@ python3 ${CLAUDE_PLUGIN_ROOT}/scripts/verify-store.py prefilter \
     [--only-ids <CANDIDATE_IDS>]    # round ≥1 only; omit on round 0 (full manifest)
 ```
 
-Omit `--only-ids` on round 0; pass it on round ≥1 (a rephrased sentence often becomes an exact substring match against the claim it was aligned to). `--prose-density <PROSE_DENSITY>` (resolved in Step 0.6) makes the pre-filter a no-op on an `executive` draft — it writes a zeroed fragment and routes every citation to `remaining_ids` (the LLM verifier) instead of scanning, since executive paraphrase yields a 0% verbatim hit rate by design; on a `standard` draft the scan runs unchanged. `--draft` lets the prefilter confirm each manifest `draft_sentence` is actually in the current draft (the same `sentence_not_in_draft` staleness guard the verifier applies) before it dares classify `verbatim`. Capture `data.matched_ids` (classified `verbatim` without a model call, written to the `verify-shard-prefilter-v<N>.json` fragment) and `data.remaining_ids`. The pre-filter is **fail-safe** — it only ever asserts `verbatim` on a substantial exact substring of an in-draft sentence; anything it cannot confidently match (short/block-scalar/cross-language/stale, or every citation on an executive draft) is left in `remaining_ids` for the LLM, and it never emits a deviation or a drop.
+Omit `--only-ids` on round 0; pass it on round ≥1 (a rephrased sentence often becomes an exact substring match against the claim it was aligned to). `--prose-density <PROSE_DENSITY>` (resolved in Step 0.6, which explains why) makes the pre-filter a no-op on an `executive` draft — it writes a zeroed fragment and routes every citation to `remaining_ids` (the LLM verifier) instead of scanning; on a `standard` draft the scan runs unchanged. `--draft` lets the prefilter confirm each manifest `draft_sentence` is actually in the current draft (the same `sentence_not_in_draft` staleness guard the verifier applies) before it dares classify `verbatim`. Capture `data.matched_ids` (classified `verbatim` without a model call, written to the `verify-shard-prefilter-v<N>.json` fragment) and `data.remaining_ids`. The pre-filter is **fail-safe** — it only ever asserts `verbatim` on a substantial exact substring of an in-draft sentence; anything it cannot confidently match (short/block-scalar/cross-language/stale, or every citation on an executive draft) is left in `remaining_ids` for the LLM, and it never emits a deviation or a drop.
 
 **(b) Shard the remaining ids.** Run this **every round, even when `remaining_ids` is empty** — `shard` is the step that clears stale numbered `verify-shard-[0-9]*-v<N>.json` fragments left by an interrupted prior attempt at the same draft version, so skipping it would let a stale fragment leak into the merge.
 

--- a/cogni-knowledge/skills/knowledge-verify/SKILL.md
+++ b/cogni-knowledge/skills/knowledge-verify/SKILL.md
@@ -100,6 +100,28 @@ Default `2`. If `--max-rounds` is passed:
 
 `MAX_ROUNDS` is then referenced by Step 3.2's loop-termination decision. The 2-iteration cap is a structural property of `references/inverted-pipeline.md` Phase 6, not a tunable — higher values would silently blow the < 5 min cost target.
 
+### 0.6 Resolve PROSE_DENSITY
+
+Read the run's prose density from `plan.json` (the same key `knowledge-compose` resolves) so the pre-filter can be skipped on an executive draft:
+
+```
+KNOWLEDGE_SCRIPTS="${CLAUDE_PLUGIN_ROOT}/scripts" \
+PLAN_PATH="<project_path>/.metadata/plan.json" \
+python3 -c '
+import json, os
+from pathlib import Path
+p = Path(os.environ["PLAN_PATH"])
+density = "standard"
+try:
+    density = (json.loads(p.read_text(encoding="utf-8")).get("prose_density") or "standard")
+except (OSError, ValueError):
+    pass
+print(density if density in ("standard", "executive") else "standard")
+'
+```
+
+Capture the result as `PROSE_DENSITY` (default `standard` — a missing/unreadable `plan.json` or an unknown value falls back, never aborts). It is threaded into Step 3.1(a)'s pre-filter invocation. **Why it matters:** the substring pre-filter only marks a citation `verbatim` on a near-exact draft↔claim match, but `executive` prose paraphrases sources by design (BLUF + Pyramid) — so on an executive draft the pre-filter measures a 0% hit rate yet still scans every citation and reads every cited page. Passing `--prose-density executive` skips that dead-weight scan and routes every citation straight to the LLM verifier (identical verdict set, less latency).
+
 ### 1. Resolve current draft version N
 
 ```
@@ -188,10 +210,11 @@ python3 ${CLAUDE_PLUGIN_ROOT}/scripts/verify-store.py prefilter \
     --draft-version <CURRENT_DRAFT_VERSION> \
     --draft "<project_path>/output/draft-v<CURRENT_DRAFT_VERSION>.md" \
     --out-dir "<project_path>/.metadata/verify-shards" \
+    --prose-density <PROSE_DENSITY> \
     [--only-ids <CANDIDATE_IDS>]    # round ≥1 only; omit on round 0 (full manifest)
 ```
 
-Omit `--only-ids` on round 0; pass it on round ≥1 (a rephrased sentence often becomes an exact substring match against the claim it was aligned to). `--draft` lets the prefilter confirm each manifest `draft_sentence` is actually in the current draft (the same `sentence_not_in_draft` staleness guard the verifier applies) before it dares classify `verbatim`. Capture `data.matched_ids` (classified `verbatim` without a model call, written to the `verify-shard-prefilter-v<N>.json` fragment) and `data.remaining_ids`. The pre-filter is **fail-safe** — it only ever asserts `verbatim` on a substantial exact substring of an in-draft sentence; anything it cannot confidently match (short/block-scalar/cross-language/stale) is left in `remaining_ids` for the LLM, and it never emits a deviation or a drop.
+Omit `--only-ids` on round 0; pass it on round ≥1 (a rephrased sentence often becomes an exact substring match against the claim it was aligned to). `--prose-density <PROSE_DENSITY>` (resolved in Step 0.6) makes the pre-filter a no-op on an `executive` draft — it writes a zeroed fragment and routes every citation to `remaining_ids` (the LLM verifier) instead of scanning, since executive paraphrase yields a 0% verbatim hit rate by design; on a `standard` draft the scan runs unchanged. `--draft` lets the prefilter confirm each manifest `draft_sentence` is actually in the current draft (the same `sentence_not_in_draft` staleness guard the verifier applies) before it dares classify `verbatim`. Capture `data.matched_ids` (classified `verbatim` without a model call, written to the `verify-shard-prefilter-v<N>.json` fragment) and `data.remaining_ids`. The pre-filter is **fail-safe** — it only ever asserts `verbatim` on a substantial exact substring of an in-draft sentence; anything it cannot confidently match (short/block-scalar/cross-language/stale, or every citation on an executive draft) is left in `remaining_ids` for the LLM, and it never emits a deviation or a drop.
 
 **(b) Shard the remaining ids.** Run this **every round, even when `remaining_ids` is empty** — `shard` is the step that clears stale numbered `verify-shard-[0-9]*-v<N>.json` fragments left by an interrupted prior attempt at the same draft version, so skipping it would let a stale fragment leak into the merge.
 

--- a/cogni-knowledge/tests/test_pipeline_summary.sh
+++ b/cogni-knowledge/tests/test_pipeline_summary.sh
@@ -195,6 +195,110 @@ else
   errors=$((errors + 1))
 fi
 
+# --- Scenario: finalize via run-metrics ledger (#842) --------------------
+# A project whose .metadata/ tops out at verify but whose run-metrics.json
+# carries a phases[] row with phase=="finalize" reports phase_reached=finalize.
+FL="$WORK/finalized-ledger/.metadata"
+plant "$FL/plan.json" <<'JSON'
+{"schema_version":"0.1.0","topic":"Finalized via ledger","sub_questions":[{"id":"sq-01"}]}
+JSON
+plant "$FL/verify-v1.json" <<'JSON'
+{"schema_version":"0.1.0","revision_round":1,"counts":{"verbatim":2,"paraphrase":1,"synthesis":0,"unsupported":0,"total":3}}
+JSON
+plant "$FL/run-metrics.json" <<'JSON'
+{"schema_version":"0.1.0","phases":[{"phase":"verify","elapsed_s":4.2},{"phase":"finalize","elapsed_s":1.1}]}
+JSON
+LEDGER_OUT=$(python3 "$SCRIPT" project --project-path "$WORK/finalized-ledger")
+if echo "$LEDGER_OUT" | python3 -c "
+import sys, json
+x = json.load(sys.stdin)['data']
+assert x['phase_reached'] == 'finalize', x
+" 2>/dev/null; then
+  green "PASS: project finalize — run-metrics finalize row lifts phase_reached to finalize (#842)"
+else
+  red "FAIL: run-metrics finalize detection wrong"
+  red "  got: $LEDGER_OUT"
+  errors=$((errors + 1))
+fi
+
+# A run-metrics.json present but with NO finalize row must NOT report finalize
+# (the ledger check is specific to the finalize phase, not "ledger exists").
+NF="$WORK/notfinal-ledger/.metadata"
+plant "$NF/plan.json" <<'JSON'
+{"schema_version":"0.1.0","topic":"Not finalized","sub_questions":[{"id":"sq-01"}]}
+JSON
+plant "$NF/verify-v1.json" <<'JSON'
+{"schema_version":"0.1.0","revision_round":1,"counts":{"verbatim":1,"paraphrase":0,"synthesis":0,"unsupported":0,"total":1}}
+JSON
+plant "$NF/run-metrics.json" <<'JSON'
+{"schema_version":"0.1.0","phases":[{"phase":"compose","elapsed_s":3.0},{"phase":"verify","elapsed_s":4.2}]}
+JSON
+NF_OUT=$(python3 "$SCRIPT" project --project-path "$WORK/notfinal-ledger")
+if echo "$NF_OUT" | python3 -c "
+import sys, json
+x = json.load(sys.stdin)['data']
+assert x['phase_reached'] == 'verify', x
+" 2>/dev/null; then
+  green "PASS: project finalize — run-metrics without a finalize row stays phase_reached=verify (no false positive) (#842)"
+else
+  red "FAIL: run-metrics no-finalize-row false positive"
+  red "  got: $NF_OUT"
+  errors=$((errors + 1))
+fi
+
+# --- Scenario: finalize via binding research_projects[] (#842) -----------
+# A project finalized before the run-metrics ledger existed (no run-metrics.json)
+# is still detected via the bound binding.json's research_projects[] entry whose
+# project_path matches. The binding sits at <knowledge_root>/.cogni-knowledge/,
+# resolved by the project-path-parent convention with no --knowledge-root flag.
+KBF="$WORK/kb-final"
+PROJ="$KBF/proj-x"
+plant "$PROJ/.metadata/plan.json" <<'JSON'
+{"schema_version":"0.1.0","topic":"Finalized via binding","sub_questions":[{"id":"sq-01"}]}
+JSON
+plant "$PROJ/.metadata/verify-v1.json" <<'JSON'
+{"schema_version":"0.1.0","revision_round":1,"counts":{"verbatim":1,"paraphrase":0,"synthesis":0,"unsupported":0,"total":1}}
+JSON
+# Write the binding with the RESOLVED project path so the match holds regardless
+# of any /var -> /private/var style symlink in the mktemp root.
+PROJ="$PROJ" KBF="$KBF" python3 - <<'PY'
+import json, os
+from pathlib import Path
+proj = str(Path(os.environ["PROJ"]).resolve())
+bdir = Path(os.environ["KBF"]) / ".cogni-knowledge"
+bdir.mkdir(parents=True, exist_ok=True)
+(bdir / "binding.json").write_text(json.dumps({
+    "schema_version": "0.1.5",
+    "research_projects": [{"slug": "proj-x", "project_path": proj, "report_source": "wiki"}],
+}), encoding="utf-8")
+PY
+BIND_OUT=$(python3 "$SCRIPT" project --project-path "$PROJ")
+if echo "$BIND_OUT" | python3 -c "
+import sys, json
+x = json.load(sys.stdin)['data']
+assert x['phase_reached'] == 'finalize', x
+" 2>/dev/null; then
+  green "PASS: project finalize — binding research_projects[] match lifts phase_reached to finalize via parent convention (#842)"
+else
+  red "FAIL: binding finalize detection wrong"
+  red "  got: $BIND_OUT"
+  errors=$((errors + 1))
+fi
+
+# Same binding, addressed via an explicit --knowledge-root override.
+BIND_OUT2=$(python3 "$SCRIPT" project --project-path "$PROJ" --knowledge-root "$KBF")
+if echo "$BIND_OUT2" | python3 -c "
+import sys, json
+x = json.load(sys.stdin)['data']
+assert x['phase_reached'] == 'finalize', x
+" 2>/dev/null; then
+  green "PASS: project finalize — explicit --knowledge-root resolves the binding deposit (#842)"
+else
+  red "FAIL: --knowledge-root override did not resolve finalize"
+  red "  got: $BIND_OUT2"
+  errors=$((errors + 1))
+fi
+
 # --- cache-health: empty -------------------------------------------------
 KB="$WORK/kb"
 mkdir -p "$KB/.cogni-knowledge"

--- a/cogni-knowledge/tests/test_verify_store.sh
+++ b/cogni-knowledge/tests/test_verify_store.sh
@@ -437,6 +437,43 @@ else
   errors=$((errors + 1))
 fi
 
+# 7b-exec. EXECUTIVE DENSITY BYPASS (#842) — `--prose-density executive` skips the
+#          substring scan entirely (executive paraphrase = 0% hit rate by design):
+#          every citation routes to remaining_ids, the fragment is zeroed, and the
+#          standard path's verbatim match (cit-p1) is NOT marked. Fail-safe: the
+#          standard path would have produced the same empty match set, just slower.
+PFSHX="$WORK/pf-shards-exec"
+OUT=$(python3 "$SCRIPT" prefilter --manifest "$PFM" --wiki-root "$PFWIKI" --draft-version 1 --draft "$PFDRAFT" --out-dir "$PFSHX" --prose-density executive)
+if echo "$OUT" | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+assert d['success'] is True, d
+assert d['data']['matched_ids'] == [], d['data']
+assert d['data']['matched_count'] == 0, d['data']
+assert sorted(d['data']['remaining_ids']) == ['cit-p1', 'cit-p2', 'cit-p3'], d['data']
+assert d['data']['remaining_count'] == 3, d['data']
+assert d['data'].get('skipped') == 'executive-density', d['data']
+" 2>/dev/null; then
+  green "PASS: prefilter --prose-density executive routes every citation to remaining (0 matched), bypassing the scan (#842)"
+else
+  red "FAIL: executive-density bypass did not route all citations to remaining"
+  red "  got: $OUT"
+  errors=$((errors + 1))
+fi
+if python3 - <<PY > /dev/null
+import json
+frag = json.load(open("$PFSHX/verify-shard-prefilter-v1.json"))
+assert frag['verified'] == [], frag
+assert frag['deviations'] == [], frag
+assert frag['counts']['total'] == 0 and frag['counts']['verbatim'] == 0, frag
+PY
+then
+  green "PASS: executive-density bypass writes a zeroed prefilter fragment (#842)"
+else
+  red "FAIL: executive-density fragment not zeroed"
+  errors=$((errors + 1))
+fi
+
 # 7b-q. QUESTION FAMILY (#432) — the prefilter resolves a `type: question` node's
 #        `answer_claims:` (acl-NNN, no excerpt_quote → text is the needle) exactly like
 #        a distilled page, fast-pathing a verbatim answer-claim citation.


### PR DESCRIPTION
Closes #842.

Two small, independent observability/efficiency cleanups the perf study surfaced, shipped together (one plugin version line).

## Summary
- **Part A — skip the verify prefilter under `executive` density.** The deterministic zero-LLM `verify-store.py prefilter` asserts `verbatim` only on exact substring matches; executive prose paraphrases sources, so it matched 0 of 38 (run 1) / 0 of 33 (run 2) — pure latency for zero shard reduction. A new optional `--prose-density` arg (default `standard`); when `executive`, `cmd_prefilter` writes the same zeroed fragment it already emits in the no-match path and returns early (`matched_ids: []`, `remaining_ids: <all>`), so every citation flows to the LLM verifier exactly as before, minus the wasted scan. Fail-safe — the standard path would have produced the identical empty match set.
- **Part A wiring — resolve + thread `prose_density` in `knowledge-verify`.** A new Step 0.6 resolves `PROSE_DENSITY` from `.metadata/plan.json` (the same key `knowledge-compose` reads; default `standard`, fail-soft), threaded as `--prose-density <PROSE_DENSITY>` into the Step 3.1(a) prefilter invocation.
- **Part B — `pipeline-summary.py` detects `finalize`.** Append `finalize` to `_PHASE_ORDER` **and** to the `cmd_project` `present{}` dict in lockstep (the `phase_reached` loop indexes `present[phase]`, so a `_PHASE_ORDER` entry with no `present` key would `KeyError`). A new `_finalize_reached` helper sets `present['finalize']` as the OR of (a) a `run-metrics.json` `phases[].phase == 'finalize'` row and (b) the binding's `research_projects[]` carrying an entry whose `project_path` matches the resolved project path (binding at `<knowledge_root>/.cogni-knowledge/binding.json`, with an optional `--knowledge-root` override mirroring `cmd_cache_health`, defaulting to `project_path.parent`). The lines 51-52 docstring is rewritten to describe the new detection.

## Scope decisions
- **In:** both acceptance criteria (A prefilter skip + SKILL wiring, B finalize detection) — the issue calls them small, independent, no behavioral risk, and asks for ONE PR.
- **Note (corrected from triage):** `knowledge-verify` did NOT previously resolve `prose_density`; the SKILL delta both resolves it from `plan.json` and threads it.
- **Out:** nothing deferred. `knowledge-resume` / `knowledge-dashboard` callers need no change — the `project_path.parent` convention resolves the binding without an explicit `--knowledge-root`.
- **Version:** patch bump `1.0.11 → 1.0.12` in `plugin.json` + mirrored in repo-root `marketplace.json`.

## Test plan
- [x] `tests/test_verify_store.sh` — new executive-bypass case (matched_count==0, all citations to remaining, zeroed fragment) + existing standard-path cases unchanged. **ALL PASS.**
- [x] `tests/test_pipeline_summary.sh` — new finalize scenarios (run-metrics row, run-metrics-without-finalize negative, binding match via parent convention, explicit `--knowledge-root`) + existing FULL `phase_reached=verify` no-false-positive + legacy no-crash. **ALL PASS.**
- [x] `python3 verify-store.py prefilter --help` shows `--prose-density`.
- [x] `plugin.json` + `marketplace.json` both read `1.0.12`.