### PR TITLE
cogni-consult: advisory lint for stale non-terminal diagnostic gate

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -35,7 +35,7 @@
     {
       "name": "cogni-consult",
       "source": "./cogni-consult",
-      "version": "0.1.36",
+      "version": "0.1.37",
       "maturity": "preview",
       "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
       "keywords": [

--- a/cogni-consult/.claude-plugin/plugin.json
+++ b/cogni-consult/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-consult",
-  "version": "0.1.36",
+  "version": "0.1.37",
   "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-consult/references/dependency-model.md
+++ b/cogni-consult/references/dependency-model.md
@@ -146,6 +146,31 @@ Inferred edges are **advisory**:
 Resolution degrades gracefully: a deliverable with no artifact `.md`, no frontmatter,
 no `sources[]`, or only external/unresolvable references contributes no inferred edge.
 
+## Stale diagnostic gate (non-terminal field-0 target)
+
+`consult-action-fields` auto-wires each solution-field deliverable's `depends_on[]` to
+the **positional terminal** (last entry) of the diagnostic field-0's `deliverables[]` —
+the gate "depends on the diagnostic's conclusion". The wiring is positional; there is no
+separate terminal marker. The idempotency guard deliberately leaves prior-session edges
+alone, so if field-0 is re-planned **after** the gate was wired (a new deliverable
+appended), the existing edge keeps pointing at the **former** terminal — a real
+diagnostic deliverable, but no longer the conclusion. This is staleness, not breakage.
+
+`deliverable-graph.py validate` surfaces it as a **stale diagnostic gate** advisory:
+
+- It derives the current terminal by reading the diagnostic field's `field.json`
+  (`deliverables[-1]` bearing a slug) and reports any solution-field → `diagnostic-as-is`
+  edge whose target is not that terminal in `stale_diagnostic_gate_edges[]` /
+  `stale_diagnostic_gate_edge_count`, plus a human-readable `warnings[]` entry, and
+  **stays `success:true`** — like inferred edges, it never feeds cycle or dangling
+  detection (those remain `depends_on`-only hard errors).
+- It is **detect-only**: the lint never re-points the edge and never writes `field.json`
+  — re-pointing the gate at the current terminal is an explicit author action. This
+  preserves the leave-prior-edges-alone idempotency discipline (the lint makes the drift
+  machine-detectable; it does not auto-repair) and the read-time `blocks[]` contract.
+- When the engagement has no diagnostic field, or the diagnostic `field.json` is
+  unreadable, the check skips silently — it never degrades the hard-error path.
+
 ## Cascade semantics
 
 When an upstream deliverable changes, `cascade-stale` propagates the staleness to

--- a/cogni-consult/scripts/deliverable-graph.py
+++ b/cogni-consult/scripts/deliverable-graph.py
@@ -19,6 +19,13 @@ are advisory (validate stays success:true; they never feed cycle/dangling detect
 and never mutate field.json). Pass --include-inferred to impact / cascade-stale to
 fold them into the blast radius, closing the silent-zero-dependents gap.
 
+Stale diagnostic gate: `validate` also surfaces solution-field depends_on[] edges
+that target a `diagnostic-as-is` deliverable which is no longer the positional
+terminal of field-0's deliverables[] (field-0 was re-planned after the gate was
+wired). Advisory only (validate stays success:true via `stale_diagnostic_gate_edges`
++ a `warnings[]` entry; never a hard error, never mutates field.json — the lint
+detects the drift, it does not auto-repair).
+
 Data model (references/data-model.md, references/dependency-model.md):
   Each action-fields/<slug>/field.json carries deliverables[]. A deliverable may
   declare depends_on[] — an array of {action_field, deliverable} WBS-coordinate
@@ -358,6 +365,60 @@ def transitive(seed_key, adjacency):
     return seen
 
 
+DIAGNOSTIC_FIELD_SLUG = "diagnostic-as-is"
+
+
+def _stale_diagnostic_gate_edges(graph):
+    """Solution-field depends_on[] edges that target a diagnostic-as-is deliverable
+    which is no longer the positional terminal of the diagnostic field's
+    deliverables[] — i.e. field-0 was re-planned (a new deliverable appended) after
+    the gate was wired, so the edge still names a real diagnostic deliverable but no
+    longer its conclusion.
+
+    Advisory only — never a hard error, never mutates field.json. Returns a list of
+    {"from": key, "to": key} edges (empty when there is no diagnostic field, or no
+    drift). The terminal is derived by re-reading the diagnostic field's field.json
+    (load_graph already proved it readable) and taking the last slug-bearing
+    deliverable — mirroring the positional-terminal contract consult-action-fields
+    wires to. Skips silently on any read/parse miss so the advisory never degrades
+    the hard-error path.
+    """
+    nodes = graph["nodes"]
+    diag_node = next(
+        (n for n in nodes.values() if n["action_field"] == DIAGNOSTIC_FIELD_SLUG),
+        None,
+    )
+    if diag_node is None:
+        return []
+    try:
+        with open(diag_node["field_path"]) as f:
+            fjson = json.load(f)
+    except (json.JSONDecodeError, OSError):
+        return []
+    terminal_slug = None
+    for deliv in fjson.get("deliverables") or []:
+        dslug = deliv.get("slug")
+        if dslug:
+            terminal_slug = dslug
+    if terminal_slug is None:
+        return []
+    terminal_key = node_key(DIAGNOSTIC_FIELD_SLUG, terminal_slug)
+    stale = []
+    for from_key, ups in graph["depends_on"].items():
+        from_node = nodes.get(from_key)
+        if from_node is None or from_node["action_field"] == DIAGNOSTIC_FIELD_SLUG:
+            continue
+        for up_key in ups:
+            up_node = nodes.get(up_key)
+            if (
+                up_node is not None
+                and up_node["action_field"] == DIAGNOSTIC_FIELD_SLUG
+                and up_key != terminal_key
+            ):
+                stale.append({"from": from_key, "to": up_key})
+    return stale
+
+
 def cmd_validate(graph):
     """Detect cycles + dangling depends_on refs across all field.json (hard errors)."""
     cycles = find_cycles(graph["depends_on"])
@@ -394,6 +455,15 @@ def cmd_validate(graph):
             "--include-inferred to impact/cascade-stale to fold them into the blast "
             "radius (the graph never rewrites field.json on its own)."
         )
