### PR TITLE
cogni-knowledge: knowledge-index --repair for drifted machine-owned regions

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "cogni-knowledge",
       "source": "./cogni-knowledge",
-      "version": "1.0.23",
+      "version": "1.0.24",
       "maturity": "released",
       "description": "Wiki-first research that compounds. Binds each run to a wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`. The shallow `knowledge-query` rung is read-only by default and can optionally file its answer back as an un-verified synthesis page via `--file-back`.",
       "keywords": [

--- a/cogni-knowledge/.claude-plugin/plugin.json
+++ b/cogni-knowledge/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-knowledge",
-  "version": "1.0.23",
+  "version": "1.0.24",
   "description": "Wiki-first research that compounds. Binds each run to a wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`. The shallow `knowledge-query` rung is read-only by default and can optionally file its answer back as an un-verified synthesis page via `--file-back`.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-knowledge/scripts/migrate-layout.py
+++ b/cogni-knowledge/scripts/migrate-layout.py
@@ -81,11 +81,27 @@ from _knowledge_lib import (  # noqa: E402
 from sub_index import REGISTRY, _import_wiki_lock  # noqa: E402
 
 TARGET_SCHEMA = "0.0.8"
+# The current engine schema. `--repair` reconciles a lagging already-curated
+# base up to this (the curated layout + the first-class person type), the same
+# value knowledge-setup seeds for a new base.
+ENGINE_SCHEMA = "0.0.9"
 # Pre-per-type-dirs bases (< 0.0.5) hard-fail across the plugin; this migrator
 # only bridges the curated-layout gap, not the page-directory cutover.
 FLOOR_SCHEMA = "0.0.5"
 
 CONTROL_FILES = ("log.md", "context_brief.md", "open_questions.md")
+
+# A degraded curated front door: a per-theme ROOT-LINKS machine span whose
+# inner text is the empty-state sentinel — the same signal health.py's
+# structural_drift check keys on. root_index.py owns both the span name and the
+# sentinel string; re-stated here only as the drift-detection needle (the regen
+# itself delegates to root_index.py render, never re-implements the link build).
+ROOT_LINKS_EMPTY_SENTINEL = "_(no pages yet)_"
+_ROOT_LINKS_SPAN_RE = re.compile(
+    r"<!--\s*MACHINE-OWNED:ROOT-LINKS:START\s*-->(.*?)"
+    r"<!--\s*MACHINE-OWNED:ROOT-LINKS:END\s*-->",
+    re.DOTALL,
+)
 
 OVERVIEW_NARRATIVE_NAME = "OVERVIEW-NARRATIVE"
 OVERVIEW_STUB_LINE = (
@@ -346,6 +362,152 @@ def _relocate_only(
     return _emit(True, data=data)
 
 
+def _root_links_drifted(wiki_root: Path) -> "tuple[bool, str]":
+    """True when wiki/index.md has any empty-sentinel ROOT-LINKS span.
+
+    Mirrors health.py's structural_drift ROOT-LINKS check: a per-theme
+    `MACHINE-OWNED:ROOT-LINKS` span whose inner text stripped equals the
+    empty-state sentinel means the curated front door was never (re)populated
+    with theme-scoped deep links. Returns (drifted, error).
+    """
+    index_path = wiki_root / "wiki" / "index.md"
+    try:
+        index_text = index_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return False, f"index.md unreadable: {exc}"
+    for inner in _ROOT_LINKS_SPAN_RE.findall(index_text):
+        if inner.strip() == ROOT_LINKS_EMPTY_SENTINEL:
+            return True, ""
+    return False, ""
+
+
+def cmd_repair(args: argparse.Namespace) -> int:
+    """Regenerate drifted machine-owned regions on an already-curated base.
+
+    The repair counterpart to the version-floored migration: keyed on the
+    structural-drift class health.py emits (not the schema floor), it
+    regenerates the theme-scoped ROOT-LINKS region via root_index.py render
+    and reconciles a lagging schema_version up to ENGINE_SCHEMA. Dry-run by
+    default (stages the proposed root MAP as a diff surface); --apply writes
+    under the renderer's own lock. Idempotent: a non-drifted, current-schema
+    base reaches action:noop; a second --apply is a clean no-op.
+
+    Scope boundary: root_index.py render carries the OVERVIEW-NARRATIVE block
+    VERBATIM and never re-authors a bootstrap placeholder — re-authoring that
+    region is the skill orchestrator's portal-narrator step (knowledge-index
+    SKILL.md ### Repair mode), gated on health structural_drift findings that
+    name the OVERVIEW-NARRATIVE region. This script repairs ROOT-LINKS +
+    schema lag; it deliberately does not touch OVERVIEW-NARRATIVE.
+    """
+    wiki_root = Path(args.wiki_root).expanduser().resolve()
+    if not (wiki_root / "wiki").is_dir():
+        return _emit(False, error=f"wiki_root has no wiki/ dir: {wiki_root}")
+
+    schema_before, err = _read_schema_version(wiki_root)
+    if err:
+        return _emit(False, error=err)
+    # Repair operates on an already-curated base; a pre-0.0.8 base needs the
+    # full layout migration first, not a region regen.
+    if not _is_version_at_least(schema_before, TARGET_SCHEMA):
+        return _emit(False, error=(
+            f"--repair requires an already-curated base (schema >= "
+            f"{TARGET_SCHEMA}); this base is at {schema_before!r} — run the "
+            f"full migration via knowledge-index --migrate first"
+        ))
+
+    links_drifted, err = _root_links_drifted(wiki_root)
+    if err:
+        return _emit(False, error=err)
+    schema_lagging = not _is_version_at_least(schema_before, ENGINE_SCHEMA)
+
+    drifted_regions = ["ROOT-LINKS"] if links_drifted else []
+    data: dict = {
+        "wiki_root": str(wiki_root),
+        "applied": bool(args.apply),
+        "schema_before": schema_before,
+        "schema_after": schema_before,
+        "drifted_regions": drifted_regions,
+        "schema_lagging": schema_lagging,
+    }
+
+    if not (links_drifted or schema_lagging):
+        data["action"] = "noop"
+        data["reason"] = "no_drift_detected"
+        return _emit(True, data=data)
+
+    own_dir = Path(__file__).resolve().parent
+    wiki_scripts, err = _resolve_scripts(args)
+    if err:
+        return _emit(False, error=err)
+
+    if not args.apply:
+        # Dry-run: stage the proposed root MAP (lock-free; live index
+        # untouched) as the content-diff surface, mirroring --migrate.
+        if links_drifted:
+            ok, payload = _run_renderer(
+                own_dir, "root_index.py",
+                ["stage", "--wiki-root", str(wiki_root)],
+            )
+            data["staged"] = [{
+                "type": "root",
+                "ok": ok,
+                "path": payload.get("path", ""),
+                **({"error": payload.get("error", "")} if not ok else {}),
+            }]
+        data["action"] = "dry_run"
+        data["reason"] = "repair_pending"
+        return _emit(True, data=data)
+
+    # --- apply path -------------------------------------------------------
+    # ROOT-LINKS regen: root_index.py render self-locks (no parent lock held).
+    if links_drifted:
+        ok, payload = _run_renderer(
+            own_dir, "root_index.py",
+            ["render", "--wiki-root", str(wiki_root),
+             "--wiki-scripts-dir", str(wiki_scripts)],
+        )
+        data["rendered"] = [{
+            "type": "root",
+            "ok": ok,
+            "changed": payload.get("changed"),
+            **({"error": payload.get("error", "")} if not ok else {}),
+        }]
+        if not ok:
+            return _emit(False, data=data, error="root MAP render failed")
+
+    # Schema reconciliation: bump to ENGINE_SCHEMA when it lags (config_bump
+    # locks its own write — same subprocess shape as cmd_migrate Phase 3).
+    if schema_lagging:
+        proc = subprocess.run(
+            [sys.executable, str(wiki_scripts / "config_bump.py"),
+             "--wiki-root", str(wiki_root),
+             "--key", "schema_version", "--set-string", ENGINE_SCHEMA],
+            capture_output=True,
+            text=True,
+        )
+        try:
+            bump = json.loads(proc.stdout)
+        except ValueError:
+            bump = {"success": False, "error": (proc.stderr or "").strip()[:500]}
+        if not bump.get("success"):
+            return _emit(False, data=data,
+                         error=f"schema bump failed: {bump.get('error', 'unknown')}")
+        data["schema_after"] = ENGINE_SCHEMA
+
+    repairs = []
+    if links_drifted:
+        repairs.append("regenerated ROOT-LINKS")
+    if schema_lagging:
+        repairs.append(f"reconciled schema {schema_before} -> {ENGINE_SCHEMA}")
+    if repairs:
+        _append_migrate_log(
+            wiki_root,
+            f"migrate | curated-layout repair: {', '.join(repairs)}",
+        )
+    data["action"] = "repaired"
+    return _emit(True, data=data)
+
+
 def cmd_migrate(args: argparse.Namespace) -> int:
     wiki_root = Path(args.wiki_root).expanduser().resolve()
     if not (wiki_root / "wiki").is_dir():
@@ -527,7 +689,24 @@ def main(argv: "list[str]") -> int:
             "Actually relocate files, render indexes, and bump the schema. "
             "Without this flag the run is dry: planned moves are reported and "
             "the proposed indexes are staged to .cogni-wiki/*-proposed.md as "
-            "the content-diff surface; nothing live is touched."
+            "the content-diff surface; nothing live is touched. With --repair: "
+            "render the regenerated root MAP under the renderer's lock and "
+            "reconcile schema_version up to the current engine schema."
+        ),
+    )
+    parser.add_argument(
+        "--repair",
+        action="store_true",
+        help=(
+            "Regenerate drifted machine-owned regions on an already-curated "
+            "base (schema >= 0.0.8) — keyed on the structural-drift class "
+            "health.py emits, not the version floor. Regenerates the "
+            "theme-scoped ROOT-LINKS region via root_index.py render and "
+            "reconciles a lagging schema_version. Dry-run by default; pair "
+            "with --apply to write. Idempotent (noop on a non-drifted, "
+            "current-schema base). Does NOT re-author the OVERVIEW-NARRATIVE "
+            "placeholder — that is the orchestrator's portal-narrator step. "
+            "REFUSES a pre-0.0.8 base (run --migrate first)."
         ),
     )
     parser.add_argument(
@@ -543,6 +722,8 @@ def main(argv: "list[str]") -> int:
         ),
     )
     args = parser.parse_args(argv)
+    if getattr(args, "repair", False):
+        return cmd_repair(args)
     return cmd_migrate(args)
 
 

--- a/cogni-knowledge/skills/knowledge-index/SKILL.md
+++ b/cogni-knowledge/skills/knowledge-index/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: knowledge-index
-description: "Rebuild the curated root index + per-type sub-indexes of a cogni-knowledge base on demand, or migrate an EXISTING pre-0.0.8 wiki to the curated layout (control files into wiki/meta/, overview folded into the index intro, flat root split into root-map + sub-indexes, schema 0.0.7→0.0.8). Use this skill whenever the user says 'rebuild the index', 'rebuild the knowledge index', 'regenerate the wiki indexes', 'refresh the sub-indexes', 'migrate my wiki to the curated layout', 'upgrade the wiki layout', 'migrate the knowledge base structure', or knowledge-resume surfaces a schema_version < 0.0.8 migration nudge."
+description: "Rebuild the curated root index + per-type sub-indexes of a cogni-knowledge base on demand, migrate an EXISTING pre-0.0.8 wiki to the curated layout (control files into wiki/meta/, overview folded into the index intro, flat root split into root-map + sub-indexes, schema 0.0.7→0.0.8), or repair drifted machine-owned regions (theme-scoped ROOT-LINKS, schema lag) on a base already >= 0.0.8. Use this skill whenever the user says 'rebuild the index', 'rebuild the knowledge index', 'regenerate the wiki indexes', 'refresh the sub-indexes', 'migrate my wiki to the curated layout', 'upgrade the wiki layout', 'migrate the knowledge base structure', 'repair the knowledge index', 'regenerate the curated front door', 'fix the structural drift', or knowledge-resume / knowledge-health surfaces a schema_version < 0.0.8 migration nudge or a structural-drift verdict."
 allowed-tools: Read, Bash, Glob
 ---
 
@@ -20,6 +20,17 @@ place:
   control files relocate into `wiki/meta/`, the `overview.md` narrative folds
   into the `index.md` intro, the flat root index splits into root-map +
   per-type sub-indexes, and the schema bumps to `0.0.8`. Dry-run first, always.
+- **Repair** — on a base already on the curated layout (`schema_version >=
+  0.0.8`), regenerate drifted machine-owned regions keyed on the
+  structural-drift class `health.py` emits (not the version floor): a
+  theme-scoped `ROOT-LINKS` span stuck on the empty-state sentinel is
+  re-rendered via `root_index.py render`, and a lagging `schema_version` is
+  reconciled to the current engine schema. Same dry-run-first / `--apply`
+  ergonomics as migrate. Idempotent: a non-drifted, current-schema base is a
+  `noop`. **Scope boundary:** the script repairs ROOT-LINKS + schema lag; a
+  degraded OVERVIEW-NARRATIVE (stuck on the bootstrap placeholder) is
+  re-authored by a separate orchestrator step (see 2c) — `root_index.py
+  render` carries that block verbatim and never re-authors it.
 
 The migrate split is the lossy transform — human content could be dropped when
 the flat root becomes a MAP. It is delegated to `root_index.py render`, which
@@ -33,6 +44,9 @@ relocate into the sub-indexes). The migrator never re-implements the split.
 - `knowledge-resume` surfaced a `schema_version < 0.0.8` migration nudge
 - A base predates the curated layout and the user wants the new structure
 - After hand-editing wiki pages, to re-derive the indexes from disk
