### PR TITLE
cogni-knowledge: trim knowledge-compose SKILL under the 500-line cap

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "cogni-knowledge",
       "source": "./cogni-knowledge",
-      "version": "1.0.60",
+      "version": "1.0.61",
       "maturity": "released",
       "description": "Wiki-first research that compounds. Binds each run to a wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`. The shallow `knowledge-query` rung is read-only by default and can optionally file its answer back as an un-verified synthesis page via `--file-back`.",
       "keywords": [

--- a/cogni-knowledge/.claude-plugin/plugin.json
+++ b/cogni-knowledge/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-knowledge",
-  "version": "1.0.60",
+  "version": "1.0.61",
   "description": "Wiki-first research that compounds. Binds each run to a wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`. The shallow `knowledge-query` rung is read-only by default and can optionally file its answer back as an un-verified synthesis page via `--file-back`.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-knowledge/CHANGELOG.md
+++ b/cogni-knowledge/CHANGELOG.md
@@ -1,5 +1,27 @@
 # cogni-knowledge changelog
 
+## 1.0.61 — knowledge-compose trimmed under the 500-line soft cap (quality-only)
+
+Quality refactor, no behaviour change. `knowledge-compose`'s `SKILL.md` was over
+the 500-line skill-creator soft cap (539 lines) with an over-budget frontmatter
+`description` (~218 words). Two cleanups bring it back in line:
+
+- **Description trimmed** to its triggering essentials — the Phase-5 "what", the
+  `--source wiki` capability one-liner, the trigger-phrase list, and the
+  `knowledge-verify` next-step pointer. The internal-contract detail it
+  re-documented (citation-marker mechanics, the distilled/answer citation rates,
+  `OUTPUT_LANGUAGE` threading, the outline-recovery contract) was dropped from the
+  description; it already lives in the body.
+- **Step 5.5 / Step 7 coverage heredocs offloaded** to a new stdlib-only
+  `scripts/compose-coverage.py` (subcommands `coverage-deficit`, `expand-sections`,
+  `per-sq-coverage`). The subcommands emit the exact raw stdout shapes the SKILL
+  captures — a JSON object, a bare comma-list, and the per-sub-question lines — so
+  the orchestration is byte-identical. The Step 5 on-disk integrity verifier stays
+  inline (it is self-contained).
+
+Result: `SKILL.md` body back under the cap (486 lines) with `test_compose_contract.sh`,
+`test_prose_density_contract.sh`, and a new `test_compose_coverage.sh` all green.
+
 ## 1.0.59 — coverage-gated expansion fires under executive density (ceiling-guarded)
 
 `knowledge-compose`'s Step 5.5 bounded coverage-gated expansion now **acts** on a source-coverage

--- a/cogni-knowledge/scripts/compose-coverage.py
+++ b/cogni-knowledge/scripts/compose-coverage.py
@@ -31,7 +31,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import os
 import sys
 from pathlib import Path
 

--- a/cogni-knowledge/scripts/compose-coverage.py
+++ b/cogni-knowledge/scripts/compose-coverage.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""
+compose-coverage.py — knowledge-compose Step 5.5 / Step 7 coverage helper.
+
+Offloads the three `_knowledge_lib`-delegating coverage snippets that used to
+live inline in `skills/knowledge-compose/SKILL.md` (Step 5.5 coverage-deficit +
+section selector, Step 7 per-sub-question breakdown) so the SKILL body stays
+under the 500-line soft cap. Pure refactor — the logic is byte-for-byte the
+former inline blocks.
+
+Unlike the rest of the cogni-knowledge scripts, the three subcommands print the
+**exact raw stdout shapes** the SKILL captures with `$(...)`, NOT the
+`{"success","data","error"}` envelope — that is the behaviour-preserving
+contract (the SKILL reads `$COVERAGE` as a raw JSON object, `$EXPAND_SECTIONS`
+as a bare comma-list, and the per-sq lines verbatim):
+
+  coverage-deficit  → one JSON object: {"uncited_evidence_sq_ids":[...],
+                                        "zero_cited_sq_ids":[...]}
+  expand-sections   → a bare comma-separated list of section indices ("" if none)
+  per-sq-coverage   → a header line + one "  sq-NN: <cited>/<available> ..." line
+                      per sub-question with ≥1 ingested source (nothing if none)
+
+Fail-soft to match the SKILL's posture: coverage-deficit / expand-sections print
+nothing and exit 1 on any error (the SKILL treats empty output as "no deficit,
+skip expansion"); per-sq-coverage prints nothing and exits 0 (the SKILL wraps it
+`2>/dev/null || true`). Stdlib only; imports `_knowledge_lib` from this script's
+own directory.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _knowledge_lib import coverage_report  # noqa: E402
+
+
+def _load(p: str) -> dict:
+    return json.loads(Path(p).read_text(encoding="utf-8"))
+
+
+def cmd_coverage_deficit(args) -> int:
+    """Step 5.5 Block B — the per-sq deficit + zero-cited sets that drive selection."""
+    rep = coverage_report(_load(args.plan), _load(args.ingest), _load(args.citation))
+    zero_cited = [sq for sq, v in rep["per_sq"].items() if not v["cited"]]
+    print(json.dumps({"uncited_evidence_sq_ids": rep["uncited_evidence_sq_ids"],
+                      "zero_cited_sq_ids": zero_cited}))
+    return 0
+
+
+def cmd_expand_sections(args) -> int:
+    """Step 5.5 Block C — the topical sections eligible to deepen (density-aware)."""
+    o = _load(args.outline)
+    cov = json.loads(args.coverage_json)
+    density = args.density or "standard"
+    deficit = set(cov["uncited_evidence_sq_ids"])
+    zero = set(cov["zero_cited_sq_ids"])
+    chosen = []
+    for s in o.get("sections", []):
+        covers = s.get("covers_sub_questions") or []
+        budget = s.get("budget")
+        if not covers or not isinstance(budget, int):
+            continue  # References / structural section (covers_sub_questions: [])
+        if not (deficit & set(covers)):
+            continue  # no uncited evidence maps to this section — leave it alone
+        covers_zero = bool(zero & set(covers))
+        if density == "executive":
+            # executive caps length: only a zero-cited section qualifies (never thin-but-cited)
+            if covers_zero:
+                chosen.append(str(s["index"]))
+            continue
+        drafted = s.get("drafted_words")
+        thin = isinstance(drafted, int) and drafted < budget * 0.9
+        if thin or covers_zero:
+            chosen.append(str(s["index"]))
+    print(",".join(chosen))
+    return 0
+
+
+def cmd_per_sq_coverage(args) -> int:
+    """Step 7 Block D — the per-sub-question ingested-source cited/available breakdown."""
+    rep = coverage_report(_load(args.plan), _load(args.ingest), _load(args.citation))
+    out = []
+    for sq, v in rep["per_sq"].items():
+        a = len(v["available"])
+        c = len(v["cited"])
+        if a:
+            out.append("  %s: %d/%d ingested sources cited" % (sq, c, a))
+    if out:
+        print("Per-sub-question source coverage (executive caps length, not breadth):")
+        print("\n".join(out))
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="knowledge-compose coverage helper (Step 5.5 / Step 7).")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p_def = sub.add_parser("coverage-deficit", help="Step 5.5 deficit + zero-cited sq-id sets.")
+    p_def.add_argument("--plan", required=True)
+    p_def.add_argument("--ingest", required=True)
+    p_def.add_argument("--citation", required=True)
+    p_def.set_defaults(func=cmd_coverage_deficit, fail_soft_exit=1)
+
+    p_exp = sub.add_parser("expand-sections", help="Step 5.5 EXPAND_SECTIONS selector (density-aware).")
+    p_exp.add_argument("--outline", required=True)
+    p_exp.add_argument("--coverage-json", required=True, dest="coverage_json")
+    p_exp.add_argument("--density", default="standard")
+    p_exp.set_defaults(func=cmd_expand_sections, fail_soft_exit=1)
+
+    p_psq = sub.add_parser("per-sq-coverage", help="Step 7 per-sub-question source-coverage breakdown.")
+    p_psq.add_argument("--plan", required=True)
+    p_psq.add_argument("--ingest", required=True)
+    p_psq.add_argument("--citation", required=True)
+    p_psq.set_defaults(func=cmd_per_sq_coverage, fail_soft_exit=0)
+
+    args = parser.parse_args()
+    try:
+        return args.func(args)
+    except Exception:
+        # Fail-soft: print nothing; the SKILL treats empty output as "no deficit"
+        # (deficit/selector → exit 1) and swallows per-sq errors (exit 0).
+        return args.fail_soft_exit
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/cogni-knowledge/skills/knowledge-compose/SKILL.md
+++ b/cogni-knowledge/skills/knowledge-compose/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: knowledge-compose
-description: "Phase 5 of the inverted pipeline. Reads <project>/.metadata/plan.json + <project>/.metadata/ingest-manifest.json + the populated cogni-wiki, dispatches a wiki-composer pass (plus ONE bounded fail-soft zero-network coverage-gated re-dispatch when a sub-question has ingested evidence the draft left uncited — under standard density target_words is a soft upper budget (never a floor); under executive density the re-dispatch is ceiling-bounded and zero-cited-only so it never breaches the target_words ceiling), and lands <project>/output/draft-vN.md + <project>/.metadata/citation-manifest.json. Inline citations are clickable numbered [N] markers; [[sources/<slug>]] wikilinks live only in the reference list. Surfaces the per-kind citation breakdown — the distilled-citation rate (dcl) and the question-node answer-citation rate (acl) — in its claim_kinds output, the wiki/log.md line, and the run summary. Output language + reference heading follow plan.json::output_language (threaded as OUTPUT_LANGUAGE). Preserves the outline-recovery contract — a leftover writer-outline-vN.json from a crashed prior run causes Phase 1 of the composer to be skipped. Supports --source wiki to compose a report grounded only in the bound wiki + fetch-cache with no web crawl (default web unchanged; local/hybrid staged). Use this skill whenever the user says 'compose the draft', 'write the report from the wiki', 'wiki-only report', 'compose from the wiki only', 'no web crawl report', 'phase 5 of the knowledge pipeline', 'knowledge compose', 'draft v1', or 'run the writer'. After compose, knowledge-verify will run the zero-network claim alignment."
+description: "Phase 5 of the inverted pipeline. Reads <project>/.metadata/plan.json + <project>/.metadata/ingest-manifest.json + the populated cogni-wiki, dispatches a wiki-composer pass (plus ONE bounded fail-soft zero-network coverage-gated re-dispatch when a sub-question has ingested evidence the draft left uncited), and lands <project>/output/draft-vN.md + <project>/.metadata/citation-manifest.json. Supports --source wiki to compose a report grounded only in the bound wiki + fetch-cache with no web crawl (default web unchanged; local/hybrid staged). Use this skill whenever the user says 'compose the draft', 'write the report from the wiki', 'wiki-only report', 'compose from the wiki only', 'no web crawl report', 'phase 5 of the knowledge pipeline', 'knowledge compose', 'draft v1', or 'run the writer'. After compose, knowledge-verify will run the zero-network claim alignment."
 allowed-tools: Read, Write, Bash, Task
 ---
 
