### PR TITLE
cogni-knowledge: deterministic sub-index lead-in fallback (no pipeline leak)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "cogni-knowledge",
       "source": "./cogni-knowledge",
-      "version": "1.0.46",
+      "version": "1.0.47",
       "maturity": "released",
       "description": "Wiki-first research that compounds. Binds each run to a wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`. The shallow `knowledge-query` rung is read-only by default and can optionally file its answer back as an un-verified synthesis page via `--file-back`.",
       "keywords": [

--- a/cogni-knowledge/.claude-plugin/plugin.json
+++ b/cogni-knowledge/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-knowledge",
-  "version": "1.0.46",
+  "version": "1.0.47",
   "description": "Wiki-first research that compounds. Binds each run to a wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`. The shallow `knowledge-query` rung is read-only by default and can optionally file its answer back as an un-verified synthesis page via `--file-back`.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-knowledge/scripts/sub_index.py
+++ b/cogni-knowledge/scripts/sub_index.py
@@ -292,7 +292,7 @@ def _make_cfg(
         ownership_marker=f"<!-- MACHINE-OWNED:{upper}-INDEX -->",
         intro_line=intro_line,
         leadin_prefix=f"{upper}-LEADIN:",
-        leadin_placeholder="_(theme lead-in pending narration)_",
+        leadin_placeholder=f"_This theme groups the {type_name} below._",
         uncategorized="Uncategorized",
         count_key=count_key,
         count_label=type_name,

--- a/cogni-knowledge/tests/test_backfill_concepts_index.sh
+++ b/cogni-knowledge/tests/test_backfill_concepts_index.sh
@@ -115,8 +115,8 @@ assert_grep '^# Concepts$' "$IDX" "page H1 '# Concepts'"
 assert_grep 'MACHINE-OWNED:CONCEPTS-INDEX' "$IDX" "page ownership marker"
 assert_grep 'MACHINE-OWNED:CONCEPTS-LEADIN:regulatory-scope:START' \
   "$IDX" "Regulatory Scope lead-in sentinel span present"
-assert_grep 'theme lead-in pending narration' \
-  "$IDX" "fresh backfill uses the lead-in placeholder (render-only, narration deferred)"
+assert_grep 'This theme groups the concepts below' \
+  "$IDX" "fresh backfill uses the deterministic lead-in fallback (render-only, narration deferred)"
 
 # --- 2. BYTE-IDEMPOTENT re-run -----------------------------------------------
 cp "$IDX" "$WORK/idx.before"
@@ -148,8 +148,8 @@ PY
 OUT=$(python3 "$DRIVER" --wiki-root "$WIKI" --wiki-scripts-dir "$WSD")
 assert_grep 'Authored framing: the legal boundaries' \
   "$IDX" "narrator-authored lead-in carried forward across a backfill re-run (no clobber)"
-assert_grep 'theme lead-in pending narration' \
-  "$IDX" "untouched theme keeps the placeholder after carry-forward"
+assert_grep 'This theme groups the concepts below' \
+  "$IDX" "untouched theme keeps the deterministic fallback after carry-forward"
 
 # --- 4. EMPTY-CONCEPTS base -> noop ------------------------------------------
 EWIKI="$WORK/empty-wiki"

--- a/cogni-knowledge/tests/test_concepts_index.sh
+++ b/cogni-knowledge/tests/test_concepts_index.sh
@@ -164,8 +164,8 @@ assert_grep '\[\[penalties\]\]' "$IDX" "penalties bullet has [[slug]] wikilink"
 # --- 4. lead-in sentinel spans, placeholder on a fresh render ----------------
 assert_grep 'MACHINE-OWNED:CONCEPTS-LEADIN:regulatory-scope:START' \
   "$IDX" "Regulatory Scope lead-in sentinel span present"
-assert_grep 'theme lead-in pending narration' \
-  "$IDX" "fresh render uses the lead-in placeholder"
+assert_grep 'This theme groups the concepts below' \
+  "$IDX" "fresh render uses the deterministic lead-in fallback"
 
 # --- 5. CARRY-FORWARD: a narrator-authored lead-in survives a re-render -------
 python3 - "$IDX" "$SCRIPTS_DIR" <<'PY'
@@ -182,9 +182,9 @@ PY
 OUT=$(python3 "$SCRIPT" render --wiki-root "$WIKI" --wiki-scripts-dir "$WSD")
 assert_grep 'Authored framing: the legal boundaries' \
   "$IDX" "authored lead-in carried forward across re-render (no clobber)"
-# The untouched Enforcement theme still shows the placeholder.
-assert_grep 'theme lead-in pending narration' \
-  "$IDX" "untouched theme keeps the placeholder after carry-forward"
+# The untouched Enforcement theme still shows the deterministic fallback.
+assert_grep 'This theme groups the concepts below' \
+  "$IDX" "untouched theme keeps the deterministic fallback after carry-forward"
 
 # --- 6. BYTE-IDEMPOTENT re-render --------------------------------------------
 cp "$IDX" "$WORK/idx.before"

--- a/cogni-knowledge/tests/test_sub_index.sh
+++ b/cogni-knowledge/tests/test_sub_index.sh
@@ -202,8 +202,8 @@ for T in $TYPES; do
   assert_grep "\[\[$THEMED\]\]" "$IDX" "[$T] themed bullet has [[slug]] wikilink"
   assert_grep "MACHINE-OWNED:$U-LEADIN:regulatory-scope:START" "$IDX" \
     "[$T] Regulatory Scope lead-in sentinel span present"
-  assert_grep 'theme lead-in pending narration' "$IDX" \
-    "[$T] fresh render uses the lead-in placeholder"
+  assert_grep "This theme groups the $T below" "$IDX" \
+    "[$T] fresh render uses the deterministic lead-in fallback"
 
   # BYTE-IDEMPOTENT re-render
   cp "$IDX" "$WORK/$T.before"


### PR DESCRIPTION
Closes #932.

## Summary
- Replace the internal placeholder `_(theme lead-in pending narration)_` in `sub_index.py` `_make_cfg` with a deterministic, type-aware static fallback (`_This theme groups the <type_name> below._`) that reads as a finished one-line theme intro and never exposes pipeline state.
- One factory-line change fixes all six page types (concepts, entities, people, sources, questions, syntheses); `concepts_index.py` inherits it via `REGISTRY["concepts"]` (no edit needed).
- The fallback is static (no per-theme count), so it stays idempotent under the sticky carry-forward render semantics — the rendered fallback is written back into the machine-owned span and carried forward verbatim, so a baked-in count would freeze and go stale.
- Three tests that asserted the old literal updated to the new fallback.
- Patch-bump `cogni-knowledge` 1.0.46 → 1.0.47, mirrored in `marketplace.json`.

## Acceptance criteria
- **AC1** — `grep -rn 'pending narration' cogni-knowledge/` returns no hits ✓
- **AC2** — a narrator-authored lead-in still wins over the fallback (existing carry-forward path; covered by the carry-forward tests) ✓
- **AC3** — fallback is deterministic + idempotent on re-render (static string; the byte-idempotent re-render tests pass) ✓

## Test plan
- `bash cogni-knowledge/tests/test_sub_index.sh` — ALL PASS
- `bash cogni-knowledge/tests/test_concepts_index.sh` — ALL PASS
- `bash cogni-knowledge/tests/test_backfill_concepts_index.sh` — all pass

## Scope decisions
- **Static vs count-bearing fallback:** chose static. A count-bearing `<N>` would freeze at first-render count under the carry-forward semantics, arguably violating AC3.
- **Out of scope (deferred):** localizing the fallback for non-English output bases — the existing placeholder and the per-type `intro_line` constants are English-only. Filed as #940.

## Follow-up issues
- #940 — localize the sub-index lead-in fallback for non-English bases (out of #932's scope per the issue body)