### PR TITLE
cogni-knowledge: structural/schema drift detection in health.py

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "cogni-knowledge",
       "source": "./cogni-knowledge",
-      "version": "1.0.20",
+      "version": "1.0.21",
       "maturity": "released",
       "description": "Wiki-first research that compounds. Binds each run to a wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`. The shallow `knowledge-query` rung is read-only by default and can optionally file its answer back as an un-verified synthesis page via `--file-back`.",
       "keywords": [

--- a/cogni-knowledge/.claude-plugin/plugin.json
+++ b/cogni-knowledge/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-knowledge",
-  "version": "1.0.20",
+  "version": "1.0.21",
   "description": "Wiki-first research that compounds. Binds each run to a wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`. The shallow `knowledge-query` rung is read-only by default and can optionally file its answer back as an un-verified synthesis page via `--file-back`.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-knowledge/CHANGELOG.md
+++ b/cogni-knowledge/CHANGELOG.md
@@ -1,5 +1,28 @@
 # cogni-knowledge changelog
 
+## 1.0.21 — 2026-06-19 — structural/schema drift detection in health.py
+
+The vendored `health.py` gains a read-only, fail-soft **structural/schema drift** class distinct from
+the numeric count-drift checks, on a curated (`schema_version >= 0.0.8`) base — so health can no longer
+return a confident `OK` on a base whose curated front door is degraded. A new `_check_structural_drift`
+(gated on the same pre-0.0.8 guard as `_check_curated_layout`, wired in right after it) emits two new
+**warning** classes (verdict `OK → WARN`, never a hard error):
+
+- `schema_version_lag` — `config.json` `schema_version` trails the engine's current expected structure
+  (the new `ENGINE_SCHEMA = "0.0.9"` constant). Repair: `knowledge-index --migrate`.
+- `structural_drift` — a machine-owned curated front-door region a completed phase should have populated
+  is still on its bootstrap state: the `index.md` `OVERVIEW-NARRATIVE` block still carries the finalize
+  placeholder, or a `ROOT-LINKS` span has no theme-scoped deep links. Repair: re-run `knowledge-finalize`
+  (or `knowledge-index`).
+
+The check is self-contained (an inlined `_extract_machine_block` keeps `health.py` importing only from
+the vendored `_wikilib`), never fires on a pre-0.0.8 base, and is read-only (health writes nothing). The
+`knowledge-health` SKILL surfaces both classes + their repair next-actions. New
+`tests/test_structural_drift_health.sh` covers the detection ACs; the existing curated-layout +
+health-contract tests are unaffected (the new classes land in `warnings[]`, so a clean base still reports
+`errors: 0`). This is the detect-seam keystone of the curated-layout-health work; the repair command and
+resume-surfacing land in their own changes.
+
 ## 1.0.20 — 2026-06-17 — consolidate ingest post-processing into a first-party orchestrator
 
 `knowledge-ingest` Step 4's model-managed per-slug wiki-integration **shell loop** is replaced with one

--- a/cogni-knowledge/scripts/vendor/cogni-wiki/skills/wiki-health/scripts/health.py
+++ b/cogni-knowledge/scripts/vendor/cogni-wiki/skills/wiki-health/scripts/health.py
@@ -24,6 +24,11 @@ Detects:
         - Stub pages (body shorter than STUB_PAGE_MIN_CHARS)
         - entries_count drift between config.json and filesystem
         - index.md <-> filesystem drift (entries on one side missing on the other)
+        - schema_version_lag: config schema_version trails the engine's current
+          expected structure (ENGINE_SCHEMA)
+        - structural_drift: a machine-owned curated front-door region a completed
+          phase should have populated is still on its bootstrap placeholder
+          (OVERVIEW-NARRATIVE) or empty-state sentinel (ROOT-LINKS)
     Stats:
         - pages_audited, errors, warnings
         - entries_count_config / _actual / _drift
@@ -48,6 +53,7 @@ from __future__ import annotations
 import argparse
 import datetime as dt
 import json
+import re
 import sys
 from pathlib import Path
 
@@ -75,6 +81,21 @@ REQUIRED_FRONTMATTER = {"id", "title", "type", "created", "updated"}
 # The curated layout (schema_version >= 0.0.8) moves the visible control
 # files off the flat wiki/ root into wiki/meta/.
 CURATED_LAYOUT_SCHEMA = "0.0.8"
+
+# The engine's current expected wiki schema. A curated base recorded behind
+# this lags the structure the engine now produces — a read-forward, additive
+# gap surfaced as a warning, not a hard fail (0.0.5 stays the hard-fail
+# boundary, owned by fail_if_pre_migration).
+ENGINE_SCHEMA = "0.0.9"
+
+# Bootstrap state a completed phase should have replaced. `knowledge-setup`
+# seeds the OVERVIEW-NARRATIVE block with this placeholder and `root_index.py`
+# renders an empty ROOT-LINKS span with the sentinel; a finalized base that
+# still carries either has a degraded curated front door.
+OVERVIEW_BOOTSTRAP_PLACEHOLDER = (
+    "_Overview pending — authored on the first knowledge-finalize run._"
+)
+ROOT_LINKS_EMPTY_SENTINEL = "_(no pages yet)_"
 
 
 def _load_last_resweep(wiki_root: Path) -> dict | None:
@@ -211,6 +232,109 @@ def _check_curated_layout(
                     ),
                 }
             )