@@ -314,26 +314,13 @@ A draft is **complete** when every sub-question is grounded in the evidence the 
 **Compute the coverage deficit (deterministic).** Word count plays **no** role in deciding to expand. Read `plan.json` + `ingest-manifest.json` + `citation-manifest.json` and call `_knowledge_lib.coverage_report` (the single canonical coverage surface, unit-tested in `tests/test_knowledge_lib.sh`) to get, per sub-question, the ingested source slugs `available` / `cited` / `uncited`, plus `uncited_evidence_sq_ids` (the sub-questions with ≥1 uncited ingested source — a coverage deficit WITH evidence to close it). Paths via env vars:
 
 ```
-COVERAGE=$(KNOWLEDGE_SCRIPTS="${CLAUDE_PLUGIN_ROOT}/scripts" \
-PLAN_PATH="<project_path>/.metadata/plan.json" \
-INGEST_PATH="<project_path>/.metadata/ingest-manifest.json" \
-MANIFEST_PATH="<project_path>/.metadata/citation-manifest.json" \
-python3 -c '
-import json, os, sys
-from pathlib import Path
-sys.path.insert(0, os.environ["KNOWLEDGE_SCRIPTS"])
-from _knowledge_lib import coverage_report
-def _load(p):
-    return json.loads(Path(p).read_text(encoding="utf-8"))
-rep = coverage_report(_load(os.environ["PLAN_PATH"]),
-                      _load(os.environ["INGEST_PATH"]),
-                      _load(os.environ["MANIFEST_PATH"]))
-# The deficit sq-id set + the per-sq zero-cited set drive section selection below.
-zero_cited = [sq for sq, v in rep["per_sq"].items() if not v["cited"]]
-print(json.dumps({"uncited_evidence_sq_ids": rep["uncited_evidence_sq_ids"],
-                  "zero_cited_sq_ids": zero_cited}))
-')
+COVERAGE=$(python3 "${CLAUDE_PLUGIN_ROOT}/scripts/compose-coverage.py" coverage-deficit \
+    --plan "<project_path>/.metadata/plan.json" \
+    --ingest "<project_path>/.metadata/ingest-manifest.json" \
+    --citation "<project_path>/.metadata/citation-manifest.json")
 ```
