### PR TITLE
cogni-knowledge: read-only retrieval-quality baseline harness (hit@k / MRR)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "cogni-knowledge",
       "source": "./cogni-knowledge",
-      "version": "1.0.29",
+      "version": "1.0.30",
       "maturity": "released",
       "description": "Wiki-first research that compounds. Binds each run to a wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`. The shallow `knowledge-query` rung is read-only by default and can optionally file its answer back as an un-verified synthesis page via `--file-back`.",
       "keywords": [

--- a/cogni-knowledge/.claude-plugin/plugin.json
+++ b/cogni-knowledge/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-knowledge",
-  "version": "1.0.29",
+  "version": "1.0.30",
   "description": "Wiki-first research that compounds. Binds each run to a wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`. The shallow `knowledge-query` rung is read-only by default and can optionally file its answer back as an un-verified synthesis page via `--file-back`.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-knowledge/scripts/retrieval-eval.py
+++ b/cogni-knowledge/scripts/retrieval-eval.py
@@ -1,0 +1,281 @@
+#!/usr/bin/env python3
+"""retrieval-eval.py — read-only retrieval-quality baseline harness.
+
+Runs a labelled `question -> expected-page(s)` set through the existing
+`wiki-grounding.py` `rank` primitive and computes hit@1, hit@5, and MRR
+(rank-of-first-relevant as a click-depth proxy) per-query and aggregate.
+
+WHY THIS EXISTS
+    The engagement's success metric is downstream-agent retrieval hit-rate /
+    click-depth, but nothing measures it. `wiki-grounding.py rank` is the live
+    discovery primitive (the curate read-side and the query skill both resolve
+    to it), yet it emits only `overlap_score` / a coverage verdict — there is no
+    hit@k / MRR baseline anywhere. Without a baseline, the deferred
+    navigation-redesign track is unfalsifiable. This harness captures that
+    baseline so before/after is durable and the redesign becomes measurable.
+
+STRICTLY READ-ONLY against the pipeline. The harness only *reads* the existing
+ranking primitive (it never edits wiki pages, manifests, or any pipeline state)
+and writes its own eval artifacts under `<wiki_root>/.cogni-knowledge/`:
+    - the labelled set:  <wiki_root>/.cogni-knowledge/retrieval-eval-set.json
+    - the run results:   <wiki_root>/.cogni-knowledge/retrieval-eval.json
+
+The labelled set seeds from the bound base's `wiki/questions/*.md` nodes
+(`sources_answering:` is the ground-truth page set; the node `title:` is the
+query text, `theme_label:` the theme), so the regression floor is grounded in
+real question nodes. Held-out queries can be appended to the set file by hand;
+re-seeding never overwrites an existing set unless `--reseed` is passed.
+
+stdlib + python3 only. JSON `{success, data, error}` envelope on stdout.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Load the shared ranking primitive and the shared lib.
+#
+# `wiki-grounding.py` is hyphenated, so it is NOT an importable module name —
+# load it by path via importlib.util.spec_from_file_location (the same idiom the
+# tests use). `_knowledge_lib` IS importable; add scripts/ to sys.path for it.
+# ---------------------------------------------------------------------------
+_SCRIPTS_DIR = Path(__file__).resolve().parent
+
+
+def _load_by_path(name: str, filename: str):
+    spec = importlib.util.spec_from_file_location(name, _SCRIPTS_DIR / filename)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"cannot load {filename}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_wg = _load_by_path("wiki_grounding", "wiki-grounding.py")
+collect_pages = _wg.collect_pages
+sq_token_set = _wg.sq_token_set
+rank_pages = _wg.rank_pages
+DEFAULT_THRESHOLD = _wg.DEFAULT_THRESHOLD
+
+sys.path.insert(0, str(_SCRIPTS_DIR))
+from _knowledge_lib import atomic_write, frontmatter_scalar, _unquote_scalar  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Envelope
+# ---------------------------------------------------------------------------
+def _emit(success: bool, data: dict | None = None, error: str = "") -> int:
+    payload = {"success": success, "data": data or {}, "error": error}
+    print(json.dumps(payload, indent=2, ensure_ascii=False))
+    return 0 if success else 1
+
+
+def _now_iso() -> str:
+    return datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+# ---------------------------------------------------------------------------
+# Question-node seeding
+# ---------------------------------------------------------------------------
+def _parse_inline_list(raw: str) -> list[str]:
+    """Parse a YAML inline list scalar (e.g. `[slug-a, slug-b]`, as
+    `frontmatter_scalar` returns it) into bare string items. Question nodes write
+    `sources_answering:` with unquoted kebab slugs, so stripping the brackets and
+    a comma split + unquote is sufficient and fail-soft (an empty body yields
+    [])."""
+    raw = raw.strip()
+    if raw.startswith("[") and raw.endswith("]"):
+        raw = raw[1:-1]
+    items = []
+    for part in raw.split(","):
+        v = part.strip()
+        if not v:
+            continue
+        items.append(_unquote_scalar(v))
+    return items
+
+
+def seed_from_questions(wiki_root: Path) -> list[dict]:
+    """Build a labelled set from `wiki/questions/*.md`. Each question node whose
+    `sources_answering:` is non-empty becomes one labelled query:
+        {query: <title>, theme_label: <theme_label>, expected_slugs: [...]}
+    A node with no ground-truth answering set is skipped (no label to score).
+
+    Frontmatter scalars are read via the shared `_knowledge_lib.frontmatter_scalar`
+    (column-0 key, inline-comment strip, `_unquote_scalar`) so this stays in lock-
+    step with how the rest of the engine parses question-node frontmatter."""
+    qdir = wiki_root / "wiki" / "questions"
+    queries: list[dict] = []
+    if not qdir.is_dir():
+        return queries
+    for page in sorted(qdir.glob("*.md")):
+        if page.name == "index.md":
+            continue
+        text = page.read_text(encoding="utf-8")
+        title = frontmatter_scalar(text, "title")
+        expected = _parse_inline_list(frontmatter_scalar(text, "sources_answering"))
+        if not (title and expected):
+            continue
+        queries.append({
+            "query": title,
+            "theme_label": frontmatter_scalar(text, "theme_label"),
+            "expected_slugs": expected,
+            "source_node": page.stem,
+        })
+    return queries
+
+
+# ---------------------------------------------------------------------------
+# Metrics
+# ---------------------------------------------------------------------------
+def _rank_of_first_relevant(pages: list[dict], query: dict,
+                            threshold: float) -> int | None:
+    """Rank (1-indexed) of the first ranked page whose slug is in the query's
+    expected set, or None if no expected page is in the passing set.
+
+    Uses a top_k large enough to return the FULL passing set, so MRR and hit@5
+    are never truncated by the default rank cap (the refiner's faithful-
+    measurement fix)."""
+    expected = set(query.get("expected_slugs") or [])
+    sq_tokens = sq_token_set({
+        "query": query.get("query", ""),
+        "theme_label": query.get("theme_label", ""),
+    })
+    full_k = max(len(pages), 5)
+    ranked = rank_pages(pages, sq_tokens, threshold, full_k)
+    for idx, page in enumerate(ranked["covered_pages"], start=1):
+        if page["slug"] in expected:
+            return idx
+    return None
+
+
+def run_eval(wiki_root: Path, queries: list[dict], threshold: float) -> dict:
+    # include_interviews=True: interview pages are source-class evidence on the
+    # read side, so a question whose ground-truth answer is an interview note
+    # must not score as a false miss (the refiner's faithful-measurement fix).
+    pages = collect_pages(wiki_root, include_interviews=True)
+    per_query = []
+    hits_at_1 = 0
+    hits_at_5 = 0
+    rr_sum = 0.0
+    for q in queries:
+        rank = _rank_of_first_relevant(pages, q, threshold)
+        rr = (1.0 / rank) if rank else 0.0
+        h1 = 1 if rank == 1 else 0
+        h5 = 1 if (rank is not None and rank <= 5) else 0
+        hits_at_1 += h1
+        hits_at_5 += h5
+        rr_sum += rr
+        per_query.append({
+            "query": q.get("query", ""),
+            "theme_label": q.get("theme_label", ""),
+            "expected_slugs": q.get("expected_slugs") or [],
+            "source_node": q.get("source_node"),
+            "rank_of_first_relevant": rank,
+            "reciprocal_rank": round(rr, 4),
+            "hit_at_1": h1,
+            "hit_at_5": h5,
+        })
+    n = len(queries)
+    aggregate = {
+        "n_queries": n,
+        "hit_at_1": round(hits_at_1 / n, 4) if n else 0.0,
+        "hit_at_5": round(hits_at_5 / n, 4) if n else 0.0,
+        "mrr": round(rr_sum / n, 4) if n else 0.0,
+    }
+    return {
+        "wiki_root": str(wiki_root),
+        "threshold": threshold,
+        "pages_scanned": len(pages),
+        "run_at": _now_iso(),
+        "aggregate": aggregate,
+        "per_query": per_query,
+    }
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+def cmd_eval(args: argparse.Namespace) -> int:
+    threshold = args.threshold
+    if not (0.0 < threshold <= 1.0):
+        return _emit(False, error=f"--threshold must be in (0.0, 1.0], got {threshold}")
+
+    wiki_root = Path(args.wiki_root)
+    if not (wiki_root / "wiki").is_dir():
+        return _emit(False, error=f"no wiki/ dir under --wiki-root {wiki_root}")
+
+    base_dir = wiki_root / ".cogni-knowledge"
+    set_path = Path(args.eval_set) if args.eval_set else base_dir / "retrieval-eval-set.json"
+    out_path = Path(args.out) if args.out else base_dir / "retrieval-eval.json"
+
+    # Resolve the labelled set: load an existing one, or seed from question
+    # nodes. --reseed forces a fresh seed even when a set file exists.
+    if set_path.exists() and not args.reseed:
+        try:
+            stored = json.loads(set_path.read_text(encoding="utf-8"))
+            queries = stored.get("queries") if isinstance(stored, dict) else stored
+            if not isinstance(queries, list):
+                return _emit(False, error=f"malformed eval set at {set_path}")
+        except (OSError, ValueError) as exc:
+            return _emit(False, error=f"cannot read eval set {set_path}: {exc}")
+        seeded = False
+    else:
+        queries = seed_from_questions(wiki_root)
+        if not queries:
+            return _emit(False, error=(
+                "no labelled queries: wiki/questions/*.md yielded no nodes with a "
+                "non-empty sources_answering set to seed from, and no --eval-set "
+                "was supplied"
+            ))
+        atomic_write(set_path, {"version": 1, "seeded_at": _now_iso(), "queries": queries})
+        seeded = True
+
+    result = run_eval(wiki_root, queries, threshold)
+    atomic_write(out_path, {"success": True, "data": result, "error": ""})
+
+    return _emit(True, data={
+        **result,
+        "eval_set_path": str(set_path),
+        "eval_set_seeded_this_run": seeded,
+        "out_path": str(out_path),
+    })
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(
+        description="Read-only retrieval-quality baseline harness (hit@k / MRR) "
+                    "over wiki-grounding.py rank."
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p = sub.add_parser("eval", help="Run the labelled set through rank and emit hit@1/hit@5/MRR.")
+    p.add_argument("--wiki-root", required=True,
+                   help="Directory containing wiki/ (the bound base).")
+    p.add_argument("--eval-set", default=None,
+                   help="Path to a labelled-set JSON. Default: "
+                        "<wiki_root>/.cogni-knowledge/retrieval-eval-set.json")
+    p.add_argument("--reseed", action="store_true",
+                   help="Re-seed the labelled set from question nodes even if a set file exists.")
+    p.add_argument("--threshold", type=float, default=DEFAULT_THRESHOLD,
+                   help=f"Coverage threshold passed to rank_pages (default {DEFAULT_THRESHOLD}).")
+    p.add_argument("--out", default=None,
+                   help="Path to write run results. Default: "
+                        "<wiki_root>/.cogni-knowledge/retrieval-eval.json")
+    p.set_defaults(func=cmd_eval)
+
+    args = parser.parse_args(argv)
+    try:
+        return args.func(args)
+    except Exception as exc:  # fail-soft: never traceback to the caller
+        return _emit(False, error=f"{type(exc).__name__}: {exc}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/cogni-knowledge/tests/test_retrieval_eval.sh
+++ b/cogni-knowledge/tests/test_retrieval_eval.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+# test_retrieval_eval.sh — script unit tests for scripts/retrieval-eval.py
+# (the read-only retrieval-quality baseline harness: hit@1 / hit@5 / MRR over
+# the shared wiki-grounding.py rank primitive).
+#
+# Contract under test:
+#   1. `eval` envelope shape: success:true with
+#      data.aggregate.{hit_at_1,hit_at_5,mrr,n_queries} + data.per_query[] on a
+#      populated base, and the results JSON written under .cogni-knowledge/.
+#   2. An exact-match query (ground-truth page IS the top covering page) scores
+#      hit_at_1==1 / hit_at_5==1 / reciprocal_rank==1.0.
+#   3. A no-match query (ground-truth slug present, but the query overlaps no
+#      page) scores hit_at_1==0 / hit_at_5==0 / reciprocal_rank==0.0.
+#   4. Aggregate over the two: hit_at_1==0.5, hit_at_5==0.5, mrr==0.5.
+#   5. Seeding from wiki/questions/*.md sources_answering: the harness writes a
+#      versioned retrieval-eval-set.json on first run.
+#   6. READ-ONLY invariant: the wiki/ tree is byte-identical before and after a
+#      run (the harness only writes under .cogni-knowledge/).
+#
+# bash 3.2 + python3 stdlib only (no pytest, no pip). Matches tests/README.md.
+
+set -eu
+
+PLUGIN_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+EVAL="$PLUGIN_ROOT/scripts/retrieval-eval.py"
+
+. "$(dirname "$0")/fixtures/test_helpers.sh"
+
+errors=0
+
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+WIKI="$WORK/base"
+mkdir -p "$WIKI/wiki/sources" "$WIKI/wiki/questions"
+
+# One source page that strongly overlaps the "high-risk classification" query.
+cat > "$WIKI/wiki/sources/eu-ai-act-high-risk-classification.md" <<'MD'
+---
+title: EU AI Act high-risk classification
+tags: [source]
+sources: ["https://eur-lex.europa.eu/ai-act"]
+pre_extracted_claims:
+  - id: clm-001
+    text: "Article 6 sets the high-risk classification rules for AI systems."
+MD
+
+# A second, unrelated source page so the base has >1 page (rank ordering is real).
+cat > "$WIKI/wiki/sources/unrelated-topic.md" <<'MD'
+---
+title: Quantum cryptography hardware roadmaps
+tags: [source]
+pre_extracted_claims:
+  - id: clm-001
+    text: "Lattice-based primitives dominate post-quantum hardware accelerators."
+MD
+
+cat > "$WIKI/wiki/index.md" <<'MD'
+# Wiki Index
+
+## Sources
+- [[eu-ai-act-high-risk-classification]] — EU AI Act high-risk classification scope and rules
+- [[unrelated-topic]] — Quantum cryptography hardware roadmaps
+MD
+
+# Question node 1: query overlaps the high-risk source -> exact hit at rank 1.
+cat > "$WIKI/wiki/questions/q-high-risk.md" <<'MD'
+---
+id: q-high-risk
+title: "EU AI Act high-risk classification rules for AI systems"
+type: question
+tags: [question]
+theme_label: "High Risk Classification"
+sub_question_id: sq-01
+sources_answering: [eu-ai-act-high-risk-classification]
+---
+
+## Findings
+
+- [[eu-ai-act-high-risk-classification]]
+MD
+
+# Question node 2: query overlaps NEITHER page, but its ground truth slug exists
+# -> guaranteed miss (rank None -> hit@1=0, hit@5=0, RR=0).
+cat > "$WIKI/wiki/questions/q-nomatch.md" <<'MD'
+---
+id: q-nomatch
+title: "Maritime shipping container logistics tariffs schedules"
+type: question
+tags: [question]
+theme_label: "Maritime Logistics"
+sub_question_id: sq-02
+sources_answering: [eu-ai-act-high-risk-classification]
+---
+
+## Findings
+
+- [[eu-ai-act-high-risk-classification]]
+MD
+
+# Snapshot the wiki/ tree to prove the read-only invariant later.
+WIKI_HASH_BEFORE=$(find "$WIKI/wiki" -type f -exec shasum {} \; | sort | shasum)
+
+# --- Run the harness -------------------------------------------------------
+OUT=$("$EVAL" eval --wiki-root "$WIKI" 2>/dev/null) || true
+echo "$OUT" > "$WORK/eval-out.json"
+
+# 1. Envelope shape.
+assert_grep '"success": true' "$WORK/eval-out.json" "eval emits success:true envelope"
+assert_grep '"aggregate"'     "$WORK/eval-out.json" "data carries an aggregate block"
+assert_grep '"per_query"'     "$WORK/eval-out.json" "data carries a per_query block"
+assert_grep '"mrr"'           "$WORK/eval-out.json" "aggregate reports mrr"
+
+# Pull the computed metrics out with python for exact-value assertions.
+python3 - "$WORK/eval-out.json" <<'PY' > "$WORK/metrics.txt" 2>/dev/null || true
+import json, sys
+d = json.load(open(sys.argv[1]))
+agg = d["data"]["aggregate"]
+pq = {p["query"][:12]: p for p in d["data"]["per_query"]}
+print("n_queries", agg["n_queries"])
+print("hit_at_1", agg["hit_at_1"])
+print("hit_at_5", agg["hit_at_5"])
+print("mrr", agg["mrr"])
+# the high-risk query (exact match) and the maritime query (no match)
+hr = next(p for p in d["data"]["per_query"] if "high-risk" in p["query"].lower())
+nm = next(p for p in d["data"]["per_query"] if "maritime" in p["query"].lower())
+print("hr_rank", hr["rank_of_first_relevant"])
+print("hr_h1", hr["hit_at_1"])
+print("nm_rank", nm["rank_of_first_relevant"])
+print("nm_h1", nm["hit_at_1"])
+print("nm_rr", nm["reciprocal_rank"])
+PY
+
+# 2. Exact-match query: rank 1, hit@1.
+assert_grep '^hr_rank 1$' "$WORK/metrics.txt" "exact-match query ranks its ground-truth page at 1"
+assert_grep '^hr_h1 1$'   "$WORK/metrics.txt" "exact-match query scores hit@1"
+
+# 3. No-match query: no relevant page in passing set, RR 0.
+assert_grep '^nm_rank None$' "$WORK/metrics.txt" "no-match query finds no relevant page"
+assert_grep '^nm_h1 0$'      "$WORK/metrics.txt" "no-match query scores hit@1==0"
+assert_grep '^nm_rr 0.0$'    "$WORK/metrics.txt" "no-match query scores reciprocal_rank==0.0"
+
+# 4. Aggregate over the two queries.
+assert_grep '^n_queries 2$' "$WORK/metrics.txt" "two queries seeded from question nodes"
+assert_grep '^hit_at_1 0.5$' "$WORK/metrics.txt" "aggregate hit@1 == 0.5"
+assert_grep '^hit_at_5 0.5$' "$WORK/metrics.txt" "aggregate hit@5 == 0.5"
+assert_grep '^mrr 0.5$'      "$WORK/metrics.txt" "aggregate MRR == 0.5"
+
+# 5. Seeding wrote a versioned labelled set + a results file under .cogni-knowledge/.
+if [ -f "$WIKI/.cogni-knowledge/retrieval-eval-set.json" ]; then
+  green "PASS: labelled set seeded to .cogni-knowledge/retrieval-eval-set.json"
+else
+  red "FAIL: labelled set was not written under .cogni-knowledge/"
+  errors=$((errors + 1))
+fi
+if [ -f "$WIKI/.cogni-knowledge/retrieval-eval.json" ]; then
+  green "PASS: run results persisted to .cogni-knowledge/retrieval-eval.json"
+else
+  red "FAIL: run results were not persisted under .cogni-knowledge/"
+  errors=$((errors + 1))
+fi
+
+# 6. READ-ONLY invariant: wiki/ tree unchanged.
+WIKI_HASH_AFTER=$(find "$WIKI/wiki" -type f -exec shasum {} \; | sort | shasum)
+if [ "$WIKI_HASH_BEFORE" = "$WIKI_HASH_AFTER" ]; then
+  green "PASS: wiki/ tree byte-unchanged after eval (read-only invariant holds)"
+else
+  red "FAIL: wiki/ tree changed during eval — harness is not read-only"
+  errors=$((errors + 1))
+fi
+
+# --- bad-threshold rejection ----------------------------------------------
+BAD=$("$EVAL" eval --wiki-root "$WIKI" --threshold 0 2>/dev/null) || true
+echo "$BAD" > "$WORK/bad.json"
+assert_grep '"success": false' "$WORK/bad.json" "threshold 0 is rejected (exclusive lower bound)"
+
+if [ "$errors" -eq 0 ]; then
+  green "All retrieval-eval tests passed."
+  exit 0
+else
+  red "$errors retrieval-eval test(s) failed."
+  exit 1
+fi


### PR DESCRIPTION
Closes #875.

## Summary
- New `cogni-knowledge/scripts/retrieval-eval.py` (`eval` subcommand): runs a labelled question→expected-page(s) set through the existing `wiki-grounding.py` `rank` path via the Python-import surface (`collect_pages` / `sq_token_set` / `rank_pages`), computing **hit@1**, **hit@5**, and **MRR** (rank-of-first-relevant as a click-depth proxy) per-query and aggregate.
- Loads the hyphenated `wiki-grounding.py` module via `importlib.util.spec_from_file_location` (the tests' idiom — `wiki-grounding` is not an importable module name).
- Calls `collect_pages(wiki_root, include_interviews=True)` so interview ground-truth pages are not scored as false misses, and `rank_pages(..., top_k>=len(pages))` so hit@5 / MRR are never truncated by the default rank cap (faithful-measurement fixes).
- Labelled set seeds from the bound base's `wiki/questions/*.md` nodes (`sources_answering:` = ground-truth pages; node `title:` = query text, `theme_label:` = theme), parsed via the shared `_knowledge_lib.frontmatter_scalar`. Versioned inside the base at `<wiki_root>/.cogni-knowledge/retrieval-eval-set.json`; run results persist to `<wiki_root>/.cogni-knowledge/retrieval-eval.json` via `_knowledge_lib.atomic_write` (atomic, durable before/after). Held-out queries can be appended to the set file by hand; re-seeding never overwrites unless `--reseed`.
- **Strictly read-only against the pipeline**: the harness only *reads* the existing ranking primitive and writes its own eval artifacts under `.cogni-knowledge/` — no wiki page, manifest, or pipeline behaviour changes.
- New `cogni-knowledge/tests/test_retrieval_eval.sh` (bash 3.2, synthetic wiki + 2-query labelled set): asserts hit@1==1.0 / MRR==1.0 on an exact match, hit@1==0 / hit@5==0 / RR==0.0 on a no-match, aggregate hit@1==0.5 / hit@5==0.5 / MRR==0.5, the JSON envelope shape, the seeded set + results files, the read-only (byte-unchanged wiki tree) invariant, and bad-threshold rejection.
- Version bump 1.0.29 → 1.0.30 in `plugin.json` + `marketplace.json` (new script).

## Acceptance signal
Baseline captured: hit@1, hit@5, MRR over the labelled set; harness is strictly read-only (no pipeline behaviour change). Verified against a real finalized base — 3 questions → hit@1=0.667, hit@5=1.0, MRR=0.75.

## Scope decisions
- **In:** the harness, its test, the version bump — one coherent, strictly read-only deliverable.
- **Out (deferred, not required to close):** a `run-metrics.py` row — `run-metrics.py record` requires a `<project>/.metadata/` dir that does not exist under a wiki root, so wiring it would mean inventing a project context the read-only harness has no business owning; the issue itself marks it optional. The navigation-redesign track this baseline *gates* is separate, downstream, and out of scope here.

## Test plan
- [x] `bash cogni-knowledge/tests/test_retrieval_eval.sh` passes (17 assertions).
- [x] `bash cogni-knowledge/tests/test_wiki_grounding.sh` still passes (no regression to the shared ranking primitive — the harness imports it, never edits it).
- [x] Manual smoke on a finalized base emits a JSON envelope with `aggregate.{hit_at_1,hit_at_5,mrr}`, writes `<base>/.cogni-knowledge/retrieval-eval.json`, and leaves the wiki tree byte-unchanged.
- [x] `plugin.json` + `marketplace.json` both show 1.0.30.