+- `knowledge-health` surfaced a `structural_drift` verdict (empty ROOT-LINKS,
+  placeholder OVERVIEW-NARRATIVE) or a `schema_version_lag` on a curated base,
+  and the user wants the one-command repair (`--repair`)
 
 ## Never run when
 
@@ -48,7 +62,8 @@ relocate into the sub-indexes). The migrator never re-implements the split.
 | `--knowledge-slug` | Yes | Slug of the knowledge base. Resolves to `cogni-knowledge/<slug>/` unless `--knowledge-root` overrides. |
 | `--knowledge-root` | No | Override the default knowledge-base directory. |
 | `--migrate` | No | Run the layout migration instead of a plain rebuild. Dry-run by default. |
-| `--apply` | No | With `--migrate`: actually relocate files, render, and bump the schema. Without it the migrator stages proposals and reports, touching nothing live. |
+| `--repair` | No | Regenerate drifted machine-owned regions (theme-scoped ROOT-LINKS, schema lag) on an already-curated (`>= 0.0.8`) base, keyed on health's structural-drift class. Dry-run by default. Refuses a pre-0.0.8 base (run `--migrate` first). |
+| `--apply` | No | With `--migrate`: actually relocate files, render, and bump the schema. With `--repair`: render the regenerated root MAP under the renderer's lock and reconcile `schema_version` to the current engine schema. Without it the run stages proposals and reports, touching nothing live. |
 
 ## Workflow
 