+
+`compose-coverage.py coverage-deficit` calls `_knowledge_lib.coverage_report` and prints one JSON object — `{"uncited_evidence_sq_ids": [...], "zero_cited_sq_ids": [...]}` (`zero_cited_sq_ids` = the sub-questions with no cited ingested source) — captured verbatim into `$COVERAGE`. It prints nothing and exits non-zero on any error, so the empty-output skip below is the fail-soft path.
 
 If the snippet errors or returns empty (e.g. an unreadable manifest), treat it as no deficit and skip expansion with `expansion skipped: coverage report unavailable` — the whole step is fail-soft, so a missing measurement never blocks the deposit. If `uncited_evidence_sq_ids` is empty, skip with `expansion skipped: coverage met (every sub-question's ingested evidence is cited)` — a short-but-fully-grounded draft is the intended outcome, not a deficit.
 
@@ -344,40 +331,13 @@ The coverage gate is deliberately independent of the `wiki-reviewer` advisory Wo
 **Select `EXPAND_SECTIONS`** from the just-written outline `<project_path>/.metadata/writer-outline-v<N>.json` — the topical sections (excluding the References section, `covers_sub_questions: []`) that **cover ≥1 sq in `uncited_evidence_sq_ids`**. Under `standard` density a section qualifies when it is **thin** (`drafted_words < budget × 0.9`) **or covers a zero-cited sq** (a sq in `zero_cited_sq_ids`). Under `executive` density the thin path is dropped — **only a section that covers a zero-cited sq qualifies** (executive caps *length*, so a section that already carries its citation must never be padded toward a thin-budget threshold; deepen only the thinnest, zero-cited sub-questions). This is conservative by design — the brevity-first intent prefers under-firing (no padding) over over-firing. Paths via env vars (`COVERAGE` is the JSON the snippet above printed; `PROSE_DENSITY` is the resolved density):
 
 ```
-OUTLINE_PATH="<project_path>/.metadata/writer-outline-v<N>.json" \
-COVERAGE_JSON="$COVERAGE" \
-PROSE_DENSITY_VAL="<PROSE_DENSITY>" \
-python3 -c '
-import json, os
-from pathlib import Path
-o = json.loads(Path(os.environ["OUTLINE_PATH"]).read_text(encoding="utf-8"))
-cov = json.loads(os.environ["COVERAGE_JSON"])
-density = os.environ.get("PROSE_DENSITY_VAL", "standard")
-deficit = set(cov["uncited_evidence_sq_ids"])
-zero = set(cov["zero_cited_sq_ids"])
-chosen = []
-for s in o.get("sections", []):
-    covers = s.get("covers_sub_questions") or []
-    budget = s.get("budget")
-    if not covers or not isinstance(budget, int):
-        continue  # References / structural section (covers_sub_questions: [])
-    if not (deficit & set(covers)):
-        continue  # no uncited evidence maps to this section — leave it alone
-    covers_zero = bool(zero & set(covers))
-    if density == "executive":
-        # executive caps length: only a zero-cited section qualifies (never thin-but-cited)
-        if covers_zero:
-            chosen.append(str(s["index"]))
-        continue
-    drafted = s.get("drafted_words")
-    thin = isinstance(drafted, int) and drafted < budget * 0.9
-    if thin or covers_zero:
-        chosen.append(str(s["index"]))
-print(",".join(chosen))
-'
+EXPAND_SECTIONS=$(python3 "${CLAUDE_PLUGIN_ROOT}/scripts/compose-coverage.py" expand-sections \
+    --outline "<project_path>/.metadata/writer-outline-v<N>.json" \
+    --coverage-json "$COVERAGE" \
+    --density "<PROSE_DENSITY>")
 ```
 