+
+
+def _machine_block_pattern(name: str) -> str:
+    """Regex source for a MACHINE-OWNED:<name>:START..:END span (group 1 = inner).
+
+    The single source of truth for the comment-delimiter shape, shared by the
+    first-span helper below and the all-spans ROOT-LINKS scan.
+    """
+    esc = re.escape(name)
+    return (
+        r"<!--\s*MACHINE-OWNED:" + esc + r":START\s*-->"
+        r"(.*?)<!--\s*MACHINE-OWNED:" + esc + r":END\s*-->"
+    )
+
+
+def _extract_machine_block(text: str, name: str) -> str | None:
+    """Inner text of the first MACHINE-OWNED:<name>:START..:END span, or None.
+
+    Self-contained port of _knowledge_lib.extract_machine_block — the vendored
+    engine imports only from _wikilib, so health.py must not reach into
+    cogni-knowledge's _knowledge_lib.
+    """
+    m = re.search(_machine_block_pattern(name), text, re.DOTALL)
+    return m.group(1) if m else None
+
+
+def _check_structural_drift(
+    wiki_root: Path, cfg: dict, errors: list, warnings: list
+) -> None:
+    """Flag structural / schema drift on a curated (schema >= 0.0.8) base.
+
+    Read-only and fail-soft, distinct from the numeric count-drift checks:
+        - schema_version_lag: config schema_version trails the engine's current
+          ENGINE_SCHEMA (a read-forward gap; repair via knowledge-index --migrate)
+        - structural_drift: a machine-owned curated front-door region a completed
+          phase should have populated is still on its bootstrap placeholder
+          (OVERVIEW-NARRATIVE) or empty-state sentinel (ROOT-LINKS)
+
+    Never fires on a pre-0.0.8 base (same guard as _check_curated_layout). All
+    findings are warnings — a degraded front door moves the verdict OK -> WARN,
+    never to a hard error.
+    """
+    schema = str(cfg.get("schema_version", ""))
+    if not schema or not version_at_least(schema, CURATED_LAYOUT_SCHEMA):
+        return
+
+    # (a) schema_version lag behind the engine's current expected structure.
+    if not version_at_least(schema, ENGINE_SCHEMA):
+        warnings.append(
+            {
+                "class": "schema_version_lag",
+                "page": "(.cogni-wiki/config.json)",
+                "message": (
+                    f"schema_version={schema} trails the engine's expected "
+                    f"{ENGINE_SCHEMA}; run knowledge-index --migrate to "
+                    f"converge the curated layout"
+                ),
+            }
+        )
+
+    # (b) + (c) curated front-door regions left on their bootstrap state. Fires
+    # only when the machine-owned region is PRESENT and unpopulated, so a base
+    # whose index.md carries no such region (e.g. a minimal fixture) is silent.
+    index_path = wiki_root / "wiki" / "index.md"
+    if not index_path.is_file():
+        return
+    try:
+        index_text = index_path.read_text(encoding="utf-8")
+    except OSError:
+        # Unreadable index.md — stay fail-soft (the curated-layout check owns
+        # hard structural errors; this read-only drift pass never aborts).
+        return
+
+    overview = _extract_machine_block(index_text, "OVERVIEW-NARRATIVE")
+    if overview is not None and overview.strip() == OVERVIEW_BOOTSTRAP_PLACEHOLDER:
+        warnings.append(
+            {
+                "class": "structural_drift",
+                "page": "(wiki/index.md)",
+                "message": (
+                    "OVERVIEW-NARRATIVE is still the bootstrap placeholder "
+                    "though a finalize should have authored it; re-run "
+                    "knowledge-finalize (or knowledge-index --repair) to "
+                    "regenerate the curated front door"
+                ),
+            }
+        )
+
+    root_links_re = re.compile(_machine_block_pattern("ROOT-LINKS"), re.DOTALL)
+    for m in root_links_re.finditer(index_text):
+        if m.group(1).strip() == ROOT_LINKS_EMPTY_SENTINEL:
+            warnings.append(
+                {
+                    "class": "structural_drift",
+                    "page": "(wiki/index.md)",
+                    "message": (
+                        "a ROOT-LINKS span carries no theme-scoped deep links "
+                        "(still the empty-state sentinel); re-run "
+                        "knowledge-index to populate the curated root map"
+                    ),
+                }
+            )
+            break
 
 
 def main() -> None:
