### PR TITLE
cogni-consult: documented engagement source-inbox (sources/)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -35,7 +35,7 @@
     {
       "name": "cogni-consult",
       "source": "./cogni-consult",
-      "version": "0.1.38",
+      "version": "0.1.39",
       "maturity": "preview",
       "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
       "keywords": [

--- a/cogni-consult/.claude-plugin/plugin.json
+++ b/cogni-consult/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-consult",
-  "version": "0.1.38",
+  "version": "0.1.39",
   "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-consult/CLAUDE.md
+++ b/cogni-consult/CLAUDE.md
@@ -78,6 +78,7 @@ Each engagement lives in `cogni-consult/{slug}/` with:
 - `scope/` — key question + 5 scoping dimensions + derived action-field list
 - `action-fields/{field-slug}/` — one directory per WBS field: `field.json` (single source of truth for the field's deliverable states) + deliverable markdown artifacts
 - `personas/` — acting stakeholder personas (JSON)
+- `sources/` — engagement source inbox: the documented drop location for raw material (LOI, specs, notes, transcripts) to ground a deliverable; scaffolded at setup with a `README.md`, the Empathize stage ingests it into the bound base or reads it into a deliverable's `sources[]`
 - `.metadata/` — execution-log, method-log, decision-log (all addressed by `action_field` + `deliverable`)
 
 Full schemas: `references/data-model.md`.

--- a/cogni-consult/README.md
+++ b/cogni-consult/README.md
@@ -99,6 +99,7 @@ You elect a format — `slides`, `web-poster`, `report`, or `infographic` — an
 | Deliverable artifact | `action-fields/{field-slug}/{deliverable-slug}.md` | Markdown + YAML frontmatter with `sources[]` lineage triples (`kb_ref` for knowledge-base claims) |
 | Research synthesis | `action-fields/{field-slug}/research/{topic-slug}.md` | Finalized cogni-knowledge syntheses copied per the Research Routing Rule |
 | Persona | `personas/{persona-slug}.json` | Acting stakeholder persona (role, core tension, empathy map, work log) |
+| Source inbox | `sources/` | Documented drop location for raw consultant-supplied material (LOI, specs, transcripts); the Empathize stage ingests it into the bound base or reads it into a deliverable's `sources[]` |
 | Logs | `.metadata/` | Execution, method, and decision logs addressed by field + deliverable |
 
 Field and engagement completion are derived at read time — never stored. Full schemas: `references/data-model.md`.

--- a/cogni-consult/references/data-model.md
+++ b/cogni-consult/references/data-model.md
@@ -28,13 +28,27 @@ cogni-consult/{engagement-slug}/
 │           └── {topic-slug}.md            # Research syntheses copied from the knowledge
 │                                          #   base after knowledge-finalize (see
 │                                          #   references/research-routing.md)
-└── personas/
-    └── {persona-slug}.json                # Acting stakeholder personas (partner, PM, ...)
+├── personas/
+│   └── {persona-slug}.json                # Acting stakeholder personas (partner, PM, ...)
+└── sources/                              # Engagement source inbox (drop location)
+    ├── README.md                          # Scaffolded at setup; describes the inbox
+    └── {raw-material}                     # LOI text, specs, transcripts, working notes;
+                                           #   the Empathize stage reads from here
 ```
 
 There are no numbered phase directories. The engagement's shape is defined by
 its action fields; skills iterate deliverables within fields, each deliverable
 running its own design-thinking loop.
+
+The `sources/` directory is the engagement's **source inbox** — a documented,
+consultant-facing drop location for raw material to ground a deliverable (the
+full LOI, architecture specs, working notes, transcripts). It is scaffolded at
+`consult-setup` time and carries a `README.md` describing its use, so the
+location is discoverable from inside the engagement without knowing the bound
+knowledge base's directory layout. The `consult-design-thinking` Empathize
+stage offers two sinks for what lands here — ingest into the bound knowledge
+base (so every deliverable's research finds it) or read directly into a single
+deliverable's `sources[]` evidence base — and owns that routing decision.
 
 ## State Ownership (single source of truth)
 

--- a/cogni-consult/scripts/engagement-init.sh
+++ b/cogni-consult/scripts/engagement-init.sh
@@ -18,7 +18,7 @@ if [ -f "$BASE_DIR/consult-project.json" ]; then
   exit 0
 fi
 
-mkdir -p "$BASE_DIR"/{scope,action-fields,personas,.metadata}
+mkdir -p "$BASE_DIR"/{scope,action-fields,personas,sources,.metadata}
 
 SLUG="$SLUG" NAME="$NAME" BASE_DIR="$BASE_DIR" python3 - <<'PY'
 import json, os, datetime
@@ -45,6 +45,23 @@ for log, payload in [
     with open(os.path.join(base, ".metadata", log), "w") as f:
         json.dump(payload, f, indent=2)
         f.write("\n")
+
+# Source inbox: a documented, consultant-facing drop location for raw material
+# (see references/data-model.md). Self-documenting via its own README so a
+# consultant who never reads the reference still knows what it is for.
+with open(os.path.join(base, "sources", "README.md"), "w") as f:
+    f.write(
+        "# Source inbox\n\n"
+        "Drop raw material to ground a deliverable here — LOI text, architecture\n"
+        "specs, working notes, interview transcripts, prior board/decision notes,\n"
+        "or any first-party document the scoping conversation did not capture.\n\n"
+        "The design-thinking loop's Empathize stage offers two ways to use what\n"
+        "you drop here:\n\n"
+        "- **Ingest into the bound knowledge base** so every deliverable's research\n"
+        "  finds it (via `cogni-knowledge:knowledge-ingest-source`).\n"
+        "- **Read directly into a single deliverable's `sources[]`** evidence base,\n"
+        "  when the material is deliverable-local and should not enter the shared base.\n"
+    )
 
 # Manifest written last: its existence marks a completed init (see the
 # idempotency check above).

--- a/cogni-consult/skills/consult-design-thinking/SKILL.md
+++ b/cogni-consult/skills/consult-design-thinking/SKILL.md
@@ -185,7 +185,8 @@ knowledge — persona files can be added later without redoing the loop.
 
 **Interactive mode — input material first.** Before the gap-check, ask the
 consultant whether additional source material is available to ground this
-deliverable — file paths, pasted text, or URLs (internal reports, the full LOI,
+deliverable — file paths (drop files in the engagement's `sources/` inbox, or
+give any path), pasted text, or URLs (internal reports, the full LOI,
 architecture specs, interview transcripts, prior board/decision notes). This
 intake runs before the gap-check so the evidence base is as complete as the
 consultant can make it before any coverage check runs; it matters most on a

--- a/cogni-consult/skills/consult-setup/SKILL.md
+++ b/cogni-consult/skills/consult-setup/SKILL.md
@@ -46,7 +46,7 @@ Run the init script from the workspace root:
 bash $CLAUDE_PLUGIN_ROOT/scripts/engagement-init.sh "<engagement-slug>" "<engagement-name>"
 ```
 
-The script creates `cogni-consult/<slug>/{scope,action-fields,personas,.metadata}/`, writes the three `.metadata/` logs, and writes `consult-project.json` last (its existence is the idempotency key). On `"success": false` with `"engagement already initialized"`, stop and route to the existing engagement via `consult-resume` — never overwrite.
+The script creates `cogni-consult/<slug>/{scope,action-fields,personas,sources,.metadata}/`, writes the three `.metadata/` logs, writes a `sources/README.md` (the `sources/` directory is the engagement's **source inbox** — the documented drop location for raw material to ground a deliverable; see `$CLAUDE_PLUGIN_ROOT/references/data-model.md`), and writes `consult-project.json` last (its existence is the idempotency key). On `"success": false` with `"engagement already initialized"`, stop and route to the existing engagement via `consult-resume` — never overwrite.
 
 Then enrich `consult-project.json` with `Edit` — never rewrite the file (the `created`/`updated` timestamps the script set must survive):
 


### PR DESCRIPTION
Closes #952.

## Summary
- Scaffold a `sources/` inbox inside `cogni-consult/<engagement>/` at `consult-setup` time, with a self-documenting `sources/README.md` (drop LOI / specs / notes / transcripts here; from Empathize, ingest into the bound base or read directly into a deliverable's `sources[]`).
- Name the inbox in the Empathize "input material first" rung so the prompt points at a concrete path (`<engagement-dir>/sources/`) instead of generic "file paths".
- Document the inbox in `references/data-model.md` (engagement tree entry + prose: the two Empathize sinks, `consult-design-thinking` owns the routing), and keep the developer-guide `CLAUDE.md` `## Data Model` enumeration and the README `## Data model` table in sync.
- Bump cogni-consult 0.1.38 → 0.1.39 (plugin.json + marketplace.json).

## Why
This is the complementary affordance to the now-merged Empathize input-material prompt: that prompt asks "what else do you have?", and this PR answers "here is exactly where it goes". Previously the only canonical raw-source folder was the bound knowledge base's `raw/` directory — a sibling-plugin, KB-scoped tree a consultant working inside the engagement had no reason to know existed. An engagement-scoped `sources/` inbox lives where the consultant already works and is self-documenting.

## Approach
Chose an engagement-scoped `sources/` directory over surfacing the bound KB `raw/` path: `raw/` is exactly the location the consultant could not discover from inside cogni-consult. All three acceptance criteria — created at setup / named in the prompt / documented in the scaffold — ship together as one atomic affordance. `consult-resume` is deliberately untouched (read-only WBS surface; setup-scaffold + Empathize naming + data-model docs are sufficient discoverability).

## Test plan
- [x] `engagement-init.sh test-inbox "Test Inbox"` creates `cogni-consult/test-inbox/sources/README.md` with drop-location guidance (verified).
- [x] Re-run is idempotent (`engagement already initialized`, no overwrite) (verified).
- [x] `consult-setup` Step 3 enumerates `sources` in the created-dirs list.
- [x] `consult-design-thinking` §3 "input material first" rung names the `sources/` inbox path.
- [x] `references/data-model.md` engagement tree + `CLAUDE.md` Data Model + README Data model table all include `sources/`.
- [x] plugin.json and marketplace.json both read `0.1.39`; breadcrumb guard + skill-name check clean.