-Capture this as `EXPAND_SECTIONS`. **The gate fires iff `EXPAND_SECTIONS` is non-empty.** If it is empty, skip with `expansion skipped: no thin/zero-cited section maps to the uncited evidence` (under `executive`: `expansion skipped: no zero-cited section maps to the uncited evidence`) — deepening a section already at budget (or, under executive, one that already carries its citation) would only pad.
+`compose-coverage.py expand-sections` reads the outline + the `$COVERAGE` JSON and prints the bare comma-list of qualifying section indices. Its selector branches on `density == "executive"` (only a zero-cited section qualifies — executive caps *length*, so it never deepens a thin-but-already-cited section) vs `standard` (a section qualifies when it is **thin**, `drafted_words < budget × 0.9`, **or** covers a zero-cited sq); a section whose `covers_sub_questions` doesn't intersect `uncited_evidence_sq_ids` is left alone. **The gate fires iff `EXPAND_SECTIONS` is non-empty.** If it is empty, skip with `expansion skipped: no thin/zero-cited section maps to the uncited evidence` (under `executive`: `expansion skipped: no zero-cited section maps to the uncited evidence`) — deepening a section already at budget (or, under executive, one that already carries its citation) would only pad.
 
 Stamp `START_MS=$(python3 -c 'import time; print(int(time.time()*1000))')` immediately before the re-dispatch (same Option B timing as Step 4). **Re-dispatch the composer ONCE** at `N+1` in expansion mode (same knob values as Step 4). Its purpose is to deepen the named sections **from the specific not-yet-cited wiki evidence** for their sub-questions, not to close a word count:
 
