### PR TITLE
cogni-knowledge: opt-in PDF-body normalization at extract_pdf_text

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "cogni-knowledge",
       "source": "./cogni-knowledge",
-      "version": "1.0.59",
+      "version": "1.0.60",
       "maturity": "released",
       "description": "Wiki-first research that compounds. Binds each run to a wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`. The shallow `knowledge-query` rung is read-only by default and can optionally file its answer back as an un-verified synthesis page via `--file-back`.",
       "keywords": [

--- a/cogni-knowledge/.claude-plugin/plugin.json
+++ b/cogni-knowledge/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-knowledge",
-  "version": "1.0.59",
+  "version": "1.0.60",
   "description": "Wiki-first research that compounds. Binds each run to a wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`. The shallow `knowledge-query` rung is read-only by default and can optionally file its answer back as an un-verified synthesis page via `--file-back`.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-knowledge/scripts/_knowledge_lib.py
+++ b/cogni-knowledge/scripts/_knowledge_lib.py
@@ -360,6 +360,34 @@ def excerpt_present(needle: str, haystack: str) -> bool:
     return bool(n) and n in _normalize_excerpt_text(haystack)
 
 
+def normalize_pdf_body_text(s: str) -> str:
+    """Structure-preserving normalization of a PDF text layer, for storage.
+
+    Unlike `_normalize_excerpt_text` (which flattens every whitespace run to a
+    single space for *matching*), this keeps paragraph structure so the stored
+    `wiki/sources/<slug>.md` body stays readable: NFKC-fold ligatures
+    (U+FB01/U+FB02 etc.) + map smart quotes / dashes to ASCII via the shared
+    `_SMART_QUOTE_TABLE`, rejoin hyphenated column-wrap breaks
+    ("exam-\\nple" -> "example"), then fold the remaining single soft-wrap
+    newlines to a space (so wrapped words never run together) while preserving
+    blank-line paragraph breaks.
+
+    Opt-in only — `extract_pdf_text(..., normalize_pdf_body=True)`. The default
+    path never calls this, so the stored body / its `content_hash` stay
+    byte-identical."""
+    if not s:
+        return ""
+    folded = unicodedata.normalize("NFKC", s).translate(_SMART_QUOTE_TABLE)
+    # Rejoin hyphenated intra-word wraps: "exam-\nple" -> "example".
+    folded = re.sub(r"(\w)-\n(\w)", r"\1\2", folded)
+    # Stash blank-line paragraph breaks, fold the remaining single soft-wrap
+    # newlines to a space, then restore the paragraph breaks.
+    folded = re.sub(r"\n[ \t]*\n[ \t\n]*", "\x00", folded)
+    folded = re.sub(r"[ \t]*\n[ \t]*", " ", folded)
+    folded = folded.replace("\x00", "\n\n")
+    return folded.strip()
+
+
 def ref_heading(lang: str | None) -> str:
     """Reference-section heading word for `lang` (default/unknown → English).
 
@@ -2214,7 +2242,7 @@ class PdfExtractResult(NamedTuple):
     error: str = ""
 
 
-def extract_pdf_text(path, min_chars: int = 200) -> PdfExtractResult:
+def extract_pdf_text(path, min_chars: int = 200, normalize_pdf_body: bool = False) -> PdfExtractResult:
     """Extract a PDF's text layer via the optional pypdf dependency (in-process).
 
     The single text-layer extraction mechanism for the poppler-less fallback: the
@@ -2249,6 +2277,11 @@ def extract_pdf_text(path, min_chars: int = 200) -> PdfExtractResult:
         return PdfExtractResult(
             None, pages, "no_text_layer", "No usable text layer extracted (image-only / scanned PDF)."
         )
+    # Opt-in: clean the stored body (ligatures / smart quotes / column-wrap).
+    # The text-layer gate above ran on the raw extraction, so the failure paths
+    # stay byte-identical; only the kept "ok" body is normalized.
+    if normalize_pdf_body:
+        text = normalize_pdf_body_text(text)
     return PdfExtractResult(text, pages, "ok")
 
 

--- a/cogni-knowledge/scripts/pdf-extract.py
+++ b/cogni-knowledge/scripts/pdf-extract.py
@@ -8,7 +8,7 @@ pure-Python text-layer extraction (via the optional pypdf dependency) before the
 curator records the honest `pdf_render_unavailable` outcome.
 
 Usage:
-  python3 pdf-extract.py --path <file.pdf> [--min-chars 200]
+  python3 pdf-extract.py --path <file.pdf> [--min-chars 200] [--normalize-pdf-body]
 
 pypdf resolution:
   1. the interpreter running this script (host `pip install pypdf`);
@@ -94,13 +94,21 @@ def main() -> int:
         help="Non-trivial-text gate: below this many extracted chars the PDF is "
         "treated as image-only (success: false). Default 200.",
     )
+    parser.add_argument(
+        "--normalize-pdf-body",
+        action="store_true",
+        help="Opt-in: clean the extracted body (NFKC-fold ligatures, map smart "
+        "quotes/dashes to ASCII, rejoin hyphenated column-wrap breaks) while "
+        "preserving paragraph structure. Default off — the stored body is "
+        "byte-identical to the raw text layer.",
+    )
     args = parser.parse_args()
 
     pdf_path = Path(args.path)
     if not pdf_path.is_file():
         return _emit(False, {"reason": "not_found"}, f"PDF not found: {args.path}")
 
