### PR TITLE
cogni-knowledge: sub_index type block + preamble + population cue

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "cogni-knowledge",
       "source": "./cogni-knowledge",
-      "version": "1.0.48",
+      "version": "1.0.49",
       "maturity": "released",
       "description": "Wiki-first research that compounds. Binds each run to a wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`. The shallow `knowledge-query` rung is read-only by default and can optionally file its answer back as an un-verified synthesis page via `--file-back`.",
       "keywords": [

--- a/cogni-knowledge/.claude-plugin/plugin.json
+++ b/cogni-knowledge/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-knowledge",
-  "version": "1.0.48",
+  "version": "1.0.49",
   "description": "Wiki-first research that compounds. Binds each run to a wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`. The shallow `knowledge-query` rung is read-only by default and can optionally file its answer back as an un-verified synthesis page via `--file-back`.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-knowledge/references/SCHEMA.md
+++ b/cogni-knowledge/references/SCHEMA.md
@@ -1,0 +1,95 @@
+---
+schema_version: "1.0"
+purpose: >-
+  Canonical, machine-readable definition of the six cogni-knowledge wiki page
+  types. This file is the single source of truth for what each type *is*; the
+  per-type `definition` and `stage` strings in `scripts/sub_index.py`'s REGISTRY
+  mirror the values below verbatim and are read at render time to stamp a
+  definition preamble + population cue onto every `wiki/<type>/index.md`.
+types:
+  - type_key: concepts
+    plural_label: Concepts
+    stage: distill
+    listing_order: alpha-slug
+    definition: >-
+      A concept is a recurring idea, theme, or abstraction distilled from
+      multiple sources — the durable "what it means" of the knowledge base,
+      independent of any single document.
+  - type_key: entities
+    plural_label: Entities
+    stage: distill
+    listing_order: alpha-slug
+    definition: >-
+      An entity is a named organization, system, product, standard, or other
+      non-person actor the sources refer to — the concrete "who/what" the
+      knowledge base tracks.
+  - type_key: people
+    plural_label: People
+    stage: distill
+    listing_order: alpha-slug
+    definition: >-
+      A person is a named individual referenced across the sources — an author,
+      official, researcher, or other human actor whose statements or roles the
+      knowledge base tracks.
+  - type_key: sources
+    plural_label: Sources
+    stage: ingest
+    listing_order: alpha-slug
+    definition: >-
+      A source is a single ingested document (article, report, page, or
+      dataset) with its extracted claims — the primary evidence the rest of the
+      wiki is grounded in.
+  - type_key: questions
+    plural_label: Research questions
+    stage: ingest
+    listing_order: alpha-slug
+    definition: >-
+      A research question is a sub-question the knowledge base set out to
+      answer, paired with the claims from sources that address it — the "what we
+      asked" spine of a research run.
+  - type_key: syntheses
+    plural_label: Syntheses
+    stage: compose
+    listing_order: alpha-slug
+    definition: >-
+      A synthesis is a composed, verified report deposited back into the wiki —
+      the cross-source narrative answer that cites the sources, concepts, and
+      questions it draws on.
+---
+
+# Wiki page-type schema
+
+cogni-knowledge stores every distilled and ingested page under one of **six page
+types**. This document is the canonical, machine-readable definition of those
+types — what each one *is*, which pipeline stage produces its instances, and the
+order its sub-index lists them in.
+
+The renderer (`scripts/sub_index.py`) carries a verbatim copy of each type's
+`definition` and `stage` in its `REGISTRY`, and stamps them — together with a
+deterministic population cue — onto the machine-owned head of every
+`wiki/<type>/index.md`. When this schema changes, update the matching REGISTRY
+entry in the same change so the two surfaces never drift.
+
+| Type | Label | Stage | Listing order | What it is |
+|------|-------|-------|---------------|-----------|
+| `concepts` | Concepts | distill | alpha-slug | A recurring idea, theme, or abstraction distilled from multiple sources — the durable "what it means" of the knowledge base. |
+| `entities` | Entities | distill | alpha-slug | A named organization, system, product, or standard the sources refer to — the concrete "who/what" the base tracks. |
+| `people` | People | distill | alpha-slug | A named individual referenced across the sources — an author, official, or researcher whose statements or roles the base tracks. |
+| `sources` | Sources | ingest | alpha-slug | A single ingested document with its extracted claims — the primary evidence the rest of the wiki is grounded in. |
+| `questions` | Research questions | ingest | alpha-slug | A sub-question the base set out to answer, paired with the claims that address it — the "what we asked" spine of a run. |
+| `syntheses` | Syntheses | compose | alpha-slug | A composed, verified report deposited back into the wiki — the cross-source narrative answer that cites its evidence. |
+
+## Fields
+
+- **`type_key`** — the REGISTRY key and the `wiki/<type>/` directory name.
+- **`plural_label`** — the page H1 heading text (without the leading `# `).
+- **`stage`** — the pipeline phase that produces instances of this type:
+  `ingest` (deposited per-source at ingest time), `distill` (clustered from
+  source claims at distill time), or `compose` (written by the composer and
+  deposited at finalize).
+- **`listing_order`** — how the sub-index orders pages within each theme.
+  `alpha-slug` means ascending by page slug (the order all six types use today).
+- **`definition`** — a one- or two-sentence prose definition of what a single
+  instance of the type *is*. Written to be **instance-free**: a reader can state
+  what the type means without opening any instance page, and the text carries no
+  `[[wikilink]]` to a specific instance.

--- a/cogni-knowledge/scripts/sub_index.py
+++ b/cogni-knowledge/scripts/sub_index.py
@@ -116,6 +116,8 @@ class TypeConfig:
     page_h1: str
     ownership_marker: str
     intro_line: str
+    definition: str         # instance-free type definition (mirrors references/SCHEMA.md)
+    stage: str              # pipeline stage producing instances: ingest | distill | compose
     leadin_prefix: str
     leadin_placeholder: str
     uncategorized: str
@@ -271,6 +273,8 @@ def _make_cfg(
     theme_fn: Callable,
     summary_fn: Callable,
     *,
+    definition: str,
+    stage: str,
     count_key: str = "page_count",
     writer_name: str = "sub_index.py",
 ) -> TypeConfig:
@@ -291,6 +295,8 @@ def _make_cfg(
         page_h1=page_h1,
         ownership_marker=f"<!-- MACHINE-OWNED:{upper}-INDEX -->",
         intro_line=intro_line,
+        definition=definition,
+        stage=stage,
         leadin_prefix=f"{upper}-LEADIN:",
         leadin_placeholder=f"_This theme groups the {type_name} below._",
         uncategorized="Uncategorized",
@@ -311,6 +317,10 @@ REGISTRY: "dict[str, TypeConfig]" = {
         "_Auto-generated concept map. Per-theme lead-ins are narrated by the "
         "concepts-outliner; concept bullets are regenerated on each finalize._",
         theme_via_backing_sources, summary_distilled,
+        definition="A concept is a recurring idea, theme, or abstraction "
+        "distilled from multiple sources — the durable \"what it means\" of the "
+        "knowledge base, independent of any single document.",
+        stage="distill",
         count_key="concept_count", writer_name="concepts_index.py",
     ),
     "entities": _make_cfg(
@@ -318,30 +328,50 @@ REGISTRY: "dict[str, TypeConfig]" = {
         "_Auto-generated entity map. Per-theme lead-ins are narrated by the "
         "engine; entity bullets are regenerated on each finalize._",
         theme_via_backing_sources, summary_distilled,
+        definition="An entity is a named organization, system, product, "
+        "standard, or other non-person actor the sources refer to — the "
+        "concrete \"who/what\" the knowledge base tracks.",
+        stage="distill",
     ),
     "people": _make_cfg(
         "people", "# People",
         "_Auto-generated people map. Per-theme lead-ins are narrated by the "
         "engine; person bullets are regenerated on each finalize._",
         theme_via_backing_sources, summary_distilled,
+        definition="A person is a named individual referenced across the "
+        "sources — an author, official, researcher, or other human actor whose "
+        "statements or roles the knowledge base tracks.",
+        stage="distill",
     ),
     "sources": _make_cfg(
         "sources", "# Sources",
         "_Auto-generated source map. Per-theme lead-ins are narrated by the "
         "engine; source bullets are regenerated on each ingest._",
         theme_via_own_slug, summary_source,
+        definition="A source is a single ingested document (article, report, "
+        "page, or dataset) with its extracted claims — the primary evidence the "
+        "rest of the wiki is grounded in.",
+        stage="ingest",
     ),
     "questions": _make_cfg(
         "questions", "# Research questions",
         "_Auto-generated research-question map. Per-theme lead-ins are narrated "
         "by the engine; question bullets are regenerated on each ingest._",
         theme_via_frontmatter, summary_title,
+        definition="A research question is a sub-question the knowledge base "
+        "set out to answer, paired with the claims from sources that address "
+        "it — the \"what we asked\" spine of a research run.",
+        stage="ingest",
     ),
     "syntheses": _make_cfg(
         "syntheses", "# Syntheses",
         "_Auto-generated synthesis map. Per-theme lead-ins are narrated by the "
         "engine; synthesis bullets are regenerated on each finalize._",
         theme_via_backing_sources, summary_title,
+        definition="A synthesis is a composed, verified report deposited back "
+        "into the wiki — the cross-source narrative answer that cites the "
+        "sources, concepts, and questions it draws on.",
+        stage="compose",
     ),
 }
 
@@ -487,6 +517,19 @@ def _render_leadin(name: str, inner: str) -> str:
     )
 
 
+def _population_cue(cfg: TypeConfig, page_count: int, theme_count: int) -> str:
+    """A deterministic, stamp-free per-surface population cue line: how many
+    pages, how many themes, which pipeline stage produced them, and the listing
+    order. Built only from the counts already in scope at render time (no clock,
+    no filesystem) so a re-render of an unchanged surface stays byte-identical."""
+    pages_word = "page" if page_count == 1 else "pages"
+    themes_word = "theme" if theme_count == 1 else "themes"
+    return (
+        f"_{page_count} {pages_word} · {theme_count} {themes_word} · "
+        f"stage: {cfg.stage} · listed alphabetically by slug_"
+    )
+
+
 def _build_page(
     cfg: TypeConfig,
     pages: "list[dict]",
@@ -512,7 +555,20 @@ def _build_page(
         ordered.append(cfg.uncategorized)
 
     used_names: dict = {}
-    parts: list = [cfg.page_h1, cfg.ownership_marker, "", cfg.intro_line, ""]
+    # Machine-owned head: H1 + marker, then the type *definition* preamble
+    # (what this type IS, mirrored from references/SCHEMA.md), a deterministic
+    # population cue (count · stage · order), and the lifecycle intro line.
+    parts: list = [
+        cfg.page_h1,
+        cfg.ownership_marker,
+        "",
+        f"_{cfg.definition}_",
+        "",
+        _population_cue(cfg, len(pages), len(ordered)),
+        "",
+        cfg.intro_line,
+        "",
+    ]
     for theme in ordered:
         name = _leadin_name(cfg, theme, used_names)
         carried = extract_machine_block(existing_text, name)

--- a/cogni-knowledge/tests/test_sub_index.sh
+++ b/cogni-knowledge/tests/test_sub_index.sh
@@ -79,8 +79,8 @@ PY
 # --- fixture wiki ------------------------------------------------------------
 WIKI="$WORK/wiki-root"
 mkdir -p "$WIKI/.cogni-wiki" \
-  "$WIKI/wiki/concepts" "$WIKI/wiki/entities" "$WIKI/wiki/sources" \
-  "$WIKI/wiki/questions" "$WIKI/wiki/syntheses"
+  "$WIKI/wiki/concepts" "$WIKI/wiki/entities" "$WIKI/wiki/people" \
+  "$WIKI/wiki/sources" "$WIKI/wiki/questions" "$WIKI/wiki/syntheses"
 echo '{"schema_version":"0.0.8","entries_count":0}' > "$WIKI/.cogni-wiki/config.json"
 
 # Portal: Regulatory Scope owns the backing source src-scope-a (which is itself a
@@ -154,6 +154,11 @@ for t in concepts entities; do
   mk_backed "$t" "$t-themed" "${t%s}" "${t} themed" "A themed ${t} page." src-scope-a
   mk_backed "$t" "$t-loose"  "${t%s}" "${t} loose"  "A loose ${t} page."  src-loose
 done
+# people: distilled type backed by sources, same strategy as concepts/entities
+# (the loop's `${t%s}` suffix-strip does not yield `person`, so file it explicitly).
+mk_backed people people-themed person "People themed" "A themed people page." src-scope-a
+mk_backed people people-loose  person "People loose"  "A loose people page."  src-loose
+
 # syntheses: summary is the title (summary_fn=summary_title); still backing-sourced.
 mk_backed syntheses syntheses-themed synthesis "Syntheses themed" "ignored" src-scope-a
 mk_backed syntheses syntheses-loose  synthesis "Syntheses loose"  "ignored" src-loose
@@ -168,7 +173,7 @@ mk_question q-loose  "An unthemed question?" ""
 
 # Per-type expected (type, themed_slug, loose_slug).
 # A bash-3.2-safe parallel-array loop (no associative arrays).
-TYPES="concepts entities syntheses sources questions"
+TYPES="concepts entities people syntheses sources questions"
 themed_for() { case "$1" in
   sources) echo "src-scope-a" ;; questions) echo "q-themed" ;; *) echo "$1-themed" ;;
 esac; }