@@ -143,9 +158,61 @@ Report from the envelope: control files moved, the overview fold, the rendered
 indexes, and `schema_after: 0.0.8`. A second `--apply` is a clean no-op, so
 re-running after an interruption is safe.
 
-### 2c. SCHEMA.md truth-up (both modes, idempotent)
+### 2c. Repair mode (`--repair`)
 
-After a rebuild render or a migrate `--apply` (never on a dry run), truth-up
+For a base **already** on the curated layout (`schema_version >= 0.0.8`) whose
+machine-owned regions have drifted — the case `knowledge-health` flags as
+`structural_drift` / `schema_version_lag` but the `--migrate` path (version-floored)
+never reaches. The script repairs two regions; a third (OVERVIEW-NARRATIVE) is an
+orchestrator step, below.
+
+**Dry-run first, always.** Run the repair without `--apply`:
+
+```bash
+python3 "${CLAUDE_PLUGIN_ROOT}/scripts/migrate-layout.py" \
+  --wiki-root "<wiki_path>" --wiki-scripts-dir "$WIKI_INGEST_SCRIPTS" --repair
+```
+
+- `success: false` (pre-0.0.8 base) → the base is not curated; route to
+  `--migrate` first (the error names it). Do not `--apply`.
+- `action: noop` / `reason: no_drift_detected` → the curated front door is
+  healthy and the schema is current; nothing to repair. Offer a plain rebuild
+  if the indexes merely look stale.
+- `action: dry_run` / `reason: repair_pending` → present the preview from the
+  envelope: `data.drifted_regions[]` (e.g. `ROOT-LINKS`), `data.schema_lagging`,
+  and the staged proposal path (`data.staged[].path` — `.cogni-wiki/root-index-proposed.md`).
+  That staged root MAP is the **content diff surface**: point the user at it so
+  they can diff it against the live `wiki/index.md` before committing.
+
+Then, only when the user passed `--apply` (or confirms after the preview):
+
+```bash
+python3 "${CLAUDE_PLUGIN_ROOT}/scripts/migrate-layout.py" \
+  --wiki-root "<wiki_path>" --wiki-scripts-dir "$WIKI_INGEST_SCRIPTS" --repair --apply
+```
+
+Report from the envelope: `data.rendered` (the regenerated ROOT-LINKS region) and
+`schema_after` (reconciled to the current engine schema when it lagged). A
+non-drifted, current-schema base reaches `action: noop`; a second `--apply` is a
+clean no-op, so re-running after an interruption is safe.
+
+**OVERVIEW-NARRATIVE drift is an orchestrator step, not a script flag.**
+`health.py` emits **two** `structural_drift` classes: an empty ROOT-LINKS span
+(script-repairable here) and an OVERVIEW-NARRATIVE block stuck on the bootstrap
+placeholder (`_Overview pending — authored on the first knowledge-finalize
+run._`). `--repair` resolves the first; it deliberately does **not** touch the
+second, because `root_index.py render` carries the OVERVIEW-NARRATIVE block
+verbatim and re-authoring real narrative is an LLM task. When health flags the
+OVERVIEW-NARRATIVE region, dispatch the `portal-narrator` agent and splice its
+output with `overview_update.py narrative-splice --target-file index.md` (the
+same path `knowledge-finalize` Step 10.5 sub-step 3.5 / 3.5.1 uses) **before**
+the `--repair --apply` call — so the one run lands both the re-authored narrative
+and the regenerated ROOT-LINKS, leaving health clean.
+
+### 2d. SCHEMA.md truth-up (all modes, idempotent)
+
+After a rebuild render, a migrate `--apply`, or a repair `--apply` (never on a
+dry run), truth-up
 the base's self-describing contract. `SCHEMA.md` is not a locked shared-state
 file, so this is an orchestrator-side check-then-overwrite, not a
 `migrate-layout.py` phase. Detect by the **positive provenance sentinel** the