-    result = extract_pdf_text(pdf_path, min_chars=args.min_chars)
+    result = extract_pdf_text(pdf_path, min_chars=args.min_chars, normalize_pdf_body=args.normalize_pdf_body)
 
     if result.reason == "pypdf_unavailable":
         # pypdf isn't importable in this interpreter. If a workspace venv is

--- a/cogni-knowledge/tests/test_pdf_extract.sh
+++ b/cogni-knowledge/tests/test_pdf_extract.sh
@@ -149,9 +149,27 @@ def assert_main_envelope_mapping():
         pe.extract_pdf_text = orig
 
 
+def assert_normalize_pdf_body():
+    # The opt-in body normalizer (host-independent — no pypdf needed).
+    f = kl.normalize_pdf_body_text
+    # Empty / falsy input → "".
+    assert f("") == "", repr(f(""))
+    # NFKC folds the ﬁ/ﬂ ligatures (ﬁ→"fi", ﬂ→"fl").
+    assert f("ﬁle ﬂag") == "file flag", repr(f("ﬁle ﬂag"))
+    # Smart quotes / en-dash map to ASCII via _SMART_QUOTE_TABLE.
+    assert f("“Quote” – ok") == '"Quote" - ok', repr(f("“Quote” – ok"))
+    # Hyphenated column-wrap rejoins into one word.
+    assert f("exam-\nple") == "example", repr(f("exam-\nple"))
+    # A non-hyphenated soft wrap folds to a SPACE (words never run together).
+    assert f("the quick\nbrown fox") == "the quick brown fox", repr(f("the quick\nbrown fox"))
+    # Blank-line paragraph breaks are preserved.
+    assert f("Para one.\n\nPara two.") == "Para one.\n\nPara two.", repr(f("Para one.\n\nPara two."))
+
+
 check("not_found_subprocess", assert_not_found_subprocess)
 check("venv_python_resolution", assert_venv_python_resolution)
 check("main_envelope_mapping", assert_main_envelope_mapping)
+check("normalize_pdf_body", assert_normalize_pdf_body)
 PY
 )
 
@@ -172,6 +190,7 @@ grade() {
 grade not_found_subprocess   "pdf-extract.py CLI — missing path returns success:false data.reason=not_found with an error (real subprocess, no pypdf needed)"
 grade venv_python_resolution "_venv_python — COGNI_WORKSPACE_PYTHON_VENV unset→None, set-but-no-bin/python→None, set-with-bin/python→that path (workspace-venv re-exec resolution)"
 grade main_envelope_mapping  "main() reason→envelope mapping — ok/no_text_layer/extract_failed/pypdf_unavailable, install hint on pypdf_unavailable (faked extract_pdf_text, host-independent)"
+grade normalize_pdf_body     "normalize_pdf_body_text — NFKC ligature fold + smart-quote/dash map + hyphenated-wrap rejoin + soft-wrap→space, paragraph breaks preserved (opt-in stored-body cleaner)"
 
 if [ $errors -gt 0 ]; then
   red "$errors case(s) failed."


### PR DESCRIPTION
## Summary

Adds an **opt-in** PDF-body normalization to `extract_pdf_text`, surfaced as the `--normalize-pdf-body` CLI flag on `pdf-extract.py`. When enabled, the stored PDF text layer is cleaned at extraction time; the default path is byte-identical.

Closes #962.

## What changed

- **`cogni-knowledge/scripts/_knowledge_lib.py`** — new structure-preserving `normalize_pdf_body_text(s)` helper (NFKC ligature fold + `_SMART_QUOTE_TABLE` smart-quote/dash map + hyphenated column-wrap rejoin + soft-wrap-newline→space, **paragraph breaks preserved**); new `normalize_pdf_body: bool = False` kwarg on `extract_pdf_text`, applied to the kept body **after** the text-layer gate so the `no_text_layer`/`extract_failed` paths stay byte-identical.
- **`cogni-knowledge/scripts/pdf-extract.py`** — new `--normalize-pdf-body` store_true flag, threaded into the `extract_pdf_text` call; docstring `Usage:` updated.
- **`cogni-knowledge/tests/test_pdf_extract.sh`** — new `normalize_pdf_body` case asserting ligature fold, smart-quote/dash map, hyphenated rejoin, soft-wrap→space, and paragraph-break preservation (host-independent, no pypdf).
- **version** — cogni-knowledge `1.0.59 → 1.0.60` (plugin.json + marketplace.json mirror).

## Why opt-in / blast radius

The flag changes the **stored** `wiki/sources/<slug>.md` body and therefore its `content_hash:`, which the Step 3.5 integrity sweep (`ingest-integrity.py`) and the fetch-cache key on. Default-off keeps the stored body / `content_hash` byte-identical, so `fetch-cache.py` and `ingest-integrity.py` need no code change. Complements the surface-local excerpt-match fix by cleaning the on-disk artifact itself.

## Implementation note

The plan's literal one-line de-wrap regex `(\w)-?\n(\w)→\1\2` would join non-hyphenated soft-wrapped words **without** a space ("quick\nbrown"→"quickbrown"), harming readability of the stored body. This implements the plan's stated goal ("de-wrap intra-word newlines, preserving paragraph breaks") correctly: de-hyphenate, fold soft-wrap single newlines to a space, preserve blank-line paragraph breaks.

## Testing

`bash cogni-knowledge/tests/test_pdf_extract.sh` — all 4 cases pass (incl. the new one). `test_knowledge_lib.sh` green.

## Follow-up issues

- #970 — surface `--normalize-pdf-body` as an orchestrator opt-in (source-curator / knowledge-ingest-source)
- #971 — operator runbook for fetch-cache eviction before enabling on an existing base