### PR TITLE
cogni-knowledge: make the curate serial tail measurable via max_agent_duration_ms

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "cogni-knowledge",
       "source": "./cogni-knowledge",
-      "version": "1.0.32",
+      "version": "1.0.33",
       "maturity": "released",
       "description": "Wiki-first research that compounds. Binds each run to a wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`. The shallow `knowledge-query` rung is read-only by default and can optionally file its answer back as an un-verified synthesis page via `--file-back`.",
       "keywords": [

--- a/cogni-knowledge/.claude-plugin/plugin.json
+++ b/cogni-knowledge/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-knowledge",
-  "version": "1.0.32",
+  "version": "1.0.33",
   "description": "Wiki-first research that compounds. Binds each run to a wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`. The shallow `knowledge-query` rung is read-only by default and can optionally file its answer back as an un-verified synthesis page via `--file-back`.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-knowledge/agents/source-curator.md
+++ b/cogni-knowledge/agents/source-curator.md
@@ -79,6 +79,13 @@ Phase 0 → Phase 1 → Phase 2 → Phase 3 → Phase 4
 2. Read the market config from `MARKET_CONFIG_PATH` (the orchestrator-resolved `get-market-config.py` envelope). Parse the envelope's **`data`** field — the merged market config — and store it as `market_config` (this is the shape Phases 1 and 3 consume: `market_config.authority_sources`, `market_config.local_query_tips`, …). Do **not** re-resolve the config and do **not** fall back to `_default`: the orchestrator already validated it (or aborted the run). If `MARKET_CONFIG_PATH` is missing/unreadable, is not valid JSON, or the envelope has no `data`, this is a **hard error** (defence-in-depth) — return the failure summary `{"ok": false, "sub_question_id": "<SUB_QUESTION_ID>", "reason": "market_config_unavailable"}` and stop. The orchestrator records it in `failed_curators[]`.
 3. **Load this sub-question's wiki coverage (read-before-web).** The manifest is produced by the shared `wiki-grounding.py` discovery primitive (via `wiki-coverage.py` at `knowledge-curate` Step 0.5) — the same index→select→read→score mechanism the re-homed query skill uses, so the pages surfaced here are exactly the pages a direct query would ground against. If `WIKI_COVERAGE_PATH` is provided and readable, parse the envelope's `data.sub_questions[]` and locate the entry whose `sq_id == SUB_QUESTION_ID`. Keep its `coverage_verdict` (`covered` / `partial` / `uncovered`) and `covered_pages[]` (each carrying `slug`, `type`, `page_path`, `title`, `overlap_score`). If `WIKI_COVERAGE_PATH` is absent, unreadable, not valid JSON, or has no entry for this sub-question, treat the verdict as **`uncovered`** — this is **not** an error (unlike the market config above). Read-before-web is an optimization; missing coverage just means a full search.
 4. Confirm `BATCH_OUTPUT_PATH`'s parent directory exists; create if not.
+5. **Capture the dispatch start time** for the Phase-4 `duration_ms` field. Record a millisecond timestamp at the very start of work, before any WebSearch/WebFetch, so the measured wall clock spans this agent's full lifetime:
+
+   ```
+   START_MS=$(python3 -c 'import time; print(int(time.time() * 1000))')
+   ```
+
+   Hold `START_MS` for Phase 4. It lets the `knowledge-curate` orchestrator read the slowest curator's wall clock and record the curate phase's `max_agent_duration_ms`, which makes the orchestrator serial tail directly readable in the run-metrics ledger.
 
 ### Phase 1: Search Query Generation
 
@@ -321,10 +328,13 @@ Return a compact summary:
  "fetched": 7, "cache_hits": 2, "unavailable": 2,
  "reasons": {"webfetch_4xx": 1, "webfetch_timeout": 1},
  "wiki_coverage_verdict": "uncovered", "wiki_covered_pages": 0, "queries_issued": 6,
- "cost_estimate": {"input_words": 0, "output_words": 13000, "estimated_usd": 0.036}}
+ "cost_estimate": {"input_words": 0, "output_words": 13000, "estimated_usd": 0.036},
+ "duration_ms": 18430}
 ```
 
 `wiki_coverage_verdict` echoes the Phase-0 verdict (`covered` / `partial` / `uncovered`); `wiki_covered_pages` is the count of `covered_pages[]` you saw; `queries_issued` is how many WebSearch queries you actually ran (vs the 5–7 baseline) — so the orchestrator can report how much the read-before-web narrowing saved.
+
+`duration_ms` is this agent's full wall-clock in milliseconds — `int(time.time() * 1000) - START_MS` using the Phase-0 `START_MS`. It spans the search, scoring, and survivor body-fetch, so it is the per-agent figure the orchestrator maxes into the curate phase's `max_agent_duration_ms`. Compute it once, just before writing this summary, e.g. `python3 -c 'import os,time; print(int(time.time()*1000) - int(os.environ["START_MS"]))'`. A failure path that reaches Phase 4 with `START_MS` set still reports `duration_ms`; the early Phase-0 market-config abort (which returns before `START_MS` is captured) simply omits it — the orchestrator's accumulator is fail-soft, so a missing `duration_ms` contributes `0` and never breaks the phase record.
 
 `cost_estimate` covers content read (search results + fetched bodies) and produced (batch JSON). See `cogni-research/references/model-strategy.md` for the formula; carry it through unchanged at fork time. A WebFetch exception while fetching one candidate must not abort the batch — record it `unavailable` with the closest applicable class and move on. If a `fetch-cache.py store` call itself fails (disk full, permission denied), record that candidate `unavailable` with `reason: cache_write_failed` (in `VALID_REASONS`) and continue — the orchestrator will see the rate climb and decide. Remove temp files at end of batch (`trap rm -f "$TMP" EXIT` or equivalent).
 

--- a/cogni-knowledge/references/run-metrics-wiring.md
+++ b/cogni-knowledge/references/run-metrics-wiring.md
@@ -56,6 +56,34 @@ fatal). Surface a one-line warning at most.
 **Append-only.** A re-run of a phase appends a new row rather than overwriting;
 `run-metrics.py report` sums all rows, so retries stay visible.
 
+## Computing `MAX_DURATION_MS` per fan-out phase
+
+`--max-agent-duration-ms` is only as good as the per-agent `duration_ms` the
+phase can see. For a fan-out phase the pattern is **init → accumulate → pass**:
+
+1. **Init** — at the top of the workflow (Step 0), alongside `PHASE_START`,
+   initialise a run-level accumulator `MAX_DURATION_MS=0`.
+2. **Accumulate** — wherever the orchestrator reads each dispatched agent's
+   return summary (the same place it sums `cost_estimate.estimated_usd`), fold
+   the agent's reported `duration_ms` in: `MAX_DURATION_MS = max(MAX_DURATION_MS,
+   duration_ms)`. **Fail-soft** — an agent return without a `duration_ms` (an
+   older envelope, or an early abort that returned before its start clock was
+   captured) contributes `0` and never breaks the accumulation.
+3. **Pass** — at phase exit, pass `--max-agent-duration-ms <MAX_DURATION_MS>` to
+   `run-metrics.py record`.
+
+**The agent must self-report `duration_ms` for this to be non-zero.** An agent
+self-captures a start timestamp only if it has the `Bash` tool — e.g.
+`START_MS=$(python3 -c 'import time; print(int(time.time()*1000))')` in its load
+phase, then `duration_ms = int(time.time()*1000) - START_MS` in its return
+envelope. `source-ingester` (the `ingest` phase) and `source-curator` (the
+`curate` phase) follow this pattern and are the live examples. A fan-out phase
+whose agents lack the `Bash` tool, and therefore cannot self-capture a start
+clock, has two options: give those agents the tool so they self-report, or have
+the orchestrator measure each dispatched task's wall clock itself (it already
+has `Bash`); until one is chosen, that phase's agents contribute `0` and the row
+stores `max_agent_duration_ms: 0` — honest, not misleading.
+
 ## Reading it back
 
 ```