@@ -179,9 +246,9 @@ else echo "generic"; fi
 End with a compact block: base title + wiki path, the mode that ran, per-type
 render results (or the migration actions), the schema version, and the
 SCHEMA.md truth-up outcome (`overwritten` / `already-current` /
-`no-SCHEMA-found → seeded`, or `skipped — dry run` when 2c did not run). For a
-migrate dry-run, the last line names the apply command so the user can execute
-the preview.
+`no-SCHEMA-found → seeded`, or `skipped — dry run` when 2d did not run). For a
+migrate or repair dry-run, the last line names the apply command so the user can
+execute the preview.
 
 ## Edge cases
 

--- a/cogni-knowledge/skills/knowledge-index/SKILL.md
+++ b/cogni-knowledge/skills/knowledge-index/SKILL.md
@@ -6,7 +6,7 @@ allowed-tools: Read, Bash, Glob
 
 # Knowledge Index
 
-Two related operations on a bound knowledge base, both delegating to the locked
+Three related operations on a bound knowledge base, all delegating to the locked
 renderers (`sub_index.py`, `root_index.py`) so index-shaping logic lives in one
 place:
 
@@ -180,8 +180,9 @@ python3 "${CLAUDE_PLUGIN_ROOT}/scripts/migrate-layout.py" \
   if the indexes merely look stale.
 - `action: dry_run` / `reason: repair_pending` → present the preview from the
   envelope: `data.drifted_regions[]` (e.g. `ROOT-LINKS`), `data.schema_lagging`,
