### PR TITLE
cogni-workspace: drop launch-time permission-mode prompt (native Shift+Tab)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -118,7 +118,7 @@
     {
       "name": "cogni-workspace",
       "source": "./cogni-workspace",
-      "version": "0.6.34",
+      "version": "0.6.35",
       "maturity": "preview",
       "description": "Foundation-layer plugin for insight-wave marketplace plugins. Manages shared infrastructure (env vars, settings), MCP server installation and Desktop config patching, theme management, theme picker, plugin discovery, workspace health, an interactive workspace-configuration dashboard, Obsidian vault integration, and a bundled vendor-curated insight-wave reference wiki queryable via the ask skill.",
       "keywords": [

--- a/cogni-workspace/.claude-plugin/plugin.json
+++ b/cogni-workspace/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-workspace",
-  "version": "0.6.34",
+  "version": "0.6.35",
   "description": "Foundation-layer plugin for insight-wave marketplace plugins. Manages shared infrastructure (env vars, settings), MCP server installation and Desktop config patching, theme management, theme picker, plugin discovery, workspace health, an interactive workspace-configuration dashboard, Obsidian vault integration, and a bundled vendor-curated insight-wave reference wiki queryable via the ask skill.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-workspace/templates/obsidian/plugins/terminal/workspace-orchestrator.sh
+++ b/cogni-workspace/templates/obsidian/plugins/terminal/workspace-orchestrator.sh
@@ -81,20 +81,6 @@ select_language() {
     esac
 }
 
-select_permission_mode() {
-    echo -e "${YELLOW}Permission Mode:${NC}" >&2
-    echo -e "  ${GREEN}1${NC}) Standard — approval required for each operation" >&2
-    echo -e "  ${GREEN}2${NC}) Auto-approved — uninterrupted workflow" >&2
-    echo "" >&2
-    echo -ne "${GREEN}Choose (1-2, default: 1): ${NC}" >&2
-    read -r mode_choice
-
-    case "$mode_choice" in
-        2) echo "bypass" ;;
-        *) echo "standard" ;;
-    esac
-}
-
 copy_claude_template() {
     local lang="$1"
     local template="$WORKPLACE_ROOT/.claude/templates/CLAUDE.${lang}.md"
@@ -149,17 +135,7 @@ launch_claude() {
     fi
     echo ""
 
-    local PERMISSION_MODE
-    PERMISSION_MODE="$(select_permission_mode)"
-    echo ""
-    echo "──────────────────────────"
-    echo ""
-
-    if [[ "$PERMISSION_MODE" == "bypass" ]]; then
-        exec "$CLAUDE_CMD" --permission-mode bypassPermissions
-    else
-        exec "$CLAUDE_CMD"
-    fi
+    exec "$CLAUDE_CMD"
 }
 
 main() {


### PR DESCRIPTION
Closes #859.

## Summary
- Delete `select_permission_mode()` from `templates/obsidian/plugins/terminal/workspace-orchestrator.sh`.
- In `launch_claude()`, drop the `PERMISSION_MODE` selection, the trailing separator divider, and the bypass conditional — the launcher now ends with a bare `exec "$CLAUDE_CMD"` and never passes `--permission-mode bypassPermissions`.
- Bump `cogni-workspace` 0.6.34 → 0.6.35 in `plugin.json` and mirror it in the root `marketplace.json`.

## Scope decisions
- In: full removal of the prompt + bypass logic per the issue's acceptance criteria; the visual separator that framed the prompt is removed with it for clean output.
- Out: nothing. `select_permission_mode`/`PERMISSION_MODE` are grep-confirmed file-local with no test/doc references, so this fully resolves the issue. `setup-obsidian.sh` copies this template by path rather than embedding the prompt, so no second source requires editing.
- Permission mode remains user-controllable at any time via Claude Code's native Shift+Tab cycle, which is the motivation for the change.

## Test plan
- [x] `bash -n cogni-workspace/templates/obsidian/plugins/terminal/workspace-orchestrator.sh` parses clean.
- [x] `grep -n 'select_permission_mode\|PERMISSION_MODE\|bypassPermissions' …workspace-orchestrator.sh` returns nothing.
- [x] `cogni-workspace/.claude-plugin/plugin.json` and the root `marketplace.json` cogni-workspace entry both read `0.6.35`.