@@ -402,6 +526,7 @@ def main() -> None:
         )
 
     _check_curated_layout(wiki_root, cfg, errors, warnings)
+    _check_structural_drift(wiki_root, cfg, errors, warnings)
 
     index_slugs = _index_slugs(wiki_root)
     if index_slugs:

--- a/cogni-knowledge/skills/knowledge-health/SKILL.md
+++ b/cogni-knowledge/skills/knowledge-health/SKILL.md
@@ -103,6 +103,8 @@ On a curated-layout base (`schema_version >= 0.0.8`) the engine additionally ass
 
 - `curated_layout_violation` (error) — a control file (`log.md` / `context_brief.md` / `open_questions.md`) at the flat `wiki/` root, a missing `wiki/meta/`, or an `overview.md` still carrying the narrative machine block. Repair: `knowledge-lint --fix=misplaced_control_files`.
 - `missing_subindex` (warning) — a sub-indexed type dir with pages but no `index.md`. Repair: `knowledge-index`.
+- `schema_version_lag` (warning) — the base's `config.json` `schema_version` trails the engine's current expected structure (`ENGINE_SCHEMA`), so it predates a curated-layout contract the engine now produces. Repair: `knowledge-index --migrate`.
+- `structural_drift` (warning) — a machine-owned curated front-door region a completed phase should have populated is still on its bootstrap state: the `index.md` `OVERVIEW-NARRATIVE` block still carries the finalize placeholder, or a `ROOT-LINKS` span has no theme-scoped deep links. Repair: re-run `knowledge-finalize` (or `knowledge-index`) to regenerate the front door. These two structural-drift classes are read-only and fail-soft, never fire on a pre-0.0.8 base, and move the verdict `OK -> WARN` (never a hard error).
 - Per-type sub-indexes themselves are exempt from `entries_count` and the page walk; pre-0.0.8 bases are untouched by these assertions.
 
 Parse the JSON envelope `{success, data, error}`. On `success: false` (e.g. `<wiki_path>/.cogni-wiki/config.json` absent), surface `error` and stop. Otherwise capture `data.errors`, `data.warnings`, and `data.stats` (`pages_audited`, `entries_count_config`, `entries_count_actual`, `entries_count_drift`, `claim_drift_count`).
@@ -121,6 +123,8 @@ Print a compact verdict block:
   - Entries/claim drift present, no hard errors → "Drift detected — run `knowledge-lint --knowledge-slug <slug> --fix=all` to reconcile, then re-run health."
   - Hard errors → "Fix the structural errors above before composing or sharing. `knowledge-lint --knowledge-slug <slug> --fix=all` repairs the mechanical classes; the rest need a manual look." A `curated_layout_violation` repairs via `knowledge-lint --knowledge-slug <slug> --fix=misplaced_control_files`.
   - `missing_subindex` warning present (any verdict state) → "Re-render the per-type sub-indexes via `knowledge-index`."