-  and the staged proposal path (`data.staged[].path` — `.cogni-wiki/root-index-proposed.md`).
-  That staged root MAP is the **content diff surface**: point the user at it so
+  and the staged proposal path (`data.staged[].path` — e.g.
+  `.cogni-wiki/root-index-proposed.md`). That staged root MAP is the
+  **content diff surface**: point the user at it so
   they can diff it against the live `wiki/index.md` before committing.
 
 Then, only when the user passed `--apply` (or confirms after the preview):

--- a/cogni-knowledge/tests/test_repair_mode.sh
+++ b/cogni-knowledge/tests/test_repair_mode.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+# test_repair_mode.sh — functional test for scripts/migrate-layout.py --repair
+# (the curated-layout REPAIR mode that regenerates drifted machine-owned
+# regions on an already-curated base, keyed on the structural-drift class
+# health.py emits — not the version floor the --migrate path uses).
+#
+# Executes the real code path against synthetic curated (>= 0.0.8) bases:
+#   AC1.  Dry-run (default, no --apply) on a degraded base (empty ROOT-LINKS
+#         span) reports action:dry_run / reason:repair_pending, names the
+#         drifted ROOT-LINKS region, stages the proposed root MAP to
+#         .cogni-wiki/root-index-proposed.md, and leaves the live index.md
+#         byte-identical (empty sentinel untouched).
+#   AC1.  --apply regenerates ROOT-LINKS via root_index.py render: the live
+#         index.md ROOT-LINKS span is populated (empty sentinel gone), and a
+#         repair log line lands under wiki/meta/log.md.
+#   AC2.  Re-running the vendored health.py on the repaired base reports zero
+#         structural_drift findings (errors stay 0).
+#   AC3.  --repair on a clean curated base is action:noop / no_drift_detected,
+#         and a second --apply is a clean no-op too.
+#   lag.  A base recorded at 0.0.8 (behind the engine's 0.0.9) with populated
+#         links repairs the schema lag only: --apply bumps schema_version to
+#         0.0.9 (action:repaired, no ROOT-LINKS region in drifted_regions).
+#   guard. A pre-0.0.8 base is REFUSED (success:false, pointer to --migrate)
+#         rather than silently running the lossy full migration.
+#
+# bash 3.2 + python3 stdlib only. Exits non-zero on any failure.
+
+set -eu
+
+PLUGIN_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT="$PLUGIN_ROOT/scripts/migrate-layout.py"
+HEALTH="$PLUGIN_ROOT/scripts/vendor/cogni-wiki/skills/wiki-health/scripts/health.py"
+WSD="$PLUGIN_ROOT/scripts/vendor/cogni-wiki/skills/wiki-ingest/scripts"
+
+. "$(dirname "$0")/fixtures/test_helpers.sh"
+
+errors=0
+
+if [ ! -d "$WSD" ]; then
+  red "FAIL: vendored cogni-wiki wiki-ingest scripts not found at $WSD"
+  exit 1
+fi
+
+WORK="$(mktemp -d)"
+cleanup() { rm -rf "$WORK"; }
+trap cleanup EXIT
+
+# The exact literals the detector strip-compares against (pinned to the live
+# root_index.py empty-state sentinel).
+ROOT_LINKS_EMPTY='_(no pages yet)_'
+REAL_OVERVIEW='This base surveys EU AI Act scope and obligations for SMEs.'
+POPULATED_LINKS='**Explore:** [Sources (1)](sources/index.md#Regulierung)'
+
+# Build a curated-layout fixture wiki with a configurable index.md carrying the
+# OVERVIEW-NARRATIVE + ROOT-LINKS machine-owned blocks. The single source page
+# carries theme_label "Regulierung" so root_index.py render maps it under that
+# theme and produces a populated count-link on --apply.
+#   $1 = root dir, $2 = schema_version, $3 = overview inner, $4 = root-links inner
+build_curated() {
+  rm -rf "$1"
+  mkdir -p "$1/wiki/sources" "$1/wiki/meta" "$1/.cogni-wiki"
+  cat > "$1/.cogni-wiki/config.json" <<EOF
+{"wiki_slug": "fixture", "title": "Fixture Base", "entries_count": 1, "schema_version": "$2"}
+EOF
+  cat > "$1/wiki/index.md" <<EOF
+# Fixture Base
+
+<!-- MACHINE-OWNED:OVERVIEW-NARRATIVE:START -->
+$3
+<!-- MACHINE-OWNED:OVERVIEW-NARRATIVE:END -->
+
+## Regulierung
+
+<!-- MACHINE-OWNED:ROOT-LINKS:START -->
+$4
+<!-- MACHINE-OWNED:ROOT-LINKS:END -->
+EOF
+  printf '_The overview narrative now lives in [index.md](index.md)._\n\n## Recent syntheses\n\n- none yet\n' > "$1/wiki/overview.md"
+  printf '# Log\n' > "$1/wiki/meta/log.md"
+  printf '# Context brief\n' > "$1/wiki/meta/context_brief.md"
+  printf '# Open questions\n' > "$1/wiki/meta/open_questions.md"
+  cat > "$1/wiki/sources/eu-ai-act-scope.md" <<'EOF'
+---
+id: eu-ai-act-scope
+title: "Scope of the EU AI Act"
+type: source
+theme_label: "Regulierung"
+created: 2026-01-01
+updated: 2026-01-01
+sources:
+  - https://example.org/ai-act
+---
+
+# Scope of the EU AI Act
+
+Body text long enough to clear the stub-page threshold comfortably.
+EOF
+  printf '# Sources\n\n## Regulierung\n\n- [[eu-ai-act-scope]] — Scope of the EU AI Act.\n' > "$1/wiki/sources/index.md"
+}
+
+# ===========================================================================
+# AC1. Dry-run on a degraded base (empty ROOT-LINKS span, current schema 0.0.9)
+# ===========================================================================
+WIKI="$WORK/degraded"
+build_curated "$WIKI" "0.0.9" "$REAL_OVERVIEW" "$ROOT_LINKS_EMPTY"
+cp "$WIKI/wiki/index.md" "$WORK/degraded-index.before"
+
+DRY="$WORK/dry.json"
+python3 "$SCRIPT" --wiki-root "$WIKI" --wiki-scripts-dir "$WSD" --repair > "$DRY"
+assert_grep '"success": true' "$DRY" "AC1 dry-run succeeds"
+assert_grep '"action": "dry_run"' "$DRY" "AC1 dry-run is the default (no --apply)"
+assert_grep '"reason": "repair_pending"' "$DRY" "AC1 dry-run reason is repair_pending"
+assert_grep 'ROOT-LINKS' "$DRY" "AC1 dry-run names the drifted ROOT-LINKS region"
+assert_grep 'root-index-proposed.md' "$DRY" "AC1 dry-run stages the proposed root MAP"
+if cmp -s "$WIKI/wiki/index.md" "$WORK/degraded-index.before"; then
+  green "PASS: AC1 dry-run leaves the live index.md byte-identical"
+else
+  red "FAIL: AC1 dry-run mutated the live index.md"
+  errors=$((errors + 1))
+fi
+
+# ===========================================================================
+# AC1. --apply regenerates the ROOT-LINKS region
+# ===========================================================================
+APPLY="$WORK/apply.json"
+python3 "$SCRIPT" --wiki-root "$WIKI" --wiki-scripts-dir "$WSD" --repair --apply > "$APPLY"
+assert_grep '"success": true' "$APPLY" "AC1 --apply succeeds"
+assert_grep '"action": "repaired"' "$APPLY" "AC1 --apply action is repaired"
+assert_not_grep "$ROOT_LINKS_EMPTY" "$WIKI/wiki/index.md" \
+  "AC1 --apply replaced the empty ROOT-LINKS sentinel in the live index.md"
+assert_grep 'Sources (1)' "$WIKI/wiki/index.md" \
+  "AC1 --apply populated the ROOT-LINKS span with the theme-scoped count-link"
+assert_grep 'curated-layout repair' "$WIKI/wiki/meta/log.md" \
+  "AC1 --apply appended a repair log line"
+
+# ===========================================================================
+# AC2. Re-running health on the repaired base reports zero structural_drift
+# ===========================================================================
+HOUT="$WORK/health-after-repair.json"
+python3 "$HEALTH" --wiki-root "$WIKI" > "$HOUT"
+assert_grep '"success": true' "$HOUT" "AC2 health succeeds on the repaired base"
+assert_not_grep 'structural_drift' "$HOUT" \
+  "AC2 repaired base fires no structural_drift"
+assert_grep '"errors": 0' "$HOUT" "AC2 repaired base has zero errors"
+
+# ===========================================================================
+# AC3. --repair on a clean curated base is a noop; a second --apply too
+# ===========================================================================
+CLEAN="$WORK/clean"
+build_curated "$CLEAN" "0.0.9" "$REAL_OVERVIEW" "$POPULATED_LINKS"
+NOOP="$WORK/noop.json"
+python3 "$SCRIPT" --wiki-root "$CLEAN" --wiki-scripts-dir "$WSD" --repair > "$NOOP"
+assert_grep '"action": "noop"' "$NOOP" "AC3 clean base reaches action:noop"
+assert_grep '"reason": "no_drift_detected"' "$NOOP" "AC3 clean base reason is no_drift_detected"
+
+NOOP2="$WORK/noop2.json"
+python3 "$SCRIPT" --wiki-root "$CLEAN" --wiki-scripts-dir "$WSD" --repair --apply > "$NOOP2"
+assert_grep '"action": "noop"' "$NOOP2" "AC3 second --apply on a clean base is a clean no-op"
+
+# ===========================================================================
+# lag. Schema-lag-only repair: 0.0.8 base with populated links bumps to 0.0.9
+# ===========================================================================
+LAG="$WORK/lag"
+build_curated "$LAG" "0.0.8" "$REAL_OVERVIEW" "$POPULATED_LINKS"
+LAGOUT="$WORK/lag.json"
+python3 "$SCRIPT" --wiki-root "$LAG" --wiki-scripts-dir "$WSD" --repair --apply > "$LAGOUT"
+assert_grep '"action": "repaired"' "$LAGOUT" "lag --apply repairs the schema lag"
+assert_grep '"schema_after": "0.0.9"' "$LAGOUT" "lag --apply reports schema_after 0.0.9"
+assert_grep '"schema_version": "0.0.9"' "$LAG/.cogni-wiki/config.json" \
+  "lag --apply bumped the on-disk schema_version to 0.0.9"
+
+# ===========================================================================
+# guard. A pre-0.0.8 base is refused (run --migrate first)
+# ===========================================================================
+OLD="$WORK/old"
+build_curated "$OLD" "0.0.7" "$REAL_OVERVIEW" "$ROOT_LINKS_EMPTY"
+GUARD="$WORK/guard.json"
+python3 "$SCRIPT" --wiki-root "$OLD" --wiki-scripts-dir "$WSD" --repair > "$GUARD" || true
+assert_grep '"success": false' "$GUARD" "guard: pre-0.0.8 base is refused"
+assert_grep 'migrate' "$GUARD" "guard: refusal points at the full migration (--migrate)"
+
+# ---------------------------------------------------------------------------
+if [ "$errors" -eq 0 ]; then
+  green "test_repair_mode.sh: ALL PASS"
+  exit 0
+else
+  red "test_repair_mode.sh: $errors FAILURE(S)"
+  exit 1
+fi


