### PR TITLE
cogni-consult: Empathize input-material intake rung before gap-check

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -35,7 +35,7 @@
     {
       "name": "cogni-consult",
       "source": "./cogni-consult",
-      "version": "0.1.37",
+      "version": "0.1.38",
       "maturity": "preview",
       "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
       "keywords": [

--- a/cogni-consult/.claude-plugin/plugin.json
+++ b/cogni-consult/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-consult",
-  "version": "0.1.37",
+  "version": "0.1.38",
   "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-consult/references/data-model.md
+++ b/cogni-consult/references/data-model.md
@@ -235,6 +235,17 @@ updated: 2026-06-11
 ...
 ```
 
+A `sources[]` entry may instead be **read-direct first-party** material. When
+the `consult-design-thinking` Empathize stage reads consultant-supplied input
+material (a path, pasted text, or a URL) directly into the deliverable rather
+than depositing it into the bound knowledge base, the entry carries a
+`file://<abspath>` `source_url`, an added `evidence_class: first-party` field,
+and **no** `kb_ref` (there is no knowledge-base page behind it). The
+`source_url`/`entity_ref`/`propagated_at` lineage triple still applies so
+cogni-claims corrections cascade. This is the deliverable-`sources[]` analogue
+of the diagnostic `as-is-seed.md` first-party seed (`references/research-routing.md`,
+First-party seed carve-out).
+
 ### .metadata/ logs
 
 All three logs address work by the same structured coordinates —

--- a/cogni-consult/references/research-routing.md
+++ b/cogni-consult/references/research-routing.md
@@ -98,6 +98,16 @@ so it carries `evidence_class: first-party` frontmatter and no `kb_ref` lineage
 triple — there is no knowledge-base page behind it. Everything else in `research/`
 follows the knowledge-finalize rule above.
 
+A second first-party entry path exists outside `research/`: the
+`consult-design-thinking` Empathize stage's input-material intake rung can read
+consultant-supplied material (a path, pasted text, or a URL) **directly** into a
+deliverable's `sources[]` array instead of depositing it into the bound base.
+Like the seed, that entry carries `evidence_class: first-party` with a `file://`
+provenance URI and no `kb_ref` lineage triple — first-party evidence with no
+knowledge-base page behind it. The consultant chooses this read-direct sink over
+the ingest sink (`cogni-knowledge:knowledge-ingest-source`) when the material is
+deliverable-local rather than reusable across deliverables.
+
 ## The Only Exception
 
 A quick fact-check during conversation (confirming a date, a name, a number)

--- a/cogni-consult/skills/consult-design-thinking/SKILL.md
+++ b/cogni-consult/skills/consult-design-thinking/SKILL.md
@@ -64,12 +64,15 @@ session's conversation flow and is never written to `field.json`,
 `consult-project.json`, or any log; the state-write ownership and the logging
 contract below are identical in both modes.
 
-In interactive mode, at each stage gate marked **Interactive mode** below (end
-of Define, end of Ideate, start of Prototype, Test), before the stage's write:
-surface the *reasoning* behind the stage decision (why this HMW spec, why this
-ideation method, why this prototype shape, why these persona dispositions) ahead
-of the log entry, name exactly what is about to be written, and pause for the
-consultant's explicit confirmation — revise on feedback, then write. In
+In interactive mode, at each stage gate marked **Interactive mode** below (start
+of Empathize, end of Define, end of Ideate, start of Prototype, Test), before
+the stage's write: surface the *reasoning* behind the stage decision (why this
+HMW spec, why this ideation method, why this prototype shape, why these persona
+dispositions) ahead of the log entry, name exactly what is about to be written,
+and pause for the consultant's explicit confirmation — revise on feedback, then
+write. The start-of-Empathize gate is the exception in kind: it pauses to gather
+input material to ground the deliverable rather than to narrate a write (see
+Empathize below). In
 auto-walk mode, skip the pauses and proceed directly through each gate. The
 gates only add confirmation seams and reasoning narration around the existing
 writes; they never change what gets written or who owns it.
@@ -180,6 +183,37 @@ for the personas that matter to this deliverable (`personas/*.json`). When the
 directory is empty, say so and continue with the consultant's own stakeholder
 knowledge — persona files can be added later without redoing the loop.
 
+**Interactive mode — input material first.** Before the gap-check, ask the
+consultant whether additional source material is available to ground this
+deliverable — file paths, pasted text, or URLs (internal reports, the full LOI,
+architecture specs, interview transcripts, prior board/decision notes). This
+intake runs before the gap-check so the evidence base is as complete as the
+consultant can make it before any coverage check runs; it matters most on a
+first-party internal diagnostic, where the bound base is empty and external web
+research is inappropriate, so the loop would otherwise begin drafting on
+whatever the scoping conversation happened to capture. For each item supplied,
+choose the sink:
+
+- **Ingest into the bound base** (the item is reusable evidence later
+  deliverables should also find): dispatch
+  `Skill(cogni-knowledge:knowledge-ingest-source, --file <path>|--url <url>|--paste <tmpfile>, --knowledge-slug <plugin_refs.knowledge_base>, --title "<material title>", --theme "Consulting Deliverables")`
+  — the same deposit signature Step 8 reuses; the material lands as a
+  `type: source` page so this gap-check and every later research run find it.
+- **Read directly into the deliverable's evidence base** (the consultant
+  prefers not to deposit, or the material is deliverable-local): `Read` the
+  file and carry it as a `sources[]` entry on the deliverable artifact with a
+  `file://<abspath>` provenance URI and `evidence_class: first-party` — no
+  `kb_ref`, no knowledge-base page written (the read-direct first-party
+  `sources[]` shape in `$CLAUDE_PLUGIN_ROOT/references/data-model.md`).
+
+When no additional material is offered, proceed. **Idempotency (the loop may
+re-enter Empathize):** `knowledge-ingest-source` runs its own diff-before-write
+dedup gate, so re-ingesting a covering source is a no-op; for the read-direct
+sink, before appending scan the deliverable's `sources[]` for an entry with the
+same `file://` URI and append only when none exists — so a re-entry neither
+re-prompts settled material nor double-records it. **In auto-walk mode, skip
+this prompt** and proceed directly to the gap-check on the scope-time material.
+
 Research for this stage follows the Research Routing Rule in
 `$CLAUDE_PLUGIN_ROOT/references/research-routing.md` — the canonical
 contract for every research run in the engagement. Start with the gap-check
