### PR TITLE
cogni-knowledge: theme-scoped curated-root Explore deep links

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "cogni-knowledge",
       "source": "./cogni-knowledge",
-      "version": "1.0.22",
+      "version": "1.0.23",
       "maturity": "released",
       "description": "Wiki-first research that compounds. Binds each run to a wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`. The shallow `knowledge-query` rung is read-only by default and can optionally file its answer back as an un-verified synthesis page via `--file-back`.",
       "keywords": [

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "cogni-knowledge",
       "source": "./cogni-knowledge",
-      "version": "1.0.21",
+      "version": "1.0.22",
       "maturity": "released",
       "description": "Wiki-first research that compounds. Binds each run to a wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`. The shallow `knowledge-query` rung is read-only by default and can optionally file its answer back as an un-verified synthesis page via `--file-back`.",
       "keywords": [

--- a/cogni-knowledge/.claude-plugin/plugin.json
+++ b/cogni-knowledge/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-knowledge",
-  "version": "1.0.22",
+  "version": "1.0.23",
   "description": "Wiki-first research that compounds. Binds each run to a wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`. The shallow `knowledge-query` rung is read-only by default and can optionally file its answer back as an un-verified synthesis page via `--file-back`.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-knowledge/.claude-plugin/plugin.json
+++ b/cogni-knowledge/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-knowledge",
-  "version": "1.0.21",
+  "version": "1.0.22",
   "description": "Wiki-first research that compounds. Binds each run to a wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`. The shallow `knowledge-query` rung is read-only by default and can optionally file its answer back as an un-verified synthesis page via `--file-back`.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-knowledge/scripts/root_index.py
+++ b/cogni-knowledge/scripts/root_index.py
@@ -206,18 +206,19 @@ def _heading_anchor(theme: str) -> str:
 
     Each theme's Explore links deep-link into the matching `## <theme>`
     section the sub-indexes render (`sub_index._build_page` emits the raw
-    `## {theme}` label). The fragment must match the anchor a Markdown
-    renderer derives from that literal heading — lowercase, drop punctuation,
-    spaces→hyphens — and NOT `slugify`, which transliterates
-    (`Überwachung`→`ueberwachung`, `ß`→`ss`) and so would resolve to no
-    heading for non-ASCII (German/European) themes. Unicode letters are kept
-    verbatim, matching the GitHub-flavoured-Markdown / Obsidian heading-anchor
-    convention. Deterministic, so the curated MAP re-renders byte-identically.
+    `## {theme}` label). The wiki is browsed in Obsidian, which resolves a
+    heading link by the heading's *literal text*: the fragment is the heading
+    text with whitespace runs URL-encoded to `%20` and case + non-ASCII
+    letters preserved verbatim (`KI Bußgelder` → `#KI%20Bußgelder`) — NOT a
+    GitHub-flavoured-Markdown slug (no lowercasing, no punctuation-dropping,
+    no transliteration), which would resolve to no heading in Obsidian. Only
+    whitespace is encoded — the non-ASCII bytes themselves stay literal (the
+    deep link reads `Bußgelder`, never `%C3%9F`). Deterministic, so the
+    curated MAP re-renders byte-identically.
     """
-    lowered = (theme or "").strip().lower()
-    # Keep Unicode word chars / whitespace / hyphen; drop other punctuation.
-    cleaned = re.sub(r"[^\w\s-]", "", lowered, flags=re.UNICODE)
-    return re.sub(r"\s+", "-", cleaned).strip("-")
+    # Literal heading text; collapse ASCII-whitespace runs to %20, preserve
+    # everything else (case, ß/ü/ö/ä, punctuation) exactly as the heading reads.
+    return re.sub(r"\s+", "%20", (theme or "").strip())
 
 
 def _build_map(wiki_root: Path, existing_text: str) -> str:

--- a/cogni-knowledge/scripts/root_index.py
+++ b/cogni-knowledge/scripts/root_index.py
@@ -201,6 +201,25 @@ def _is_human_root(existing_text: str) -> bool:
     return not has_h2 and not has_machine
 
 
+def _heading_anchor(theme: str) -> str:
+    """In-page anchor for a sub-index `## {theme}` heading.
+
+    Each theme's Explore links deep-link into the matching `## <theme>`
+    section the sub-indexes render (`sub_index._build_page` emits the raw
+    `## {theme}` label). The fragment must match the anchor a Markdown
+    renderer derives from that literal heading — lowercase, drop punctuation,
+    spaces→hyphens — and NOT `slugify`, which transliterates
+    (`Überwachung`→`ueberwachung`, `ß`→`ss`) and so would resolve to no
+    heading for non-ASCII (German/European) themes. Unicode letters are kept
+    verbatim, matching the GitHub-flavoured-Markdown / Obsidian heading-anchor
+    convention. Deterministic, so the curated MAP re-renders byte-identically.
+    """
+    lowered = (theme or "").strip().lower()
+    # Keep Unicode word chars / whitespace / hyphen; drop other punctuation.
+    cleaned = re.sub(r"[^\w\s-]", "", lowered, flags=re.UNICODE)
+    return re.sub(r"\s+", "-", cleaned).strip("-")
+
+
 def _build_map(wiki_root: Path, existing_text: str) -> str:
     """Assemble the full proposed curated-MAP `wiki/index.md` text."""
     # Per-(theme, type) counts from the SAME theme assignment as the sub-indexes.
@@ -242,11 +261,16 @@ def _build_map(wiki_root: Path, existing_text: str) -> str:
         if leadin:
             parts.extend(leadin)
             parts.append("")
+        # Deep-link each type into THIS theme's `## <theme>` section of the
+        # sub-index, so the per-theme Explore line is distinct per theme rather
+        # than the shared unfiltered links. Counts still come from theme_counts
+        # (no count drift); the anchor is deterministic (idempotent re-render).
+        anchor = _heading_anchor(theme)
         links = []
         for tname, label in TYPE_DISPLAY:
             n = per_type_counts[tname].get(theme, 0)
             if n > 0:
-                links.append(f"[{label} ({n})]({tname}/index.md)")
+                links.append(f"[{label} ({n})]({tname}/index.md#{anchor})")
         link_line = "**Explore:** " + " · ".join(links) if links else "_(no pages yet)_"
         parts.append(_render_span(ROOT_LINKS_NAME, link_line))
         parts.append("")

--- a/cogni-knowledge/tests/test_root_index.sh
+++ b/cogni-knowledge/tests/test_root_index.sh
@@ -86,6 +86,22 @@ pre_extracted_claims:
 ---
 Body B.
 EOF
+# --- a source under a NON-ASCII theme ("KI Bußgelder") to prove the deep-link
+#     anchor matches the rendered `## <theme>` heading (lowercase + space→hyphen,
+#     ß preserved) and NOT slugify's transliterated form (`ki-bussgelder`). ---
+cat > "$WIKI/wiki/sources/src-pen.md" <<'EOF'
+---
+id: src-pen
+title: Source Pen
+type: source
+theme_label: KI Bußgelder
+sources: ["https://example.com/pen"]
+pre_extracted_claims:
+  - id: clm-1
+    text: A claim about penalties.
+---
+Body Pen.
+EOF
 cat > "$WIKI/wiki/concepts/high-risk.md" <<'EOF'
 ---
 id: high-risk
@@ -163,12 +179,26 @@ echo "$OUT" | grep -q '"changed": true' \
   || { red "FAIL: 1 render not changed:true ($OUT)"; errors=$((errors+1)); }
 assert_grep "MACHINE-OWNED:ROOT-INDEX" "$IDX" "1 ROOT-INDEX ownership marker present"
 assert_grep "Curated map of this knowledge base" "$IDX" "1 curated intro line present"
+# AC#3 (no-fabrication half): the source fixture index carried no
+# OVERVIEW-NARRATIVE block, so the renderer must NOT invent a placeholder one.
+assert_not_grep "MACHINE-OWNED:OVERVIEW-NARRATIVE" "$IDX" "1b no narrative span fabricated when none authored"
 
-# === 2. per-theme count-links with counts ===
-assert_grep "Sources (2)](sources/index.md)" "$IDX" "2 Sources (2) sub-index link"
-assert_grep "Concepts (1)](concepts/index.md)" "$IDX" "2 Concepts (1) sub-index link"
-assert_grep "Questions (1)](questions/index.md)" "$IDX" "2 Questions (1) sub-index link"
-assert_grep "Syntheses (1)](syntheses/index.md)" "$IDX" "2 Syntheses (1) sub-index link (folded into theme)"
+# === 2. per-theme count-links with counts AND theme-scoped deep-link anchors ===
+# The link now deep-links into the theme's `## <theme>` section of each
+# sub-index (`<type>/index.md#<anchor>`), not the bare unfiltered sub-index.
+assert_grep "Sources (2)](sources/index.md#scope)" "$IDX" "2 Sources (2) deep-link to #scope"
+assert_grep "Concepts (1)](concepts/index.md#scope)" "$IDX" "2 Concepts (1) deep-link to #scope"
+assert_grep "Questions (1)](questions/index.md#scope)" "$IDX" "2 Questions (1) deep-link to #scope"
+assert_grep "Syntheses (1)](syntheses/index.md#scope)" "$IDX" "2 Syntheses (1) deep-link to #scope (folded into theme)"
+
+# === 2b. distinct per-theme anchors + non-ASCII heading-anchor (the slugify gap) ===
+assert_grep '^## KI Bußgelder' "$IDX" "2b non-ASCII theme heading kept verbatim"
+# The deep link must match the anchor the rendered `## KI Bußgelder` heading
+# produces (lowercase, space→hyphen, ß preserved): #ki-bußgelder — distinct
+# from the Scope theme's #scope (so per-theme Explore lines differ).
+assert_grep "Sources (1)](sources/index.md#ki-bußgelder)" "$IDX" "2b non-ASCII theme deep-links to #ki-bußgelder"
+# Regression: NOT slugify's transliterated form (would not resolve to the heading).
+assert_not_grep "sources/index.md#ki-bussgelder)" "$IDX" "2b anchor is NOT the transliterated slugify form #ki-bussgelder"
 
 # === 3. no per-page source bullets remain on the root ===
 assert_not_grep '^- \[\[src-a\]\]' "$IDX" "3 per-page src-a bullet dropped from root"
@@ -196,6 +226,12 @@ OUT2="$(python3 "$ROOT_SCRIPT" render --wiki-root "$WIKI" --wiki-scripts-dir "$W
 echo "$OUT2" | grep -q '"changed": false' \
   && green "PASS: 7 re-render is byte-identical no-op (changed:false)" \
   || { red "FAIL: 7 re-render not idempotent ($OUT2)"; errors=$((errors+1)); }
+
+# === 7b. AC#3 (verbatim-preservation half): a real OVERVIEW-NARRATIVE survives
+#         another re-render byte-for-byte (section 6 authored it; re-render again
+#         and confirm the prose is still carried verbatim, not reset/placeheld). ===
+python3 "$ROOT_SCRIPT" render --wiki-root "$WIKI" --wiki-scripts-dir "$WSD" >/dev/null
+assert_grep "This base maps scope for SMEs." "$IDX" "7b real OVERVIEW-NARRATIVE preserved verbatim across re-render"
 
 # === 8. reflow/collapse stability ===
 BEFORE="$(mktemp)"; cp "$IDX" "$BEFORE"

--- a/cogni-knowledge/tests/test_root_index.sh
+++ b/cogni-knowledge/tests/test_root_index.sh
@@ -186,18 +186,22 @@ assert_not_grep "MACHINE-OWNED:OVERVIEW-NARRATIVE" "$IDX" "1b no narrative span 
 # === 2. per-theme count-links with counts AND theme-scoped deep-link anchors ===
 # The link now deep-links into the theme's `## <theme>` section of each
 # sub-index (`<type>/index.md#<anchor>`), not the bare unfiltered sub-index.
-assert_grep "Sources (2)](sources/index.md#scope)" "$IDX" "2 Sources (2) deep-link to #scope"
-assert_grep "Concepts (1)](concepts/index.md#scope)" "$IDX" "2 Concepts (1) deep-link to #scope"
-assert_grep "Questions (1)](questions/index.md#scope)" "$IDX" "2 Questions (1) deep-link to #scope"
-assert_grep "Syntheses (1)](syntheses/index.md#scope)" "$IDX" "2 Syntheses (1) deep-link to #scope (folded into theme)"
+# Obsidian resolves a heading link by the heading's literal text: the anchor
+# preserves case (theme "Scope" → `## Scope` → #Scope), spaces → %20.
+assert_grep "Sources (2)](sources/index.md#Scope)" "$IDX" "2 Sources (2) deep-link to #Scope"
+assert_grep "Concepts (1)](concepts/index.md#Scope)" "$IDX" "2 Concepts (1) deep-link to #Scope"
+assert_grep "Questions (1)](questions/index.md#Scope)" "$IDX" "2 Questions (1) deep-link to #Scope"
+assert_grep "Syntheses (1)](syntheses/index.md#Scope)" "$IDX" "2 Syntheses (1) deep-link to #Scope (folded into theme)"
 
-# === 2b. distinct per-theme anchors + non-ASCII heading-anchor (the slugify gap) ===
+# === 2b. distinct per-theme anchors + non-ASCII heading-anchor (Obsidian convention) ===
 assert_grep '^## KI Bußgelder' "$IDX" "2b non-ASCII theme heading kept verbatim"
-# The deep link must match the anchor the rendered `## KI Bußgelder` heading
-# produces (lowercase, space→hyphen, ß preserved): #ki-bußgelder — distinct
-# from the Scope theme's #scope (so per-theme Explore lines differ).
-assert_grep "Sources (1)](sources/index.md#ki-bußgelder)" "$IDX" "2b non-ASCII theme deep-links to #ki-bußgelder"
-# Regression: NOT slugify's transliterated form (would not resolve to the heading).
+# The deep link is the Obsidian heading-text anchor for `## KI Bußgelder`:
+# literal text, space → %20, case + ß preserved verbatim (#KI%20Bußgelder) —
+# distinct from the Scope theme's #Scope (so per-theme Explore lines differ).
+assert_grep "Sources (1)](sources/index.md#KI%20Bußgelder)" "$IDX" "2b non-ASCII theme deep-links to #KI%20Bußgelder"
+# Regression: NOT the GFM slug form, and NOT slugify's transliterated form
+# (neither resolves to the heading in Obsidian).
+assert_not_grep "sources/index.md#ki-bußgelder)" "$IDX" "2b anchor is NOT the GFM slug form #ki-bußgelder"
 assert_not_grep "sources/index.md#ki-bussgelder)" "$IDX" "2b anchor is NOT the transliterated slugify form #ki-bussgelder"
 
 # === 3. no per-page source bullets remain on the root ===


### PR DESCRIPTION
Closes #864.

## Summary
- `root_index.py` `_build_map` now emits each theme's `ROOT-LINKS` "Explore:" line as a theme-scoped deep link (`<type>/index.md#<anchor>`) instead of the bare unfiltered `<type>/index.md`, so the per-theme Explore block is distinct per theme and anchors into the matching `## <theme>` section the sub-indexes already group by.
- The fragment `<anchor>` is the **Obsidian heading-text anchor** for the `## <theme>` line, via a small `_heading_anchor` helper: the literal heading text with whitespace runs → `%20` and case + non-ASCII preserved verbatim (`KI Bußgelder` → `#KI%20Bußgelder`). This matches how the wiki's reader (Obsidian) resolves a heading link — **not** a GFM slug (no lowercasing/punctuation-dropping) and **not** `slugify()` (which transliterates ü→ue / ß→ss and would resolve to no heading for non-ASCII themes).
- Per-(theme,type) counts still come from `sub_index.theme_counts` (unchanged), so the displayed counts cannot drift from the sub-indexes — the existing `_build_map` invariant is preserved (AC#2).
- Human lead-ins (`MACHINE-OWNED:PORTAL-LEADIN` / non-sentineled) stay preserved verbatim via `_carry_leadin`; the fragment is deterministic so an already-correct base re-renders byte-identically.
- `OVERVIEW-NARRATIVE` confirmed correct-by-design in the renderer (`extract_machine_block` carries a real narrative verbatim and only leaves the placeholder when none was authored); added regression tests (no fabrication when none authored + verbatim preservation across re-render) for AC#3.
- Patch version bump (`plugin.json` + `marketplace.json`, 1.0.21 → 1.0.23).

## Scope
- In scope: the renderer link-assembly change (AC#1, AC#2), the heading-anchor helper so the deep link resolves for non-ASCII themes, the deterministic idempotent fragment, and renderer-level regression tests including a non-ASCII (`KI Bußgelder`) theme (AC#3).
- Deferred: any finalize-orchestrator carve-out repair for the placeholder persistence observed on an already-degraded base. That lives in `knowledge-finalize/SKILL.md`, is a separate concern from this renderer substrate, and is the explicit job of the repair child #865 which re-renders this seam.

## Test plan
- `bash cogni-knowledge/tests/test_root_index.sh` — ALL PASS, including the theme-scoped Obsidian-anchor and AC#3 regressions.
- Adjacent renderers green: `test_perspectives_index.sh`, `test_structural_drift_health.sh`, `test_curated_layout_health.sh`.

## Resolved decisions
- **Heading-anchor convention** (was an open question): the maintainer confirmed the **Obsidian heading-text convention** — the wiki is Obsidian-browsable, so the fragment is the literal heading text with spaces → `%20` and case + non-ASCII preserved (`#KI%20Bußgelder`), not a GFM slug. Implemented in `_heading_anchor` with a non-ASCII regression fixture asserting `#KI%20Bußgelder`.

---
Resolution plan record: https://github.com/cogni-work/insight-wave/issues/864#issuecomment-4749148544
