### PR TITLE
cogni-knowledge: honest root-portal count-links (fix A1 false filtering)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "cogni-knowledge",
       "source": "./cogni-knowledge",
-      "version": "1.0.47",
+      "version": "1.0.48",
       "maturity": "released",
       "description": "Wiki-first research that compounds. Binds each run to a wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`. The shallow `knowledge-query` rung is read-only by default and can optionally file its answer back as an un-verified synthesis page via `--file-back`.",
       "keywords": [

--- a/cogni-knowledge/.claude-plugin/plugin.json
+++ b/cogni-knowledge/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-knowledge",
-  "version": "1.0.47",
+  "version": "1.0.48",
   "description": "Wiki-first research that compounds. Binds each run to a wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`. The shallow `knowledge-query` rung is read-only by default and can optionally file its answer back as an un-verified synthesis page via `--file-back`.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-knowledge/scripts/sub_index.py
+++ b/cogni-knowledge/scripts/sub_index.py
@@ -205,7 +205,7 @@ def theme_via_own_slug(
     by the `source` type."""
     label = frontmatter_scalar(text, "theme_label")
     if label and label.strip():
-        return label.strip()
+        return _collapse(label)
     return source_theme.get(slug)
 
 
@@ -219,7 +219,7 @@ def theme_via_frontmatter(
     (question-store.py writes it on every `type: question` node) — the cleanest
     theme signal, no portal round-trip. Used by the `question` type."""
     label = frontmatter_scalar(text, "theme_label")
-    return label.strip() if label and label.strip() else None
+    return _collapse(label) if label and label.strip() else None
 
 
 # --- one-line summary strategies ----------------------------------------------
@@ -393,7 +393,7 @@ def _parse_portal_themes(portal_text: str) -> "tuple[dict, list]":
     for line in (portal_text or "").splitlines():
         hm = _THEME_HEADING_RE.match(line)
         if hm:
-            current_theme = hm.group(1).strip()
+            current_theme = _collapse(hm.group(1))
             if current_theme not in theme_order:
                 theme_order.append(current_theme)
             continue
@@ -429,7 +429,7 @@ def _source_themes_from_frontmatter(wiki_root: Path) -> dict:
             continue
         label = frontmatter_scalar(text, "theme_label")
         if label and label.strip():
-            out[page.stem] = label.strip()
+            out[page.stem] = _collapse(label)
     return out
 
 

--- a/cogni-knowledge/tests/test_root_index.sh
+++ b/cogni-knowledge/tests/test_root_index.sh
@@ -102,6 +102,26 @@ pre_extracted_claims:
 ---
 Body Pen.
 EOF
+# --- a source whose theme_label carries a DOUBLE internal space + trailing
+#     whitespace ("AI  Liability ") — the A1 false-filtering drift case (#933).
+#     The renderer collapses theme whitespace to a single space at the producer
+#     sites, so the heading reads `## AI Liability` and root_index._heading_anchor
+#     ( \s+ → %20 ) yields `#AI%20Liability`, which MATCHES the rendered heading.
+#     Without the collapse the heading would keep the double space (`## AI  Liability`)
+#     while the anchor still collapsed to a single %20 → silent page-top landing. ---
+cat > "$WIKI/wiki/sources/src-drift.md" <<'EOF'
+---
+id: src-drift
+title: Source Drift
+type: source
+theme_label: "AI  Liability "
+sources: ["https://example.com/drift"]
+pre_extracted_claims:
+  - id: clm-1
+    text: A claim about AI liability.
+---
+Body Drift.
+EOF
 cat > "$WIKI/wiki/concepts/high-risk.md" <<'EOF'
 ---
 id: high-risk
@@ -213,6 +233,18 @@ assert_grep "Sources (1)](sources/index.md#KI%20Bußgelder)" "$IDX" "2b non-ASCI
 # (neither resolves to the heading in Obsidian).
 assert_not_grep "sources/index.md#ki-bußgelder)" "$IDX" "2b anchor is NOT the GFM slug form #ki-bußgelder"
 assert_not_grep "sources/index.md#ki-bussgelder)" "$IDX" "2b anchor is NOT the transliterated slugify form #ki-bussgelder"
+
+# === 2c. A1 false-filtering fix (#933): theme-label whitespace is normalized so
+#         the rendered `## <theme>` heading and the count-link anchor AGREE. ===
+# The fixture theme_label is "AI  Liability " (double internal space + trailing).
+# The producer-site _collapse normalizes it to "AI Liability", so the heading is
+# single-space and the anchor is the matching single-%20 fragment.
+assert_grep '^## AI Liability' "$IDX" "2c double-space theme heading collapsed to single space"
+assert_not_grep '^## AI  Liability' "$IDX" "2c heading does NOT keep the double space (the drift)"
+assert_grep "Sources (1)](sources/index.md#AI%20Liability)" "$IDX" "2c count-link anchors to the single-%20 fragment that matches the heading"
+# Regression: the heading↔anchor MUST agree — the drift would have rendered the
+# double-space heading while the anchor collapsed, landing the click at page top.
+assert_not_grep "sources/index.md#AI%20%20Liability)" "$IDX" "2c anchor is NOT the un-collapsed double-%20 form"
 
 # === 3. no per-page source bullets remain on the root ===
 assert_not_grep '^- \[\[src-a\]\]' "$IDX" "3 per-page src-a bullet dropped from root"

--- a/cogni-knowledge/tests/test_sub_index.sh
+++ b/cogni-knowledge/tests/test_sub_index.sh
@@ -323,6 +323,36 @@ python3 "$SCRIPT" render --type concepts --wiki-root "$FMWIKI" --wiki-scripts-di
   && green "PASS: distilled page resolves theme transitively via frontmatter source map" \
   || { red "FAIL: con-fm not under Regulatory Scope via backing-source frontmatter"; errors=$((errors+1)); }
 
+# --- 9b. A1 false-filtering fix (#933): theme-label whitespace is normalized ---
+# A source whose theme_label carries a double internal space + trailing whitespace
+# ("AI  Liability ") must render its sub-index `## <theme>` heading collapsed to a
+# single space ("AI Liability"), so it agrees with root_index._heading_anchor's
+# \s+ → %20 fragment (#AI%20Liability). Without the producer-site _collapse the
+# heading would keep the double space and the root deep-link would land at page top.
+{
+  printf -- '---\n'
+  printf 'title: AI Liability Drift Source\n'
+  printf 'type: source\n'
+  printf 'sources: ["https://example.org/fm-drift"]\n'
+  printf 'theme_label: "AI  Liability "\n'
+  printf 'pre_extracted_claims:\n'
+  printf -- '  - id: clm-001\n'
+  printf '    text: A claim.\n'
+  printf '    excerpt_quote: A claim.\n'
+  printf '    excerpt_position: 1\n'
+  printf -- '---\n'
+  printf '# AI Liability Drift Source\nbody\n'
+} > "$FMWIKI/wiki/sources/src-drift.md"
+python3 "$SCRIPT" render --type sources --wiki-root "$FMWIKI" --wiki-scripts-dir "$WSD" >/dev/null
+[ "$(bullet_section src-drift "$FMWIKI/wiki/sources/index.md")" = "AI Liability" ] \
+  && green "PASS: double-space theme_label collapsed to single-space heading (#933)" \
+  || { red "FAIL: src-drift heading not collapsed to 'AI Liability' (A1 drift)"; errors=$((errors+1)); }
+if grep -q '^## AI  Liability' "$FMWIKI/wiki/sources/index.md"; then
+  red "FAIL: sub-index heading kept the double space (the A1 drift, #933)"; errors=$((errors+1))
+else
+  green "PASS: sub-index heading does NOT keep the double space (#933)"
+fi
+
 # --- 10. unknown type is a clean fail-soft error -----------------------------
 if python3 "$SCRIPT" stage --type bogus --wiki-root "$WIKI" >/dev/null 2>&1; then
   red "FAIL: unknown --type did not error"; errors=$((errors+1))


### PR DESCRIPTION
Closes #933. Epic #937 Wave 1 child.

## Summary
- Normalize `theme_label` to single-space form at the **four** `sub_index.py` theme-producing sites — `theme_via_own_slug`, `theme_via_frontmatter`, `_source_themes_from_frontmatter`, and the portal-heading parse in `_parse_portal_themes` — using the file's existing `_collapse` helper, so the same normalized theme string feeds both the rendered `## {theme}` sub-index heading and `root_index._heading_anchor`.
- This makes the root portal's per-(theme,type) count-links deep-link to the matching theme section **by construction**: a `theme_label` with double internal spaces or trailing whitespace (`"AI  Liability "`) no longer renders a heading the `%20`-collapsed anchor cannot match (A1 false filtering → silent page-top landing).
- The `_parse_portal_themes` site covers the distilled types (`theme_via_backing_sources`: concepts/entities/people/syntheses), not only the frontmatter-driven source/question types — `root_index.py` imports `_parse_portal_themes` for its `heading_order`, so the single edit normalizes the sub-index ordering and the root's `heading_order` in lockstep (no `root_index.py` change).
- Preserves the per-theme deep-link wayfinding (the **richer path**) rather than dropping the fragment, since epic #937 is a reader-wayfinding uplift and the deep-link is the wayfinding feature.

## Scope decisions
- **In:** whitespace normalization of theme labels in `sub_index.py` (the boundary where the heading and the anchor-feeding theme string both originate) + regression tests + version bump.
- **Richer over cheap path:** the issue offered dropping the misleading fragment (cheap) or guaranteeing the anchor matches (richer). Chose the richer path — a small, single-file application of an existing helper that keeps the wayfinding feature honest.
- **Out:** no `root_index.py` change (its in-process heading/anchor pair share a loop variable and never drift); no schema/manifest change; no broader theme-label sanitization beyond whitespace.

## Acceptance criteria
1. ✅ No root-portal count-link presents a filtered count whose deep link can silently land at page top due to heading/anchor drift — heading and anchor now derive from the same `_collapse`-normalized theme string.
2. ✅ Deterministic and idempotent — `_collapse` is a pure function; existing byte-idempotent re-render tests stay green.
3. ✅ Anchor generation stays consistent with the rendered heading text — normalized at the producer, so no divergence.

## Test plan
- [x] `bash cogni-knowledge/tests/test_sub_index.sh` — ALL PASS, incl. new 9b: a `theme_label: "AI  Liability "` source renders `## AI Liability` (single space) in the sub-index.
- [x] `bash cogni-knowledge/tests/test_root_index.sh` — ALL PASS, incl. new 2c: the count-link anchors to the single-`%20` fragment matching the heading; existing `#KI%20Bußgelder` single-space assertion stays green.
- [x] 11 related contract tests (wiki-coverage, wiki-grounding, perspectives/portal, finalize, ingest-postprocess, curated-layout-health, …) — zero regressions.

Version: cogni-knowledge 1.0.47 → 1.0.48 (mirrored in marketplace.json).