@@ -262,7 +296,10 @@ Draft the deliverable artifact at
 `action-fields/<field-slug>/<deliverable-slug>.md` — Obsidian markdown with
 YAML frontmatter exactly per the data model: `slug`, `action_field`,
 `sources[]` (each entry the lineage triple `source_url`, `entity_ref`,
-`propagated_at`, plus `kb_ref` when the claim came from the knowledge base),
+`propagated_at`, plus `kb_ref` when the claim came from the knowledge base —
+or, for read-direct first-party material carried in from the Empathize intake
+rung, a `file://` `source_url` with `evidence_class: first-party` and no
+`kb_ref`; canonical shape in `$CLAUDE_PLUGIN_ROOT/references/data-model.md`),
 and `updated`. State is intentionally absent from the frontmatter — it lives
 in `field.json` only.
 


### PR DESCRIPTION
Closes #951.

## Summary
- Add an explicit "is there more input material to ground this deliverable?" intake rung at the start of the `consult-design-thinking` Empathize stage (§3), inserted **before** the knowledge-base gap-check.
- Supplied paths / pasted text / URLs route to one of two sinks: (a) ingested into the bound base via `cogni-knowledge:knowledge-ingest-source` (reusing the Step 8 deposit signature verbatim — no cogni-knowledge change), or (b) read directly into the deliverable's empathize evidence base as a `sources[]` entry with a `file://<abspath>` provenance URI and `evidence_class: first-party` (no `kb_ref`, no KB page written).
- Surfaced by default (interactive-mode preamble matching Define/Ideate/Prototype/Test); the pause is skipped in auto-walk mode, consistent with the existing auto-walk vs. interactive contract. Re-entry into Empathize neither re-prompts nor double-records, mirroring the Step 8 append-once-on-resume deposit discipline.

## Why
For first-party internal diagnostics — where the bound KB is empty and external web research is inappropriate — the loop previously went straight to the gap-check and silently assumed the scope-time material was the complete evidence base, beginning to draft on a partial one. The consultant often holds more grounding material (full LOI, architecture specs, transcripts, prior decision notes) than the scoping conversation captured. This makes "what else do you have?" a first-class, default step of Empathize.

## Reference-doc accuracy
- `research-routing.md` First-party seed carve-out now names the Empathize intake rung as a second accepted first-party entry path.
- `data-model.md` Deliverable-artifacts schema now documents the read-direct first-party `sources[]` variant (`file://` URI, `evidence_class: first-party`, no `kb_ref`).
- Interaction-mode gate enumeration updated to include the new start-of-Empathize gate (flagged as an input-intake gate, distinct from the reasoning-before-write gates).

## Version
- cogni-consult 0.1.37 → 0.1.38 (plugin.json + marketplace.json).

## Test plan
- [ ] Run `consult-design-thinking` in interactive mode against an empty/first-party bound base; confirm the intake prompt appears at the start of Empathize, before any `knowledge-query` gap-check.
- [ ] Supply a `--file` path; confirm it is ingested via `cogni-knowledge:knowledge-ingest-source` into the bound base with theme "Consulting Deliverables".
- [ ] Supply read-direct material; confirm it lands as a `sources[]` entry with a `file://` URI and `evidence_class: first-party`, with no KB page written.
- [ ] Re-enter Empathize on the same deliverable; confirm the material is not re-ingested or double-appended.
- [ ] Run in auto-walk mode; confirm the intake pause is skipped and the loop proceeds straight to the gap-check.
- [ ] Confirm cogni-consult reads 0.1.38 in both plugin.json and marketplace.json.