### PR TITLE
cogni-knowledge: additive dual-level (entity + cross-document) retrieval

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "cogni-knowledge",
       "source": "./cogni-knowledge",
-      "version": "1.0.34",
+      "version": "1.0.35",
       "maturity": "released",
       "description": "Wiki-first research that compounds. Binds each run to a wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`. The shallow `knowledge-query` rung is read-only by default and can optionally file its answer back as an un-verified synthesis page via `--file-back`.",
       "keywords": [

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "cogni-knowledge",
       "source": "./cogni-knowledge",
-      "version": "1.0.33",
+      "version": "1.0.34",
       "maturity": "released",
       "description": "Wiki-first research that compounds. Binds each run to a wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`. The shallow `knowledge-query` rung is read-only by default and can optionally file its answer back as an un-verified synthesis page via `--file-back`.",
       "keywords": [

--- a/cogni-knowledge/.claude-plugin/plugin.json
+++ b/cogni-knowledge/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-knowledge",
-  "version": "1.0.33",
+  "version": "1.0.34",
   "description": "Wiki-first research that compounds. Binds each run to a wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`. The shallow `knowledge-query` rung is read-only by default and can optionally file its answer back as an un-verified synthesis page via `--file-back`.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-knowledge/.claude-plugin/plugin.json
+++ b/cogni-knowledge/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-knowledge",
-  "version": "1.0.34",
+  "version": "1.0.35",
   "description": "Wiki-first research that compounds. Binds each run to a wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`. The shallow `knowledge-query` rung is read-only by default and can optionally file its answer back as an un-verified synthesis page via `--file-back`.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-knowledge/scripts/_knowledge_lib.py
+++ b/cogni-knowledge/scripts/_knowledge_lib.py
@@ -769,14 +769,55 @@ def _absorb_claim_kv(item: dict, kv: str, wanted_keys: tuple) -> None:
     item[key] = _unquote_scalar(value)
 
 
-def _parse_claim_block(page_text: str, key_re, wanted_keys: tuple) -> list[dict]:
+def _parse_inline_str_list(value: str) -> list[str]:
+    """Parse a single-line YAML/JSON inline list of strings (`["a", "b"]`) into a
+    real `list[str]`. concept-store.py renders `backlinks:` / `source_claim_refs:`
+    via `json.dumps`, so the value is valid JSON; `json.loads` is the exact decoder.
+    Returns [] for anything that does not cleanly parse as a list (the fail-safe
+    default — a malformed value yields no backlinks, so the dual-level join skips
+    that claim rather than crashing)."""
+    value = value.strip()
+    if not (value.startswith("[") and value.endswith("]")):
+        return []
+    try:
+        parsed = json.loads(value)
+    except (ValueError, TypeError):
+        return []
+    if not isinstance(parsed, list):
+        return []
+    return [s for s in parsed if isinstance(s, str) and s]
+
+
+def _absorb_list_kv(item: dict, kv: str, list_keys: tuple) -> None:
+    """Absorb a `key: [...]` inline-list line into `item[key]` as a real `list[str]`.
+    `_absorb_claim_kv` only reads scalars, so an inline-list field (e.g. `backlinks`)
+    needs this dedicated parse. A non-list / unparseable / empty value leaves the key
+    absent (the claim simply lacks it)."""
+    if ":" not in kv:
+        return
+    key, _, value = kv.partition(":")  # first colon only
+    key = key.strip()
+    if key not in list_keys:
+        return
+    parsed = _parse_inline_str_list(value)
+    if parsed:
+        item[key] = parsed
+
+
+def _parse_claim_block(page_text: str, key_re, wanted_keys: tuple,
+                       list_keys: tuple = ()) -> list[dict]:
     """Single-line YAML block-list parser shared by `parse_pre_extracted_claims`
     (`pre_extracted_claims:`) and `parse_distilled_claims` (`distilled_claims:`).
     Walks the frontmatter for `key_re`, reads the run of blank / indented / bullet
     lines after it, and absorbs only `wanted_keys` per `- ` item. Returns [] for any
     page without a parseable block. Tolerant of indent width, of the first key
     sitting inline after the `- ` bullet, and of block sequences whose `- ` bullets
-    sit at the parent key's column; only single-line `key: value` scalars are read."""
+    sit at the parent key's column; only single-line `key: value` scalars are read.
+
+    `list_keys` (default `()`) names per-item keys whose value is a single-line YAML
+    inline list (`["a", "b"]`) to absorb as a real `list[str]` — additive, so a
+    caller that passes nothing reads exactly the scalar `wanted_keys` as before
+    (the existing readers stay byte-identical)."""
     if not page_text:
         return []
     m = _FRONTMATTER_RE.match(page_text)
@@ -813,8 +854,12 @@ def _parse_claim_block(page_text: str, key_re, wanted_keys: tuple) -> list[dict]
             rest = stripped[1:].strip()
             if rest:
                 _absorb_claim_kv(current, rest, wanted_keys)
+                if list_keys:
+                    _absorb_list_kv(current, rest, list_keys)
         elif current is not None:
             _absorb_claim_kv(current, stripped, wanted_keys)
+            if list_keys:
+                _absorb_list_kv(current, stripped, list_keys)
     if current is not None:
         claims.append(current)
     return claims
@@ -948,6 +993,23 @@ def parse_distilled_claims_with_id(page_text: str) -> list[dict]:
     so callers using this for substring matching must take `text` as the needle.
     Returns [] for any page without a parseable block (same fail-safe contract)."""
     return _parse_claim_block(page_text, _DISTILLED_KEY_RE, _DISTILLED_ID_WANTED_KEYS)
+
+
+def parse_distilled_claims_with_backlinks(page_text: str) -> list[dict]:
+    """Extract `[{claim_id, text, backlinks: [<source-slug>, …]}, …]` from a distilled
+    page's `distilled_claims:` block. Same block as `parse_distilled_claims_with_id`,
+    but ALSO surfaces each claim's `backlinks` — the source-page slugs that contributed
+    the claim (written by concept-store.py as a single-line inline JSON list). This is
+    the citation edge the dual-level retrieval join (`wiki-grounding.py`) needs to
+    connect a distilled page back to the source pages it cites; the other distilled
+    readers drop `backlinks` by design (their `wanted_keys` are scalar-only and
+    `_absorb_claim_kv` reads only scalars), so this is the dedicated reader for that
+    edge. The remaining writer-side metadata (norm_key / source_claim_refs / dates)
+    stays concept-store-private and is ignored. A claim with no parseable `backlinks`
+    simply omits the key (→ the join skips it). Returns [] for any page without a
+    parseable block (same fail-safe contract)."""
+    return _parse_claim_block(page_text, _DISTILLED_KEY_RE, _DISTILLED_ID_WANTED_KEYS,
+                              list_keys=("backlinks",))
 
 
 def parse_answer_claims_with_id(page_text: str) -> list[dict]:

--- a/cogni-knowledge/scripts/_knowledge_lib.py
+++ b/cogni-knowledge/scripts/_knowledge_lib.py
@@ -1006,10 +1006,15 @@ def parse_distilled_claims_with_backlinks(page_text: str) -> list[dict]:
     `_absorb_claim_kv` reads only scalars), so this is the dedicated reader for that
     edge. The remaining writer-side metadata (norm_key / source_claim_refs / dates)
     stays concept-store-private and is ignored. A claim with no parseable `backlinks`
-    simply omits the key (→ the join skips it). Returns [] for any page without a
-    parseable block (same fail-safe contract)."""
-    return _parse_claim_block(page_text, _DISTILLED_KEY_RE, _DISTILLED_ID_WANTED_KEYS,
-                              list_keys=("backlinks",))
+    normalizes to `backlinks: []`, so every returned claim carries the key as a list
+    — a uniform shape for the dual-level join (`collect_pages`' set comprehension
+    never needs a `.get` default). Returns [] for any page without a parseable block
+    (same fail-safe contract)."""
+    claims = _parse_claim_block(page_text, _DISTILLED_KEY_RE, _DISTILLED_ID_WANTED_KEYS,
+                                list_keys=("backlinks",))
+    for claim in claims:
+        claim.setdefault("backlinks", [])
+    return claims
 
 
 def parse_answer_claims_with_id(page_text: str) -> list[dict]:

--- a/cogni-knowledge/scripts/retrieval-eval.py
+++ b/cogni-knowledge/scripts/retrieval-eval.py
@@ -135,37 +135,41 @@ def seed_from_questions(wiki_root: Path) -> list[dict]:
 # Metrics
 # ---------------------------------------------------------------------------
 def _rank_of_first_relevant(pages: list[dict], query: dict,
-                            threshold: float) -> int | None:
+                            threshold: float, *, dual_level: bool = False) -> int | None:
     """Rank (1-indexed) of the first ranked page whose slug is in the query's
     expected set, or None if no expected page is in the passing set.
 
     Uses a top_k large enough to return the FULL passing set, so MRR and hit@5
     are never truncated by the default rank cap (the refiner's faithful-
-    measurement fix)."""
+    measurement fix). `dual_level` forwards to `rank_pages` to measure the opt-in
+    dual-level rank against the same labelled set (default off = the baseline)."""
     expected = set(query.get("expected_slugs") or [])
     sq_tokens = sq_token_set({
         "query": query.get("query", ""),
         "theme_label": query.get("theme_label", ""),
     })
     full_k = max(len(pages), 5)
-    ranked = rank_pages(pages, sq_tokens, threshold, full_k)
+    ranked = rank_pages(pages, sq_tokens, threshold, full_k, dual_level=dual_level)
     for idx, page in enumerate(ranked["covered_pages"], start=1):
         if page["slug"] in expected:
             return idx
     return None
 
 
-def run_eval(wiki_root: Path, queries: list[dict], threshold: float) -> dict:
+def run_eval(wiki_root: Path, queries: list[dict], threshold: float,
+             *, dual_level: bool = False) -> dict:
     # include_interviews=True: interview pages are source-class evidence on the
     # read side, so a question whose ground-truth answer is an interview note
     # must not score as a false miss (the refiner's faithful-measurement fix).
-    pages = collect_pages(wiki_root, include_interviews=True)
+    # include_backlinks mirrors dual_level so the source↔distilled edge is present
+    # only when the dual-level rank needs it (default off = byte-identical baseline).
+    pages = collect_pages(wiki_root, include_interviews=True, include_backlinks=dual_level)
     per_query = []
     hits_at_1 = 0
     hits_at_5 = 0
     rr_sum = 0.0
     for q in queries:
-        rank = _rank_of_first_relevant(pages, q, threshold)
+        rank = _rank_of_first_relevant(pages, q, threshold, dual_level=dual_level)
         rr = (1.0 / rank) if rank else 0.0
         h1 = 1 if rank == 1 else 0
         h5 = 1 if (rank is not None and rank <= 5) else 0
@@ -192,6 +196,7 @@ def run_eval(wiki_root: Path, queries: list[dict], threshold: float) -> dict:
     return {
         "wiki_root": str(wiki_root),
         "threshold": threshold,
+        "dual_level": dual_level,
         "pages_scanned": len(pages),
         "run_at": _now_iso(),
         "aggregate": aggregate,
@@ -237,7 +242,7 @@ def cmd_eval(args: argparse.Namespace) -> int:
         atomic_write(set_path, {"version": 1, "seeded_at": _now_iso(), "queries": queries})
         seeded = True
 
-    result = run_eval(wiki_root, queries, threshold)
+    result = run_eval(wiki_root, queries, threshold, dual_level=args.dual_level)
     atomic_write(out_path, {"success": True, "data": result, "error": ""})
 
     return _emit(True, data={
@@ -268,6 +273,10 @@ def main(argv: list[str]) -> int:
     p.add_argument("--out", default=None,
                    help="Path to write run results. Default: "
                         "<wiki_root>/.cogni-knowledge/retrieval-eval.json")
+    p.add_argument("--dual-level", action="store_true",
+                   help="Measure the opt-in dual-level rank (wiki-grounding.py rank "
+                        "--dual-level) instead of the single-level baseline. Run once "
+                        "without and once with this flag to compare hit@k / MRR.")
     p.set_defaults(func=cmd_eval)
 
     args = parser.parse_args(argv)

--- a/cogni-knowledge/scripts/wiki-grounding.py
+++ b/cogni-knowledge/scripts/wiki-grounding.py
@@ -58,6 +58,7 @@ from _knowledge_lib import (  # noqa: E402
     _unquote_scalar,
     compound_match,
     parse_distilled_claims,
+    parse_distilled_claims_with_backlinks,
     parse_pre_extracted_claims,
     token_weight,
     tokenize,
@@ -81,6 +82,15 @@ MIN_MATCHED_WEIGHT = 1.0
 TOP_K = 8
 # Max pre_extracted_claims[].text fields folded into a page's token signal.
 MAX_CLAIMS_PER_PAGE = 8
+# Dual-level rank (opt-in, default off) combine weights. ALPHA weighs the
+# cross-document signal (a citing/backing page's overlap), BETA the page's own
+# token overlap. Used two ways by `_fold_dual_level`: a source/synthesis page is
+# lifted by `own + ALPHA * best_citing_distilled_overlap` (additive — never lowers
+# its own score), and a distilled page is folded in by `ALPHA * best_covered_source
+# + BETA * own_overlap`. Named constants so the single tuning knob is reviewable;
+# sweeping them is a follow-up if the first measurement misses the acceptance bar.
+DUAL_LEVEL_ALPHA = 0.6
+DUAL_LEVEL_BETA = 0.4
 # Page-type → wiki subdirectory. Plural of "synthesis" is "syntheses", NOT
 # "synthesiss" — so emit the resolved relative path per page and never let a
 # consumer pluralize `type` itself.
@@ -191,13 +201,22 @@ def _read_text(path: Path) -> str:
         return ""
 
 
-def collect_pages(wiki_root: Path, *, include_interviews: bool = False) -> list[dict]:
+def collect_pages(wiki_root: Path, *, include_interviews: bool = False,
+                  include_backlinks: bool = False) -> list[dict]:
     """Gather source/synthesis/concept/entity/person pages with their title/
     tags/index-summary + per-type claim text (`pre_extracted_claims[].text` for
     source/synthesis, `distilled_claims[].text` for concept/entity/person).
 
     Returns a list of {slug, type, page_path (wiki-root-relative), title,
     tags, tokens}. A missing wiki/ dir (fresh base) yields [].
