### PR TITLE
cogni-knowledge: localize sub-index lead-in fallback for non-English bases

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "cogni-knowledge",
       "source": "./cogni-knowledge",
-      "version": "1.0.49",
+      "version": "1.0.50",
       "maturity": "released",
       "description": "Wiki-first research that compounds. Binds each run to a wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`. The shallow `knowledge-query` rung is read-only by default and can optionally file its answer back as an un-verified synthesis page via `--file-back`.",
       "keywords": [

--- a/cogni-knowledge/.claude-plugin/plugin.json
+++ b/cogni-knowledge/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-knowledge",
-  "version": "1.0.49",
+  "version": "1.0.50",
   "description": "Wiki-first research that compounds. Binds each run to a wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`. The shallow `knowledge-query` rung is read-only by default and can optionally file its answer back as an un-verified synthesis page via `--file-back`.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-knowledge/scripts/_knowledge_lib.py
+++ b/cogni-knowledge/scripts/_knowledge_lib.py
@@ -267,6 +267,95 @@ def ref_heading(lang: str | None) -> str:
     return REF_HEADING.get(str(lang or "en").lower(), REF_HEADING["en"])
 
 
+# --- Localized sub-index theme lead-in fallback --------------------------------
+# The deterministic sub-index renderer seeds each theme group with a lead-in
+# placeholder before a narrator authors the real prose. The placeholder is a
+# full sentence, so on a non-English base it must read in the base's
+# `output_language` — a half-localized string (localized sentence wrapped around
+# an English noun) still reads broken, which is exactly the wrong-language defect
+# this exists to fix. Keyed on the project's `output_language` (ISO 639-1, from
+# plan.json / binding.json); unknown / absent / non-str codes fall back to
+# English, matching `ref_heading`'s default-to-safe posture.
+#
+# The sentence template and the per-type noun phrase are stored separately so the
+# small matrix stays maintainable. In the gendered / article languages the noun
+# phrase carries its article (German "die Konzepte", Spanish "los conceptos") so
+# the rendered sentence agrees. The per-type map keys on the PLURAL `type_name`
+# the renderer uses (`concepts`/`entities`/`people`/`sources`/`questions`/
+# `syntheses`/`interviews`) — NOT the singular `_TYPE_DISPLAY` keys. English is
+# the identity case: the template's `{noun}` is the raw `type_name`, so a caller
+# that passes no language renders the legacy
+# `_This theme groups the <type_name> below._` byte-for-byte.
+_LEADIN_TEMPLATE = {
+    "en": "_This theme groups the {noun} below._",
+    "de": "_Dieses Thema gruppiert {noun} weiter unten._",
+    "fr": "_Ce thème regroupe {noun} ci-dessous._",
+    "it": "_Questo tema raggruppa {noun} qui sotto._",
+    "pl": "_Ten temat grupuje {noun} poniżej._",
+    "nl": "_Dit thema groepeert {noun} hieronder._",
+    "es": "_Este tema agrupa {noun} a continuación._",
+}
+
+_LEADIN_NOUN = {
+    "de": {
+        "concepts": "die Konzepte", "entities": "die Entitäten",
+        "people": "die Personen", "sources": "die Quellen",
+        "questions": "die Fragen", "syntheses": "die Synthesen",
+        "interviews": "die Interviews",
+    },
+    "fr": {
+        "concepts": "les concepts", "entities": "les entités",
+        "people": "les personnes", "sources": "les sources",
+        "questions": "les questions", "syntheses": "les synthèses",
+        "interviews": "les entretiens",
+    },
+    "it": {
+        "concepts": "i concetti", "entities": "le entità",
+        "people": "le persone", "sources": "le fonti",
+        "questions": "le domande", "syntheses": "le sintesi",
+        "interviews": "le interviste",
+    },
+    "pl": {
+        "concepts": "pojęcia", "entities": "encje",
+        "people": "osoby", "sources": "źródła",
+        "questions": "pytania", "syntheses": "syntezy",
+        "interviews": "wywiady",
+    },
+    "nl": {
+        "concepts": "de concepten", "entities": "de entiteiten",
+        "people": "de personen", "sources": "de bronnen",
+        "questions": "de vragen", "syntheses": "de syntheses",
+        "interviews": "de interviews",
+    },
+    "es": {
+        "concepts": "los conceptos", "entities": "las entidades",
+        "people": "las personas", "sources": "las fuentes",
+        "questions": "las preguntas", "syntheses": "las síntesis",
+        "interviews": "las entrevistas",
+    },
+}
+
+
+def leadin_placeholder(type_name: str | None, lang: str | None) -> str:
+    """Localized sub-index theme lead-in placeholder for `type_name`/`lang`.
+
+    Mirrors `ref_heading`'s default-to-safe posture: an unknown / absent /
+    non-str `lang` falls back to the English template, and an unmapped
+    `type_name` falls back to the raw `type_name` word (so a future page type
+    degrades to an English noun rather than crashing). `str(...)` coerces a
+    non-str argument to a harmless lookup miss instead of raising on `.lower()`.
+
+    English is the identity case — `_This theme groups the <type_name> below._`
+    — so callers that pass no language stay byte-stable with the legacy
+    deterministic fallback.
+    """
+    key = str(lang or "en").lower()
+    template = _LEADIN_TEMPLATE.get(key, _LEADIN_TEMPLATE["en"])
+    tname = str(type_name or "")
+    noun = _LEADIN_NOUN.get(key, {}).get(tname, tname)
+    return template.format(noun=noun)
+
+
 # --- Reader-facing page-type header line ---------------------------------------
 # Every rendered wiki page emits a deterministic, engine-owned type line directly
 # under its H1 so a reader landing mid-wiki can state what a page is on arrival.

--- a/cogni-knowledge/scripts/concepts_index.py
+++ b/cogni-knowledge/scripts/concepts_index.py
@@ -54,11 +54,11 @@ CONCEPTS_CONFIG = REGISTRY["concepts"]
 
 
 def cmd_render(args) -> int:
-    return render_index(CONCEPTS_CONFIG, args.wiki_root, args.wiki_scripts_dir)
+    return render_index(CONCEPTS_CONFIG, args.wiki_root, args.wiki_scripts_dir, args.lang)
 
 
 def cmd_stage(args) -> int:
-    return stage_index(CONCEPTS_CONFIG, args.wiki_root)
+    return stage_index(CONCEPTS_CONFIG, args.wiki_root, args.lang)
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -76,6 +76,9 @@ def _build_parser() -> argparse.ArgumentParser:
     rn.add_argument("--wiki-root", required=True)
     rn.add_argument("--wiki-scripts-dir", required=True,
                     help="cogni-wiki wiki-ingest/scripts dir (for _wiki_lock).")
+    rn.add_argument("--lang", default="en",
+                    help="output_language (ISO 639-1) for the per-theme lead-in "
+                         "placeholder fallback; unknown/absent → English.")
     rn.set_defaults(func=cmd_render)
 
     st = sub.add_parser(
@@ -85,6 +88,9 @@ def _build_parser() -> argparse.ArgumentParser:
              "lock and without touching the live page.",
     )
     st.add_argument("--wiki-root", required=True)
+    st.add_argument("--lang", default="en",
+                    help="output_language (ISO 639-1) for the per-theme lead-in "
+                         "placeholder fallback; unknown/absent → English.")
     st.set_defaults(func=cmd_stage)
 
     return parser

--- a/cogni-knowledge/scripts/knowledge-ingest-postprocess.py
+++ b/cogni-knowledge/scripts/knowledge-ingest-postprocess.py
@@ -371,7 +371,8 @@ def main() -> int:
         rc, out, err = _run(["python3", str(sub_index), "render",
                              "--type", "sources",
                              "--wiki-root", wiki_root,
-                             "--wiki-scripts-dir", str(wiki_scripts)])
+                             "--wiki-scripts-dir", str(wiki_scripts),
+                             "--lang", args.output_language])
         data["sources_subindex"] = "rendered" if rc == 0 else "failed"
         if rc != 0:
             data["warnings"].append(
@@ -535,7 +536,8 @@ def main() -> int:
         rc, out, err = _run(["python3", str(sub_index), "render",
                              "--type", "questions",
                              "--wiki-root", wiki_root,
-                             "--wiki-scripts-dir", str(wiki_scripts)])
+                             "--wiki-scripts-dir", str(wiki_scripts),
+                             "--lang", args.output_language])
         data["questions_subindex"] = "rendered" if rc == 0 else "failed"
         if rc != 0:
             data["warnings"].append(

--- a/cogni-knowledge/scripts/sub_index.py
+++ b/cogni-knowledge/scripts/sub_index.py
@@ -79,6 +79,7 @@ from _knowledge_lib import (  # noqa: E402
     atomic_write_text,
     extract_machine_block,
     frontmatter_scalar,
+    leadin_placeholder,
     parse_distilled_claims,
     parse_pre_extracted_claims,
     slugify,
@@ -119,7 +120,6 @@ class TypeConfig:
     definition: str         # instance-free type definition (mirrors references/SCHEMA.md)
     stage: str              # pipeline stage producing instances: ingest | distill | compose
     leadin_prefix: str
-    leadin_placeholder: str
     uncategorized: str
     count_key: str          # envelope data key for the page count
     count_label: str        # stage-header label (`<label>=<n>`)
@@ -278,11 +278,14 @@ def _make_cfg(
     count_key: str = "page_count",
     writer_name: str = "sub_index.py",
 ) -> TypeConfig:
-    """Build a TypeConfig, deriving the eight mechanical fields from `type_name`
+    """Build a TypeConfig, deriving the mechanical fields from `type_name`
     (the wiki dir == the type name for all six types): the dir/index/stage
     paths, the `MACHINE-OWNED:<TYPE>-INDEX` marker, the `<TYPE>-LEADIN:` prefix,
-    the lead-in placeholder + Uncategorized label, the stage-header display path,
-    and the count label. Only the genuinely per-type values are passed in;
+    the Uncategorized label, the stage-header display path, and the count label.
+    (The per-theme lead-in placeholder is no longer a config field — it is
+    derived per render from `_knowledge_lib.leadin_placeholder(type_name, lang)`
+    so it can localize to the base's output_language.) Only the genuinely
+    per-type values are passed in;
     `concepts` additionally overrides `count_key`/`writer_name` to stay
     byte-stable with the legacy concepts_index.py (envelope key `concept_count`,
     stage header naming `concepts_index.py`)."""
@@ -298,7 +301,6 @@ def _make_cfg(
         definition=definition,
         stage=stage,
         leadin_prefix=f"{upper}-LEADIN:",
-        leadin_placeholder=f"_This theme groups the {type_name} below._",
         uncategorized="Uncategorized",
         count_key=count_key,
         count_label=type_name,
@@ -535,14 +537,18 @@ def _build_page(
     pages: "list[dict]",
     theme_order: "list[str]",
     existing_text: str,
+    lang: str = "en",
 ) -> str:
     """Assemble the full proposed `wiki/<type>/index.md` text.
 
     Themes render in portal order; a trailing `## Uncategorized` collects pages
     with no resolvable theme. Each section carries a per-theme lead-in span whose
     inner is CARRIED FORWARD verbatim from `existing_text` when already present
-    (so the narrator's prose is never clobbered) and a stable placeholder
-    otherwise. Bullets within a section are sorted by slug."""
+    (so the narrator's prose is never clobbered) and a localized placeholder
+    otherwise — the placeholder reads in `lang` (the base's `output_language`,
+    default English) so a non-English base does not show an English fallback
+    until a narrator authors the real lead-in. Bullets within a section are
+    sorted by slug."""
     buckets: dict = {}
     for c in pages:
         theme = c["theme"] or cfg.uncategorized
@@ -572,7 +578,7 @@ def _build_page(
     for theme in ordered:
         name = _leadin_name(cfg, theme, used_names)
         carried = extract_machine_block(existing_text, name)
-        inner = carried if carried is not None else cfg.leadin_placeholder
+        inner = carried if carried is not None else leadin_placeholder(cfg.type_name, lang)
         parts.append(f"## {theme}")
         parts.append("")
         parts.append(_render_leadin(name, inner))
@@ -591,10 +597,11 @@ def _is_human_page(cfg: TypeConfig, existing_text: str) -> bool:
     return bool(existing_text.strip()) and cfg.ownership_marker not in existing_text
 
 
-def _assemble(cfg: TypeConfig, wiki_root: Path, existing_text: str) -> str:
+def _assemble(cfg: TypeConfig, wiki_root: Path, existing_text: str, lang: str = "en") -> str:
     """Pure read+build: parse the portal themes and pages off disk and assemble
     the full proposed `index.md` text against `existing_text` (so an
-    already-authored lead-in is carried forward)."""
+    already-authored lead-in is carried forward). `lang` localizes the per-theme
+    lead-in placeholder (default English)."""
     portal_path = wiki_root.joinpath(*PORTAL_INDEX_REL)
     portal_text = portal_path.read_text(encoding="utf-8") if portal_path.is_file() else ""
     portal_source_theme, theme_order = _parse_portal_themes(portal_text)
@@ -606,7 +613,7 @@ def _assemble(cfg: TypeConfig, wiki_root: Path, existing_text: str) -> str:
     source_theme.update(_source_themes_from_frontmatter(wiki_root))
     pages_dir = wiki_root.joinpath(*cfg.dir_rel)
     pages = _gather_pages(cfg, pages_dir, source_theme, theme_order) if pages_dir.is_dir() else []
-    return _build_page(cfg, pages, theme_order, existing_text)
+    return _build_page(cfg, pages, theme_order, existing_text, lang)
 
 
 def _gather_count(pages_dir: Path) -> int:
@@ -647,10 +654,11 @@ def theme_counts(cfg: TypeConfig, wiki_root: Path) -> "dict[str, int]":
     return {t: buckets[t] for t in ordered}
 
 
-def _prepare(cfg: TypeConfig, wiki_root_arg: str) -> "tuple[Optional[dict], Optional[str]]":
+def _prepare(cfg: TypeConfig, wiki_root_arg: str, lang: str = "en") -> "tuple[Optional[dict], Optional[str]]":
     """Shared read+assemble for both subcommands. Returns `(payload, error)`
     where payload carries `wiki_root`, `index_path`, `existing_text`,
-    `proposed`, `page_count`, `theme_count`. Never writes."""
+    `proposed`, `page_count`, `theme_count`. `lang` localizes the per-theme
+    lead-in placeholder (default English). Never writes."""
     wiki_root = Path(wiki_root_arg).resolve()
     if not (wiki_root / "wiki").is_dir():
         return None, f"wiki_root has no wiki/ dir: {wiki_root}"
@@ -664,7 +672,7 @@ def _prepare(cfg: TypeConfig, wiki_root_arg: str) -> "tuple[Optional[dict], Opti
             return None, f"{cfg.type_name} index not readable: {exc}"
 
     pages_dir = wiki_root.joinpath(*cfg.dir_rel)
-    proposed = _assemble(cfg, wiki_root, existing_text)
+    proposed = _assemble(cfg, wiki_root, existing_text, lang)
     theme_count = proposed.count("\n## ") + (1 if proposed.startswith("## ") else 0)
     return {
         "wiki_root": wiki_root,
@@ -679,13 +687,14 @@ def _prepare(cfg: TypeConfig, wiki_root_arg: str) -> "tuple[Optional[dict], Opti
 # --- public render / stage entry points (called by concepts_index.py too) -----
 
 
-def render_index(cfg: TypeConfig, wiki_root_arg: str, wiki_scripts_dir: str) -> int:
+def render_index(cfg: TypeConfig, wiki_root_arg: str, wiki_scripts_dir: str, lang: str = "en") -> int:
     """`render` subcommand body for one type. Locked, atomic, idempotent,
-    no-clobber. Returns a shell exit code (and prints the envelope)."""
+    no-clobber. `lang` localizes the per-theme lead-in placeholder (default
+    English). Returns a shell exit code (and prints the envelope)."""
     _wiki_lock, err = _import_wiki_lock(wiki_scripts_dir)
     if err:
         return _emit(False, error=err)
-    payload, err = _prepare(cfg, wiki_root_arg)
+    payload, err = _prepare(cfg, wiki_root_arg, lang)
     if err:
         return _emit(False, error=err)
     index_path = payload["index_path"]
@@ -717,7 +726,7 @@ def render_index(cfg: TypeConfig, wiki_root_arg: str, wiki_scripts_dir: str) -> 
             # Rebuild against the locked-read text so a lead-in authored between
             # the unlocked _prepare read and now is still carried forward.
             if current != existing_text:
-                proposed = _assemble(cfg, payload["wiki_root"], current)
+                proposed = _assemble(cfg, payload["wiki_root"], current, lang)
             changed = proposed != current
             if changed:
                 index_path.parent.mkdir(parents=True, exist_ok=True)
@@ -734,10 +743,11 @@ def render_index(cfg: TypeConfig, wiki_root_arg: str, wiki_scripts_dir: str) -> 
     })
 
 
-def stage_index(cfg: TypeConfig, wiki_root_arg: str) -> int:
+def stage_index(cfg: TypeConfig, wiki_root_arg: str, lang: str = "en") -> int:
     """`stage` subcommand body for one type. Lock-free; never touches the live
-    page. Returns a shell exit code (and prints the envelope)."""
-    payload, err = _prepare(cfg, wiki_root_arg)
+    page. `lang` localizes the per-theme lead-in placeholder (default English).
+    Returns a shell exit code (and prints the envelope)."""
+    payload, err = _prepare(cfg, wiki_root_arg, lang)
     if err:
         return _emit(False, error=err)
     stage_path = payload["wiki_root"].joinpath(*cfg.stage_rel)
@@ -780,14 +790,14 @@ def cmd_render(args) -> int:
     cfg, err = _resolve_cfg(args.type)
     if err:
         return _emit(False, error=err)
-    return render_index(cfg, args.wiki_root, args.wiki_scripts_dir)
+    return render_index(cfg, args.wiki_root, args.wiki_scripts_dir, args.lang)
 
 
 def cmd_stage(args) -> int:
     cfg, err = _resolve_cfg(args.type)
     if err:
         return _emit(False, error=err)
-    return stage_index(cfg, args.wiki_root)
+    return stage_index(cfg, args.wiki_root, args.lang)
 
 
 def cmd_counts(args) -> int:
@@ -823,6 +833,9 @@ def _build_parser() -> argparse.ArgumentParser:
     rn.add_argument("--wiki-root", required=True)
     rn.add_argument("--wiki-scripts-dir", required=True,
                     help="cogni-wiki wiki-ingest/scripts dir (for _wiki_lock).")
+    rn.add_argument("--lang", default="en",
+                    help="output_language (ISO 639-1) for the per-theme lead-in "
+                         "placeholder fallback; unknown/absent → English.")
     rn.set_defaults(func=cmd_render)
 
     st = sub.add_parser(
@@ -834,6 +847,9 @@ def _build_parser() -> argparse.ArgumentParser:
     st.add_argument("--type", required=True, choices=sorted(REGISTRY),
                     help="The wiki page type to stage an index for.")
     st.add_argument("--wiki-root", required=True)
+    st.add_argument("--lang", default="en",
+                    help="output_language (ISO 639-1) for the per-theme lead-in "
+                         "placeholder fallback; unknown/absent → English.")
     st.set_defaults(func=cmd_stage)
 
     ct = sub.add_parser(

--- a/cogni-knowledge/skills/knowledge-distill/SKILL.md
+++ b/cogni-knowledge/skills/knowledge-distill/SKILL.md
@@ -348,17 +348,29 @@ After the per-slug index/backlink loop and the `entries_count` bump, re-render t
 Run **one render per type, each gated on its own per-type counter** (`n_new_entities` / `n_new_people` from Step 7 sub-step 2) — a clean re-run that merged every page in place added no new index row for that type, so its sub-index is already current and the render is skipped (idempotent: an unchanged wiki is a no-op). Each render must run **after** the per-slug `wiki_index_update.py --category` calls above (which file every new distilled page under its `## <theme>` heading in `wiki/index.md`) — otherwise a just-written page lands in the renderer's trailing `## Uncategorized` group. The generic renderer groups each page under its own portal theme (`theme_via_own_slug`, same as the sources render) and carries any narrator-authored `MACHINE-OWNED:ENTITIES-LEADIN:<theme>` / `PEOPLE-LEADIN:<theme>` lead-in forward verbatim (no clobber), so rendering here never overwrites a lead-in a later run narrates:
 
 ```
+# Derive the base's output language so the engine-owned per-theme lead-in
+# fallback reads in-language on a non-English base (default en; the narrator
+# overwrites it on a later run regardless):
+OUTPUT_LANGUAGE=$(python3 -c '
+import json, sys
+try:
+    print((json.load(open(sys.argv[1])).get("output_language")) or "en")
+except Exception:
+    print("en")
+' "<project_path>/.metadata/plan.json")
 # One block per type; run only when that type's per-type counter > 0.
 # entities:
 python3 "${CLAUDE_PLUGIN_ROOT}/scripts/sub_index.py" render \
     --type entities \
     --wiki-root "$WIKI_ROOT" \
-    --wiki-scripts-dir "$WIKI_INGEST_SCRIPTS"
+    --wiki-scripts-dir "$WIKI_INGEST_SCRIPTS" \
+    --lang "$OUTPUT_LANGUAGE"
 # people:
 python3 "${CLAUDE_PLUGIN_ROOT}/scripts/sub_index.py" render \
     --type people \
     --wiki-root "$WIKI_ROOT" \
-    --wiki-scripts-dir "$WIKI_INGEST_SCRIPTS"
+    --wiki-scripts-dir "$WIKI_INGEST_SCRIPTS" \
+    --lang "$OUTPUT_LANGUAGE"
 ```
 
 **Fail-soft** — a renderer failure never rolls back distill: every distilled page, backlink, index row, and `entries_count` bump is already on disk. The render is lock-wrapped (`_wiki_lock`) + atomic (`atomic_write_text`) at its own write site and writes only when the proposed text differs byte-for-byte, so a forced failure leaves no partial page. `sub_index.py` is itself fail-soft (a missing wiki-scripts dir, a `_wikilib` import failure, or a non-wiki `--wiki-root` returns an error envelope rather than raising), so the orchestrator treats a non-zero result as a surfaced warning, never an abort. Surface each per-type outcome in the Step 9 summary and continue.

--- a/cogni-knowledge/skills/knowledge-finalize/SKILL.md
+++ b/cogni-knowledge/skills/knowledge-finalize/SKILL.md
@@ -690,9 +690,13 @@ The inverted pipeline writes the wiki via forked agents + direct script calls, s
    - **APPLY** — first materialise the page structure + lead-in spans under the lock, then splice each narrated lead-in into its span:
 
      ```
+     # OUTPUT_LANGUAGE is threaded from Step 5/6 (re-read from plan.json if not
+     # in hand; default en) so the engine-owned per-theme lead-in placeholder
+     # seeded for a theme that lacks one reads in-language on a non-English base.
      python3 "${CLAUDE_PLUGIN_ROOT}/scripts/concepts_index.py" render \
          --wiki-root "$WIKI_ROOT" \
-         --wiki-scripts-dir "$WIKI_INGEST_SCRIPTS"
+         --wiki-scripts-dir "$WIKI_INGEST_SCRIPTS" \
+         --lang "${OUTPUT_LANGUAGE:-en}"
      ```
 
      `render` (re)assembles `wiki/concepts/index.md` under cogni-wiki's `_wiki_lock` + `_knowledge_lib.atomic_write_text`, carrying every existing lead-in forward and seeding a `MACHINE-OWNED:CONCEPTS-LEADIN:<theme-slug>` placeholder span for any theme that lacks one — so after this call every refresh-set theme has a span to splice into. Then, in an inline `python3` that imports `_wiki_lock` from `_wikilib` (resolved via `$WIKI_INGEST_SCRIPTS`, the `concept-store.py` posture) and acquires it, read the rendered page and for each narrated theme replace its span inner via `_knowledge_lib.upsert_machine_block(text, "CONCEPTS-LEADIN:<slugify(theme)>", prose)`, then `_knowledge_lib.atomic_write_text` the result. A theme whose prose is unchanged upserts identical text → no write churn (the renarrate no-op contract). The next finalize's `render` carries the spliced prose forward verbatim.
@@ -707,11 +711,13 @@ The inverted pipeline writes the wiki via forked agents + direct script calls, s
 
    ```
    # Only when INDEX_OK=yes — the synthesis was filed this run; the renderer is
-   # idempotent (an unchanged wiki is a no-op).
+   # idempotent (an unchanged wiki is a no-op). OUTPUT_LANGUAGE (threaded from
+   # Step 5/6, default en) localizes the engine-owned per-theme lead-in fallback.
    python3 "${CLAUDE_PLUGIN_ROOT}/scripts/sub_index.py" render \
        --type syntheses \
        --wiki-root "$WIKI_ROOT" \
-       --wiki-scripts-dir "$WIKI_INGEST_SCRIPTS"
+       --wiki-scripts-dir "$WIKI_INGEST_SCRIPTS" \
+       --lang "${OUTPUT_LANGUAGE:-en}"
    ```
 
    **Fail-soft posture (explicit).** Sub-step 3.7 is a sub-index render. A renderer failure **never rolls back the synthesis** — the synthesis page, index entry, `entries_count` bump, `binding.json` append, `wiki/log.md` line, and sub-steps 1–3.6 are all already on disk. The render is lock-wrapped (`_wiki_lock`) + atomic (`atomic_write_text`) at its own write site and writes only when the proposed text differs byte-for-byte, so a forced failure leaves no partial page. `sub_index.py` is itself fail-soft (a missing wiki-scripts dir, a `_wikilib` import failure, or a non-wiki `--wiki-root` returns an error envelope rather than raising), so treat a non-zero result as a surfaced warning, never an abort. Surface the outcome in Step 11 and continue to sub-step 3.8.

--- a/cogni-knowledge/skills/knowledge-index/SKILL.md
+++ b/cogni-knowledge/skills/knowledge-index/SKILL.md
@@ -80,6 +80,22 @@ relocate into the sub-indexes). The migrator never re-implements the split.
 3. Extract `wiki_path` from the binding. Read
    `<wiki_path>/.cogni-wiki/config.json` for `schema_version` (abort with the
    config error when unreadable — the wiki is the authoritative validator).
+   Also derive `OUTPUT_LANGUAGE` from the binding's
+   `research_defaults.output_language` (default `en` on a pre-0.1.1 binding or
+   an absent key) — this base's default language, threaded to the sub-index
+   render so the engine-owned per-theme lead-in fallback reads in-language on a
+   non-English base:
+   ```bash
+   OUTPUT_LANGUAGE=$(python3 "${CLAUDE_PLUGIN_ROOT}/scripts/knowledge-binding.py" read \
+       --knowledge-root <knowledge_root> 2>/dev/null \
+     | python3 -c '
+   import json, sys
+   env = json.load(sys.stdin)
+   data = (env.get("data") or {}) if isinstance(env, dict) else {}
+   b = data.get("binding") or {}
+   print((b.get("research_defaults") or {}).get("output_language") or "en")
+   ' 2>/dev/null || printf en)
+   ```
 4. Resolve the wiki-engine scripts dir (vendored-first):
    ```bash
    . "${CLAUDE_PLUGIN_ROOT}/scripts/resolve-wiki-scripts.sh"
@@ -101,7 +117,8 @@ idempotent):
 ```bash
 for t in concepts entities people questions sources syntheses; do
   python3 "${CLAUDE_PLUGIN_ROOT}/scripts/sub_index.py" render \
-    --type "$t" --wiki-root "<wiki_path>" --wiki-scripts-dir "$WIKI_INGEST_SCRIPTS"
+    --type "$t" --wiki-root "<wiki_path>" --wiki-scripts-dir "$WIKI_INGEST_SCRIPTS" \
+    --lang "$OUTPUT_LANGUAGE"
 done
 python3 "${CLAUDE_PLUGIN_ROOT}/scripts/root_index.py" render \
   --wiki-root "<wiki_path>" --wiki-scripts-dir "$WIKI_INGEST_SCRIPTS"

--- a/cogni-knowledge/tests/test_knowledge_lib.sh
+++ b/cogni-knowledge/tests/test_knowledge_lib.sh
@@ -198,6 +198,31 @@ def assert_ref_heading():
     assert kl.ref_heading(True) == "References", "non-str (bool) → English, no crash"
 
 
+def assert_leadin_placeholder():
+    # Localized sub-index theme lead-in fallback, default/unknown → English.
+    L = kl.leadin_placeholder
+    # English is the identity case and MUST stay byte-stable with the legacy
+    # deterministic fallback (sub_index render with no --lang renders English).
+    for t in ("concepts", "entities", "people", "sources", "questions", "syntheses"):
+        assert L(t, None) == f"_This theme groups the {t} below._", L(t, None)
+        assert L(t, "en") == f"_This theme groups the {t} below._", L(t, "en")
+    # Non-English renders a fully-coherent localized sentence + noun (article
+    # carried where the language needs agreement) — never a mixed-language string.
+    assert L("concepts", "de") == "_Dieses Thema gruppiert die Konzepte weiter unten._", L("concepts", "de")
+    assert L("entities", "nl") == "_Dit thema groepeert de entiteiten hieronder._", L("entities", "nl")
+    assert L("sources", "fr") == "_Ce thème regroupe les sources ci-dessous._", L("sources", "fr")
+    assert L("people", "it") == "_Questo tema raggruppa le persone qui sotto._", L("people", "it")
+    assert L("questions", "es") == "_Este tema agrupa las preguntas a continuación._", L("questions", "es")
+    assert L("syntheses", "pl") == "_Ten temat grupuje syntezy poniżej._", L("syntheses", "pl")
+    assert L("concepts", "DE").startswith("_Dieses Thema"), "lang is case-insensitive"
+    # Default-to-safe posture (mirrors ref_heading): unknown lang → English
+    # template, unmapped type → raw type noun, non-str args never crash.
+    assert L("concepts", "xx") == "_This theme groups the concepts below._", "unknown lang → English"
+    assert L("widgets", "de") == "_Dieses Thema gruppiert widgets weiter unten._", "unmapped type → raw noun"
+    assert L("concepts", 5) == "_This theme groups the concepts below._", "non-str lang → English, no crash"
+    assert L(None, None) == "_This theme groups the  below._", "None type → empty noun, no crash"
+
+
 def assert_page_type_line():
     # #931: deterministic reader-facing `Type: <Display> · <stage>` header line.
     # Display name + stage word are properties of the type (not the page instance).
@@ -1239,6 +1264,7 @@ check("atomic_write_roundtrip", assert_atomic_write_roundtrip)
 check("control_paths", assert_control_paths)
 check("slugify", assert_slugify)
 check("ref_heading", assert_ref_heading)
+check("leadin_placeholder", assert_leadin_placeholder)
 check("page_type_line", assert_page_type_line)
 check("first_url", assert_first_url)
 check("extract_inline_citation_urls", assert_extract_inline_citation_urls)
@@ -1281,6 +1307,7 @@ grade atomic_write_roundtrip  "atomic_write round-trips payload and leaves no .t
 grade control_paths           "control-file resolver (0.0.8) — log/context_brief/open_questions prefer wiki/meta/ when present, else legacy wiki/; meta_dir unconditional; unknown name→ValueError"
 grade slugify                 "slugify — German umlaut transliteration (für→fuer), NFKD de-accent, empty/non-alnum→'' contract, max-len truncation"
 grade ref_heading             "ref_heading — localized reference heading (de→Referenzen), default/unknown→References"
+grade leadin_placeholder      "leadin_placeholder — localized sub-index lead-in fallback (de→coherent sentence+noun), EN byte-stable, unknown lang/type & non-str→safe (#940)"
 grade first_url               "first_url — JSON-list + non-JSON fallback URL extraction, no charset over-strip, file:// first-class incl. space-in-path (#572)"
 grade extract_inline_citation_urls "extract_inline_citation_urls — http(s) + file:// markers (bracketed/unbracketed), space-in-file:// captured whole, mixed file+http in one sentence yields both, bare/empty→[] (#572)"
 grade md_link_dest            "md_link_dest — angle-brackets a destination containing parens/space (paren-URL citation links)"


### PR DESCRIPTION
Closes #940.

## Summary

The engine-owned sub-index theme lead-in **placeholder** was an English-only literal (`_This theme groups the {type_name} below._`), so on a base whose `output_language` is not English the deterministic fallback read in the wrong language until a narrator authored the real lead-in.

- Add a language-keyed `leadin_placeholder(type_name, lang)` helper to `_knowledge_lib.py`, mirroring the existing `ref_heading`/`REF_HEADING` i18n precedent (keys `en/de/fr/it/pl/nl/es`, default-to-English on unknown/absent/non-str via `str(lang or "en").lower()`).
- The fallback localizes the **full sentence AND the per-type noun** (carrying the article the gendered languages need, e.g. German `die Konzepte`, Spanish `los conceptos`) so it reads coherently in-language — never a mixed-language string. **English is the identity case**, so callers that pass no `--lang` render the legacy fallback byte-for-byte.
- Thread `--lang` (default `en`) through the shared render path of `sub_index.py` (render/stage subparsers → `render_index`/`stage_index` → `_prepare` → `_assemble` → `_build_page`).
- Thread `--lang` through `concepts_index.py` too — it is a **second caller** of the same shared render path, so `wiki/concepts/index.md` (rendered there at finalize sub-step 3.6) localizes as well.
- Forward the already-parsed `output_language` from `knowledge-ingest-postprocess.py` to both `sub_index render` invocations (sources, questions).
- Thread `--lang "$OUTPUT_LANGUAGE"` at the SKILL.md render call sites: knowledge-distill (entities/people), knowledge-finalize (syntheses + concepts), knowledge-index (which derives `OUTPUT_LANGUAGE` from `binding.json::research_defaults.output_language`). knowledge-setup stays English (no language known at bootstrap).
- Remove the now-unused `TypeConfig.leadin_placeholder` field — the helper fully owns the placeholder.
- Bump cogni-knowledge 1.0.49 → 1.0.50 + mirror in marketplace.json.

## Scope decisions

- **Noun-coherence:** chose to localize the noun too (option a) over sentence-only (option b). A localized sentence wrapped around an English noun still reads broken, defeating the issue's purpose; the per-(type, lang) noun map is small and mirrors the existing `_TYPE_DISPLAY` pattern.
- **concepts_index.py folded in** (caught in plan refinement): it shares the same render path and the same fallback, so omitting it would leave `wiki/concepts/index.md` untranslated.
- `perspectives_index.py` is intentionally untouched (separate facet lead-in model, not `sub_index.py`'s placeholder).
- Full scope, nothing deferred.

## Test plan

- [x] `tests/test_knowledge_lib.sh` — new `leadin_placeholder` unit case: EN byte-stability, coherent localized sentence+noun for all 7 languages, unknown-lang/unmapped-type/non-str → safe fallback.
- [x] `tests/test_sub_index.sh`, `tests/test_concepts_index.sh`, `tests/test_ingest_postprocess.sh` pass unchanged (render with no `--lang` → English, byte-stable).
- [x] Full plugin suite: 75/75 pass.
- [x] End-to-end smoke: `sub_index.py render --type sources --lang de` on an un-narrated theme emits `_Dieses Thema gruppiert die Quellen weiter unten._`; omitting `--lang` / unknown lang → English.

[Resolution plan record](https://github.com/cogni-work/insight-wave/issues/940#issuecomment-4774403444)