### PR TITLE
cogni-consult: auto-wire solution fields to depend on the diagnostic

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -35,7 +35,7 @@
     {
       "name": "cogni-consult",
       "source": "./cogni-consult",
-      "version": "0.1.31",
+      "version": "0.1.32",
       "maturity": "preview",
       "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
       "keywords": [

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -35,7 +35,7 @@
     {
       "name": "cogni-consult",
       "source": "./cogni-consult",
-      "version": "0.1.30",
+      "version": "0.1.31",
       "maturity": "preview",
       "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
       "keywords": [

--- a/cogni-consult/.claude-plugin/plugin.json
+++ b/cogni-consult/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-consult",
-  "version": "0.1.30",
+  "version": "0.1.31",
   "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-consult/.claude-plugin/plugin.json
+++ b/cogni-consult/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-consult",
-  "version": "0.1.31",
+  "version": "0.1.32",
   "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-consult/skills/consult-action-fields/SKILL.md
+++ b/cogni-consult/skills/consult-action-fields/SKILL.md
@@ -217,6 +217,40 @@ unless the consultant explicitly chooses to change it. When the consultant does
 change it, append a fresh `framework-selection` entry (the decision-log is
 append-only) so both the prior choice and the change stay on the trail.
 
+**Auto-wire solution-field deliverables to the diagnostic field-0 gate.** A
+mandated diagnostic field-0 is only load-bearing if solution work actually
+depends on it — otherwise the diagnostic is a token the consultant can ignore.
+So whenever the field being planned is a *solution* field — any field whose slug
+is **not** `diagnostic-as-is` — gate each of its deliverables on the diagnostic.
+Before writing the deliverable entries, read
+`action-fields/diagnostic-as-is/field.json`, take the **terminal deliverable**
+(the last entry in its `deliverables[]` array — terminal is positional, there is
+no separate marker), and add a `depends_on[]` entry pointing at it to every
+deliverable being planned in this solution field:
+
+```json
+  "depends_on": [
+    { "action_field": "diagnostic-as-is", "deliverable": "<terminal-slug>" }
+  ]
+```
+
+Two skips keep the auto-wire safe and silent:
+
+- **Diagnostic present but unplanned** — `diagnostic-as-is` is in
+  `consult-project.json` `action_fields[]` but its `field.json` `deliverables[]`
+  is empty (its planning was deferred). Skip the wire and note to the consultant
+  that the gating edge can be added once field-0 is planned.
+- **No diagnostic field** — `diagnostic-as-is` is absent from
+  `consult-project.json` `action_fields[]` (the engagement recorded a
+  diagnostic-field-0 opt-out waiver, or predates the mandated field-0). Skip
+  silently — there is no gate target.
+
+The auto-wired edge is the same `{action_field, deliverable}` coordinate as any
+other dependency below (no new schema, no new field type — a field is a solution
+field positionally, by its slug), and it is covered by the same `validate`
+mandate at the end of this step — run the validator once after planning, not a
+second time for the auto-wire.
+
 Most deliverables have no upstream dependency — the entry above is the
 default shape, so leave it as is. Only when a deliverable being planned
 builds on earlier work (e.g. "this proposition assumes the market-sizing is

--- a/cogni-consult/skills/consult-action-fields/SKILL.md
+++ b/cogni-consult/skills/consult-action-fields/SKILL.md
@@ -251,6 +251,14 @@ field positionally, by its slug), and it is covered by the same `validate`
 mandate at the end of this step — run the validator once after planning, not a
 second time for the auto-wire.
 
+Write the auto-wired edge once, when the solution field's deliverables are first
+planned. On a re-run over an already-planned solution field, if a deliverable
+already carries a `depends_on[]` entry to a `diagnostic-as-is` deliverable, leave
+it — do not add a duplicate edge and do not silently re-point it at a now-changed
+terminal — the same leave-prior-session-edges-alone discipline the framework
+idempotency guard above applies (`validate` would not flag a duplicate edge to a
+still-valid target, so the discipline is the only guard against drift).
+
 Most deliverables have no upstream dependency — the entry above is the
 default shape, so leave it as is. Only when a deliverable being planned
 builds on earlier work (e.g. "this proposition assumes the market-sizing is

--- a/cogni-consult/tests/test_deliverable_graph.sh
+++ b/cogni-consult/tests/test_deliverable_graph.sh
@@ -21,6 +21,7 @@
 #  12  cascade-default       status-quo silent-zero-dependents (no flag, flags nothing)
 #  13  cascade-include-inferred  --include-inferred flags the unrecorded dependent stale
 #  14  inferred-graceful     no artifact .md -> zero inferred edges, no warnings, success
+#  15  diagnostic-gate       solution deliverable auto-wired to the diagnostic field-0 terminal validates clean
 #
 # Usage: bash cogni-consult/tests/test_deliverable_graph.sh
 # Exits non-zero on any assertion failure.
@@ -346,6 +347,51 @@ D14="$TMPROOT/graceful"; seed_chain "$D14"
 OUT="$(run "$D14" validate)"
 assert_json "inferred-graceful-no-artifacts" "$OUT" \
   "d['success'] is True and d['data']['inferred_edge_count'] == 0 and d['data']['warnings'] == []"
+
+# ---------------------------------------------------------------------------
+# 15  diagnostic-gate  (a solution deliverable auto-wired to the diagnostic
+#     field-0 terminal deliverable validates clean — the gating edge is counted,
+#     no cycles, no dangling)
+# ---------------------------------------------------------------------------
+D15="$TMPROOT/diagnostic-gate"
+mkdir -p "$D15/action-fields/diagnostic-as-is" \
+         "$D15/action-fields/growth-plays"
+cat > "$D15/consult-project.json" <<'EOF'
+{
+  "slug": "acme",
+  "name": "Acme Engagement",
+  "key_question": "How?",
+  "action_fields": ["diagnostic-as-is", "growth-plays"],
+  "workflow_state": {"scope": "complete"},
+  "created": "2026-06-15",
+  "updated": "2026-06-15"
+}
+EOF
+# diagnostic field-0 with two deliverables — terminal is the LAST entry
+cat > "$D15/action-fields/diagnostic-as-is/field.json" <<'EOF'
+{
+  "slug": "diagnostic-as-is",
+  "title": "Diagnostic: Current State",
+  "deliverables": [
+    {"slug": "current-state-scan", "title": "Current-state scan", "state": "complete", "dt_stage": "test", "producing_route": "consult-design-thinking", "persona_review": "complete"},
+    {"slug": "as-is-assessment", "title": "As-is assessment", "state": "complete", "dt_stage": "test", "producing_route": "consult-design-thinking", "persona_review": "complete"}
+  ]
+}
+EOF
+# solution field whose deliverable is auto-wired to the diagnostic terminal
+cat > "$D15/action-fields/growth-plays/field.json" <<'EOF'
+{
+  "slug": "growth-plays",
+  "title": "Growth Plays",
+  "deliverables": [
+    {"slug": "play-design", "title": "Play design", "state": "in-progress", "dt_stage": "ideate", "producing_route": "consult-design-thinking", "persona_review": "pending",
+     "depends_on": [{"action_field": "diagnostic-as-is", "deliverable": "as-is-assessment"}]}
+  ]
+}
+EOF
+OUT="$(run "$D15" validate)"
+assert_json "diagnostic-gate-clean" "$OUT" \
+  "d['success'] is True and d['data']['node_count'] == 3 and d['data']['edge_count'] == 1 and not d['data']['cycles'] and not d['data']['dangling']"
 
 # ---------------------------------------------------------------------------
 echo


### PR DESCRIPTION
Closes #893.

Makes the mandated diagnostic field-0 (scaffolded in #891) load-bearing: when planning a *solution* action field (any field whose slug != `diagnostic-as-is`), each of its deliverables auto-declares a `depends_on` edge to the diagnostic field-0's terminal deliverable. The edge reuses the existing `depends_on[]` `{action_field, deliverable}` schema — no schema change — and is caught by the existing `validate` mandate already in Step 4.

## Summary
- Add an auto-wire rule to `consult-action-fields/SKILL.md` Step 4 (before the existing `depends_on` block): when the field being planned has slug != `diagnostic-as-is`, append `{"action_field": "diagnostic-as-is", "deliverable": "<terminal-slug>"}` to each deliverable's `depends_on[]`, where terminal = the last entry in `action-fields/diagnostic-as-is/field.json` `deliverables[]`.
- Two safe skips: (i) diagnostic present but `deliverables[]` empty/unplanned → skip + note the consultant; (ii) no `diagnostic-as-is` in `action_fields[]` (recorded opt-out waiver / pre-mandate engagement) → skip silently.
- Reaffirm the existing mandate to run `deliverable-graph.py validate` after any `depends_on[]` change (no duplicate validate step).
- Add regression fixture (case 15) to `tests/test_deliverable_graph.sh`: a solution deliverable carrying the auto-wired edge to the diagnostic terminal validates clean (gating edge counted, no cycles/dangling).
- Bump cogni-consult 0.1.30 → 0.1.31 in `plugin.json` and mirror in `marketplace.json`.

## Scope decisions
- In: the auto-wire prose rule, the two skip edge cases, one validating test fixture, and the version bump — one coherent deliverable matching the single acceptance criterion (solution deliverables carry the gating edge; `validate` shows it).
- Out: no new field/kind type (classification stays positional by slug); no change to `blocks[]` (stays derived at read time — contracts C2/C3 preserved); no script/schema change.

## Test plan
- [x] `bash cogni-consult/tests/test_deliverable_graph.sh` — all 18 cases pass (incl. new `diagnostic-gate-clean`).
- [x] `test_dt_stage_advance.sh` and `test_generate_dashboard.sh` still pass (no regression).
- [x] `plugin.json` and `marketplace.json` both read `0.1.31`.

Part of epic #897 (edit 3.1 / gap A2).