+
+    `include_backlinks` is OPT-IN (default False) and keyword-only: when True, each
+    distilled (concept/entity/person) page additionally carries a sorted
+    `backing_source_slugs` list — the union of its `distilled_claims[].backlinks`
+    (the source pages whose claims were distilled into it). This is the citation
+    edge the dual-level rank (`rank_pages(..., dual_level=True)`) joins on. Default
+    False adds no field and no extra parse, so the single-level walk every existing
+    consumer drives stays byte-identical.
 
     `include_interviews` is OPT-IN (default False) and keyword-only. The
     default `_TYPE_DIRS` set covers source/synthesis/concept/entity/person; any
@@ -257,14 +276,23 @@ def collect_pages(wiki_root: Path, *, include_interviews: bool = False) -> list[
             claim_text = " ".join(
                 str(c.get("text", "")) for c in claims[:MAX_CLAIMS_PER_PAGE]
             )
-            pages.append({
+            page = {
                 "slug": slug,
                 "type": ptype,
                 "page_path": f"wiki/{subdir}/{page_file.name}",
                 "title": title,
                 "tags": tags,
                 "tokens": tokenize(title, summary, " ".join(tags), claim_text),
-            })
+            }
+            # Opt-in dual-level edge: carry the distilled page's backing source
+            # slugs (additive — only when asked, only for distilled types, so the
+            # default walk is byte-identical for every single-level consumer).
+            if include_backlinks and ptype in ("concept", "entity", "person"):
+                bl_claims = parse_distilled_claims_with_backlinks(page_text)
+                page["backing_source_slugs"] = sorted(
+                    {s for c in bl_claims for s in c.get("backlinks", [])}
+                )
+            pages.append(page)
     return pages
 
 
@@ -323,8 +351,93 @@ def match_reasons(sq_tokens: set, page: dict) -> list[str]:
 # ---------------------------------------------------------------------------
 
 
+def _fold_dual_level(pages: list[dict], sq_tokens: set,
+                     scored: list, threshold: float) -> tuple:
+    """Additive dual-level fold-in over the single-level `scored` list. Connects
+    the source level and the distilled (concept/entity/person) level through the
+    `backing_source_slugs` edge `collect_pages(..., include_backlinks=True)`
+    carries, in BOTH directions:
+
+      1. **Source lift (the acceptance-bar driver).** A source/synthesis page is
+         boosted by the best-matching distilled page that cites it:
+         `combined = own + ALPHA * best_citing_distilled_overlap`. This surfaces an
+         answering source a thematic query under-retrieves at the source level
+         alone, when a strongly-matching concept/entity vouches for it. Additive —
+         a source with no citing distilled page keeps its own score exactly, so the
+         relative order of un-boosted sources is unchanged.
+      2. **Distilled fold-in (navigation).** A distilled page that cites a covering
+         source is folded in by `ALPHA * best_covered_source + BETA * own_overlap`,
+         so the cross-document concept/entity pages a query spans become navigable
+         even when their own token overlap is thin.
+
+    Returns (merged_scored, dual_reasons) where `dual_reasons` maps slug → the
+    annotated reasons list (a `dual-level: …` lead reason + the page's normal
+    match reasons). Deterministic: the merged list re-sorts with the same
+    `(-score, slug)` key the single-level path uses. A page's score is only ever
+    raised, never lowered (each branch keeps the larger of the existing and the
+    combined score)."""
+    by_slug = {page["slug"]: (score, page) for score, page in scored}
+    covering_source_slugs = {
+        page["slug"] for score, page in scored
+        if page["type"] in ("source", "synthesis")
+    }
+    # Distilled pages + their own overlap (may be below threshold) and, per source
+    # slug, the best overlap among the distilled pages that cite it.
+    distilled: list = []
+    boost: dict = {}  # source_slug -> (best_overlap, citing_distilled_slug)
+    for page in pages:
+        if page["type"] not in ("concept", "entity", "person"):
+            continue
+        own_overlap = coverage_score(sq_tokens, page["tokens"])[0]
+        distilled.append((page, own_overlap))
+        if own_overlap <= 0.0:
+            continue
+        for src in page.get("backing_source_slugs") or []:
+            cur = boost.get(src)
+            if cur is None or own_overlap > cur[0]:
+                boost[src] = (own_overlap, page["slug"])
+
+    dual_reasons: dict = {}
+    # Effect 1 — lift source/synthesis pages cited by a matching distilled page.
+    for page in pages:
+        if page["type"] not in ("source", "synthesis"):
+            continue
+        b = boost.get(page["slug"])
+        if not b:
+            continue
+        own = coverage_score(sq_tokens, page["tokens"])[0]
+        combined = round(own + DUAL_LEVEL_ALPHA * b[0], 6)
+        existing = by_slug.get(page["slug"])
+        if existing is None or combined > existing[0]:
+            by_slug[page["slug"]] = (combined, page)
+            dual_reasons[page["slug"]] = (
+                ["dual-level: cited by " + b[1]] + match_reasons(sq_tokens, page)
+            )
+
+    # Effect 2 — fold in distilled pages that cite a covering source.
+    for page, own_overlap in distilled:
+        intersect = [s for s in (page.get("backing_source_slugs") or [])
+                     if s in covering_source_slugs]
+        if not intersect:
+            continue
+        best_src = max((by_slug.get(s, (0.0, None))[0] for s in intersect),
+                       default=0.0)
+        combined = round(DUAL_LEVEL_ALPHA * best_src + DUAL_LEVEL_BETA * own_overlap, 6)
+        existing = by_slug.get(page["slug"])
+        if existing is None or combined > existing[0]:
+            by_slug[page["slug"]] = (combined, page)
+            backers = sorted(intersect)[:2]
+            dual_reasons[page["slug"]] = (
+                ["dual-level: backs " + ", ".join(backers)] + match_reasons(sq_tokens, page)
+            )
+
+    merged = sorted(by_slug.values(), key=lambda sp: (-sp[0], sp[1]["slug"]))
+    return merged, dual_reasons
+
+
 def rank_pages(pages: list[dict], sq_tokens: set,
-               threshold: float = DEFAULT_THRESHOLD, top_k: int = TOP_K) -> dict:
+               threshold: float = DEFAULT_THRESHOLD, top_k: int = TOP_K,
+               *, dual_level: bool = False) -> dict:
     """The one discovery primitive both call sites resolve to. Given a set of
     pre-collected pages (from `collect_pages`) and a sub-question token set,
     return the ranked covering pages (index-first: highest overlap first, stable
@@ -340,7 +453,15 @@ def rank_pages(pages: list[dict], sq_tokens: set,
     match (which can clear the ratio on a small sub-question) from flipping a
     genuinely-novel sub-question to `covered` (#326). The verdict is computed on
     the FULL passing set; only the emitted list is capped (top_k >= 2 so the
-    `covered` invariant survives the truncation)."""
+    `covered` invariant survives the truncation).
+
+    `dual_level` is OPT-IN (default False) and keyword-only. When True, the
+    single-level `scored` list is passed through `_fold_dual_level`, which lifts
+    answering sources via the distilled pages that cite them and folds in those
+    distilled pages (requires pages collected with `include_backlinks=True`).
+    Default False leaves the single-level path byte-identical — every existing
+    consumer (`wiki-coverage.py`, `wiki-source-manifest.py`, the no-flag CLI,
+    `retrieval-eval.py`'s default) passes neither keyword and is unaffected."""
     scored = []
     for page in pages:
         score, matched_weight = coverage_score(sq_tokens, page["tokens"])
@@ -348,6 +469,12 @@ def rank_pages(pages: list[dict], sq_tokens: set,
             scored.append((score, page))
     # Highest overlap first; stable tie-break by slug for determinism.
     scored.sort(key=lambda sp: (-sp[0], sp[1]["slug"]))
+
+    # Opt-in additive second level — empty `dual_reasons` on the default path, so
+    # the covered_pages reasons below resolve to the single-level match reasons.
+    dual_reasons: dict = {}
+    if dual_level:
+        scored, dual_reasons = _fold_dual_level(pages, sq_tokens, scored, threshold)
 
     if len(scored) >= 2:
         verdict = "covered"
@@ -362,7 +489,8 @@ def rank_pages(pages: list[dict], sq_tokens: set,
         "page_path": page["page_path"],
         "title": page["title"],
         "overlap_score": round(score, 4),
-        "reasons": match_reasons(sq_tokens, page),
+        "reasons": (dual_reasons[page["slug"]] if page["slug"] in dual_reasons
+                    else match_reasons(sq_tokens, page)),
     } for score, page in scored[:top_k]]
 
     return {
@@ -403,8 +531,12 @@ def cmd_rank(args: argparse.Namespace) -> int:
     # include_interviews defaults False (the CLI flag below is store_true), so a
     # caller that omits --include-interviews scores against the default
     # _TYPE_DIRS set exactly as before — parity with the path-loading consumers.
-    pages = collect_pages(wiki_root, include_interviews=args.include_interviews)  # [] on a fresh / unreadable base
-    ranked = rank_pages(pages, sq_tokens, threshold, args.top_k)
+    # include_backlinks defaults False (the --dual-level flag below is store_true),
+    # so the default walk + rank stay byte-identical; it is enabled only to carry
+    # the source↔distilled edge the dual-level rank joins on.
+    pages = collect_pages(wiki_root, include_interviews=args.include_interviews,
+                          include_backlinks=args.dual_level)  # [] on a fresh / unreadable base
+    ranked = rank_pages(pages, sq_tokens, threshold, args.top_k, dual_level=args.dual_level)
 
     data = {
         "wiki_root": str(wiki_root),
@@ -443,6 +575,11 @@ def main(argv: list[str]) -> int:
                         help="Also walk wiki/interviews/ (type: interview pages) when ranking. "
                              "OPT-IN, default off — keeps coverage/compose parity; "
                              "knowledge-ingest-source's interview-note dedup passes it.")
+    p_rank.add_argument("--dual-level", action="store_true",
+                        help="Opt-in additive dual-level (entity + cross-document) rank: lift "
+                             "answering sources via the distilled concept/entity pages that cite "
+                             "them, and fold in those distilled pages. OPT-IN, default off — the "
+                             "single-level ranking is byte-identical without it.")
     p_rank.set_defaults(func=cmd_rank)
 
     args = parser.parse_args(argv)

--- a/cogni-knowledge/skills/knowledge-query/SKILL.md
+++ b/cogni-knowledge/skills/knowledge-query/SKILL.md
@@ -43,6 +43,7 @@ Read `${CLAUDE_PLUGIN_ROOT}/references/differentiation-thesis.md` once per sessi
 | `--knowledge-root` | No | Override the default knowledge-base directory. Defaults to `cogni-knowledge/<knowledge-slug>/` (relative to the current working directory). |
 | `--max-pages` | No | Cap on how many ranked pages to read and synthesize from. Default 12 (the shallow-rung ceiling). Passed to `wiki-grounding.py rank --top-k`. |
 | `--theme` | No | Optional thematic label folded into the ranking (passed to `wiki-grounding.py rank --theme-label`) to sharpen page selection on a broad question. |
+| `--dual-level` | No | **Opt-in, default off.** Passes `wiki-grounding.py rank --dual-level` — an additive dual-level (entity + cross-document) rank that lifts answering source pages via the distilled concept/entity pages that cite them, and folds those distilled pages into the ranked set. Sharpens retrieval on entity-spanning / cross-document questions a query under-retrieves at the source level alone; the single-level ranking is byte-identical without it. |
 | `--file-back` | No | Opt-in synthesis deposit. **Absent → read-only** (the default; no writes, no prompt — autonomous/cron runs stay clean). `yes` → deposit the synthesized answer as an honestly-labeled un-verified `type: synthesis` wiki page (Step 4). |
 | `--synthesis-slug` | No | Override the auto-derived deposit slug (only meaningful with `--file-back yes`). |
 | `--overwrite` | No | With `--file-back yes`, replace an existing `wiki/syntheses/<slug>.md` instead of aborting on the collision guard. |
@@ -109,12 +110,19 @@ python3 ${CLAUDE_PLUGIN_ROOT}/scripts/wiki-grounding.py rank \
     --wiki-root <wiki_path> \
     --question "<question>" \
     --top-k <max-pages, default 12> \
-    [--theme-label "<theme>"]
+    [--theme-label "<theme>"] \
+    [--dual-level]
 ```
+
+Pass `--dual-level` only when `--dual-level` was given to this skill — it is
+off by default (the single-level ranking is byte-identical without it) and
+adds the entity + cross-document fold-in described in the parameter table.
 
 Capture `data.pages[]` (each `{slug, type, page_path, title, overlap_score,
 reasons}`, ranked highest-overlap first; `page_path` is wiki-root-relative) and
-`data.coverage_verdict` (`covered` / `partial` / `uncovered`).
+`data.coverage_verdict` (`covered` / `partial` / `uncovered`). With
+`--dual-level`, a page lifted via the citation edge carries a
+`dual-level: …` lead reason so the second-level hit is visible in `reasons[]`.
 
 - **`uncovered` (no covering pages)** → do **not** synthesize from nothing. Tell
   the user the base has no page covering this question, suggest

--- a/cogni-knowledge/skills/knowledge-query/SKILL.md
+++ b/cogni-knowledge/skills/knowledge-query/SKILL.md
@@ -114,9 +114,10 @@ python3 ${CLAUDE_PLUGIN_ROOT}/scripts/wiki-grounding.py rank \
     [--dual-level]
 ```
 
-Pass `--dual-level` only when `--dual-level` was given to this skill — it is
-off by default (the single-level ranking is byte-identical without it) and
-adds the entity + cross-document fold-in described in the parameter table.
+Forward `--dual-level` to `wiki-grounding.py` only when the caller passed it to
+this skill; otherwise omit the flag entirely, leaving the single-level ranking
+byte-identical. When set, it adds the entity + cross-document fold-in described
+in the parameter table.
 
 Capture `data.pages[]` (each `{slug, type, page_path, title, overlap_score,
 reasons}`, ranked highest-overlap first; `page_path` is wiki-root-relative) and

--- a/cogni-knowledge/tests/test_knowledge_lib.sh
+++ b/cogni-knowledge/tests/test_knowledge_lib.sh
@@ -498,6 +498,50 @@ def assert_parse_distilled_claims_with_id():
     assert kl.parse_distilled_claims_with_id("---\ndistilled_claims:\n  - claim_id: dcl-x\n\n# no close\n") == []
 
 
+def assert_parse_distilled_claims_with_backlinks():
+    # #885: the dual-level retrieval join needs each distilled claim's backlinks
+    # source slugs, which the with_id sibling drops by design. This reader absorbs
+    # claim_id + text + the inline-list backlinks (concept-store renders it via
+    # json.dumps, with or without a space after the comma).
+    page = (
+        "---\n"
+        "type: concept\n"
+        "distilled_claims:\n"
+        "  - claim_id: dcl-001\n"
+        '    text: "Artikel 6: Hochrisiko-Einstufung kombiniert mehrere Quellen."\n'
+        '    norm_key: "k1"\n'
+        '    backlinks: ["src-a", "src-b"]\n'
+        '    source_claim_refs: ["src-a#c1"]\n'
+        "    created: 2026-05-29\n"
+        "  - claim_id: dcl-002\n"
+        '    text: "Zweite distillierte Aussage."\n'
+        '    backlinks: ["src-c","src-a"]\n'
+        "---\n\n# body\n"
+    )
+    claims = kl.parse_distilled_claims_with_backlinks(page)
+    assert len(claims) == 2, claims
+    assert claims[0] == {"claim_id": "dcl-001",
+                         "text": "Artikel 6: Hochrisiko-Einstufung kombiniert mehrere Quellen.",
+                         "backlinks": ["src-a", "src-b"]}, claims[0]
+    assert set(claims[0]) == {"claim_id", "text", "backlinks"}, \
+        "only claim_id+text+backlinks wanted: " + repr(claims[0])
+    assert claims[1]["backlinks"] == ["src-c", "src-a"], claims[1]
+    # A claim with no / empty inline-list backlinks simply omits the key.
+    nob = kl.parse_distilled_claims_with_backlinks(
+        "---\ndistilled_claims:\n  - claim_id: dcl-x\n    text: t\n    backlinks: []\n---\n")
+    assert nob == [{"claim_id": "dcl-x", "text": "t"}], nob
+    miss = kl.parse_distilled_claims_with_backlinks(
+        "---\ndistilled_claims:\n  - claim_id: dcl-y\n    text: t\n---\n")
+    assert miss == [{"claim_id": "dcl-y", "text": "t"}], miss
+    # The with_id sibling stays byte-identical (no backlinks key) — proves additive.
+    wid = kl.parse_distilled_claims_with_id(page)
+    assert set(wid[0]) == {"claim_id", "text"}, "with_id unaffected: " + repr(wid[0])
+    # Same fail-safe contract: inline [] / no key / empty / no-frontmatter → [].
+    assert kl.parse_distilled_claims_with_backlinks("---\ntype: concept\ndistilled_claims: []\n---\n# body\n") == []
+    assert kl.parse_distilled_claims_with_backlinks("") == []
+    assert kl.parse_distilled_claims_with_backlinks("---\ntype: concept\n---\n# body\n") == []
+
+
 def assert_parse_answer_claims_with_id():
     # #432: question nodes carry `answer_claims:` — same per-claim shape as
     # distilled_claims (acl-NNN ids, no excerpt_quote). verify-store keys an answer
@@ -1182,6 +1226,7 @@ check("renumber_inline_citations", assert_renumber_inline_citations)
 check("parse_pre_extracted_claims", assert_parse_pre_extracted_claims)
 check("parse_distilled_claims", assert_parse_distilled_claims)
 check("parse_distilled_claims_with_id", assert_parse_distilled_claims_with_id)
+check("parse_distilled_claims_with_backlinks", assert_parse_distilled_claims_with_backlinks)
 check("parse_answer_claims_with_id", assert_parse_answer_claims_with_id)
 check("parse_answer_records", assert_parse_answer_records)
 check("writer_quality_normalizers", assert_writer_quality_normalizers)

--- a/cogni-knowledge/tests/test_knowledge_lib.sh
+++ b/cogni-knowledge/tests/test_knowledge_lib.sh
@@ -526,13 +526,14 @@ def assert_parse_distilled_claims_with_backlinks():
     assert set(claims[0]) == {"claim_id", "text", "backlinks"}, \
         "only claim_id+text+backlinks wanted: " + repr(claims[0])
     assert claims[1]["backlinks"] == ["src-c", "src-a"], claims[1]
-    # A claim with no / empty inline-list backlinks simply omits the key.
+    # A claim with no / empty inline-list backlinks normalizes to backlinks=[] —
+    # every returned claim carries the key as a list (uniform join shape).
     nob = kl.parse_distilled_claims_with_backlinks(
         "---\ndistilled_claims:\n  - claim_id: dcl-x\n    text: t\n    backlinks: []\n---\n")
-    assert nob == [{"claim_id": "dcl-x", "text": "t"}], nob
+    assert nob == [{"claim_id": "dcl-x", "text": "t", "backlinks": []}], nob
     miss = kl.parse_distilled_claims_with_backlinks(
         "---\ndistilled_claims:\n  - claim_id: dcl-y\n    text: t\n---\n")
-    assert miss == [{"claim_id": "dcl-y", "text": "t"}], miss
+    assert miss == [{"claim_id": "dcl-y", "text": "t", "backlinks": []}], miss
     # The with_id sibling stays byte-identical (no backlinks key) — proves additive.
     wid = kl.parse_distilled_claims_with_id(page)
     assert set(wid[0]) == {"claim_id", "text"}, "with_id unaffected: " + repr(wid[0])

--- a/cogni-knowledge/tests/test_retrieval_eval.sh
+++ b/cogni-knowledge/tests/test_retrieval_eval.sh
@@ -174,6 +174,69 @@ BAD=$("$EVAL" eval --wiki-root "$WIKI" --threshold 0 2>/dev/null) || true
 echo "$BAD" > "$WORK/bad.json"
 assert_grep '"success": false' "$WORK/bad.json" "threshold 0 is rejected (exclusive lower bound)"
 
+# --- #885 dual-level: measurable hit@k / MRR gain over the baseline ---------
+# A base whose answering source's own tokens miss the German thematic query, but
+# which a strongly-matching concept page cites. Single-level retrieves the source
+# nowhere (hit@5 = 0); --dual-level lifts it via the citation edge (hit@5 = 1).
+DWIKI="$WORK/dual"
+mkdir -p "$DWIKI/wiki/sources" "$DWIKI/wiki/concepts" "$DWIKI/wiki/questions"
+cat > "$DWIKI/wiki/sources/art16-provider-text.md" <<'MD'
+---
+type: source
+id: art16-provider-text
+title: "Provider obligations text excerpt"
+sources: ["https://example.org/art16"]
+pre_extracted_claims:
+  - id: clm-001
+    text: "Operators shall maintain documentation per the annex provisions."
+    excerpt_quote: "documentation per the annex"
+---
+# body
+MD
+cat > "$DWIKI/wiki/concepts/pflichten-risikoklasse.md" <<'MD'
+---
+type: concept
+title: "Pflichten nach Risikoklasse fuer Anbieter"
+distilled_claims:
+  - claim_id: dcl-001
+    text: "Anbieter Pflichten Risikoklasse Hochrisiko Anforderungen kombiniert."
+    norm_key: ""
+    backlinks: ["art16-provider-text"]
+    source_claim_refs: ["art16-provider-text#clm-001"]
+    created: 2026-06-01
+    updated: 2026-06-01
+---
+# body
+MD
+cat > "$DWIKI/wiki/questions/q-pflichten.md" <<'MD'
+---
+type: question
+id: q-pflichten
+title: "Pflichten nach Risikoklasse"
+theme_label: "Pflichten nach Risikoklasse"
+sources_answering: [art16-provider-text]
+---
+## Findings
+- [[art16-provider-text]]
+MD
+"$EVAL" eval --wiki-root "$DWIKI" --reseed > "$WORK/dual_base.json" 2>/dev/null || true
+"$EVAL" eval --wiki-root "$DWIKI" --reseed --dual-level > "$WORK/dual_on.json" 2>/dev/null || true
+# Pretty-printed (multi-line) envelopes — read each file whole, never line-by-line.
+if python3 -c "
+import json,sys
+base = json.load(open('$WORK/dual_base.json'))['data']['aggregate']
+dual = json.load(open('$WORK/dual_on.json'))['data']['aggregate']
+# Baseline misses the answering source; dual-level retrieves it -> strict gain.
+ok = base['hit_at_5'] == 0.0 and dual['hit_at_5'] == 1.0 and dual['mrr'] > base['mrr']
+sys.exit(0 if ok else 1)
+"; then
+  green "PASS: --dual-level yields a measurable hit@5 / MRR gain over the single-level baseline"
+else
+  red "FAIL: --dual-level did not improve hit@5 / MRR"
+  head -20 "$WORK/dual_base.json" "$WORK/dual_on.json"
+  errors=$((errors + 1))
+fi
+
 if [ "$errors" -eq 0 ]; then
   green "All retrieval-eval tests passed."
   exit 0

--- a/cogni-knowledge/tests/test_wiki_grounding.sh
+++ b/cogni-knowledge/tests/test_wiki_grounding.sh
@@ -200,6 +200,74 @@ else
   green "PASS: out-of-range (>1) --threshold is rejected"
 fi
 
+# --- Case 5: dual-level rank — byte-identical when off, source-lift when on ---
+# A separate base: a source whose OWN tokens miss the German thematic query, but
+# which a strongly-matching concept page cites via distilled_claims[].backlinks.
+# Single-level never surfaces the source; --dual-level lifts it via the citation
+# edge (the navigation-C3 deficit the feature targets). The default (no flag)
+# output must be byte-identical to a plain run.
+DWIKI="$WORK/dual"
+mkdir -p "$DWIKI/wiki/sources" "$DWIKI/wiki/concepts"
+cat > "$DWIKI/wiki/sources/art16-provider-text.md" <<'MD'
+---
+type: source
+id: art16-provider-text
+title: "Provider obligations text excerpt"
+sources: ["https://example.org/art16"]
+pre_extracted_claims:
+  - id: clm-001
+    text: "Operators shall maintain documentation per the annex provisions."
+    excerpt_quote: "documentation per the annex"
+---
+# body
+MD
+cat > "$DWIKI/wiki/concepts/pflichten-risikoklasse.md" <<'MD'
+---
+type: concept
+title: "Pflichten nach Risikoklasse fuer Anbieter"
+distilled_claims:
+  - claim_id: dcl-001
+    text: "Anbieter Pflichten Risikoklasse Hochrisiko Anforderungen kombiniert."
+    norm_key: ""
+    backlinks: ["art16-provider-text"]
+    source_claim_refs: ["art16-provider-text#clm-001"]
+    created: 2026-06-01
+    updated: 2026-06-01
+---
+# body
+MD
+DQUERY="Pflichten nach Risikoklasse Anbieter"
+DTHEME="Pflichten nach Risikoklasse"
+# Byte-identical default: a no-flag run equals a plain run (the load-bearing
+# single-level guarantee — the citing source must NOT appear without --dual-level).
+BASE_OUT=$(python3 "$GROUNDING" rank --wiki-root "$DWIKI" --question "$DQUERY" --theme-label "$DTHEME" --top-k 10 2>/dev/null)
+DUAL_OUT=$(python3 "$GROUNDING" rank --wiki-root "$DWIKI" --question "$DQUERY" --theme-label "$DTHEME" --top-k 10 --dual-level 2>/dev/null)
+if echo "$BASE_OUT" | python3 -c "
+import json,sys
+d=json.load(sys.stdin)['data']
+slugs={p['slug'] for p in d['pages']}
+# single-level: the source whose own tokens miss the query is NOT covering.
+sys.exit(0 if ('art16-provider-text' not in slugs and 'pflichten-risikoklasse' in slugs) else 1)
+"; then
+  green "PASS: dual-level OFF — citing source absent (single-level path unchanged)"
+else
+  red "FAIL: single-level path surfaced the citing source without --dual-level"
+  echo "$BASE_OUT" | head -30; errors=$((errors+1))
+fi
+if echo "$DUAL_OUT" | python3 -c "
+import json,sys
+d=json.load(sys.stdin)['data']
+by={p['slug']:p for p in d['pages']}
+src=by.get('art16-provider-text')
+ok = src is not None and any(r.startswith('dual-level: cited by') for r in src['reasons'])
+sys.exit(0 if ok else 1)
+"; then
+  green "PASS: dual-level ON — citing source lifted into the ranked set (dual-level reason)"
+else
+  red "FAIL: --dual-level did not lift the cited source"
+  echo "$DUAL_OUT" | head -30; errors=$((errors+1))
+fi
+
 echo
 if [ "$errors" -eq 0 ]; then
   green "wiki-grounding.py shared-primitive contract all pass."


### PR DESCRIPTION
Closes #885.

## Summary
Adds an **additive, opt-in, default-off** dual-level (entity + cross-document) rank to `wiki-grounding.py`. The single-level path is **byte-identical** when the mode is off — every change is gated behind keyword-only defaults that existing call sites (`wiki-coverage.py`, `wiki-source-manifest.py`, the no-flag CLI, `retrieval-eval.py`'s default) never pass, proven by the unchanged existing test suites.

The mode connects the two retrieval levels through the `distilled_claims[].backlinks` citation edge, in the direction that serves the acceptance bar (source-slug hit@k): a strongly-matching distilled concept/entity page **lifts the answering source pages it cites** into the ranked set, and those distilled pages are folded in too. This surfaces an answering source that an entity-spanning / cross-document query under-retrieves at the source level alone — the navigation-C3 deficit (3/6 `eu-ai-act-sme` queries retrieve no relevant source).

## Changes
- **`_knowledge_lib.py`** — new `parse_distilled_claims_with_backlinks` reader (the existing distilled readers drop `backlinks[]` by design — scalar-only `wanted_keys`); `_parse_claim_block` gains an additive `list_keys` param for inline-list YAML fields. Existing readers stay byte-identical.
- **`wiki-grounding.py`** — `collect_pages(..., include_backlinks=True)` carries each distilled page's `backing_source_slugs`; `rank_pages(..., dual_level=True)` performs the source-lift + distilled fold-in (`DUAL_LEVEL_ALPHA=0.6` / `DUAL_LEVEL_BETA=0.4` named constants, deterministic `(-score, slug)` merge, `dual-level: …` `reasons[]` annotation); `--dual-level` `store_true` CLI flag.
- **`retrieval-eval.py`** — `--dual-level` threads `cmd_eval → run_eval → _rank_of_first_relevant → rank_pages` (+ `collect_pages(..., include_backlinks=dual_level)`) so the acceptance gain is measurable with the harness.
- **`knowledge-query/SKILL.md`** — documents the opt-in `--dual-level` flag.
- **tests** — new regression cases prove (a) single-level byte-identical when off, and (b) a measurable hit@5 / MRR gain when on (a synthetic base where the baseline retrieves the answering source nowhere → hit@5 0.0, and `--dual-level` lifts it via its citing concept → hit@5 1.0, MRR 0.0→0.5).
- Bump `cogni-knowledge` 1.0.33 → 1.0.34 (`plugin.json` + `marketplace.json`).

## Acceptance bar
The maintainer's bar — *re-run `retrieval-eval.py eval` on `eu-ai-act-sme` and require a measurable hit@5 / MRR gain, single-level byte-identical when off* — is wired end-to-end via `retrieval-eval.py eval --dual-level`. The `.alpha/` bases are gitignored (not in the repo), so the live `eu-ai-act-sme` re-measurement runs in the maintainer's environment; the in-repo regression test demonstrates the mechanism produces the gain on a synthetic equivalent.

## Test plan
- [x] `tests/test_knowledge_lib.sh` — new `parse_distilled_claims_with_backlinks` case + existing readers byte-identical.
- [x] `tests/test_wiki_grounding.sh` — dual-level OFF (citing source absent, single-level unchanged) + ON (source lifted, `dual-level:` reason).
- [x] `tests/test_retrieval_eval.sh` — `--dual-level` yields a strict hit@5 / MRR gain over the baseline.
- [x] Full cogni-knowledge suite green (74/74), incl. `test_wiki_coverage*.sh` / `test_wiki_source_manifest.sh` (the other `rank_pages` importers, unaffected).
- [x] `plugin.json` (1.0.34) and `marketplace.json` match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)