@@ -359,6 +364,42 @@ if python3 "$SCRIPT" stage --type bogus --wiki-root "$WIKI" >/dev/null 2>&1; the
 else
   green "PASS: unknown --type rejected (argparse choices guard)"
 fi
+
+# --- 10b. R6 instance-free legibility (the three distilled sub-indexes) -------
+# Each distilled sub-index must render an instance-free type DEFINITION preamble
+# — a reader can state what the type IS without opening any instance page, and
+# the definition line carries no [[wikilink]] to a specific instance.
+for T in concepts entities syntheses; do
+  IDX="$WIKI/wiki/$T/index.md"
+  case "$T" in
+    concepts)  DEF="A concept is a recurring idea" ;;
+    entities)  DEF="An entity is a named organization" ;;
+    syntheses) DEF="A synthesis is a composed, verified report" ;;
+  esac
+  assert_grep "$DEF" "$IDX" "[$T] renders an instance-free type-definition preamble"
+  DEFLINE=$(grep -F "$DEF" "$IDX" | head -1)
+  case "$DEFLINE" in
+    *'[['*) red "FAIL: [$T] definition preamble carries a [[wikilink]] (not instance-free)"; errors=$((errors+1)) ;;
+    *)      green "PASS: [$T] definition preamble is instance-free (no [[wikilink]])" ;;
+  esac
+done
+
+# --- 10c. R7 per-surface population cue (all six types) -----------------------
+# Each sub-index carries a deterministic cue line: count · stage · order. Stage
+# reflects the pipeline phase that produces the type; every fixture surface has
+# exactly two pages across two themes (themed -> Regulatory Scope, loose ->
+# Uncategorized), so the count/theme figures are deterministic.
+for T in $TYPES; do
+  IDX="$WIKI/wiki/$T/index.md"
+  case "$T" in
+    concepts|entities|people) STAGE="distill" ;;
+    sources|questions)        STAGE="ingest" ;;
+    syntheses)                STAGE="compose" ;;
+  esac
+  assert_grep "stage: $STAGE" "$IDX" "[$T] population cue shows stage: $STAGE"
+  assert_grep "listed alphabetically by slug" "$IDX" "[$T] population cue shows the order flag"
+  assert_grep "2 pages · 2 themes" "$IDX" "[$T] population cue reflects the actual page/theme counts"
+done
 
 # --- 11. python3.9 floor -----------------------------------------------------
 assert_grep 'from __future__ import annotations' "$SCRIPT" \