@@ -464,26 +424,13 @@ Surface a density-aware summary line — but do not auto-retry. The two densitie
 Then, **under either density**, surface a **per-sub-question source-coverage breakdown** so the operator sees an evidence-*breadth* gap (e.g. a sub-question whose ingested first-party sources went uncited) before finalize — executive density legitimately caps *length*, never *breadth*. The two aggregate lines above (`Sources:` and the `coverage:`/ceiling line) hide which sub-questions are thin, and on an `executive` run Step 5.5's `COVERAGE` may not be in this scope (it is computed inside the Step-5.5 subshell, and Step 5.5 can short-circuit before computing it — e.g. the executive ceiling pre-check), so compute `_knowledge_lib.coverage_report` here **density-independently**. Re-declare the three manifest paths inline (they live only inside the Step-5.5 subshell, not in this scope, exactly as the `Sources:` line re-declares its `C`/`I`) and print, per sub-question with ≥1 ingested (`available`) source, a `  sq-NN: <cited>/<available> ingested sources cited` line — omitting any sub-question with no ingested evidence (zero `available` is not a gap, mirroring `coverage_report`'s own exclusion from `uncited_evidence_sq_ids`). The `per_sq[sq].available`/`.cited` values are source-slug **lists**, so display their `len()`. Fail-soft via the env-var `python3 -c` pattern (never interpolate paths into the literal): on any compute error omit the breakdown silently, never blocking the summary.
 
 ```
-PLAN="$PROJECT_PATH/.metadata/plan.json" \
-ING="$PROJECT_PATH/.metadata/ingest-manifest.json" \
-CIT="$PROJECT_PATH/.metadata/citation-manifest.json" \
-KS="${CLAUDE_PLUGIN_ROOT}/scripts" python3 -c '
-import json, os, sys
-sys.path.insert(0, os.environ["KS"])
-from _knowledge_lib import coverage_report
-def L(p):
-    return json.load(open(p, encoding="utf-8"))
-rep = coverage_report(L(os.environ["PLAN"]), L(os.environ["ING"]), L(os.environ["CIT"]))
-out = []
-for sq, v in rep["per_sq"].items():
-    a = len(v["available"]); c = len(v["cited"])
-    if a:
-        out.append("  %s: %d/%d ingested sources cited" % (sq, c, a))
-if out:
-    print("Per-sub-question source coverage (executive caps length, not breadth):")
-    print("\n".join(out))
-' 2>/dev/null || true
+python3 "${CLAUDE_PLUGIN_ROOT}/scripts/compose-coverage.py" per-sq-coverage \
+    --plan "$PROJECT_PATH/.metadata/plan.json" \
+    --ingest "$PROJECT_PATH/.metadata/ingest-manifest.json" \
+    --citation "$PROJECT_PATH/.metadata/citation-manifest.json" 2>/dev/null || true
 ```