--- a/cogni-knowledge/skills/knowledge-curate/SKILL.md
+++ b/cogni-knowledge/skills/knowledge-curate/SKILL.md
@@ -191,21 +191,23 @@ Parse the result for the final summary. Print ≤ 8 lines:
 - Candidates: `<total>` (`<primary_count>` primary / `<secondary_count>` secondary / `<supporting_count>` supporting)
 - Fetched: `<fetched>` (`<cache_hits>` from cache) / Unavailable: `<unavailable>` (`<reason_top_3>`) — summed across curator returns
 - Cost: `$X.XX` (sum of `cost_estimate.estimated_usd` across curator return summaries)
+- Max agent duration: `<MAX_DURATION_MS / 1000>s` (slowest single `source-curator` wall clock — with the phase elapsed it makes the curate serial tail directly readable in the run-metrics ledger). Compute it here as you read the curator summaries: carry `MAX_DURATION_MS=0` from the Step 0 pre-flight and fold each curator's returned `duration_ms` in with `MAX_DURATION_MS = max(MAX_DURATION_MS, duration_ms)`. A curator summary without a `duration_ms` (an early market-config abort, or a pre-`duration_ms` envelope) contributes `0` — fail-soft, never abort the summary.
 - Failed sub-questions (if any): `sq-NN, sq-MM` — re-run with `--sub-question-ids sq-NN,sq-MM`
 - Next: run `knowledge-fetch --knowledge-slug <slug> --project-path <project_path>` to build the fetch manifest (a near no-op — bodies are already cached; add `--cobrowse` only if you want to recover WebFetch misses via your browser)
 
 ### 5. Record run metrics (phase-exit ledger)
 
