### PR TITLE
cogni-consult: document first-party in evidence_class vocabulary

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -35,7 +35,7 @@
     {
       "name": "cogni-consult",
       "source": "./cogni-consult",
-      "version": "0.1.35",
+      "version": "0.1.36",
       "maturity": "preview",
       "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
       "keywords": [

--- a/cogni-consult/.claude-plugin/plugin.json
+++ b/cogni-consult/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-consult",
-  "version": "0.1.35",
+  "version": "0.1.36",
   "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-consult/references/data-model.md
+++ b/cogni-consult/references/data-model.md
@@ -166,7 +166,7 @@ stored slug is visible to every consumer that reads the deliverable entry.
 `evidence_class` (optional, default `null`) records the provenance class of the
 evidence the deliverable rests on — a short free-text classification (e.g.
 `"desk-research"`, `"primary-research"`, `"expert-interview"`, `"internal-data"`,
-`"assumption"`) that makes the deliverable's evidence base machine-checkable
+`"first-party"`, `"assumption"`) that makes the deliverable's evidence base machine-checkable
 rather than buried in prose. It pairs with the deliverable's provenance record in
 the decision-log: at completion the design-thinking loop requires either a
 recorded `gap-check` verdict or an explicit `evidence-provenance-waiver` naming


### PR DESCRIPTION
Closes #923.

## Summary
- Add `"first-party"` to the `evidence_class` vocabulary example list in `cogni-consult/references/data-model.md` (the parenthetical at ~lines 166-169), between `"internal-data"` and `"assumption"`. The value is already emitted live by `consult-scope` on `as-is-seed.md` frontmatter (`skills/consult-scope/SKILL.md:77`, `references/research-routing.md:97`) and described in the same file's later prose (lines 178-181) — this closes the doc/code consistency gap in the canonical list.
- Bump `cogni-consult/.claude-plugin/plugin.json` version 0.1.35 → 0.1.36 (additive-change convention) and mirror it in the root `marketplace.json` cogni-consult entry.

## Scope decisions
- Included: the single vocabulary-list insertion plus the mandated version bump + marketplace mirror. Confirmed `first-party` is the ONLY missing live-emitted value — the other five (`desk-research`, `primary-research`, `expert-interview`, `internal-data`, `assumption`) are already present and retained.
- Excluded: no change to the lines 178-181 prose (already correct) and no widening of any other doc section, per AC (3).
- Nothing deferred — all three acceptance criteria ship here.

## Test plan
- [x] `grep -n 'first-party' cogni-consult/references/data-model.md` shows the value in the vocabulary list (line 169) AND the existing prose (lines 178-181).
- [x] The five previously-documented values are all still present in the list.
- [x] `plugin.json` `version` reads `0.1.36` and the `marketplace.json` cogni-consult entry mirrors `0.1.36`.
- [x] Diff is exactly the one list line plus the two version lines (3 files, 3 insertions, 3 deletions).