### PR TITLE
cogni-knowledge: promote 5W1H spine + perspectives facet cleanup

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "cogni-knowledge",
       "source": "./cogni-knowledge",
-      "version": "1.0.44",
+      "version": "1.0.45",
       "maturity": "released",
       "description": "Wiki-first research that compounds. Binds each run to a wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`. The shallow `knowledge-query` rung is read-only by default and can optionally file its answer back as an un-verified synthesis page via `--file-back`.",
       "keywords": [

--- a/cogni-knowledge/.claude-plugin/plugin.json
+++ b/cogni-knowledge/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-knowledge",
-  "version": "1.0.44",
+  "version": "1.0.45",
   "description": "Wiki-first research that compounds. Binds each run to a wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`. The shallow `knowledge-query` rung is read-only by default and can optionally file its answer back as an un-verified synthesis page via `--file-back`.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-knowledge/scripts/perspectives_index.py
+++ b/cogni-knowledge/scripts/perspectives_index.py
@@ -4,7 +4,7 @@
 A derived OVERLAY sibling of `root_index.py`. Where `root_index.py` renders the
 curated root MAP grouped by THEME, this renders a single `wiki/perspectives.md`
 that re-projects the canonical type-first layout into 5W1H **perspectives**
-(Who / What / When / Where / Why / How) WITHOUT changing the canonical layout.
+(Who / What / When / Where / Why) WITHOUT changing the canonical layout.
 Every page keeps its real home in its type directory; this page is a second,
 derived way in:
 
@@ -18,10 +18,10 @@ derived way in:
   <!-- MACHINE-OWNED:PERSPECTIVES-FACET:who:START --> … <!-- …:END -->
   **Explore:** [People (n)](people/index.md) · [Entities (m)](entities/index.md)
 
-  ## What … ## Why … ## When … ## Where … ## How
+  ## What … ## Why … ## When … ## Where
 
 **Tier 1 — the facets that re-project surviving types deterministically.** Each
-facet maps to zero or more of the six surviving page types and shows a single
+facet maps to zero or more of the surviving page types and shows a single
 count-link line per backing type (the cross-base TOTAL count from
 `sub_index.theme_counts`, summed across themes), linking that type's sub-index.
 The mapping:
@@ -31,13 +31,17 @@ The mapping:
   Why   → questions + syntheses  (inquiry drivers + conclusions)
   When  → wiki/log.md             log-derived timeline (v1; grouped by month)
   Where → source `market:` FM      sources grouped by market (v1; geo: is v2)
-  How   → (none yet)             honest-empty — its former backing types
-                                 (the cross-source `summary` + run-level
-                                 `learning`) were retired as dead vocabulary
 
-An empty facet still renders its heading + engine-owned lead-in + an honest
-`_(no pages in this facet yet)_` line, so the overlay is complete and the
-When/Where section children have a stable slot to fill.
+The former `How` facet was dropped: its backing types (the cross-source
+`summary` + run-level `learning`) were retired as dead vocabulary, leaving it
+permanently empty — a dead facet rather than an honestly-forthcoming one.
+
+`When`/`Where` are thin v1 facets (log-derived timeline / market grouping); when
+a base has no activity log or no market-tagged sources they render an explicit
+honest signpost about that forthcoming state rather than a bare empty line. A
+type-backed facet whose types are all zero-count still renders its heading +
+engine-owned lead-in + an honest `_(no pages in this facet yet)_` line, so the
+overlay is complete.
 
 **Ownership + idempotence (the same contract every renderer holds).** The page
 carries a `MACHINE-OWNED:PERSPECTIVES-INDEX` marker; each facet's lead-in lives
@@ -95,10 +99,24 @@ INTRO_LINE = (
     "derived — the canonical home of every page stays its type directory._"
 )
 
+# Secondary-view labels (R10/R11): the alternative projections of the same pages
+# this overlay complements, so the reader knows the views available beyond the
+# 5W1H spine — the curated map (by theme), the per-type sub-indexes, and a
+# signpost to the Recent-syntheses overview stub so it is reachable from the
+# spine rather than orphaned. A constant preamble line — deterministic and
+# idempotent, like every other line the renderer assembles from constants.
+SECONDARY_VIEWS_LINE = (
+    "_Other views: the [curated map](index.md) (by theme) · the per-type "
+    "sub-indexes (Concepts · Sources · Questions · Entities · People · "
+    "Syntheses) · [Recent syntheses](overview.md)._"
+)
+
 # One entry per facet: (slug, heading, [backing type names], default lead-in).
-# The backing type names index sub_index.REGISTRY; an empty list is an
-# honest-empty facet (no backing page type today). The default lead-in is what
-# the engine seeds before a narrator authors the facet's PERSPECTIVES-FACET span.
+# The backing type names index sub_index.REGISTRY. who/what/why are type-backed;
+# when/where carry an empty list but render a custom builder body (timeline /
+# market grouping), NOT the honest-empty count-link path. The default lead-in is
+# what the engine seeds before a narrator authors the facet's PERSPECTIVES-FACET
+# span. (The former `how` facet was removed — permanently dead, no backing type.)
 FACET_DISPLAY = (
     ("who", "Who", ["people", "entities"],
      "_The named subjects this base tracks — the people and organizations behind "
@@ -115,10 +133,6 @@ FACET_DISPLAY = (
     ("where", "Where", [],
      "_The geography — sources grouped by the market they were researched for. "
      "Finer-grained per-source geography is a future (v2) extension._"),
-    ("how", "How", [],
-     "_The method. No backing page type yet — its former backing types (the "
-     "cross-source summary and run-level learning) were retired as dead "
-     "vocabulary._"),
 )
 
 # Per-type display labels for the count-link line (mirrors root_index TYPE_DISPLAY
@@ -160,7 +174,13 @@ def _type_total(tname: str, wiki_root: Path) -> int:
 # v1 timeline. Anchored at line start so prose and the `# Log` H1 never match.
 _WHEN_LOG_RE = re.compile(r"^##\s*\[(\d{4})-(\d{2})-\d{2}\]\s+(\S+)")
 WHEN_INTRO = "_Activity timeline from the base's append-only log (newest month first)._"
-WHEN_EMPTY_LINE = "_(no timeline yet)_"
+# Honest signpost for the thin When facet (R9): names WHY it is empty and how it
+# fills, instead of a bare "no pages" line — When is a forthcoming v1 facet, not
+# a dead one.
+WHEN_EMPTY_LINE = (
+    "_(When: no activity timeline yet — it builds from the base's append-only log "
+    "as research cycles run.)_"
+)
 
 
 def _build_when_timeline(wiki_root: Path) -> "list[str]":
@@ -205,6 +225,13 @@ def _build_when_timeline(wiki_root: Path) -> "list[str]":
 
 
 WHERE_INTRO = "_Sources grouped by the market they were researched for._"
+# Honest signpost for the thin Where facet (R9): distinct from the type-backed
+# facets' generic EMPTY_FACET_LINE — Where is a forthcoming v1 facet that fills
+# once sources carry a `market:`, so it says so rather than reading "no pages".
+WHERE_EMPTY_LINE = (
+    "_(Where: no market-tagged sources yet — sources gain a market at ingest, and "
+    "this view groups them once they do.)_"
+)
 
 
 def _build_where_grouping(wiki_root: Path) -> "list[str]":
@@ -213,8 +240,8 @@ def _build_where_grouping(wiki_root: Path) -> "list[str]":
     the source side of the same frontmatter-resident-membership pattern
     `theme_label:` uses). Deterministic — markets sorted alphabetically. A base
     whose sources carry no `market:` (legacy / not-yet-tagged) renders the honest
-    `EMPTY_FACET_LINE` (the same line the type-backed facets use), never a
-    fabricated grouping.
+    `WHERE_EMPTY_LINE` signpost (distinct from the type-backed facets' generic
+    empty line — Where is a forthcoming v1 facet), never a fabricated grouping.
 
     v1 groups by the run-level `market:` only; finer-grained per-source `geo:`
     is the v2 extension (no per-source geo signal exists at ingest today)."""
@@ -230,7 +257,7 @@ def _build_where_grouping(wiki_root: Path) -> "list[str]":
             counts[market] = counts.get(market, 0) + 1
 
     if not counts:
-        return [EMPTY_FACET_LINE]
+        return [WHERE_EMPTY_LINE]
 
     out = [WHERE_INTRO, ""]
     for market in sorted(counts):
@@ -246,6 +273,10 @@ def _build_perspectives(wiki_root: Path, existing_text: str) -> str:
     parts.append(PERSPECTIVES_INDEX_MARKER)
     parts.append("")
     parts.append(INTRO_LINE)
+    parts.append("")
+    # Secondary-view labels (R10) + the overview-stub signpost (R11). A constant
+    # preamble line, so it stays a deterministic, idempotent reflow fixpoint.
+    parts.append(SECONDARY_VIEWS_LINE)
     parts.append("")
 
     for slug, heading, type_names, default_leadin in FACET_DISPLAY:

--- a/cogni-knowledge/scripts/root_index.py
+++ b/cogni-knowledge/scripts/root_index.py
@@ -101,10 +101,27 @@ INTRO_LINE = (
     "_Curated map of this knowledge base. Each theme below links to its per-type "
     "sub-indexes with live counts — open one to read the pages._"
 )
-# A constant cross-theme preamble line linking the derived 5W1H overlay
-# (perspectives_index.py renders wiki/perspectives.md). Not a per-theme link, so
-# it lives in the preamble, not in TYPE_DISPLAY / the per-theme ROOT-LINKS span.
-PERSPECTIVES_LINK_LINE = "_See also: [Perspectives (5W1H)](perspectives.md) — the same pages, re-projected by perspective._"
+# R8 — the 5W1H perspectives spine, promoted to a PRIMARY front-door wayfinding
+# entry (was a secondary italic "_See also:_" line). The intent spine is the
+# minimal-hop way into the base, so it leads with bold emphasis. Still a constant
+# cross-theme preamble line (no per-theme link, no `## ` heading, no `- [[slug]]`
+# bullet) so it stays a reflow/collapse fixpoint, not in TYPE_DISPLAY / ROOT-LINKS.
+PERSPECTIVES_LINK_LINE = (
+    "**Start here — browse by intent:** [Perspectives (5W1H) →](perspectives.md) "
+    "— who · what · when · where · why. The spine re-projects every page by the "
+    "question it answers."
+)
+
+# R10/R11 — secondary-view labels: the alternative projections of the same pages,
+# so the reader knows the views available beyond the intent spine. Names the
+# theme browse (this page) and the per-type sub-index facet, and signposts the
+# Recent-syntheses overview stub so it is reachable from the spine rather than
+# orphaned. A constant preamble line — deterministic, idempotent, reflow fixpoint.
+SECONDARY_VIEWS_LINE = (
+    "_Other views: themes below (this page) · the per-type sub-indexes (Sources · "
+    "Concepts · Questions · Entities · People · Syntheses) · "
+    "[Recent syntheses](overview.md)._"
+)
 
 # Per-theme count line: which types to show, in reading order, with their labels.
 # The link target is the per-type sub-index, relative to wiki/index.md.
@@ -250,9 +267,13 @@ def _build_map(wiki_root: Path, existing_text: str) -> str:
     parts.append("")
     parts.append(INTRO_LINE)
     parts.append("")
-    # Cross-theme link to the derived 5W1H overlay. A constant preamble line (no
-    # `- [[slug]]` bullet, no `## ` heading) so it stays a reflow/collapse fixpoint.
+    # The 5W1H intent spine, promoted to a primary front-door entry (R8), then the
+    # secondary-view labels + overview-stub signpost (R10/R11). Both are constant
+    # preamble lines (no `- [[slug]]` bullet, no `## ` heading) so they stay
+    # reflow/collapse fixpoints.
     parts.append(PERSPECTIVES_LINK_LINE)
+    parts.append("")
+    parts.append(SECONDARY_VIEWS_LINE)
     parts.append("")
 
     for theme in ordered:

--- a/cogni-knowledge/tests/test_perspectives_index.sh
+++ b/cogni-knowledge/tests/test_perspectives_index.sh
@@ -3,19 +3,22 @@
 #
 # perspectives_index.py is a derived OVERLAY sibling of root_index.py: it renders
 # wiki/perspectives.md as a 5W1H re-projection (Who/What/Why backed by surviving
-# types; When/Where/How honest-empty) WITHOUT changing the canonical type-first
-# layout. The vendored engine is never touched, so test_vendored_engine_parity.sh
-# stays green.
+# types; When/Where thin v1 facets with honest signposts) WITHOUT changing the
+# canonical type-first layout. The former `How` facet was dropped (permanently
+# dead, no backing type). The vendored engine is never touched, so
+# test_vendored_engine_parity.sh stays green.
 #
 # Asserts:
 #   1. render creates wiki/perspectives.md with a well-formed envelope + changed:true.
 #   2. The page carries the # Perspectives H1 + the MACHINE-OWNED:PERSPECTIVES-INDEX
-#      marker + the intro line.
-#   3. Each 5W1H facet renders `## <Facet>` + a MACHINE-OWNED:PERSPECTIVES-FACET:<slug>
-#      lead-in span.
+#      marker + the intro line + the secondary-view labels / overview signpost.
+#   3. Each of the five 5W1H facets renders `## <Facet>` + a MACHINE-OWNED:
+#      PERSPECTIVES-FACET:<slug> lead-in span, and `## How` no longer renders.
 #   4. Backed facets (Who=people+entities, What=concepts+sources, Why=questions+
 #      syntheses) show **Explore:** count-links to wiki/<type>/index.md with counts.
-#   5. Empty facets (When/Where/How) render the honest-empty line.
+#   5. When/Where render their custom bodies (timeline / market grouping) when the
+#      fixture has data, and an honest signpost (not the generic empty line) when
+#      thin; no facet renders the generic honest-empty line in this fixture.
 #   6. BYTE-IDEMPOTENT: a re-render on an unchanged wiki reports changed:false and
 #      leaves the page byte-identical.
 #   7. CARRY-FORWARD: a narrator-edited facet lead-in survives a re-render verbatim
@@ -134,16 +137,33 @@ grep -q 'MACHINE-OWNED:PERSPECTIVES-INDEX' "$PAGE" \
   && green "PASS: page carries the PERSPECTIVES-INDEX ownership marker" \
   || { red "FAIL: missing PERSPECTIVES-INDEX marker"; errors=$((errors+1)); }
 
+# --- 2b. secondary-view labels (R10) + overview-stub signpost (R11) -----------
+grep -q 'Other views:' "$PAGE" \
+  && green "PASS: page carries the secondary-view labels line (R10)" \
+  || { red "FAIL: missing secondary-view labels line"; errors=$((errors+1)); }
+grep -q '\[Recent syntheses\](overview.md)' "$PAGE" \
+  && green "PASS: page signposts the overview stub — Recent syntheses (R11)" \
+  || { red "FAIL: missing overview.md (Recent syntheses) signpost"; errors=$((errors+1)); }
+
 # --- 3. every facet renders its heading + PERSPECTIVES-FACET span -------------
+# Five facets now (the dead `How` facet was dropped).
 facet_ok=1
-for pair in "Who who" "What what" "Why why" "When when" "Where where" "How how"; do
+for pair in "Who who" "What what" "Why why" "When when" "Where where"; do
   heading="${pair%% *}"; slug="${pair##* }"
   grep -q "^## ${heading}\$" "$PAGE" || { facet_ok=0; red "  missing ## ${heading}"; }
   grep -q "MACHINE-OWNED:PERSPECTIVES-FACET:${slug}:START" "$PAGE" || { facet_ok=0; red "  missing FACET span ${slug}"; }
 done
 [ "$facet_ok" -eq 1 ] \
-  && green "PASS: all six 5W1H facets render heading + PERSPECTIVES-FACET span" \
+  && green "PASS: all five 5W1H facets render heading + PERSPECTIVES-FACET span" \
   || { red "FAIL: a facet heading or span is missing"; errors=$((errors+1)); }
+
+# --- 3b. the dead How facet no longer renders --------------------------------
+grep -q '^## How$' "$PAGE" \
+  && { red "FAIL: the dropped How facet still renders"; errors=$((errors+1)); } \
+  || green "PASS: the dead How facet no longer renders (R9)"
+grep -q 'MACHINE-OWNED:PERSPECTIVES-FACET:how:START' "$PAGE" \
+  && { red "FAIL: a How PERSPECTIVES-FACET span still renders"; errors=$((errors+1)); } \
+  || green "PASS: no How PERSPECTIVES-FACET span renders (R9)"
 
 # --- 4. backed facets show count-links ---------------------------------------
 grep -q '\[People (1)\](people/index.md)' "$PAGE" \
@@ -155,16 +175,19 @@ grep -q '\[People (1)\](people/index.md)' "$PAGE" \
   && green "PASS: backed facets (Who/What/Why) show count-links to the sub-indexes" \
   || { red "FAIL: a backed-facet count-link is missing/incorrect"; errors=$((errors+1)); }
 
-# --- 5. empty facets render the honest-empty line ----------------------------
-# When carries the log-derived timeline and Where groups by market: frontmatter
-# (the src-a fixture carries market: "dach"), so only How renders honest-empty.
+# --- 5. no facet renders the generic honest-empty line in this fixture --------
+# How was dropped (it was the only generic-empty emitter); When carries the
+# log-derived timeline and Where groups by market: frontmatter (the src-a fixture
+# carries market: "dach"), and who/what/why are all type-backed — so the generic
+# "_(no pages in this facet yet)_" line renders zero times here.
 EMPTY_COUNT="$(grep -c '_(no pages in this facet yet)_' "$PAGE" || true)"
-[ "$EMPTY_COUNT" -eq 1 ] \
-  && green "PASS: How renders the honest-empty line (1 occurrence)" \
-  || { red "FAIL: expected 1 honest-empty line, got $EMPTY_COUNT"; errors=$((errors+1)); }
+[ "$EMPTY_COUNT" -eq 0 ] \
+  && green "PASS: no generic honest-empty line renders (How dropped; When/Where backed)" \
+  || { red "FAIL: expected 0 generic honest-empty lines, got $EMPTY_COUNT"; errors=$((errors+1)); }
 
 # --- 5c. Where (v1) groups source pages by their market: frontmatter ----------
-WHERE_BLOCK="$(sed -n '/^## Where$/,/^## How$/p' "$PAGE")"
+# Where is now the last facet (How dropped), so the block runs to EOF.
+WHERE_BLOCK="$(sed -n '/^## Where$/,$p' "$PAGE")"
 echo "$WHERE_BLOCK" | grep -q 'Sources grouped by the market' \
   && green "PASS: Where facet renders the market-grouping intro" \
   || { red "FAIL: Where grouping intro missing"; errors=$((errors+1)); }
@@ -259,12 +282,23 @@ theme_label: Scope
 body'
 python3 "$PERSP_SCRIPT" render --wiki-root "$NOLOG" --wiki-scripts-dir "$WSD" >/dev/null
 NOLOG_WHEN="$(sed -n '/^## When$/,/^## Where$/p' "$NOLOG/wiki/perspectives.md")"
-echo "$NOLOG_WHEN" | grep -q '_(no timeline yet)_' \
-  && green "PASS: When facet renders the honest no-timeline fallback when log.md is absent" \
-  || { red "FAIL: missing no-timeline fallback for an absent log.md"; errors=$((errors+1)); }
+# R9: thin When renders an honest signpost (names why it is empty + how it fills),
+# not a bare "no pages" line.
+echo "$NOLOG_WHEN" | grep -q 'When: no activity timeline yet' \
+  && green "PASS: When facet renders the honest no-timeline signpost when log.md is absent (R9)" \
+  || { red "FAIL: missing no-timeline signpost for an absent log.md"; errors=$((errors+1)); }
 echo "$NOLOG_WHEN" | grep -q 'Activity timeline from the base' \
   && { red "FAIL: When fabricated a timeline intro with no log.md"; errors=$((errors+1)); } \
   || green "PASS: When does not fabricate a timeline when log.md is absent"
+# R9: thin Where (no market-tagged sources in this fixture) renders its own honest
+# signpost, distinct from the generic "_(no pages in this facet yet)_" line.
+NOLOG_WHERE="$(sed -n '/^## Where$/,$p' "$NOLOG/wiki/perspectives.md")"
+echo "$NOLOG_WHERE" | grep -q 'Where: no market-tagged sources yet' \
+  && green "PASS: Where facet renders the honest thin-facet signpost when no source carries a market (R9)" \
+  || { red "FAIL: missing Where thin-facet signpost"; errors=$((errors+1)); }
+echo "$NOLOG_WHERE" | grep -q '_(no pages in this facet yet)_' \
+  && { red "FAIL: Where reused the generic honest-empty line instead of its signpost"; errors=$((errors+1)); } \
+  || green "PASS: Where uses its own signpost, not the generic honest-empty line (R9)"
 rm -rf "$NOLOG" 2>/dev/null || true
 
 if [ "$errors" -eq 0 ]; then

--- a/cogni-knowledge/tests/test_root_index.sh
+++ b/cogni-knowledge/tests/test_root_index.sh
@@ -183,6 +183,16 @@ assert_grep "Curated map of this knowledge base" "$IDX" "1 curated intro line pr
 # OVERVIEW-NARRATIVE block, so the renderer must NOT invent a placeholder one.
 assert_not_grep "MACHINE-OWNED:OVERVIEW-NARRATIVE" "$IDX" "1b no narrative span fabricated when none authored"
 
+# === 1c. the 5W1H intent spine is a PRIMARY front-door entry (R8) ===
+# Promoted from a secondary italic "_See also:_" line to a bold primary
+# wayfinding entry leading with the intent spine.
+assert_grep "Start here — browse by intent:" "$IDX" "1c intent spine promoted to a primary front-door line (R8)"
+assert_grep "Perspectives (5W1H) →](perspectives.md)" "$IDX" "1c spine links the 5W1H perspectives overlay (R8)"
+assert_not_grep "_See also: \[Perspectives (5W1H)\](perspectives.md)" "$IDX" "1c old secondary 'See also' framing is gone (R8)"
+# === 1d. secondary-view labels (R10) + overview-stub signpost (R11) ===
+assert_grep "Other views:" "$IDX" "1d secondary-view labels render on the root portal (R10)"
+assert_grep "\[Recent syntheses\](overview.md)" "$IDX" "1d overview stub signposted from the spine — Recent syntheses (R11)"
+
 # === 2. per-theme count-links with counts AND theme-scoped deep-link anchors ===
 # The link now deep-links into the theme's `## <theme>` section of each
 # sub-index (`<type>/index.md#<anchor>`), not the bare unfiltered sub-index.


### PR DESCRIPTION
Closes #935.

A four-part render-layer bundle for the curated wiki portal + 5W1H perspectives overlay. All four sub-changes land together as one unit (per the bundle AC); the overlay stays a derived render-time projection — no content-model change (that is the separate gated Wave-3 child #936, which this issue blocks).

## Summary
- **Intent-spine Phase-1 promotion (R8)** — the root portal (`root_index.py`) now leads with the 5W1H spine as a primary wayfinding entry (`**Start here — browse by intent:** [Perspectives (5W1H) →](perspectives.md) …`) instead of the italic secondary `_See also:_` line. The constant's already-correct front-door position (between the intro and the first `## <theme>`) is unchanged, so it stays a reflow/collapse fixpoint.
- **Dead How facet removed; thin When/Where signposted (R9)** — the `How` entry (empty `[]` backing types, permanently dead) is dropped from `perspectives_index.py`'s `FACET_DISPLAY`, so `## How` no longer renders. New `WHEN_EMPTY_LINE` / `WHERE_EMPTY_LINE` signpost constants (distinct from the generic `EMPTY_FACET_LINE`) give the thin When/Where facets an honest forthcoming-state signpost when a base has no activity log / no market-tagged sources.
- **Secondary-view labels (R10)** — a deterministic, idempotent `_Other views: …_` line renders in both `root_index.py` and `perspectives_index.py` preambles so the reader sees the alternative projections (theme browse, per-type sub-index facet).
- **Overview stub folded into the spine (R11)** — a render-text `[Recent syntheses](overview.md)` link is added to the spine preamble of both renderers, so the overview stub is reachable from the spine and no longer orphaned. `overview_update.py` itself needs no change (R11 is a link *from* the spine).
- The module docstring + test header were updated to the five-facet model. Patch version bumped `1.0.44 → 1.0.45` in `plugin.json` + `marketplace.json`.

## Scope decisions
- **In:** R8–R11 as one inseparable render-layer bundle across `root_index.py` + `perspectives_index.py` (`overview_update.py` unchanged by design) plus their tests; the version bump.
- **Out:** any content-model change. The perspectives overlay remains a derived render-time projection assembled from constants (inherently idempotent). Restructuring the underlying page/type model is the gated Wave-3 child and is deliberately untouched.

## Test plan
- [x] `bash cogni-knowledge/tests/test_perspectives_index.sh` passes — `## How` no longer renders, the generic honest-empty count is 0, and the new When/Where signposts + secondary-view label + overview link assert present (incl. the thin-facet signpost in the no-log fixture).
- [x] `bash cogni-knowledge/tests/test_root_index.sh` passes — the 5W1H spine asserts as a primary front-door line, the old "See also" framing is gone, the secondary-view labels + overview link render, and the preamble-shape + idempotency checks still hold.
- [x] `bash cogni-knowledge/tests/test_overview_update.sh` passes unchanged (no code change to that script).
- [x] Full cogni-knowledge suite: 75/75 pass (byte-idempotent re-render preserved; vendored engine untouched).
- [x] `plugin.json` version is `1.0.45` and matches the `cogni-knowledge` entry in `.claude-plugin/marketplace.json`.