-Persist this phase's timing + cost to `<project_path>/.metadata/run-metrics.json` so the run leaves a durable per-phase ledger (read by `knowledge-resume` / `knowledge-dashboard` / a perf study). Capture `PHASE_START=$(date -u +%FT%TZ)` at the top of this skill's run (Step 0); then at exit:
+Persist this phase's timing + cost to `<project_path>/.metadata/run-metrics.json` so the run leaves a durable per-phase ledger (read by `knowledge-resume` / `knowledge-dashboard` / a perf study). Capture `PHASE_START=$(date -u +%FT%TZ)` **and** initialise `MAX_DURATION_MS=0` at the top of this skill's run (Step 0) — `MAX_DURATION_MS` is the run-level slowest-curator accumulator folded in the Step 4 summary above; then at exit:
 
 ```
 python3 "${CLAUDE_PLUGIN_ROOT}/scripts/run-metrics.py" record \
     --project-path "<project_path>" --phase curate \
     --started-at "$PHASE_START" --ended-at "$(date -u +%FT%TZ)" \
-    --agent-count <curators dispatched> --cost-usd <summed curator cost_estimate.estimated_usd>
+    --agent-count <curators dispatched> --cost-usd <summed curator cost_estimate.estimated_usd> \
+    --max-agent-duration-ms <MAX_DURATION_MS — the slowest source-curator duration from the Step 4 summary>
 ```
 
-Note the curate cost is the dominant per-run spend, so capturing it here is what makes the cost ledger meaningful. Fail-soft — a record failure never blocks the phase. Full contract: `${CLAUDE_PLUGIN_ROOT}/references/run-metrics-wiring.md`.
+Note the curate cost is the dominant per-run spend, so capturing it here is what makes the cost ledger meaningful. `--max-agent-duration-ms` lets `run-metrics.py report` show the curate serial tail directly (`serial_tail ≈ elapsed_s − max_agent_duration_ms/1000`). Fail-soft — a record failure never blocks the phase. Full contract: `${CLAUDE_PLUGIN_ROOT}/references/run-metrics-wiring.md`.
 
 ## Edge cases
 


### PR DESCRIPTION
Refs #889.

## Summary

