### PR TITLE
cogni-consult: codify diagnostic-first norm in scope-dimensions method

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -35,7 +35,7 @@
     {
       "name": "cogni-consult",
       "source": "./cogni-consult",
-      "version": "0.1.28",
+      "version": "0.1.29",
       "maturity": "preview",
       "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
       "keywords": [

--- a/cogni-consult/.claude-plugin/plugin.json
+++ b/cogni-consult/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-consult",
-  "version": "0.1.28",
+  "version": "0.1.29",
   "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-consult/references/methods/scope-dimensions.md
+++ b/cogni-consult/references/methods/scope-dimensions.md
@@ -47,6 +47,8 @@ Close by naming the main areas of action needed to resolve the central problem �
 
 **Opt-out with a recorded reason.** The diagnostic field-0 is scaffolded by default. An engagement may opt out of it, but only on the record: capture the rationale in the engagement decision log (`.metadata/decision-log.json`, the entry's `rationale` field) so opting out is never off-book and stays auditable.
 
+> The diagnostic-first norm above is a codified scoping **convention**. Its structural enforcement — scaffolding the field-0 slot at WBS-close and gating solution fields on the diagnostic via the deliverable graph — is tracked as separate downstream method work, not enforced by this reference.
+
 ## Output Convention
 
 Write the result to `scope/key-question.md`:

--- a/cogni-consult/references/methods/scope-dimensions.md
+++ b/cogni-consult/references/methods/scope-dimensions.md
@@ -43,6 +43,10 @@ Work through each dimension as a guided conversation, capturing concise structur
 
 Close by naming the main areas of action needed to resolve the central problem — 3–6 fields, each one line. Unlike research-seed approaches, action fields here ARE the work-breakdown structure: every later deliverable lives inside exactly one of them. Each field carries a kebab-case slug, a title, and a one-line framing (its intent phrased as a question or charge); the persistence shape is defined in `references/data-model.md`.
 
+**Diagnostic first.** Field-0 is always a diagnostic of the current state — a CMO/as-is assessment of where the client stands today on the central problem. It is the diagnostic, not one of the 3–6 solution fields: it precedes them, and every solution field gates on it. A solution field cannot be worked until field-0 has established the as-is baseline it builds from. This fixes the WBS-close ordering: order the fields diagnostic-first — field-0 (the as-is diagnostic), then the 3–6 solution fields in delivery order.
+
+**Opt-out with a recorded reason.** The diagnostic field-0 is scaffolded by default. An engagement may opt out of it, but only on the record: capture the rationale in the engagement decision log (`.metadata/decision-log.json`, the entry's `rationale` field) so opting out is never off-book and stays auditable.
+
 ## Output Convention
 
 Write the result to `scope/key-question.md`:
@@ -78,6 +82,7 @@ updated: {ISO date}
 ...
 
 ## Action fields
+0. **Diagnostic: Current State** (`diagnostic-as-is`) — {one-line CMO/as-is diagnostic framing}
 1. **{Field title}** (`{field-slug}`) — {one-line intent}
 2. ...
 ```


### PR DESCRIPTION
Closes #890.

## Summary
- Codify the diagnostic-first norm in `references/methods/scope-dimensions.md`: field-0 must be a CMO/as-is diagnostic and solution action fields gate on it.
- Add a diagnostic-first ordering rule to the "## Action Fields — the WBS Close" section.
- Document the opt-out-with-recorded-reason convention (rationale recorded in the engagement decision log, `.metadata/decision-log.json` `rationale` field).
- Add a `0.` diagnostic field-0 slot to the `## Action fields` list in the embedded key-question.md output-convention template.
- Bump cogni-consult `0.1.28` → `0.1.29` in plugin.json and mirror in root marketplace.json.

## Scope decisions
All three triage acceptance criteria (gap edits 1.1, 1.2, 4.1) are one coherent additive doc change to the single reference the consult-scope skill reads, so they ship together as full scope. The change is **codify-only** — it documents the norm; it does not enforce it (the A1 scaffold and A2 gate are separate downstream epic-#897 children, intentionally out of scope here per codify-before-enforce). No state file or script is touched.

The appended prose keeps the method reference internally consistent: field-0 is framed as **the diagnostic that precedes the 3–6 solution fields** (not one of them), so the existing "3–6 fields" phrasing in the same section — and in `consult-scope/SKILL.md` / `data-model.md` — stays correct and is left untouched.

## Test plan
- [ ] The "## Action Fields — the WBS Close" section states field-0 is a CMO/as-is diagnostic, that solution fields gate on it, and carries the opt-out-with-recorded-reason convention.
- [ ] The same section carries an explicit diagnostic-first ordering rule applied at WBS-close.
- [ ] The embedded key-question.md template's "## Action fields" list shows `0. **Diagnostic: Current State** (`diagnostic-as-is`) — …` before item 1, matching the existing list style.
- [ ] No state file, script, or other skill file is modified; the diff is method-reference prose plus two version bumps.
- [ ] `plugin.json` and root `.claude-plugin/marketplace.json` both read `0.1.29` for cogni-consult.

Note: version base was 0.1.28 on origin/main (a concurrent merge advanced it from the issue-time 0.1.27), so this bumps 0.1.28 → 0.1.29.