### PR DESCRIPTION
Closes #934.

## Summary
- **R4** Add `cogni-knowledge/references/SCHEMA.md` — a canonical, machine-readable type block defining all six wiki page types (concepts, entities, people, sources, questions, syntheses) with `type_key` / `plural_label` / `stage` / `listing_order` / `definition`. The single source of truth the renderer's REGISTRY mirrors.
- **R5** Add a `definition` field to `TypeConfig`, thread it through `_make_cfg` and all six REGISTRY entries (text mirrored from SCHEMA.md), and render it as a short definition preamble in `_build_page`'s machine-owned head — what each type *is*, ahead of the generic lifecycle `intro_line`.
- **R7** Add a `stage` field and render a deterministic per-surface population cue line (`_N pages · M themes · stage: <stage> · listed alphabetically by slug_`), computed from the page/theme counts in `_build_page`'s local scope (`len(pages)` / `len(ordered)`).
- **R6** Add an inline, instance-free legibility assertion for the three distilled sub-indexes (concepts, entities, syntheses) to `test_sub_index.sh` — the rendered `index.md` carries the definition preamble and that preamble contains no `[[wikilink]]`; plus population-cue assertions across all six types. Add the `people` type (fixture dir + fixtures + TYPES loop) to close a pre-existing coverage gap.
- Bump `cogni-knowledge` 1.0.48 → 1.0.49 (and mirror in `marketplace.json`).

