### PR TITLE
cogni-consult: deliverable evidence-provenance record

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -35,7 +35,7 @@
     {
       "name": "cogni-consult",
       "source": "./cogni-consult",
-      "version": "0.1.27",
+      "version": "0.1.28",
       "maturity": "preview",
       "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
       "keywords": [

--- a/cogni-consult/.claude-plugin/plugin.json
+++ b/cogni-consult/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-consult",
-  "version": "0.1.27",
+  "version": "0.1.28",
   "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-consult/references/data-model.md
+++ b/cogni-consult/references/data-model.md
@@ -116,7 +116,8 @@ and their states.
       "dt_stage": "test",
       "producing_route": "consult-design-thinking",
       "chosen_framework": "pyramid-principle",
-      "persona_review": "complete"
+      "persona_review": "complete",
+      "evidence_class": "desk-research"
     },
     {
       "slug": "competitor-landscape",
@@ -161,6 +162,19 @@ below) and read-only thereafter. Like `producing_route` and `persona_review`,
 it needs no script change to reach read surfaces: `engagement-status.sh` passes
 every deliverable field through verbatim (its rollup reads only `state`), so the
 stored slug is visible to every consumer that reads the deliverable entry.
+
+`evidence_class` (optional, default `null`) records the provenance class of the
+evidence the deliverable rests on — a short free-text classification (e.g.
+`"desk-research"`, `"primary-research"`, `"expert-interview"`, `"internal-data"`,
+`"assumption"`) that makes the deliverable's evidence base machine-checkable
+rather than buried in prose. It pairs with the deliverable's provenance record in
+the decision-log: at completion the design-thinking loop requires either a
+recorded `gap-check` verdict or an explicit `evidence-provenance-waiver` naming
+this class (see the completion gate in `consult-design-thinking`), and
+`engagement-status.sh` warns when a `complete` deliverable has neither. Like
+`chosen_framework`, `producing_route`, and `persona_review`, it needs no script
+change to reach read surfaces: `engagement-status.sh` passes every deliverable
+field through verbatim (its rollup reads only `state`).
 
 `depends_on[]` (optional, default absent/empty) declares this deliverable's
 dependencies as an array of `{action_field, deliverable}` WBS-coordinate objects,
@@ -224,7 +238,7 @@ All three logs address work by the same structured coordinates —
 
 - **execution-log.json** — workflow-state transitions: `{"transitions": [{"action_field": "...", "deliverable": "...", "from": "pending", "to": "in-progress", "timestamp": "...", "triggered_by": "<skill>"}]}`
 - **method-log.json** — methods proposed/selected per deliverable: `{"methods": [{"action_field": "...", "deliverable": "...", "proposed": [...], "selected": [...], "rationale": "..."}]}`
-- **decision-log.json** — key decisions with rationale and evidence refs: `{"decisions": [{"id": "d-001", "action_field": "...", "deliverable": "...", "decision": "...", "rationale": "...", "evidence_refs": [...], "timestamp": "..."}]}`. Gap-check entries share the same array, discriminated by `"kind": "gap-check"`: `{"id": "d-002", "kind": "gap-check", "action_field": "...", "deliverable": "...", "question": "<verbatim --question>", "theme_label": null, "verdict": "covered", "top_hit": "<page-slug>", "top_score": 0.36, "timestamp": "..."}` (recording contract: `references/research-routing.md`, Gap-Check Recording). Framework-selection entries likewise share the array, discriminated by `"kind": "framework-selection"`: `{"id": "d-003", "kind": "framework-selection", "action_field": "...", "deliverable": "...", "candidates_presented": ["pyramid-principle", "scqa", "..."], "chosen": "pyramid-principle", "is_combination": false, "rationale": "...", "timestamp": "..."}` — `candidates_presented[]` is the top-5 framework slugs shown at deliverable creation, `chosen` is the value stored in the deliverable's `chosen_framework` (a registry slug, a `"combo:<slugA>+<slugB>"` string, or `null`), and `is_combination` is `true` when `chosen` is a combo.
+- **decision-log.json** — key decisions with rationale and evidence refs: `{"decisions": [{"id": "d-001", "action_field": "...", "deliverable": "...", "decision": "...", "rationale": "...", "evidence_refs": [...], "timestamp": "..."}]}`. Gap-check entries share the same array, discriminated by `"kind": "gap-check"`: `{"id": "d-002", "kind": "gap-check", "action_field": "...", "deliverable": "...", "question": "<verbatim --question>", "theme_label": null, "verdict": "covered", "top_hit": "<page-slug>", "top_score": 0.36, "timestamp": "..."}` (recording contract: `references/research-routing.md`, Gap-Check Recording). Framework-selection entries likewise share the array, discriminated by `"kind": "framework-selection"`: `{"id": "d-003", "kind": "framework-selection", "action_field": "...", "deliverable": "...", "candidates_presented": ["pyramid-principle", "scqa", "..."], "chosen": "pyramid-principle", "is_combination": false, "rationale": "...", "timestamp": "..."}` — `candidates_presented[]` is the top-5 framework slugs shown at deliverable creation, `chosen` is the value stored in the deliverable's `chosen_framework` (a registry slug, a `"combo:<slugA>+<slugB>"` string, or `null`), and `is_combination` is `true` when `chosen` is a combo. Evidence-provenance-waiver entries likewise share the array, discriminated by `"kind": "evidence-provenance-waiver"`: `{"id": "d-004", "kind": "evidence-provenance-waiver", "action_field": "...", "deliverable": "...", "evidence_class": "<provenance class>", "rationale": "...", "timestamp": "..."}` — appended at deliverable completion when no `gap-check` verdict covers the deliverable, naming the `evidence_class` (mirrored to the deliverable entry) and the consultant's rationale for completing without a recorded gap-check. A `gap-check` OR an `evidence-provenance-waiver` for the deliverable's `(action_field, deliverable)` coordinates is the provenance record `engagement-status.sh` checks for.
 
 ### personas/{slug}.json (Acting Stakeholder Personas)
 

--- a/cogni-consult/scripts/engagement-status.sh
+++ b/cogni-consult/scripts/engagement-status.sh
@@ -37,8 +37,8 @@ if not isinstance(field_slugs, list) or not all(isinstance(s, str) for s in fiel
 # Empathize stage) or an explicit evidence-provenance-waiver. Build the set of
 # (action_field, deliverable) coordinates already covered, so the per-deliverable
 # pass below can warn on any "complete" deliverable that lacks one. Read-only and
-# fail-soft: a missing/unreadable decision-log degrades to no coverage (warns),
-# never errors.
+# fail-soft: a missing/unreadable/wrong-shape decision-log (e.g. a top-level
+# array or non-dict entries) degrades to no coverage (warns), never errors.
 provenance_covered = set()
 decision_log_path = os.path.join(engagement_dir, ".metadata", "decision-log.json")
 try:
@@ -47,7 +47,7 @@ try:
     for entry in decisions:
         if entry.get("kind") in ("gap-check", "evidence-provenance-waiver"):
             provenance_covered.add((entry.get("action_field"), entry.get("deliverable")))
-except (FileNotFoundError, json.JSONDecodeError, OSError):
+except (FileNotFoundError, json.JSONDecodeError, OSError, AttributeError, TypeError):
     pass
 
 try:

--- a/cogni-consult/scripts/engagement-status.sh
+++ b/cogni-consult/scripts/engagement-status.sh
@@ -32,6 +32,24 @@ if not isinstance(field_slugs, list) or not all(isinstance(s, str) for s in fiel
     print(json.dumps({"success": False, "data": {"path": path}, "error": "malformed project file: action_fields must be a list of strings"}))
     raise SystemExit(0)
 
+# Provenance coverage: a deliverable that completes must carry a provenance
+# record in the decision-log — either a gap-check verdict (recorded at the
+# Empathize stage) or an explicit evidence-provenance-waiver. Build the set of
+# (action_field, deliverable) coordinates already covered, so the per-deliverable
+# pass below can warn on any "complete" deliverable that lacks one. Read-only and
+# fail-soft: a missing/unreadable decision-log degrades to no coverage (warns),
+# never errors.
+provenance_covered = set()
+decision_log_path = os.path.join(engagement_dir, ".metadata", "decision-log.json")
+try:
+    with open(decision_log_path) as f:
+        decisions = json.load(f).get("decisions") or []
+    for entry in decisions:
+        if entry.get("kind") in ("gap-check", "evidence-provenance-waiver"):
+            provenance_covered.add((entry.get("action_field"), entry.get("deliverable")))
+except (FileNotFoundError, json.JSONDecodeError, OSError):
+    pass
+
 try:
     for slug in field_slugs:
         field_path = os.path.join(engagement_dir, "action-fields", slug, "field.json")
@@ -39,6 +57,9 @@ try:
             with open(field_path) as f:
                 field = json.load(f)
             deliverables = field.get("deliverables") or []
+            for d in deliverables:
+                if d.get("state") == "complete" and (slug, d.get("slug")) not in provenance_covered:
+                    warnings.append(f"field {slug} deliverable {d.get('slug')}: complete but no provenance record")
             states = [d.get("state", "pending") for d in deliverables]
             if states and all(s == "complete" for s in states):
                 rollup = "complete"

--- a/cogni-consult/skills/consult-action-fields/SKILL.md
+++ b/cogni-consult/skills/consult-action-fields/SKILL.md
@@ -142,7 +142,8 @@ field's `field.json` once, appending all agreed entries, each shaped:
   "dt_stage": "empathize",
   "producing_route": "consult-design-thinking",
   "chosen_framework": null,
-  "persona_review": "pending"
+  "persona_review": "pending",
+  "evidence_class": null
 }
 ```
 
@@ -153,7 +154,10 @@ artifact). `persona_review` tracks the acting-persona challenge pass:
 `pending` → `in-progress` → `complete`. Both fields are manifest metadata —
 recommend the route, never dispatch it from here. `chosen_framework` records
 the deliverable's structuring framework and is selected per the sub-step below
-(default `null` until chosen).
+(default `null` until chosen). `evidence_class` records the provenance class of
+the deliverable's evidence base — left `null` at planning and set during the
+deliverable's design-thinking loop (the completion gate requires a provenance
+record naming it); see `$CLAUDE_PLUGIN_ROOT/references/data-model.md`.
 
 **Select the structuring framework for each deliverable.** Before writing each
 entry, choose its `chosen_framework` — the shape the deliverable's argument will
@@ -313,8 +317,8 @@ markdown artifact lands under the field directory either way.
 ## Important Notes
 
 - **State ownership**: deliverable `state`, `dt_stage`, `producing_route`,
-  and `persona_review` live only in the field's `field.json`; field and
-  engagement completion are derived at read time. See
+  `persona_review`, and `evidence_class` live only in the field's `field.json`;
+  field and engagement completion are derived at read time. See
   `$CLAUDE_PLUGIN_ROOT/references/data-model.md`.
 - **Edit, never rewrite**: all `consult-project.json` changes go through
   `Edit` so setup-owned fields (`created`, `plugin_refs`, `language`)

--- a/cogni-consult/skills/consult-design-thinking/SKILL.md
+++ b/cogni-consult/skills/consult-design-thinking/SKILL.md
@@ -300,10 +300,26 @@ section are the record. With no personas on disk, run the challenge against the 
 directly ("what would your engagement partner push back on?") and say the
 acting-persona pass will deepen once personas exist.
 
-If the draft survives (consultant accepts): one `Edit` of `field.json` sets
-`state` → `"complete"` (keep `dt_stage` at `"test"`), and one `Edit` of
-`.metadata/execution-log.json` appends the `in-progress` → `complete`
-transition to `transitions[]`. Then run the dependency cascade so every
+If the draft survives (consultant accepts): **first record the deliverable's
+evidence provenance — no deliverable completes without a provenance record in
+the decision-log.** Check `.metadata/decision-log.json` for an entry whose
+`(action_field, deliverable)` coordinates match this deliverable and whose
+`kind` is `"gap-check"` (the Empathize stage records one per the Research
+Routing Gap-Check Recording contract). If one exists, the provenance record is
+already present — set `evidence_class` on the `field.json` deliverable entry to
+the class that evidence represents (e.g. `"desk-research"`,
+`"primary-research"`, `"expert-interview"`) in the same `state` → `"complete"`
+`Edit`. If none exists, append an `evidence-provenance-waiver` entry to
+`decisions[]` naming the class and the consultant's rationale —
+`{"id": "d-NNN", "kind": "evidence-provenance-waiver", "action_field": ...,
+"deliverable": ..., "evidence_class": "<class>", "rationale": "<why complete
+without a gap-check>", "timestamp": ...}` — and set the matching
+`evidence_class` on the deliverable entry. The `evidence_class` vocabulary and
+the `evidence-provenance-waiver` entry shape are defined in
+`$CLAUDE_PLUGIN_ROOT/references/data-model.md`. Then: one `Edit` of `field.json` sets
+`state` → `"complete"` (keep `dt_stage` at `"test"`) and the `evidence_class`,
+and one `Edit` of `.metadata/execution-log.json` appends the `in-progress` →
+`complete` transition to `transitions[]`. Then run the dependency cascade so every
 downstream deliverable that listed this one in its `depends_on[]` is flagged
 stale:
 


### PR DESCRIPTION
Closes #895.

Closes a provenance leak: deliverables could complete without recording where their evidence came from. Every deliverable now carries an explicit evidence-provenance record and a machine-checkable `evidence_class`, serving the evidence-provenance/compounding KPI. Independent of the diagnostic-first chain.

## Summary
- **3.2 — `evidence_class` manifest field.** Optional field (default `null`) on the deliverable entry shape, documented in `references/data-model.md` and added to the `consult-action-fields` step-4 planned-entry Write template + state-ownership enumeration so new deliverables carry it from creation. Reaches read surfaces via the same additive-passthrough precedent as `chosen_framework`/`publish[]`. Adds `evidence-provenance-waiver` as a third decision-log `kind` discriminator.
- **5.1 — Completion-time provenance gate.** `consult-design-thinking` Test stage now requires, before `state` → `complete`, an evidence-provenance record: either an existing `gap-check` decision-log entry for the deliverable's `(action_field, deliverable)` coordinates (Empathize already records one), OR a new `evidence-provenance-waiver` entry naming `evidence_class` + rationale. Additive — completion is never hard-blocked (the waiver path keeps it non-breaking).
- **6.1 — Status warning.** `scripts/engagement-status.sh` reads `.metadata/decision-log.json` once (fail-soft when absent/malformed) and appends a "complete but no provenance record" warning to the existing `warnings[]` for any `complete` deliverable lacking a gap-check or waiver. No existing output field changes shape (the script had no per-deliverable loop today, so one is added).
- Bump `cogni-consult` 0.1.27 → 0.1.28 in `plugin.json` and mirror in repo-root `marketplace.json`.

## Test plan (executed)
- [x] Complete deliverable + no decision-log → emits the provenance warning; JSON still parses.
- [x] Matching `gap-check` entry → no warning.
- [x] `evidence-provenance-waiver` entry → no warning.
- [x] Malformed/missing decision-log → graceful (no error), still valid JSON, warns.
- [x] `data` field shape unchanged (slug/name/language/key_question/updated/scope_state/action_fields/plugin_refs/warnings).
- [x] `plugin.json` and `marketplace.json` both at `0.1.28`.
- [x] check-breadcrumbs.py and check-skill-names.sh pass.

## Scope
Full scope of the issue in one coherent PR. Nothing deferred. The confirm-flag in the issue body is resolved (no strict manifest-schema validator exists; `engagement-status.sh` passes deliverable fields verbatim).

Plan record: https://github.com/cogni-work/insight-wave/issues/895#issuecomment-4760272817