### PR DESCRIPTION
Closes #865.

## Summary
- Add a `--repair` mode to `migrate-layout.py` (parallel to the existing `--relocate-only` flag): dry-run by default, `--apply` to execute. On an already-curated base (`schema_version >= 0.0.8`) it regenerates the drifted theme-scoped ROOT-LINKS region via `root_index.py` (`stage` on dry-run → `.cogni-wiki/root-index-proposed.md`; `render` under the renderer's `_wiki_lock` on `--apply`) and reconciles a lagging `schema_version` to `0.0.9` via the vendored locked `config_bump.py`. Keyed on the structural-drift class `health.py` emits, NOT the version floor the `--migrate` path uses. Idempotent (no drift + current schema → `action: noop, reason: no_drift_detected`; a second `--apply` is a clean no-op); pre-0.0.8 base refused with `success: false` pointing at `--migrate`; fail-soft.
- `knowledge-index/SKILL.md`: a `--repair` Parameters row, an extended `--apply` row, a new `### 2c. Repair mode (--repair)` workflow section (renumbering the existing SCHEMA.md truth-up section to `### 2d`), and `--repair` named in the frontmatter `description:`, trigger phrases, and `## When to run`.
- New `tests/test_repair_mode.sh` covering all ACs.
- Patch bump `1.0.23 → 1.0.24` (`plugin.json` + the repo-root `marketplace.json` cogni-knowledge entry).

## Scope decisions
- **In scope (script):** ROOT-LINKS regeneration + schema-lag reconciliation — satisfies AC1's ROOT-LINKS half, AC2 (zero structural_drift after `--apply`, verified against the vendored `health.py`), and AC3 (noop on clean).
- **Script/orchestrator split (verified, not deferred):** `root_index.py render` carries the `MACHINE-OWNED:OVERVIEW-NARRATIVE` block verbatim and deliberately does NOT re-author the bootstrap placeholder. Re-authoring a degraded OVERVIEW-NARRATIVE requires the `portal-narrator` LLM agent + `overview_update.py narrative-splice --target-file index.md` — an orchestrator step the SKILL.md `### 2c` section documents (mirroring `knowledge-finalize` Step 10.5 sub-step 3.5 / 3.5.1), gated on health `structural_drift` findings that include the OVERVIEW-NARRATIVE region. So `--repair` closes the machine-deterministic half end-to-end and the OVERVIEW-NARRATIVE re-authoring is wired as a documented orchestrator step in the same skill — not split to a follow-up issue.
- **Host choice:** `migrate-layout.py` is extended (new `--repair` flag + `cmd_repair`, routed from `main` when `args.repair`) rather than adding a new driver, reusing its `_run_renderer`, `_resolve_scripts`, `_append_migrate_log`, and `_read_schema_version` plumbing.

## Test plan
- `bash cogni-knowledge/tests/test_repair_mode.sh` — ALL PASS (22 assertions): AC1 dry-run (stages + leaves live untouched) and `--apply` (ROOT-LINKS populated + repair log line); AC2 (vendored `health.py` reports zero `structural_drift`); AC3 (noop on clean + second `--apply` no-op); schema-lag `0.0.8 → 0.0.9` bump; pre-0.0.8 guard returns `success: false`.
- Adjacent renderers/health green: `test_migrate_layout.sh`, `test_structural_drift_health.sh`, `test_root_index.sh`, `test_curated_layout_health.sh`.

Resolution plan record: https://github.com/cogni-work/insight-wave/issues/865#issuecomment-4749753658