### PR TITLE
cogni-knowledge: deterministic page-header type line across all wiki page types

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "cogni-knowledge",
       "source": "./cogni-knowledge",
-      "version": "1.0.45",
+      "version": "1.0.46",
       "maturity": "released",
       "description": "Wiki-first research that compounds. Binds each run to a wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`. The shallow `knowledge-query` rung is read-only by default and can optionally file its answer back as an un-verified synthesis page via `--file-back`.",
       "keywords": [

--- a/cogni-knowledge/.claude-plugin/plugin.json
+++ b/cogni-knowledge/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-knowledge",
-  "version": "1.0.45",
+  "version": "1.0.46",
   "description": "Wiki-first research that compounds. Binds each run to a wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`. The shallow `knowledge-query` rung is read-only by default and can optionally file its answer back as an un-verified synthesis page via `--file-back`.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-knowledge/agents/source-ingester.md
+++ b/cogni-knowledge/agents/source-ingester.md
@@ -129,6 +129,8 @@ pre_extracted_claims:
 
 # <title>
 
+Type: Source · raw
+
 <body verbatim>
 ```
 
@@ -146,10 +148,11 @@ YAML frontmatter rules:
 Body rules:
 
 - First non-frontmatter line is `# <title>` (markdown H1) using the resolved title.
+- **Immediately under the H1, emit one deterministic reader-facing type line, then a blank line.** The line is a fixed constant keyed off `PAGE_TYPE` — emit `Type: Source · raw` for the default `PAGE_TYPE=source`, or `Type: Interview · raw` for `PAGE_TYPE=interview`. The separator is the U+00B7 MIDDLE DOT (`·`), and `raw` is the stage word (a source/interview page is never distilled). This is a verbatim literal, not a judgment call — re-rendering an unchanged page must produce a byte-identical line. It mirrors the engine-owned `_knowledge_lib.page_type_line(<PAGE_TYPE>)` projection the other page renderers emit (concept/entity/person, question, synthesis), so a reader landing mid-wiki can state what the page is on arrival.
 - The fetched body follows verbatim. **No** in-body highlighting markup, **no** body-level edits. The wiki-verifier will use `excerpt_position` offsets to render context.
-- If the body itself starts with an H1, drop our injected H1 to avoid double headings.
+- If the body itself starts with an H1, drop our injected `# <title>` H1 to avoid double headings — but **still emit the type line** (it is reader-facing metadata, not a heading), so it leads the body in that case.
 
-`content_hash` is the **provenance hash of the fetched source body** (from `entry.content_hash`), not a hash of this markdown file. The on-disk page is the fetched body plus the injected `# <title>` H1, and downstream bidirectional-link maintenance (`knowledge-ingest`'s `backlink_audit.py --apply-plan`, `knowledge-finalize`'s `lint --fix=reverse_link_missing`) may append a `## See also` backlink trailer. So a future integrity check must compare `content_hash` against the **fetched body in the cache**, never against `hash(<on-disk page body>)` — the latter diverges by design once backlinks are written, and `excerpt_position` offsets (anchored to the verbatim body that precedes any appended trailer) stay valid.
+`content_hash` is the **provenance hash of the fetched source body** (from `entry.content_hash`), not a hash of this markdown file. The on-disk page is the fetched body plus the injected `# <title>` H1 and the deterministic `Type: …` line, and downstream bidirectional-link maintenance (`knowledge-ingest`'s `backlink_audit.py --apply-plan`, `knowledge-finalize`'s `lint --fix=reverse_link_missing`) may append a `## See also` backlink trailer. So a future integrity check must compare `content_hash` against the **fetched body in the cache**, never against `hash(<on-disk page body>)` — the latter diverges by design once backlinks are written, and `excerpt_position` offsets (anchored to the verbatim body that precedes any appended trailer) stay valid.
 
 Write atomically via `_knowledge_lib.atomic_write_text` against `<WIKI_ROOT>/wiki/<page-type-dir>/<slug>.md` — with the default `PAGE_TYPE=source` this is `<WIKI_ROOT>/wiki/sources/<slug>.md`; for `PAGE_TYPE=interview` it is `<WIKI_ROOT>/wiki/interviews/<slug>.md` (the `<page-type-dir>` resolved in Phase 0). Pass paths via env vars so apostrophes / spaces in WIKI_ROOT or tmp paths cannot break the Python literal.
 

--- a/cogni-knowledge/references/finalize-compose-subprocess.md
+++ b/cogni-knowledge/references/finalize-compose-subprocess.md
@@ -52,7 +52,7 @@ sys.path.insert(0, os.environ["KNOWLEDGE_SCRIPTS"])
 from _knowledge_lib import (
     atomic_write_text, ref_heading, first_url, md_link_dest,
     strip_reference_section, renumber_inline_citations,
-    normalize_citation_format,
+    normalize_citation_format, page_type_line,
 )
 
 wiki_root = Path(os.environ["WIKI_ROOT"])
@@ -287,6 +287,7 @@ page_text = (
     frontmatter
     + "\n"
     + "# " + topic + "\n\n"
+    + page_type_line("synthesis") + "\n\n"
     + body.rstrip() + "\n\n"
     + "## " + heading + "\n\n"
     + ("\n".join(refs) if refs else "_No external citations recorded in citation-manifest.json._")

--- a/cogni-knowledge/scripts/_knowledge_lib.py
+++ b/cogni-knowledge/scripts/_knowledge_lib.py
@@ -267,6 +267,37 @@ def ref_heading(lang: str | None) -> str:
     return REF_HEADING.get(str(lang or "en").lower(), REF_HEADING["en"])
 
 
+# --- Reader-facing page-type header line ---------------------------------------
+# Every rendered wiki page emits a deterministic, engine-owned type line directly
+# under its H1 so a reader landing mid-wiki can state what a page is on arrival.
+# The display name AND the distilled/raw stage word are properties of the page
+# *type* (not of an individual page instance), so they live in one map here and
+# are derived per-type — never hard-coded at a call site. The separator is the
+# U+00B7 MIDDLE DOT, matching the repo's ensure_ascii=False convention.
+_TYPE_DISPLAY = {
+    "concept": ("Concept", "distilled"),
+    "entity": ("Entity", "distilled"),
+    "person": ("Person", "distilled"),
+    "question": ("Question", "raw"),
+    "source": ("Source", "raw"),
+    "interview": ("Interview", "raw"),
+    "synthesis": ("Synthesis", "distilled"),
+}
+
+
+def page_type_line(page_type: str | None) -> str:
+    """Reader-facing `Type: <Display> · <stage>` header line for `page_type`.
+
+    The display name and stage word are looked up from `_TYPE_DISPLAY` so the
+    projection is deterministic and byte-identical on re-render. An unknown or
+    non-str `page_type` falls back to a title-cased display with a `raw` stage
+    rather than crashing — mirroring `ref_heading`'s default-to-safe posture.
+    """
+    key = str(page_type or "").lower()
+    display, stage = _TYPE_DISPLAY.get(key, (key.capitalize() or "Unknown", "raw"))
+    return f"Type: {display} · {stage}"
+
+
 # --- Writer-quality knob validation (#309 P2) ---------------------------------
 # The four knobs (prose_density / tone / citation_format / target_words) are
 # resolved LLM-side in knowledge-plan Step 0.5 and threaded to wiki-composer /

--- a/cogni-knowledge/scripts/concept-store.py
+++ b/cogni-knowledge/scripts/concept-store.py
@@ -89,6 +89,7 @@ from _knowledge_lib import (  # noqa: E402
     digit_anchor_tokens,
     extract_machine_block,
     norm_key,
+    page_type_line,
     parse_concept_records,
     parse_crossmerge_records,
     parse_renarrate_records,
@@ -517,7 +518,12 @@ def _render_page(
     # with a single blank line. Without this the separator grows one newline per run.
     human_content = human_tail.lstrip("\n")
     tail_content = human_content if human_content.strip() else _HUMAN_NOTES_PLACEHOLDER
-    return frontmatter + "\n" + f"# {title}\n\n" + body_machine.rstrip("\n") + "\n\n" + tail_content
+    return (
+        frontmatter
+        + "\n" + f"# {title}\n\n"
+        + page_type_line(ptype) + "\n\n"
+        + body_machine.rstrip("\n") + "\n\n" + tail_content
+    )
 
 
 def _dedup_keep_order(seq) -> list:

--- a/cogni-knowledge/scripts/question-store.py
+++ b/cogni-knowledge/scripts/question-store.py
@@ -52,6 +52,7 @@ from _knowledge_lib import (  # noqa: E402
     claim_similarity,
     norm_key,
     normalize_url,
+    page_type_line,
     parse_answer_records,
     slugify,
     theme_norm_key,
@@ -604,7 +605,10 @@ def cmd_emit(args: argparse.Namespace) -> int:
             f"sources_answering: [{', '.join(findings)}]",
             "---",
         ]
-        body_lines = ["", "## Findings", ""]
+        # H1 + reader-facing type line directly under it (the question page had no
+        # body H1 before — its title lived only in frontmatter), then the machine
+        # ## Findings block. Matches the concept/source/synthesis header shape.
+        body_lines = ["", f"# {sq.get('query', '')}", "", page_type_line("question"), "", "## Findings", ""]
         body_lines += [f"- [[{s}]]" for s in findings]
         body_lines += ["", notes_block.rstrip() + "\n"]
         page = "\n".join(fm_lines) + "\n" + "\n".join(body_lines).rstrip() + "\n"

--- a/cogni-knowledge/tests/test_concept_store.sh
+++ b/cogni-knowledge/tests/test_concept_store.sh
@@ -90,6 +90,18 @@ assert_grep 'wiki://src-a' "$CPAGE" "concept page: wiki:// source provenance"
 assert_grep 'MACHINE-OWNED:CLAIMS:START' "$CPAGE" "concept page: machine-owned sentinels"
 assert_grep '\[\[src-a\]\]' "$CPAGE" "concept page: bare [[source-slug]] backlink (link-graph edge)"
 assert_grep 'distilled_from_research' "$CPAGE" "concept page: distilled_from_research"
+# Reader-facing engine-owned type line directly under the H1 (#931).
+assert_grep '^Type: Concept · distilled$' "$CPAGE" "concept page: Type: Concept · distilled line under H1"
+assert_grep '^Type: Entity · distilled$' "$EPAGE" "entity page: Type: Entity · distilled line under H1"
+# The type line sits immediately below the H1 (one blank line between).
+python3 - "$CPAGE" <<'PY' && green "PASS: concept page type line is immediately below the H1" || { red "FAIL: type line not directly under H1"; errors=$((errors+1)); }
+import sys
+lines = open(sys.argv[1], encoding="utf-8").read().splitlines()
+h1 = next(i for i, l in enumerate(lines) if l.startswith("# "))
+# next non-empty line after the H1 must be the type line
+nxt = next(l for l in lines[h1+1:] if l.strip())
+sys.exit(0 if nxt == "Type: Concept · distilled" else 1)
+PY
 
 # --- 2b. cross-parser no-drift (#343/#356 review #5) -------------------------
 # The read-before-web coverage scorer reads these pages with

--- a/cogni-knowledge/tests/test_finalize_contract.sh
+++ b/cogni-knowledge/tests/test_finalize_contract.sh
@@ -61,6 +61,9 @@ assert_grep 'category "Syntheses"' "$FIN" "knowledge-finalize: indexes synthesis
 # source, not page_kind=None (which would drop them from the reference list / graph).
 assert_grep '("concept", "concepts")' "$FINREF" "knowledge-finalize: resolves cited concept pages (#344)"
 assert_grep '("entity", "entities")' "$FINREF" "knowledge-finalize: resolves cited entity pages (#344)"
+# Reader-facing engine-owned type line directly under the synthesis H1.
+assert_grep 'page_type_line("synthesis")' "$FINREF" "knowledge-finalize: emits the deterministic Type: Synthesis line under the H1"
+assert_grep 'page_type_line' "$FINREF" "knowledge-finalize: imports page_type_line from _knowledge_lib"
 # #324: Step 7 passes the --max-summary word-boundary clamp backstop (cogni-wiki
 # v0.0.47+), and the "truncated to 180 chars" instruction that caused the mid-word
 # artifact is gone (the summary is authored as one crisp, complete sentence).

--- a/cogni-knowledge/tests/test_knowledge_lib.sh
+++ b/cogni-knowledge/tests/test_knowledge_lib.sh
@@ -198,6 +198,28 @@ def assert_ref_heading():
     assert kl.ref_heading(True) == "References", "non-str (bool) → English, no crash"
 
 
+def assert_page_type_line():
+    # #931: deterministic reader-facing `Type: <Display> · <stage>` header line.
+    # Display name + stage word are properties of the type (not the page instance).
+    sep = "·"  # U+00B7 MIDDLE DOT — never an ASCII substitute.
+    assert kl.page_type_line("concept") == f"Type: Concept {sep} distilled", kl.page_type_line("concept")
+    assert kl.page_type_line("entity") == f"Type: Entity {sep} distilled", kl.page_type_line("entity")
+    assert kl.page_type_line("person") == f"Type: Person {sep} distilled", kl.page_type_line("person")
+    assert kl.page_type_line("question") == f"Type: Question {sep} raw", kl.page_type_line("question")
+    assert kl.page_type_line("source") == f"Type: Source {sep} raw", kl.page_type_line("source")
+    assert kl.page_type_line("interview") == f"Type: Interview {sep} raw", kl.page_type_line("interview")
+    assert kl.page_type_line("synthesis") == f"Type: Synthesis {sep} distilled", kl.page_type_line("synthesis")
+    # Case-insensitive on the key.
+    assert kl.page_type_line("CONCEPT") == f"Type: Concept {sep} distilled", "case-insensitive key"
+    # The exact separator is the middle dot, not an ASCII bullet/hyphen.
+    assert sep in kl.page_type_line("source") and "*" not in kl.page_type_line("source"), "U+00B7 separator"
+    # Unknown / non-str / empty → safe title-cased display + raw, never a crash.
+    assert kl.page_type_line("widget") == f"Type: Widget {sep} raw", "unknown type → title-cased + raw"
+    assert kl.page_type_line(None) == f"Type: Unknown {sep} raw", "None → Unknown + raw, no crash"
+    assert kl.page_type_line("") == f"Type: Unknown {sep} raw", "empty → Unknown + raw"
+    assert kl.page_type_line(5) == f"Type: 5 {sep} raw", "non-str (int) coerced, no crash"
+
+
 def assert_first_url():
     # JSON inline-list shape (source-ingester) → first http(s) URL.
     assert kl.first_url('["https://example.org/a"]') == "https://example.org/a"
@@ -1217,6 +1239,7 @@ check("atomic_write_roundtrip", assert_atomic_write_roundtrip)
 check("control_paths", assert_control_paths)
 check("slugify", assert_slugify)
 check("ref_heading", assert_ref_heading)
+check("page_type_line", assert_page_type_line)
 check("first_url", assert_first_url)
 check("extract_inline_citation_urls", assert_extract_inline_citation_urls)
 check("md_link_dest", assert_md_link_dest)

--- a/cogni-knowledge/tests/test_question_store.sh
+++ b/cogni-knowledge/tests/test_question_store.sh
@@ -142,6 +142,19 @@ echo "$OUT" | grep -q '"sq-02"' && green "PASS: sq-02 reported in skipped_no_fin
 assert_grep 'type: question' "$SQ1" "sq-01 page is type: question"
 assert_grep 'sub_question_id: sq-01' "$SQ1" "sq-01 page carries sub_question_id"
 assert_grep '## Findings' "$SQ1" "sq-01 page has ## Findings section"
+# #931: the question page now emits an H1 + reader-facing type line (it had no body
+# H1 before). Assert the type line and that the order is H1 -> type line -> ## Findings.
+assert_grep '^Type: Question · raw$' "$SQ1" "sq-01 page: Type: Question · raw line"
+python3 - "$SQ1" <<'PY' && green "PASS: sq-01 page renders H1 then 'Type: Question · raw' then ## Findings" || { red "FAIL: question H1/type-line/findings order wrong"; errors=$((errors+1)); }
+import sys
+lines = [l for l in open(sys.argv[1], encoding="utf-8").read().splitlines()]
+h1 = next(i for i, l in enumerate(lines) if l.startswith("# "))
+nxt = next(l for l in lines[h1+1:] if l.strip())
+assert nxt == "Type: Question · raw", f"line after H1 was {nxt!r}"
+typ = lines.index("Type: Question · raw")
+fnd = lines.index("## Findings")
+sys.exit(0 if h1 < typ < fnd else 1)
+PY
 # sq-01 is answered by records-scope (sq-01 ref) AND controller-obligations (sq-01+sq-03 ref)
 assert_grep '\[\[records-scope\]\]' "$SQ1" "sq-01 Findings links its source finding"
 assert_grep 'sources_answering: \[records-scope, controller-obligations\]' "$SQ1" "sq-01 sources_answering lists both findings in order"


### PR DESCRIPTION
Closes #931.

Every rendered wiki page now emits a deterministic, engine-owned `Type: <Display> · <stage>` line directly under its H1, projecting the frontmatter `type:` and the distilled/raw stage into reader-facing text. A reader landing mid-wiki can now state at a glance whether a page is a concept, entity, person, source, question, interview, or synthesis — and whether it is distilled or raw.

## Summary
- **New shared helper** `page_type_line(page_type)` + `_TYPE_DISPLAY` map in `scripts/_knowledge_lib.py` — the single source of the display name + stage word per type (`distilled` for concept/entity/person/synthesis; `raw` for question/source/interview). The stage is a property of the *type*, derived in one place, never hard-coded per call site (AC3). Separator is U+00B7 MIDDLE DOT.
- **concept/entity/person** — `scripts/concept-store.py::_render_page` emits the line directly under the H1.
- **questions** — `scripts/question-store.py` now emits a `# <query>` H1 (previously absent — the title lived only in frontmatter) followed by the type line, above `## Findings`.
- **syntheses** — `references/finalize-compose-subprocess.md` emits the line under the synthesis H1.
- **sources/interviews** — `agents/source-ingester.md` emits the verbatim deterministic line under the H1 it already writes. This is the projection surface the issue names; the string is a fixed constant keyed off `PAGE_TYPE` (no model judgment), and source pages are write-once so the line is byte-identical on re-render (AC2). `content_hash` hashes the *fetched body*, not the on-disk page, so the inserted line is provenance-safe.
- Version bump `1.0.45 → 1.0.46`, mirrored in `marketplace.json`.

## Acceptance criteria
1. ✅ Each of the six page types renders a correctly-capitalized `Type: <Display> · <stage>` line immediately below the H1.
2. ✅ Deterministic & engine-owned — Python renderers via the shared helper; sources via a fixed constant on a write-once page.
3. ✅ Stage word is derived from the page type (via `_TYPE_DISPLAY`), not a hard-coded constant per page instance.

## Scope decision
The issue author named `agents/source-ingester.md` as the projection surface; the first-pass plan tried to splice the source line in `knowledge-ingest-postprocess.py`, but that script never edits page bodies (byte-identical contract). The source/interview line is therefore emitted by the ingester (the named surface) as a deterministic verbatim constant — keeping all six types in one PR rather than deferring sources.

## Test plan
- `bash tests/test_knowledge_lib.sh` — new `page_type_line` unit coverage (all seven types, capitalization, U+00B7 separator, safe fallbacks).
- `bash tests/test_concept_store.sh` — concept/entity pages render `Type: … · distilled` directly under the H1.
- `bash tests/test_question_store.sh` — question page renders `# <query>` H1 → `Type: Question · raw` → `## Findings` in order.
- `bash tests/test_finalize_contract.sh` — synthesis subprocess emits `page_type_line("synthesis")` under the H1.

Plan record: https://github.com/cogni-work/insight-wave/issues/931#issuecomment-4772731711