+
+`compose-coverage.py per-sq-coverage` calls `_knowledge_lib.coverage_report` and prints, per sub-question with ≥1 ingested (`available`) source, a `  sq-NN: <cited>/<available> ingested sources cited` line under a header (omitting any sub-question with no ingested evidence); it prints nothing on a compute error, so the breakdown is silently skipped fail-soft.
 
 The advisory `wiki-reviewer` (finalize Step 10.7) independently re-scores the draft — under `standard` it only flags a likely-*truncated* draft (`< 0.50` of budget), never a short-but-complete one; under `executive` it caps on excess. The compose-time line is a fast heads-up, not a gate.
 

--- a/cogni-knowledge/tests/test_compose_contract.sh
+++ b/cogni-knowledge/tests/test_compose_contract.sh
@@ -306,7 +306,8 @@ assert_grep 'capped at ONE\|capped at one\|cap = 1\|ONE bounded\|one bounded\|ON
 assert_grep 'executive ceiling already met' "$COMPOSE" "knowledge-compose: Step 5.5 executive pre-expansion ceiling guard skip token"
 assert_grep 'neither .standard. nor .executive.\|neither \`standard\` nor \`executive\`' "$COMPOSE" "knowledge-compose: Step 5.5 density skip now only fires for a density that is neither standard nor executive"
 assert_grep 'density == "executive"' "$COMPOSE" "knowledge-compose: Step 5.5 EXPAND_SECTIONS selector branches on executive density"
-assert_grep 'PROSE_DENSITY_VAL' "$COMPOSE" "knowledge-compose: Step 5.5 selector threads the resolved PROSE_DENSITY into the section chooser"
+assert_grep 'compose-coverage.py expand-sections' "$COMPOSE" "knowledge-compose: Step 5.5 selector is offloaded to compose-coverage.py expand-sections"
+assert_grep '\-\-density "<PROSE_DENSITY>"' "$COMPOSE" "knowledge-compose: Step 5.5 selector threads the resolved PROSE_DENSITY into the section chooser (--density)"
 assert_grep 'zero-cited deficit sub-question\|zero-cited deficit sub-questions\|only a section that covers a zero-cited sq qualifies' "$COMPOSE" "knowledge-compose: Step 5.5 executive selects zero-cited deficit sub-questions only (never thin-but-cited)"
 # wiki-composer must enforce the executive ceiling DURING the expansion pass, not
 # just trim afterward on the normal pass.

