### PR TITLE
cogni-consult: promote as-is dimensions into the diagnostic field-0 seed

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -35,7 +35,7 @@
     {
       "name": "cogni-consult",
       "source": "./cogni-consult",
-      "version": "0.1.32",
+      "version": "0.1.33",
       "maturity": "preview",
       "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
       "keywords": [

--- a/cogni-consult/.claude-plugin/plugin.json
+++ b/cogni-consult/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-consult",
-  "version": "0.1.32",
+  "version": "0.1.33",
   "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-consult/references/data-model.md
+++ b/cogni-consult/references/data-model.md
@@ -174,7 +174,11 @@ this class (see the completion gate in `consult-design-thinking`), and
 `engagement-status.sh` warns when a `complete` deliverable has neither. Like
 `chosen_framework`, `producing_route`, and `persona_review`, it needs no script
 change to reach read surfaces: `engagement-status.sh` passes every deliverable
-field through verbatim (its rollup reads only `state`).
+field through verbatim (its rollup reads only `state`). The same `evidence_class`
+vocabulary also appears as YAML frontmatter on first-party research artifacts —
+the diagnostic field-0's `research/as-is-seed.md`, authored by `consult-scope`
+from the as-is scoping dimensions, carries `evidence_class: first-party` on the
+file itself (see `references/research-routing.md`).
 
 `depends_on[]` (optional, default absent/empty) declares this deliverable's
 dependencies as an array of `{action_field, deliverable}` WBS-coordinate objects,

--- a/cogni-consult/references/methods/scope-dimensions.md
+++ b/cogni-consult/references/methods/scope-dimensions.md
@@ -33,11 +33,13 @@ Draft it together with the consultant: propose 2–3 candidate framings from the
 
 Work through each dimension as a guided conversation, capturing concise structured notes:
 
-1. **Strategic Context** — strategic market context; company context; main competitors and customers and their behavior. What larger movement is this engagement embedded in?
+1. **Strategic Context** `[diagnostic-seed]` — strategic market context; company context; main competitors and customers and their behavior. What larger movement is this engagement embedded in?
 2. **Scope** — the project focus; which companies/areas are affected; what is explicitly OUT of scope; adjacent problems being solved in parallel (and by whom).
 3. **Stakeholder** — who is responsible; who is affected; their interests; how decisions are made (governance, veto points, cadence).
-4. **Constraints / Barriers** — risks and mitigations; capability/competence gaps; missing facts, data, or analysis; resource and time restrictions; leadership or commitment gaps.
+4. **Constraints / Barriers** `[diagnostic-seed]` — risks and mitigations; capability/competence gaps; missing facts, data, or analysis; resource and time restrictions; leadership or commitment gaps.
 5. **Success factors** — how success is measured; key deliverables; KPIs; other performance measures the sponsor will actually be judged on.
+
+The two `[diagnostic-seed]` dimensions capture the engagement's as-is material. They are not orphaned in the scope notes: at WBS-close `consult-scope` promotes them into the diagnostic field-0's first-party as-is seed (`action-fields/diagnostic-as-is/research/as-is-seed.md`), so the diagnostic starts from what scoping already gathered rather than empty.
 
 ## Action Fields — the WBS Close
 

--- a/cogni-consult/references/research-routing.md
+++ b/cogni-consult/references/research-routing.md
@@ -90,6 +90,14 @@ claim-correction cascades. Scoping-stage research (before action fields
 exist) lands in `scope/research/<topic-slug>.md` and moves nothing when the
 fields are derived — later deliverables cite it where it is.
 
+**First-party seed carve-out.** The diagnostic field-0's
+`action-fields/diagnostic-as-is/research/as-is-seed.md` is the one file in a
+`research/` directory that is *not* a knowledge-base synthesis. `consult-scope`
+authors it directly from the `[diagnostic-seed]` scoping dimensions at WBS-close,
+so it carries `evidence_class: first-party` frontmatter and no `kb_ref` lineage
+triple — there is no knowledge-base page behind it. Everything else in `research/`
+follows the knowledge-finalize rule above.
+
 ## The Only Exception
 
 A quick fact-check during conversation (confirming a date, a name, a number)

--- a/cogni-consult/skills/consult-scope/SKILL.md
+++ b/cogni-consult/skills/consult-scope/SKILL.md
@@ -63,9 +63,38 @@ When a dimension needs evidence the consultant cannot supply from their own know
 }
 ```
 
+**Seed the diagnostic field-0 from the as-is dimensions.** When the diagnostic field-0 is scaffolded (i.e. not opted out below), promote the already-collected as-is material into it rather than leaving it empty. `Write` `action-fields/diagnostic-as-is/research/as-is-seed.md` from the two `[diagnostic-seed]` dimensions captured in Step 3 — Strategic Context and Constraints / Barriers (the markers are defined in `$CLAUDE_PLUGIN_ROOT/references/methods/scope-dimensions.md`). It is a first-party seed authored directly from the scoping conversation, not a knowledge-base synthesis, so it carries `evidence_class: first-party` frontmatter and not a `kb_ref` lineage triple (the `research/` storage-contract carve-out is in `$CLAUDE_PLUGIN_ROOT/references/research-routing.md`):
+
+```markdown
+---
+slug: as-is-seed
+evidence_class: first-party
+updated: {ISO date}
+---
+
+# As-Is Seed
+
+## Strategic Context
+{the Strategic Context dimension notes}
+
+## Constraints / Barriers
+{the Constraints / Barriers dimension notes}
+```
+
+The diagnostic field-0's own deliverables build from this seed; it is source material, never a deliverable-state container.
+
 **Opt-out with a recorded reason.** The diagnostic field-0 is scaffolded by default; an engagement may decline it, but only on the record. When the consultant opts out, do not write the `diagnostic-as-is` field or its slug — instead append a waiver to `.metadata/decision-log.json` `decisions[]`, discriminated by `"kind": "diagnostic-field-0-waiver"`, carrying the consultant's `rationale` and a `timestamp`. The waiver carries no `action_field`/`deliverable` coordinates (it is recorded before any field exists); the schema owner `$CLAUDE_PLUGIN_ROOT/references/data-model.md` explains why. Opting out leaves the engagement diagnostic-free without taking the choice off-book.
 
 **Re-run guard**: on a re-scope, never overwrite an existing `field.json` — it is the single source of truth for that field's deliverable states. For a field that survives the pivot, including a diagnostic field-0 already on record, leave its file untouched; only add stubs for genuinely new fields. When a field is dropped from `action_fields[]`, leave its directory in place and note the removal in the conversation summary — deleting deliverable history is the consultant's call, not the skill's.
+
+**Re-seed guard**: `as-is-seed.md` is the one exception to the no-overwrite rule above, because it is source material rather than deliverable state. On a re-scope that keeps the diagnostic field-0, **re-write** `action-fields/diagnostic-as-is/research/as-is-seed.md` from the freshly-collected `[diagnostic-seed]` dimension content. Then, if `diagnostic-as-is/field.json` already has a non-empty `deliverables[]` (the diagnostic has been planned), flag its downstream dependents stale via the existing engine (flag-not-rewrite, preserving contracts C2/C3) — never hand-edit `lineage_status`:
+
+```bash
+python3 "$CLAUDE_PLUGIN_ROOT/scripts/deliverable-graph.py" <engagement-dir> \
+  cascade-stale diagnostic-as-is/<field-0-deliverable-slug> --trigger deliverable_update
+```
+
+Skip the cascade-stale silently when `diagnostic-as-is/field.json` `deliverables[]` is still empty — there is no diagnostic deliverable node for the graph to flag yet, and invoking it on a missing coordinate errors.
 
 ### 5. Write the Scope Deliverable
 

--- a/cogni-consult/skills/consult-scope/SKILL.md
+++ b/cogni-consult/skills/consult-scope/SKILL.md
@@ -7,9 +7,9 @@ description: |
   Trigger on: "scope the engagement", "consult scope", "frame the key question",
   "define action fields", "add or waive the diagnostic field", "run scoping for
   the consult engagement", or when consult-setup hands off a freshly scaffolded
-  engagement for scoping. Double
-  Diamond phrasing ("0-scope phase", "diamond scoping") refers to a legacy
-  engagement model no longer in the ecosystem; all new scoping runs here.
+  engagement for scoping. Double Diamond phrasing ("0-scope phase", "diamond
+  scoping") refers to a legacy engagement model no longer in the ecosystem;
+  all new scoping runs here.
 allowed-tools: Read, Write, Edit, Bash, Skill
 ---
 
@@ -81,13 +81,13 @@ updated: {ISO date}
 {the Constraints / Barriers dimension notes}
 ```
 
-The diagnostic field-0's own deliverables build from this seed; it is source material, never a deliverable-state container.
+The diagnostic field-0's own deliverables build from this seed; it is source material, never a deliverable-state container. On a re-scope this file is re-written from fresh dimension content — see the **Re-seed guard** below.
 
 **Opt-out with a recorded reason.** The diagnostic field-0 is scaffolded by default; an engagement may decline it, but only on the record. When the consultant opts out, do not write the `diagnostic-as-is` field or its slug — instead append a waiver to `.metadata/decision-log.json` `decisions[]`, discriminated by `"kind": "diagnostic-field-0-waiver"`, carrying the consultant's `rationale` and a `timestamp`. The waiver carries no `action_field`/`deliverable` coordinates (it is recorded before any field exists); the schema owner `$CLAUDE_PLUGIN_ROOT/references/data-model.md` explains why. Opting out leaves the engagement diagnostic-free without taking the choice off-book.
 
 **Re-run guard**: on a re-scope, never overwrite an existing `field.json` — it is the single source of truth for that field's deliverable states. For a field that survives the pivot, including a diagnostic field-0 already on record, leave its file untouched; only add stubs for genuinely new fields. When a field is dropped from `action_fields[]`, leave its directory in place and note the removal in the conversation summary — deleting deliverable history is the consultant's call, not the skill's.
 
-**Re-seed guard**: `as-is-seed.md` is the one exception to the no-overwrite rule above, because it is source material rather than deliverable state. On a re-scope that keeps the diagnostic field-0, **re-write** `action-fields/diagnostic-as-is/research/as-is-seed.md` from the freshly-collected `[diagnostic-seed]` dimension content. Then, if `diagnostic-as-is/field.json` already has a non-empty `deliverables[]` (the diagnostic has been planned), flag its downstream dependents stale via the existing engine (flag-not-rewrite, preserving contracts C2/C3) — never hand-edit `lineage_status`:
+**Re-seed guard**: `as-is-seed.md` is the one exception to the no-overwrite rule above, because it is source material rather than deliverable state. On a re-scope that keeps the diagnostic field-0, **re-write** `action-fields/diagnostic-as-is/research/as-is-seed.md` from the freshly-collected `[diagnostic-seed]` dimension content. Then, if `diagnostic-as-is/field.json` already has a non-empty `deliverables[]` (the diagnostic has been planned), flag its downstream dependents stale via the existing engine (flag-not-rewrite, preserving contracts C2/C3) — never hand-edit `lineage_status`. Read the `<field-0-deliverable-slug>` to pass below from `diagnostic-as-is/field.json` `deliverables[]` — the terminal field-0 deliverable that solution fields `depend_on`:
 
 ```bash
 python3 "$CLAUDE_PLUGIN_ROOT/scripts/deliverable-graph.py" <engagement-dir> \


### PR DESCRIPTION
Closes #892.

## Summary
- Annotate the two as-is dimensions in `references/methods/scope-dimensions.md` (Strategic Context, Constraints / Barriers) with a consistent inline `[diagnostic-seed]` marker so the seed source is declared at the method layer.
- In `consult-scope` Step 4, after scaffolding the `diagnostic-as-is/field.json` stub, write `action-fields/diagnostic-as-is/research/as-is-seed.md` from the `diagnostic-seed` dimension content, with YAML frontmatter `evidence_class: first-party`.
- Extend the Step 4 Re-run guard with a Re-seed guard: on re-scope the seed is re-written from fresh dimension content (source material, not deliverable state, so safe to overwrite), then `deliverable-graph.py cascade-stale` is invoked against `diagnostic-as-is/<field-0 deliverable>` with `--trigger deliverable_update` when its `deliverables[]` is non-empty (flag-not-rewrite, preserving contracts C2/C3); skipped silently on an empty stub.
- Note in `references/research-routing.md` Storage Contract that `as-is-seed.md` is a consultant-authored first-party seed (not a knowledge-finalize synthesis), so it carries `evidence_class: first-party` rather than the `kb_ref` lineage triple the canonical rule otherwise mandates for `research/` files.
- Document `evidence_class: first-party` as a research-artifact frontmatter usage in `references/data-model.md` so the new vocabulary value is not orphaned.
- Bump `cogni-consult` 0.1.32 → 0.1.33 and mirror in `marketplace.json`.

## Scope decisions
- Delivers both acceptance criteria (edit 1.5 tag + edit 2.2 seed-write / re-seed / cascade-stale). Nothing deferred.
- No change to `deliverable-graph.py` — the existing `cascade-stale` CLI is reused as-is.
- The new `research/as-is-seed.md` write path is reconciled with the canonical research-routing storage contract via a one-line carve-out rather than left to silently contradict it.
- Depends on #891 (field-0 scaffold), already merged — the seed writes into the directory that scaffold creates.

## Test plan
- [ ] `scope-dimensions.md` dimensions 1 and 4 carry the `[diagnostic-seed]` marker; 2, 3, 5 do not.
- [ ] `consult-scope` on a fresh engagement keeping field-0: `as-is-seed.md` written with frontmatter `evidence_class: first-party` from the Strategic Context + Constraints/Barriers notes.
- [ ] Re-scope the same engagement: `as-is-seed.md` re-written from fresh content, `field.json` untouched.
- [ ] Non-empty `diagnostic-as-is/field.json deliverables[]`: cascade-stale invoked against the field-0 deliverable coordinate; empty stub: skipped (no `_require_node` failure).
- [ ] `research-routing.md` Storage Contract names `as-is-seed.md` as the first-party exception.
- [ ] `plugin.json` and `marketplace.json` both read 0.1.33.

Plan record: https://github.com/cogni-work/insight-wave/issues/892#issuecomment-4760769773