## Scope
All four R-items ship in this one PR — they touch the same `sub_index.py` rendering path and the issue defines them as a file-coherent bundle that must not be scheduled standalone. SCHEMA.md is canonical; the REGISTRY holds the Python copy read at render time (the same mirror posture the existing `intro_line` uses). The preamble + cue are emitted **stamp-free** (no date) so they preserve `_build_page`'s byte-idempotency contract — load-bearing because `concepts_index.py` delegates to `_build_page` via `REGISTRY['concepts']` and `test_concepts_index.sh` locks a byte-identical re-render. `root_index.py` / `perspectives_index.py` render different surfaces (no `_build_page`) and are correctly unaffected. Nothing deferred.

## Test plan
- [x] `bash cogni-knowledge/tests/test_sub_index.sh` passes, now covering the `people` type and the R6/R7 assertions.
- [x] `bash cogni-knowledge/tests/test_concepts_index.sh` passes (delegated render stays byte-idempotent).
- [x] `test_root_index`, `test_perspectives_index`, `test_migrate_layout`, `test_curated_layout_health`, `test_repair_mode`, `test_finalize_contract`, `test_ingest_postprocess`, `test_ingest_contract`, `test_skill_contracts`, `test_knowledge_lib` all pass.
- [x] `python3 -c 'import ast; ast.parse(...)'` parses `sub_index.py` clean.
- [x] `references/SCHEMA.md` covers all six page types with the machine-readable fields.

Part of epic #937 (Wiki reader-wayfinding uplift), Wave 2.