+  - `schema_version_lag` warning present → "Schema behind the engine — run `knowledge-index --migrate` to converge the curated layout."
+  - `structural_drift` warning present → "Curated front door degraded (placeholder overview / empty root-links) — re-run `knowledge-finalize` (or `knowledge-index`) to regenerate it."
 
 ## Edge cases
 

--- a/cogni-knowledge/tests/test_structural_drift_health.sh
+++ b/cogni-knowledge/tests/test_structural_drift_health.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+# test_structural_drift_health.sh — functional test for the vendored health.py
+# structural / schema drift detection (#863): a read-only, fail-soft warning
+# class distinct from the numeric count-drift checks, on a curated
+# (schema_version >= 0.0.8) base.
+#
+# Covers:
+#   AC1a. A degraded curated base (schema 0.0.9) whose index.md OVERVIEW-NARRATIVE
+#         block is still the bootstrap placeholder fires a structural_drift
+#         warning; the verdict is no longer bare OK (warnings > 0) and errors stay 0.
+#   AC1b. A degraded base whose ROOT-LINKS span carries only the empty-state
+#         sentinel fires structural_drift.
+#   AC2.  A correctly-finalized base (schema 0.0.9, real overview narrative +
+#         populated root-links) fires NEITHER structural_drift NOR
+#         schema_version_lag.
+#   lag.  A curated base recorded at 0.0.8 (behind the engine's 0.0.9) fires a
+#         schema_version_lag warning — in warnings[], NOT errors[] (errors stay 0).
+#   AC3.  A pre-0.0.8 base (schema 0.0.7) with placeholder regions fires NOTHING
+#         (the structural-drift assertions are schema-gated, same as the
+#         curated-layout checks).
+#
+# bash 3.2 + python3 stdlib only. Exits non-zero on any failure.
+
+set -eu
+
+PLUGIN_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+HEALTH="$PLUGIN_ROOT/scripts/vendor/cogni-wiki/skills/wiki-health/scripts/health.py"
+
+. "$(dirname "$0")/fixtures/test_helpers.sh"
+
+errors=0
+
+WORK="$(mktemp -d)"
+cleanup() { rm -rf "$WORK"; }
+trap cleanup EXIT
+
+# The exact literals the detector strip-compares against (pinned to the live
+# knowledge-setup seed and root_index.py empty-state sentinel).
+OVERVIEW_PLACEHOLDER='_Overview pending — authored on the first knowledge-finalize run._'
+ROOT_LINKS_EMPTY='_(no pages yet)_'
+
+# Build a curated-layout fixture wiki with a configurable index.md carrying the
+# OVERVIEW-NARRATIVE + ROOT-LINKS machine-owned blocks.
+#   $1 = root dir, $2 = schema_version, $3 = overview inner, $4 = root-links inner
+build_curated() {
+  rm -rf "$1"
+  mkdir -p "$1/wiki/sources" "$1/wiki/meta" "$1/.cogni-wiki"
+  cat > "$1/.cogni-wiki/config.json" <<EOF
+{"wiki_slug": "fixture", "title": "Fixture Base", "entries_count": 1, "schema_version": "$2"}
+EOF
+  cat > "$1/wiki/index.md" <<EOF
+# Fixture Base
+
+<!-- MACHINE-OWNED:OVERVIEW-NARRATIVE:START -->
+$3
+<!-- MACHINE-OWNED:OVERVIEW-NARRATIVE:END -->
+
+## Regulierung
+
+<!-- MACHINE-OWNED:ROOT-LINKS:START -->
+$4
+<!-- MACHINE-OWNED:ROOT-LINKS:END -->
+EOF
+  printf '_The overview narrative now lives in [index.md](index.md)._\n\n## Recent syntheses\n\n- none yet\n' > "$1/wiki/overview.md"
+  printf '# Log\n' > "$1/wiki/meta/log.md"
+  printf '# Context brief\n' > "$1/wiki/meta/context_brief.md"
+  printf '# Open questions\n' > "$1/wiki/meta/open_questions.md"
+  cat > "$1/wiki/sources/eu-ai-act-scope.md" <<'EOF'
+---
+id: eu-ai-act-scope
+title: "Scope of the EU AI Act"
+type: source
+created: 2026-01-01
+updated: 2026-01-01
+sources:
+  - https://example.org/ai-act
+---
+
+# Scope of the EU AI Act
+
+Body text long enough to clear the stub-page threshold comfortably.
+EOF
+  printf '# Sources\n\n- [[eu-ai-act-scope]] — Scope of the EU AI Act.\n' > "$1/wiki/sources/index.md"
+}
+
+POPULATED_LINKS='**Explore:** [Sources (1)](sources/index.md#regulierung)'
+REAL_OVERVIEW='This base surveys EU AI Act scope and obligations for SMEs.'
+
+# ---------------------------------------------------------------------------
+# AC1a. Degraded base (0.0.9): OVERVIEW-NARRATIVE on the bootstrap placeholder
+# ---------------------------------------------------------------------------
+WIKI="$WORK/overview-placeholder"
+build_curated "$WIKI" "0.0.9" "$OVERVIEW_PLACEHOLDER" "$POPULATED_LINKS"
+OUT="$WORK/overview-placeholder.json"
+python3 "$HEALTH" --wiki-root "$WIKI" > "$OUT"
+assert_grep '"success": true' "$OUT" "AC1a: health succeeds on degraded base"
+assert_grep 'structural_drift' "$OUT" \
+  "AC1a: placeholder OVERVIEW-NARRATIVE fires structural_drift"
+assert_grep '"errors": 0' "$OUT" "AC1a: structural drift is a warning, errors stay 0"
+if grep -q 'schema_version_lag' "$OUT"; then
+  red "FAIL: AC1a 0.0.9 base wrongly fired schema_version_lag"
+  errors=$((errors + 1))
+else
+  green "PASS: AC1a current-schema base fires no schema_version_lag"
+fi
+# verdict no longer bare OK: at least one warning present
+if grep -q '"warnings": 0' "$OUT"; then
+  red "FAIL: AC1a degraded base reported zero warnings (verdict still bare OK)"
+  errors=$((errors + 1))
+else
+  green "PASS: AC1a degraded base reports warnings (verdict no longer bare OK)"
+fi
+
+# ---------------------------------------------------------------------------
+# AC1b. Degraded base (0.0.9): ROOT-LINKS span carries only the empty sentinel
+# ---------------------------------------------------------------------------
+WIKI="$WORK/rootlinks-empty"
+build_curated "$WIKI" "0.0.9" "$REAL_OVERVIEW" "$ROOT_LINKS_EMPTY"
+OUT="$WORK/rootlinks-empty.json"
+python3 "$HEALTH" --wiki-root "$WIKI" > "$OUT"
+assert_grep 'structural_drift' "$OUT" \
+  "AC1b: empty ROOT-LINKS span fires structural_drift"
+assert_grep '"errors": 0' "$OUT" "AC1b: structural drift is a warning, errors stay 0"
+
+# ---------------------------------------------------------------------------
+# AC2. Correctly-finalized base (0.0.9): real overview + populated root-links
+# ---------------------------------------------------------------------------
+WIKI="$WORK/clean-finalized"
+build_curated "$WIKI" "0.0.9" "$REAL_OVERVIEW" "$POPULATED_LINKS"
+OUT="$WORK/clean-finalized.json"
+python3 "$HEALTH" --wiki-root "$WIKI" > "$OUT"
+if grep -q 'structural_drift' "$OUT"; then
+  red "FAIL: AC2 finalized base wrongly fired structural_drift"
+  errors=$((errors + 1))
+else
+  green "PASS: AC2 finalized base fires no structural_drift"
+fi
+if grep -q 'schema_version_lag' "$OUT"; then
+  red "FAIL: AC2 current-schema base wrongly fired schema_version_lag"
+  errors=$((errors + 1))
+else
+  green "PASS: AC2 current-schema base fires no schema_version_lag"
+fi
+assert_grep '"errors": 0' "$OUT" "AC2: finalized base has zero errors"
+
+# ---------------------------------------------------------------------------
+# lag. Curated base at 0.0.8 (behind engine 0.0.9) fires schema_version_lag
+# ---------------------------------------------------------------------------
+WIKI="$WORK/schema-lag"
+build_curated "$WIKI" "0.0.8" "$REAL_OVERVIEW" "$POPULATED_LINKS"
+OUT="$WORK/schema-lag.json"
+python3 "$HEALTH" --wiki-root "$WIKI" > "$OUT"
+assert_grep 'schema_version_lag' "$OUT" \
+  "lag: a 0.0.8 base behind the engine fires schema_version_lag"
+assert_grep '"errors": 0' "$OUT" "lag: schema_version_lag is a warning, errors stay 0"
+
+# ---------------------------------------------------------------------------
+# AC3. Pre-0.0.8 base (0.0.7): structural-drift assertions stay silent
+# ---------------------------------------------------------------------------
+WIKI="$WORK/legacy"
+build_curated "$WIKI" "0.0.7" "$OVERVIEW_PLACEHOLDER" "$ROOT_LINKS_EMPTY"
+OUT="$WORK/legacy.json"
+python3 "$HEALTH" --wiki-root "$WIKI" > "$OUT"
+if grep -q 'structural_drift\|schema_version_lag' "$OUT"; then
+  red "FAIL: AC3 pre-0.0.8 base fired structural/schema drift (gate broken)"
+  errors=$((errors + 1))
+else
+  green "PASS: AC3 pre-0.0.8 base fires no structural/schema drift"
+fi
+
+# ---------------------------------------------------------------------------
+if [ "$errors" -gt 0 ]; then
+  red "$errors assertion(s) failed"
+  exit 1
+fi
+green "all structural/schema drift health assertions passed"