--- a/cogni-knowledge/tests/test_compose_coverage.sh
+++ b/cogni-knowledge/tests/test_compose_coverage.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# test_compose_coverage.sh — contract test for scripts/compose-coverage.py.
+#
+# The script offloads knowledge-compose's Step 5.5 / Step 7 inline coverage
+# heredocs. The behaviour-preserving contract is that each subcommand reproduces
+# the EXACT raw stdout shape the SKILL captures with $(...):
+#   coverage-deficit → one JSON object {uncited_evidence_sq_ids, zero_cited_sq_ids}
+#   expand-sections  → a bare comma-list of section indices (density-aware)
+#   per-sq-coverage  → a header line + one per-sub-question line
+# Host-independent: synthetic fixtures, stdlib python3 only.
+
+set -eu
+
+PLUGIN_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT="$PLUGIN_ROOT/scripts/compose-coverage.py"
+
+. "$(dirname "$0")/fixtures/test_helpers.sh"
+
+if [ ! -f "$SCRIPT" ]; then
+  red "FAIL: compose-coverage.py not found at $SCRIPT"
+  exit 1
+fi
+
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+# --- fixtures -----------------------------------------------------------------
+# sq-01: 2 ingested (src-a cited, src-b uncited)  → deficit, NOT zero-cited
+# sq-02: 1 ingested (src-b, uncited)              → deficit, zero-cited
+# sq-03: 1 ingested (src-c, uncited)              → deficit, zero-cited
+cat > "$WORK/plan.json" <<'JSON'
+{"sub_questions": [{"id": "sq-01"}, {"id": "sq-02"}, {"id": "sq-03"}]}
+JSON
+cat > "$WORK/ingest.json" <<'JSON'
+{"ingested": [
+  {"slug": "src-a", "sub_question_refs": ["sq-01"]},
+  {"slug": "src-b", "sub_question_refs": ["sq-01", "sq-02"]},
+  {"slug": "src-c", "sub_question_refs": ["sq-03"]}
+]}
+JSON
+cat > "$WORK/citation.json" <<'JSON'
+{"citations": [{"wiki_slug": "src-a"}]}
+JSON
+# section 0 covers sq-01 (thin: 50/100), section 1 covers sq-02 (full: 95/100),
+# section 2 is structural (covers nothing).
+cat > "$WORK/outline.json" <<'JSON'
+{"sections": [
+  {"index": 0, "covers_sub_questions": ["sq-01"], "budget": 100, "drafted_words": 50},
+  {"index": 1, "covers_sub_questions": ["sq-02"], "budget": 100, "drafted_words": 95},
+  {"index": 2, "covers_sub_questions": [], "budget": 50, "drafted_words": 40}
+]}
+JSON
+
+errors=0
+emit() { # tag description
+  case "$1" in
+    OK) green "PASS: $2" ;;
+    *)  red "FAIL: $2"; red "  $1"; errors=$((errors + 1)) ;;
+  esac
+}
+
+# --- coverage-deficit: raw JSON with both key sets -----------------------------
+DEFICIT=$(python3 "$SCRIPT" coverage-deficit --plan "$WORK/plan.json" \
+  --ingest "$WORK/ingest.json" --citation "$WORK/citation.json")
+RES=$(DEF="$DEFICIT" python3 -c '
+import json, os
+d = json.loads(os.environ["DEF"])
+assert d["uncited_evidence_sq_ids"] == ["sq-01", "sq-02", "sq-03"], d
+assert d["zero_cited_sq_ids"] == ["sq-02", "sq-03"], d
+print("OK")
+' 2>&1 || true)
+emit "$RES" "coverage-deficit — raw JSON with uncited_evidence_sq_ids + zero_cited_sq_ids (src-b/src-c uncited; sq-02/sq-03 zero-cited)"
+
+# --- expand-sections: density-aware bare comma-list ----------------------------
+EXP_STD=$(python3 "$SCRIPT" expand-sections --outline "$WORK/outline.json" \
+  --coverage-json "$DEFICIT" --density standard)
+[ "$EXP_STD" = "0,1" ] && emit OK "expand-sections (standard) — thin sq-01 + zero-cited sq-02 → '0,1'" \
+  || emit "got: '$EXP_STD' want '0,1'" "expand-sections (standard) — thin sq-01 + zero-cited sq-02 → '0,1'"
+
+EXP_EXEC=$(python3 "$SCRIPT" expand-sections --outline "$WORK/outline.json" \
+  --coverage-json "$DEFICIT" --density executive)
+[ "$EXP_EXEC" = "1" ] && emit OK "expand-sections (executive) — only zero-cited sq-02 qualifies → '1' (thin-but-cited sq-01 dropped)" \
+  || emit "got: '$EXP_EXEC' want '1'" "expand-sections (executive) — only zero-cited sq-02 qualifies → '1' (thin-but-cited sq-01 dropped)"
+
+# --- per-sq-coverage: header + per-sub-question lines ---------------------------
+PSQ=$(python3 "$SCRIPT" per-sq-coverage --plan "$WORK/plan.json" \
+  --ingest "$WORK/ingest.json" --citation "$WORK/citation.json")
+RES=$(PSQ="$PSQ" python3 -c '
+import os
+lines = os.environ["PSQ"].splitlines()
+assert lines[0] == "Per-sub-question source coverage (executive caps length, not breadth):", lines
+assert "  sq-01: 1/2 ingested sources cited" in lines, lines
+assert "  sq-02: 0/1 ingested sources cited" in lines, lines
+assert "  sq-03: 0/1 ingested sources cited" in lines, lines
+print("OK")
+' 2>&1 || true)
+emit "$RES" "per-sq-coverage — header + per-sub-question cited/available lines"
+
+# --- fail-soft: coverage-deficit on a missing file prints nothing, exits 1 -----
+OUT=$(python3 "$SCRIPT" coverage-deficit --plan "$WORK/nope.json" \
+  --ingest "$WORK/ingest.json" --citation "$WORK/citation.json" 2>/dev/null && echo "RC0" || echo "RC1")
+[ "$OUT" = "RC1" ] && emit OK "coverage-deficit — fail-soft: missing file → no stdout, exit 1 (SKILL treats empty as 'no deficit, skip')" \
+  || emit "got: '$OUT'" "coverage-deficit — fail-soft: missing file → no stdout, exit 1"
+
+# --- fail-soft: per-sq-coverage on a missing file prints nothing, exits 0 ------
+PSQ_ERR=$(python3 "$SCRIPT" per-sq-coverage --plan "$WORK/nope.json" \
+  --ingest "$WORK/ingest.json" --citation "$WORK/citation.json" 2>/dev/null; echo "rc=$?")
+[ "$PSQ_ERR" = "rc=0" ] && emit OK "per-sq-coverage — fail-soft: missing file → no stdout, exit 0 (SKILL wraps it 2>/dev/null || true)" \
+  || emit "got: '$PSQ_ERR'" "per-sq-coverage — fail-soft: missing file → no stdout, exit 0"
+
+if [ $errors -gt 0 ]; then
+  red "$errors case(s) failed."
+  exit 1
+fi
+
+green ""
+green "All compose-coverage.py cases pass."


### PR DESCRIPTION
Closes #973.

## Summary

Quality-only refactor of `knowledge-compose` (no behavior change). The SKILL was over the 500-line skill-creator soft cap (539 lines) with an over-budget frontmatter `description` (~218 words). Two cleanups:

- **Description trimmed** to triggering essentials (Phase-5 what · `--source wiki` one-liner · trigger-phrase list · `knowledge-verify` next-step). Internal-contract detail it re-documented — citation-marker mechanics, distilled/answer citation rates, `OUTPUT_LANGUAGE` threading, the outline-recovery contract — was dropped from the description; it already lives in the body. Now ~115 words, matching sibling `knowledge-finalize`.
- **Step 5.5 / Step 7 coverage heredocs offloaded** to a new stdlib-only `scripts/compose-coverage.py` (subcommands `coverage-deficit`, `expand-sections`, `per-sq-coverage`). The Step 5 on-disk integrity verifier stays inline (self-contained).
- Body back under the cap: **539 → 486 lines**.
- Version bump cogni-knowledge `1.0.60 → 1.0.61` (plugin.json + marketplace.json mirror) + CHANGELOG.

## Behavior preservation (load-bearing)

The three subcommands emit the **exact raw stdout shapes** the SKILL captures with `$(...)` — a JSON object for `coverage-deficit`, a bare comma-list for `expand-sections`, plain per-sub-question lines for `per-sq-coverage` — **not** the `{success,data,error}` envelope, so the orchestration is byte-identical. Fail-soft posture mirrors the former inline blocks (deficit/selector → no stdout + exit 1 = "no deficit, skip"; per-sq → no stdout + exit 0). Every literal the contract tests grep for (`coverage_report`, `uncited_evidence_sq_ids`, `EXPAND_SECTIONS`, `density == "executive"`, `body_word_count`, `coverage:`, `Over ceiling`, …) is preserved in the replacement call-lines / surrounding prose.

## Testing

- `tests/test_compose_contract.sh` — pass (updated the one assertion that pinned the old inline `PROSE_DENSITY_VAL` env var to the new `--density` flag).
- `tests/test_prose_density_contract.sh` — pass.
- `tests/test_compose_coverage.sh` (new) — pass: asserts each subcommand reproduces its exact stdout shape + the standard-vs-executive selector branching + the two fail-soft exit codes.
- `python3 -m py_compile scripts/compose-coverage.py` clean; breadcrumb guard clean (0 new violations).