`run-metrics.py report` emitted `max_agent_duration_ms = 0` for every phase, collapsing `serial_tail ≈ elapsed_s − max_agent_duration_ms/1000` to wall-clock with no signal. The `record`/`report` plumbing (and `tests/test_run_metrics.sh` assertion 7) was already complete — only the callers never populated it. `knowledge-ingest` already wires it via the `source-ingester` `duration_ms` self-report; this PR brings the **curate** phase to parity.

- **`source-curator`** now self-reports a per-agent `duration_ms`: a Phase-0 `START_MS` millisecond capture + a `duration_ms` field on its return envelope, mirroring `source-ingester`. (This agent has the `Bash` tool, so the precedent transfers directly.)
- **`knowledge-curate`** inits a run-level `MAX_DURATION_MS=0` in Step 0, folds `max(MAX_DURATION_MS, duration_ms)` over each curator's return in the Step 4 summary (fail-soft — a missing `duration_ms` contributes 0), and passes `--max-agent-duration-ms <MAX_DURATION_MS>` to `run-metrics.py record` in Step 5.
- **`references/run-metrics-wiring.md`** gains a "Computing `MAX_DURATION_MS` per fan-out phase" subsection documenting the init→accumulate→pass pattern and the Bash-tool requirement for agent self-report, citing `knowledge-ingest`/`knowledge-curate` as live examples.
- Version bump `cogni-knowledge` 1.0.32 → 1.0.33 (`plugin.json` + `marketplace.json`).
- `knowledge-ingest` is already correct and is **not** modified.

This makes `max_agent_duration_ms` non-zero on **2 of the 3** acceptance phases (curate here + ingest already) with zero tool-surface widening and all 7 `test_run_metrics.sh` assertions green (no script/test change).

## Scope decision — why this is partial (`Refs`, not `Closes`)

The acceptance criterion names curate **/ ingest / verify**. The verify (and compose) phases are intentionally deferred behind the open question below, so this PR links `Refs #889` and #889 stays open as its own tracker.

## Open question (blocks verify/compose — needs a maintainer decision)

`source-ingester` and `source-curator` self-report `duration_ms` by capturing a `START_MS` timestamp via `python3 -c`, which **requires the `Bash` tool**. The remaining fan-out agents do **not** have `Bash`:

- `wiki-composer`, `wiki-verifier` — tools are `Read`/`Write`/`Glob`/`Grep` (no `Bash`).
- `revisor` — adds `Edit`, still no `Bash`; its agent doc records that `Bash` was dropped **deliberately** to keep it zero-network.

So "mirror `source-ingester`" cannot apply to those three as-is. Two options:

- **(A) Self-report** — add `Bash` to `wiki-composer`/`wiki-verifier`/`revisor` so each self-captures `START_MS`. Widens their tool surface; for the revisor it reverses an intentional zero-network design choice.
- **(B) Orchestrator-measure** — have `knowledge-compose` / `knowledge-verify` (which already dispatch via `Task` and have `Bash`) measure each task's wall-clock themselves. No agent-envelope or tool change; the three agent files are not edited. This is the narrower, no-widening path and is available today.

Once decided, the `knowledge-compose` Step 8 and `knowledge-verify` Step 7 record blocks get the same init→accumulate→pass wiring (the Step-0 inits + `--max-agent-duration-ms` pass-through are ready to drop in).

## Test plan

- [x] `cogni-knowledge/tests/test_run_metrics.sh` — all 7 assertions pass (no script/test change).
- [x] Maintainer-breadcrumb guard clean (no `#NNN`/version refs introduced in SKILL.md/agent files).
- [x] `plugin.json` + `marketplace.json` both read `1.0.33`; both valid JSON.
- [ ] (Manual, post-merge) a fresh end-to-end run produces a `run-metrics.json` with non-zero `max_agent_duration_ms` on curate (and ingest) and `run-metrics.py report` shows a meaningful `max_agent_s` column for those phases.

Plan record: https://github.com/cogni-work/insight-wave/issues/889#issuecomment-4760891781