+    stale_gate = _stale_diagnostic_gate_edges(graph)
+    if stale_gate:
+        warnings.append(
+            f"{len(stale_gate)} solution-field edge(s) target a non-terminal diagnostic "
+            "deliverable (the diagnostic field-0 was re-planned after the gate was wired): "
+            + ", ".join(f"{e['from']} -> {e['to']}" for e in stale_gate)
+            + ". The gate no longer points at the diagnostic's conclusion; re-point it "
+            "at the current terminal if the dependency should follow the conclusion."
+        )
     return {
         "success": True,
         "data": {
@@ -403,6 +473,8 @@ def cmd_validate(graph):
             "dangling": [],
             "inferred_edges": inferred,
             "inferred_edge_count": len(inferred),
+            "stale_diagnostic_gate_edges": stale_gate,
+            "stale_diagnostic_gate_edge_count": len(stale_gate),
             "warnings": warnings,
         },
         "error": "",

--- a/cogni-consult/tests/test_deliverable_graph.sh
+++ b/cogni-consult/tests/test_deliverable_graph.sh
@@ -22,6 +22,7 @@
 #  13  cascade-include-inferred  --include-inferred flags the unrecorded dependent stale
 #  14  inferred-graceful     no artifact .md -> zero inferred edges, no warnings, success
 #  15  diagnostic-gate       solution deliverable auto-wired to the diagnostic field-0 terminal validates clean
+#  16  stale-diagnostic-gate solution edge to a NON-terminal diagnostic deliverable warns (advisory, success:true)
 #
 # Usage: bash cogni-consult/tests/test_deliverable_graph.sh
 # Exits non-zero on any assertion failure.
@@ -391,7 +392,54 @@ cat > "$D15/action-fields/growth-plays/field.json" <<'EOF'
 EOF
 OUT="$(run "$D15" validate)"
 assert_json "diagnostic-gate-clean" "$OUT" \
-  "d['success'] is True and d['data']['node_count'] == 3 and d['data']['edge_count'] == 1 and not d['data']['cycles'] and not d['data']['dangling']"
+  "d['success'] is True and d['data']['node_count'] == 3 and d['data']['edge_count'] == 1 and not d['data']['cycles'] and not d['data']['dangling'] and not d['data']['stale_diagnostic_gate_edges']"
+
+# ---------------------------------------------------------------------------
+# 16  stale-diagnostic-gate  (the diagnostic field-0 gained a NEW terminal after the
+#     gate was wired — the solution edge still points at the FORMER terminal, now a
+#     non-terminal diagnostic deliverable; validate warns but stays success:true)
+# ---------------------------------------------------------------------------
+D16="$TMPROOT/stale-diagnostic-gate"
+mkdir -p "$D16/action-fields/diagnostic-as-is" \
+         "$D16/action-fields/growth-plays"
+cat > "$D16/consult-project.json" <<'EOF'
+{
+  "slug": "acme",
+  "name": "Acme Engagement",
+  "key_question": "How?",
+  "action_fields": ["diagnostic-as-is", "growth-plays"],
+  "workflow_state": {"scope": "complete"},
+  "created": "2026-06-15",
+  "updated": "2026-06-15"
+}
+EOF
+# diagnostic field-0 RE-PLANNED: a third deliverable appended, so the current
+# terminal is "synthesis-readout", NOT "as-is-assessment".
+cat > "$D16/action-fields/diagnostic-as-is/field.json" <<'EOF'
+{
+  "slug": "diagnostic-as-is",
+  "title": "Diagnostic: Current State",
+  "deliverables": [
+    {"slug": "current-state-scan", "title": "Current-state scan", "state": "complete", "dt_stage": "test", "producing_route": "consult-design-thinking", "persona_review": "complete"},
+    {"slug": "as-is-assessment", "title": "As-is assessment", "state": "complete", "dt_stage": "test", "producing_route": "consult-design-thinking", "persona_review": "complete"},
+    {"slug": "synthesis-readout", "title": "Synthesis readout", "state": "complete", "dt_stage": "test", "producing_route": "consult-design-thinking", "persona_review": "complete"}
+  ]
+}
+EOF
+# solution edge still wired to the FORMER terminal "as-is-assessment" (now non-terminal)
+cat > "$D16/action-fields/growth-plays/field.json" <<'EOF'
+{
+  "slug": "growth-plays",
+  "title": "Growth Plays",
+  "deliverables": [
+    {"slug": "play-design", "title": "Play design", "state": "in-progress", "dt_stage": "ideate", "producing_route": "consult-design-thinking", "persona_review": "pending",
+     "depends_on": [{"action_field": "diagnostic-as-is", "deliverable": "as-is-assessment"}]}
+  ]
+}
+EOF
+OUT="$(run "$D16" validate)"
+assert_json "stale-diagnostic-gate" "$OUT" \
+  "d['success'] is True and not d['data']['cycles'] and not d['data']['dangling'] and d['data']['stale_diagnostic_gate_edge_count'] == 1 and d['data']['stale_diagnostic_gate_edges'][0] == {'from': 'growth-plays/play-design', 'to': 'diagnostic-as-is/as-is-assessment'} and any('non-terminal diagnostic' in w for w in d['data']['warnings'])"
 
 # ---------------------------------------------------------------------------
 echo


### PR DESCRIPTION
Closes #924.

## Summary
- Extend `cmd_validate` in `deliverable-graph.py` to detect solution-field `depends_on[]` edges that target a `diagnostic-as-is` deliverable which is no longer the positional terminal of field-0's `deliverables[]` (field-0 re-planned after the gate was wired).
- Surface the drift through validate's existing `warnings[]` channel (advisory pattern, same as inferred edges) — `success` stays `true`; this is **not** a hard failure alongside cycles/dangling refs.
- Add a parallel `stale_diagnostic_gate_edges[]` + `stale_diagnostic_gate_edge_count` to the `data` block for programmatic inspection (mirrors `inferred_edges`).
- Add test #16 asserting the warning fires for a non-terminal target, and tighten #15 to assert no stale-gate warning on the current terminal.
- Document the new advisory class in `references/dependency-model.md` and the module docstring.
- Bump cogni-consult `0.1.36` → `0.1.37`, mirrored in `.claude-plugin/marketplace.json`.

## Scope decisions
- Terminal derived by re-reading the diagnostic node's `field_path` and taking the last slug-bearing `deliverables[]` entry; skips silently when no diagnostic field exists or the file is unreadable (never degrades the hard-error path).
- Per the issue's explicit constraints: the read-time `blocks[]` derivation is untouched, the leave-prior-edges-alone idempotency discipline in `consult-action-fields/SKILL.md` is untouched (the lint detects drift, it does not auto-repair), and validate is **not** turned into a hard failure. The doc-only alternative was explicitly rejected by the issue and is not re-litigated.

## Test plan
- [x] `bash cogni-consult/tests/test_deliverable_graph.sh` — all 19 cases pass (incl. new #16 and tightened #15).
- [x] Stale non-terminal edge → `success:true` + non-empty `warnings[]` + populated `stale_diagnostic_gate_edges`.
- [x] Terminal-targeting edge → `success:true`, no stale-gate warning.
- [x] Cycle/dangling hard-failure path and `blocks[]` derivation unchanged.
- [x] `plugin.json` and `.claude-plugin/marketplace.json` both show `0.1.37`.

Plan record: https://github.com/cogni-work/insight-wave/issues/924#issuecomment-4762558513