### PR TITLE
cogni-knowledge: knowledge-run end-of-run summary + aggregate cost ledger

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "cogni-knowledge",
       "source": "./cogni-knowledge",
-      "version": "1.0.43",
+      "version": "1.0.44",
       "maturity": "released",
       "description": "Wiki-first research that compounds. Binds each run to a wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`. The shallow `knowledge-query` rung is read-only by default and can optionally file its answer back as an un-verified synthesis page via `--file-back`.",
       "keywords": [

--- a/cogni-knowledge/.claude-plugin/plugin.json
+++ b/cogni-knowledge/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-knowledge",
-  "version": "1.0.43",
+  "version": "1.0.44",
   "description": "Wiki-first research that compounds. Binds each run to a wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`. The shallow `knowledge-query` rung is read-only by default and can optionally file its answer back as an un-verified synthesis page via `--file-back`.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-knowledge/skills/knowledge-run/SKILL.md
+++ b/cogni-knowledge/skills/knowledge-run/SKILL.md
@@ -125,15 +125,92 @@ Dispatch-time rules, each mirroring `knowledge-refresh` push-mode:
 
 `knowledge-finalize` deposits the verified draft as `<wiki>/syntheses/<slug>.md` and appends the project to `binding.json::research_projects[]` — that is the deliverable.
 
-### 3. Final summary
+### 3. End-of-run summary + aggregate cost ledger
 
-Print a short summary (≤ 6 lines):
+Roll up what the run did into a single end-of-run summary — per-phase outcome, key
+counts, the total accumulated cost, and where the synthesis landed — so the operator
+reads one surface instead of scraping per-phase output by hand. **Reuse the existing
+per-phase ledger; never add a parallel cost-tracking mechanism** — each phase already
+records its timing + cost via `run-metrics.py record` into
+`<project_path>/.metadata/run-metrics.json`, and `run-metrics.py report` rolls that up.
 
-- On success: the deposited synthesis slug and its project path, and a note that a distill failure (if any) was tolerated.
-- On a phase failure: `failed at <failed_phase>: <error>` so the operator knows exactly where to resume, plus the reminder that re-invoking `knowledge-run` with `--project-path <project_path>` (or the same `--topic` the same day) resumes the chain from the first incomplete phase — §0.5 checkpoint detection skips the completed phases as logged no-ops.
-- On the resume entry, when every phase was already complete: the §0.5 `phase_reached == "finalize"` no-op message (`project already finalized — nothing to do`).
-- On an early stop from the cost gates: `aborted before <phase>` (a `--pause-before` abort) or `stopped after <phase>` (an `--until` stop), plus the reminder that re-invoking with `--project-path <project_path>` resumes from the first incomplete phase — §0.5 checkpoint detection skips the completed phases as logged no-ops.
-- Suggested next: `/cogni-knowledge:knowledge-resume` to confirm the new deposit, or `/cogni-knowledge:knowledge-dashboard` to re-render the overlay.
+**Gather the read-side data (all read-only, fail-soft — a missing manifest degrades a
+line to a dash, it never aborts the summary):**
+
+```bash
+# Aggregate cost ledger — the existing per-phase roll-up (NO parallel mechanism).
+python3 "${CLAUDE_PLUGIN_ROOT}/scripts/run-metrics.py" report --project-path "<project_path>"
+#   → data.totals.{cost_estimate_usd, elapsed_min, agent_count}, data.rendered (ASCII table),
+#     data.ledger_present (false ⇒ no phase recorded yet — say so), data.phases[].phase = the
+#     phases that actually RAN (a skipped/not-reached phase never calls record).
+
+# Key counts — sources ingested, citations, verify verdict, phase_reached, topic.
+python3 "${CLAUDE_PLUGIN_ROOT}/scripts/pipeline-summary.py" project \
+    --project-path "<project_path>" --knowledge-root "<knowledge_root>"
+#   → data.{ingested (sources), citations, verify_counts{verbatim,paraphrase,synthesis,unsupported,total},
+#     phase_reached, topic}. --knowledge-root is optional (defaults to the project-path parent);
+#     thread it for the canonical-layout-override case.
+
+# Claims extracted — not in pipeline-summary; sum the per-source counts inline.
+python3 -c "import json,sys; m=json.load(open('<project_path>/.metadata/ingest-manifest.json')); print(sum(e.get('claims_extracted',0) for e in m.get('ingested',[])))" 2>/dev/null || echo 0
+```
+
+**Reconstruct each phase's outcome** by crossing the `_PHASE_ORDER`
+(`plan → curate → fetch → ingest → distill → compose → verify → finalize`) against the
+signals already in hand:
+
+- in `run-metrics.py report` `data.phases[].phase` → **ran**
+- in the §0.5 `skip_set` → **skipped (artifact present)**
+- equal to `failed_phase` (the §2 failure capture) → **failed: `<error>`**
+- after `failed_phase` and not skipped → **not reached**
+
+**Print the summary** (lead with the per-phase outcome table, then key counts, then the
+cost ledger's rendered table):
+
+- **On success:** the per-phase outcome table; key counts (`sources=<N> claims=<N>
+  citations=<N>` and the verify verdict as `verbatim/paraphrase/unsupported` of `total`);
+  the deposited synthesis path `<wiki>/syntheses/<slug>.md` (capture the slug + path from
+  `knowledge-finalize`'s §2 output summary, fallback `_knowledge_lib.slugify(topic)` under
+  `<WIKI_ROOT>/wiki/syntheses/`); the aggregate cost (`data.totals.cost_estimate_usd` +
+  `elapsed_min`) and the `data.rendered` per-phase ledger table; a note that a distill
+  failure (if any) was tolerated.
+- **On a phase failure:** `failed at <failed_phase>: <error>` plus the per-phase outcome
+  table up to the failure, so the summary doubles as a resume hint — re-invoking
+  `knowledge-run` with `--project-path <project_path>` (or the same `--topic` the same day)
+  resumes from the first incomplete phase (§0.5 skips the completed phases as logged
+  no-ops). The cost ledger still rolls up the phases that ran.
+- **On the resume entry, when every phase was already complete:** the §0.5
+  `phase_reached == "finalize"` no-op message (`project already finalized — nothing to
+  do`), still followed by the key counts + cost ledger for the now-complete project.
+- **On an early stop from the cost gates:** `aborted before <phase>` (a `--pause-before`
+  abort) or `stopped after <phase>` (an `--until` stop), the per-phase outcome table, and
+  the `--project-path <project_path>` resume reminder.
+- **Suggested next:** `/cogni-knowledge:knowledge-resume` to confirm the new deposit, or
+  `/cogni-knowledge:knowledge-dashboard` to re-render the overlay.
+
+**Record the run in the base's log (success only).** When `finalize` completed, append one
+fail-soft `## [YYYY-MM-DD] run | …` line to `wiki/log.md`, mirroring the per-phase log
+convention (`compose` / `verify` / `finalize` already write their own). Resolve `WIKI_ROOT`
+first the same way the phase skills do — `knowledge-binding.py read` then `data.binding.wiki_path`
+— since §3 otherwise holds no wiki root:
+
+```bash
+# Resolve WIKI_ROOT from the binding (the knowledge-finalize pattern).
+WIKI_ROOT=$(python3 "${CLAUDE_PLUGIN_ROOT}/scripts/knowledge-binding.py" read --knowledge-root "<knowledge_root>" \
+    | python3 -c "import json,sys; print((json.load(sys.stdin).get('data',{}).get('binding',{}) or {}).get('wiki_path',''))" 2>/dev/null)
+# Append the run line — fail-soft: a resolve/append miss prints a warning, never aborts the summary.
+if [ -n "$WIKI_ROOT" ] && [ -d "$WIKI_ROOT" ]; then
+  # control-path.py log prints the bare resolved path on stdout (no JSON envelope), so $(...) captures it directly.
+  LOG_PATH=$(python3 "${CLAUDE_PLUGIN_ROOT}/scripts/control-path.py" log --wiki-root "$WIKI_ROOT" 2>/dev/null)
+  [ -n "$LOG_PATH" ] && printf '## [%s] run | project=%s slug=%s sources=%s citations=%s cost_usd=%s elapsed_min=%s\n' \
+      "$DATE_STAMP" "$TOPIC" "$SYNTHESIS_SLUG" "$N_SOURCES" "$N_CITATIONS" "$TOTAL_COST" "$ELAPSED_MIN" \
+      >> "$LOG_PATH"
+fi
+```
+
+The `run` op prefix is additive (the same posture as the existing `compose` / `verify` /
+`finalize` / `ingest` / `distill` prefixes). Append on a successful finalize only — a
+failed/partial run writes no log line (its resume hint lives in the printed summary).
 
 ### Resume contract
 
@@ -146,4 +223,4 @@ The chain fails soft: a topic that dies mid-chain leaves valid manifests on disk
 - **`knowledge-compose`** — preserves the outline-recovery contract (a leftover `writer-outline-vN.json` triggers Phase-2-only re-run).
 - **`knowledge-verify` / `knowledge-finalize`** — verify is single-pass per round; finalize refuses to overwrite an existing synthesis, so a re-run after a successful finalize is a safe no-op.
 
-Explicit checkpoint detection + an idempotent `--project-path` resume entry (§0.5 + §1's resume branch) and **cost-gating** (`--pause-before` / `--until`, §0 + §2) compose on this skeleton: a `--pause-before` abort or an `--until` stop leaves the completed phases' artifacts intact, so `--project-path` resumes from the first incomplete phase and a `skip_set` phase is never re-paused. An end-of-run summary/ledger builds on this skeleton in a separate increment.
+Explicit checkpoint detection + an idempotent `--project-path` resume entry (§0.5 + §1's resume branch) and **cost-gating** (`--pause-before` / `--until`, §0 + §2) compose on this skeleton: a `--pause-before` abort or an `--until` stop leaves the completed phases' artifacts intact, so `--project-path` resumes from the first incomplete phase and a `skip_set` phase is never re-paused. The §3 end-of-run summary/ledger rolls up the same per-phase `run-metrics.json` the gates read — so an aborted or `--until`-stopped run still reports the cost of the phases that ran.

--- a/cogni-knowledge/skills/knowledge-run/SKILL.md
+++ b/cogni-knowledge/skills/knowledge-run/SKILL.md
@@ -194,6 +194,13 @@ convention (`compose` / `verify` / `finalize` already write their own). Resolve 
 first the same way the phase skills do — `knowledge-binding.py read` then `data.binding.wiki_path`
 — since §3 otherwise holds no wiki root:
 
+The printf fields all come from data already gathered above in this step: `DATE_STAMP=$(date -u +%F)`;
+`TOPIC` / `SYNTHESIS_SLUG` from the `knowledge-finalize` §2 output summary (fallback
+`_knowledge_lib.slugify(topic)`); `N_SOURCES` / `N_CITATIONS` from `pipeline-summary.py project`
+(`data.ingested` / `data.citations`); `TOTAL_COST` / `ELAPSED_MIN` from `run-metrics.py report`
+(`data.totals.cost_estimate_usd` / `data.totals.elapsed_min`). Bind them before the printf; an
+unbound field yields a sparse log line, never an abort (fail-soft).
+
 ```bash
 # Resolve WIKI_ROOT from the binding (the knowledge-finalize pattern).
 WIKI_ROOT=$(python3 "${CLAUDE_PLUGIN_ROOT}/scripts/knowledge-binding.py" read --knowledge-root "<knowledge_root>" \


### PR DESCRIPTION
Closes #922. Closes epic #860 AC6 (phase 4/4 — the last child of the knowledge-run epic).

Expands the `knowledge-run` driver's §3 from a ≤6-line stub into a real end-of-run summary that rolls up the **existing** per-phase ledger — no parallel cost-tracking mechanism (the issue's explicit constraint).

## Summary
- Roll up the aggregate cost ledger via `run-metrics.py report --project-path` (`data.totals.{cost_estimate_usd,elapsed_min}`, `data.rendered`, `data.ledger_present`, `data.phases[]`) — each phase already records into `run-metrics.json`; the driver only reads.
- Print key counts via `pipeline-summary.py project` (`ingested`, `citations`, `verify_counts`, `phase_reached`, `topic`) plus claims-extracted summed inline from `ingest-manifest.json::ingested[].claims_extracted`.
- Reconstruct per-phase outcome (ran / skipped / failed / not-reached) by crossing `_PHASE_ORDER` against the run-metrics `phases[]` (ran), the §0.5 `skip_set` (skipped), and the captured `failed_phase` (failed + after = not-reached).
- Print the deposited `wiki/syntheses/<slug>.md` path; surface a failed/partial run honestly so the summary doubles as a `--project-path` resume hint.
- Append one fail-soft `## [YYYY-MM-DD] run | …` line to `wiki/log.md` on a successful finalize — resolving `WIKI_ROOT` via `knowledge-binding.py read` → `data.binding.wiki_path` (the finalize pattern), then `control-path.py log` (bare-path stdout). The `run` op prefix is additive.
- Bump cogni-knowledge `1.0.43` → `1.0.44`, mirrored in `.claude-plugin/marketplace.json`.

## Scope decisions
- **Full scope, one file:** the §3 stub the resume-contract note explicitly deferred. That deferral clause is dropped (the increment now ships).
- **Not deferred:** the planner initially flagged "cost-gating" as deferred, but cost-gating already shipped in sibling #921 (`--pause-before`/`--until`, merged) — it is not deferred scope of #922. This PR fully delivers #922.

## Test plan
- [x] `bash cogni-knowledge/tests/test_pipeline_summary.sh` — all pass (read-side counts unchanged).
- [x] `bash cogni-knowledge/tests/test_knowledge_lib.sh` — all pass.
- [x] `python3 scripts/check-breadcrumbs.py` — 0 files affected (no new breadcrumbs in SKILL.md).
- [x] `check-skill-names.sh` — OK.
- [x] CLI signatures confirmed: `run-metrics.py report` exposes `totals.{cost_estimate_usd,elapsed_min}`+`rendered`+`ledger_present`+`phases[]`; `control-path.py log` prints a bare path on success (the snippet captures it directly, not via JSON).
- [x] Manifests valid JSON; cogni-knowledge = 1.0.44 in both plugin.json and marketplace.json.

Plan record: https://github.com/cogni-work/insight-wave/issues/922#issuecomment-4762613179