### PR DESCRIPTION
Closes #863.

Phase-1 keystone of the curated-layout-health epic (#861): `health.py` gains a read-only, fail-soft structural/schema drift class distinct from count drift, on a `schema_version >= 0.0.8` base. The front-door renderer (#864), repair command (#865), and resume-surfacing (#866) seams are separate epic children and are out of scope here — this child is detection + SKILL surface only.

## Summary
- Add module constant `ENGINE_SCHEMA = "0.0.9"` alongside the existing `CURATED_LAYOUT_SCHEMA = "0.0.8"`.
- Add a read-only, fail-soft `_check_structural_drift(wiki_root, cfg, errors, warnings)`, gated on the same pre-0.0.8 guard as `_check_curated_layout`, wired in at `main()` right after it.
- Emit two new **warning** classes (verdict moves OK → WARN, never blocking): `schema_version_lag` (config `schema_version` lags `ENGINE_SCHEMA`) on `(.cogni-wiki/config.json)`, and `structural_drift` (OVERVIEW-NARRATIVE span still the bootstrap placeholder after finalize, or a ROOT-LINKS span with no theme-scoped deep links) on `(wiki/index.md)`.
- Inline a minimal `_extract_machine_block` + a shared `_machine_block_pattern` factory so `health.py` stays self-contained (imports only from the vendored `_wikilib`).
- Surface both classes + repair next-actions in the `knowledge-health` SKILL.
- Bump cogni-knowledge `1.0.20 → 1.0.21` (plugin.json + marketplace.json) + CHANGELOG entry.

## Scope decisions
- **In:** detection of placeholder-region drift + schema-version-lag in `health.py`; SKILL surface. Read-only (health writes nothing), fail-soft, never fires on a pre-0.0.8 base.
- **Warnings, not errors:** AC1 only requires the verdict be "no longer bare OK" on a degraded base — WARN satisfies that and is the safer non-blocking posture, matching the existing `missing_subindex` warning. This also keeps the existing `test_curated_layout_health.sh` clean 0.0.8 fixture green (it hard-asserts only `errors: 0`).
- **Out (separate epic children):** the front-door curated renderer, the `--repair` class, and the resume-side surface.

## Test plan
- [x] `tests/test_structural_drift_health.sh` (new) passes: AC1 degraded base emits structural_drift + verdict no longer bare OK; AC2 finalized base emits zero; AC3 pre-0.0.8 base emits none; plus a schema_version_lag case (warning, errors stay 0).
- [x] `tests/test_curated_layout_health.sh` still passes (existing 5 cases unaffected).
- [x] `tests/test_health_contract.sh` still passes (new SKILL bullets added, no existing grep strings removed).