### PR TITLE
cogni-knowledge: operator runbook for safe --normalize-pdf-body enable on an existing base

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "cogni-knowledge",
       "source": "./cogni-knowledge",
-      "version": "1.0.62",
+      "version": "1.0.63",
       "maturity": "released",
       "description": "Wiki-first research that compounds. Binds each run to a wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`. The shallow `knowledge-query` rung is read-only by default and can optionally file its answer back as an un-verified synthesis page via `--file-back`.",
       "keywords": [

--- a/cogni-knowledge/.claude-plugin/plugin.json
+++ b/cogni-knowledge/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-knowledge",
-  "version": "1.0.62",
+  "version": "1.0.63",
   "description": "Wiki-first research that compounds. Binds each run to a wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`. The shallow `knowledge-query` rung is read-only by default and can optionally file its answer back as an un-verified synthesis page via `--file-back`.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-knowledge/CHANGELOG.md
+++ b/cogni-knowledge/CHANGELOG.md
@@ -1,5 +1,22 @@
 # cogni-knowledge changelog
 
+## 1.0.63 — operator runbook for enabling --normalize-pdf-body on an existing base
+
+Adds `references/normalize-pdf-body-runbook.md`, the operator guidance deferred from
+the `--normalize-pdf-body` opt-in work. Enabling the flag on an existing base is a
+no-op unless the affected raw-body PDF entries are first evicted from the shared
+fetch-cache — a `fetch-cache.py fetch` cache hit short-circuits re-extraction, so the
+normalized body never lands, and the normalized body's `content_hash` diverges from
+the cached raw one. The runbook documents the safe path (evict → re-fetch → re-ingest),
+the **actual** eviction surface (`fetch-cache.py key --url <URL> --bare` to locate and
+hand-delete a single entry, or `evict --older-than-days 0` for a full reset — there is
+no per-URL / per-reason `evict`), and the `content_hash` / Step 3.5 integrity-sweep
+(`ingest-integrity.py`, reason `content_hash_mismatch`) consistency requirement; a fresh
+base is safe from day one. Cross-linked from `fetch-cache-design.md` and the
+`--normalize-pdf-body` option rows of `knowledge-curate` and `knowledge-ingest-source`.
+
+Documentation-only — no script or flag change.
+
 ## 1.0.62 — opt-in --normalize-pdf-body across the orchestrator surfaces
 
 Surfaces the existing `--normalize-pdf-body` PDF-body normalization (the

--- a/cogni-knowledge/README.md
+++ b/cogni-knowledge/README.md
@@ -212,7 +212,7 @@ cogni-knowledge/
 ├── LICENSE                       AGPL-3.0
 ├── _archive/                     Archived research+report chain (see _archive/README.md)
 ├── agents/                       16 forked + new pipeline agents
-├── references/                   20 framework + design docs
+├── references/                   21 framework + design docs
 ├── scripts/                      27 utility scripts (binding, synthesis-impact, cycle-guard, fetch-cache, candidate-store, citation-store, verify-store, wiki-grounding, wiki-coverage, wiki-source-manifest, concept-store, question-store, ingest-integrity, contradiction-ingest-store, pipeline-summary, build_open_questions_payload; vendored wiki-engine: control-path, root_index, sub_index, concepts_index, perspectives_index, overview_update, pdf-extract; one-shot migrators: migrate-layout, migrate-question-index, reclassify-person-entities, backfill_concepts_index) + _knowledge_lib helper
 ├── skills/                       20 knowledge-* skills
 └── tests/                        Contract tests (one per phase)

--- a/cogni-knowledge/references/fetch-cache-design.md
+++ b/cogni-knowledge/references/fetch-cache-design.md
@@ -85,6 +85,8 @@ Default 30 days, configurable per knowledge base in `binding.json`:
 
 `fetch-cache.py --evict --older-than-days N` removes entries older than N days. Run manually (or wired into a `knowledge-refresh --vacuum` future enhancement). v0.1.0 does not auto-evict.
 
+Enabling `--normalize-pdf-body` on an existing base requires evicting the affected raw-body PDF entries first (a cache hit short-circuits re-extraction, so the normalized body never lands otherwise) — see [`normalize-pdf-body-runbook.md`](normalize-pdf-body-runbook.md) for the safe evict → re-fetch → re-ingest procedure and its `content_hash` implications.
+
 ## Reason semantics
 
 Unavailable entries carry a closed-vocabulary `reason` token. Since v0.0.29 (Option B, #292) the **`source-curator` (Phase 2) is the primary cache writer** — it writes every positive `ok` entry and the `webfetch_*` / `pdf_extraction_failed` negative entries during its Phase-4 fetch. The cobrowse-only `source-fetcher` (Phase 3, opt-in) writes only the cobrowse outcomes (`cobrowse_interactive` positives that overwrite a curator negative entry, or `cobrowse_unavailable` / `cobrowse_failed` negatives). `knowledge-fetch`'s summary aggregates the tokens; `source-ingester` reads them when a cached entry has `status: unavailable` to decide whether to skip or retry. The reason vocabulary itself is unchanged. The full list, with semantics:

--- a/cogni-knowledge/references/normalize-pdf-body-runbook.md
+++ b/cogni-knowledge/references/normalize-pdf-body-runbook.md
@@ -1,0 +1,114 @@
+# Runbook: enabling `--normalize-pdf-body` on an existing base
+
+`--normalize-pdf-body` is an opt-in toggle that makes the PDF text-layer fallback
+(`scripts/pdf-extract.py`) store a *cleaned* body — NFKC-folding ligatures, mapping
+smart quotes/dashes to ASCII, and rejoining hyphenated column-wrap breaks. It is
+surfaced as a flag on `knowledge-curate` and `knowledge-ingest-source` (threaded as
+`NORMALIZE_PDF_BODY` to `source-curator`). Default **off**: when the flag is absent
+the stored body and its `content_hash:` stay byte-identical to today.
+
+On a **fresh** base the flag is safe from day one — there are no pre-existing cache
+entries to diverge from. This runbook is only for the **existing-base** case, where
+PDFs were already fetched and stored with the raw (un-normalized) body.
+
+## The hazard
+
+The fetch-cache is content-addressed by URL: one entry per URL at
+`<knowledge-root>/.cogni-knowledge/fetch-cache/<sha256-of-url>.json`, carrying the
+extracted `body` and its `content_hash`. `fetch-cache.py fetch` **short-circuits on a
+cache hit** — it returns the cached body without re-extracting.
+
+Two consequences follow when you flip `--normalize-pdf-body` on an existing base:
+
+1. **A re-ingest alone does nothing.** The next curate/ingest run hits the cached
+   *raw* body and returns it unchanged. The normalization runs only inside
+   `pdf-extract.py` at *extract* time, which is skipped on a cache hit — so the
+   normalized body never lands until the cached entry is removed.
+2. **`content_hash` divergence.** A normalized body hashes differently from the raw
+   one. Each `wiki/sources/<slug>.md` page records the `content_hash:` it was
+   ingested with. The Step 3.5 post-wave integrity sweep
+   (`scripts/ingest-integrity.py sweep --knowledge-root …`) asserts each page's
+   `content_hash:` equals the fetch-cache entry's `content_hash` for that URL
+   (the `content_hash` leg, reason `content_hash_mismatch`). So the cached entry
+   and the page must be regenerated **together** — evict, re-fetch (normalized),
+   re-ingest — or they will disagree. (The leg is fail-safe: a cache miss or empty
+   hash on either side skips it, never a false positive — but the right fix is to
+   keep both sides consistent, not to rely on the skip.)
+
+## The eviction interface (what actually exists)
+
+`fetch-cache.py` evicts **by age only** — there is no per-URL `evict` and no
+per-reason `evict` (per-reason is an explicit future enhancement noted in
+[`fetch-cache-design.md`](fetch-cache-design.md), not shipped). The available knobs:
+
+| Command | What it does |
+|---|---|
+| `fetch-cache.py stat --knowledge-root <root>` | Cache-wide summary (entry count, ages). Start here. |
+| `fetch-cache.py key --url <URL> --bare` | Prints `sha256(<URL>)` — the entry's filename stem under `.cogni-knowledge/fetch-cache/`. Use this to locate (and hand-delete) a single entry. |
+| `fetch-cache.py evict --knowledge-root <root> --older-than-days <N> [--dry-run]` | Removes every entry older than `N` days. `--older-than-days 0` clears the whole cache. `--dry-run` previews without deleting. |
+
+## Procedure
+
+Pick **surgical** (a few known PDF URLs) or **full reset** (small base / simplest).
+
+### Option A — surgical, per-URL (preferred when you know the PDF URLs)
+
+```bash
+KROOT=<path-to-knowledge-base-root>   # the dir holding .cogni-knowledge/
+
+# 1. Locate the entry file for each affected PDF URL.
+STEM=$(python3 cogni-knowledge/scripts/fetch-cache.py key --url "<PDF_URL>" --bare)
+ENTRY="$KROOT/.cogni-knowledge/fetch-cache/$STEM.json"
+
+# 2. (Optional) confirm it is the PDF you expect before removing.
+python3 -c "import json;e=json.load(open('$ENTRY'));print(e['url'],e.get('fetch_method'),e.get('content_hash'))"
+
+# 3. Remove the entry so the next fetch re-extracts with normalization on.
+rm "$ENTRY"
+```
+
+Repeat for each affected PDF URL.
+
+### Option B — full reset (simplest; re-fetches the whole base)
+
+```bash
+# Preview first.
+python3 cogni-knowledge/scripts/fetch-cache.py evict --knowledge-root "$KROOT" --older-than-days 0 --dry-run
+# Then clear all entries.
+python3 cogni-knowledge/scripts/fetch-cache.py evict --knowledge-root "$KROOT" --older-than-days 0
+```
+
+This evicts non-PDF entries too, so the next run re-fetches everything — fine for a
+small base, wasteful for a large one (prefer Option A there).
+
+### Then enable and re-ingest
+
+```bash
+# Re-curate (re-fetches the evicted URLs; PDFs now store the normalized body) …
+/cogni-knowledge:knowledge-curate <project> --normalize-pdf-body
+# … or, for a single hand-added source:
+/cogni-knowledge:knowledge-ingest-source <project> --normalize-pdf-body
+
+# Re-ingest to rewrite the affected wiki/sources/<slug>.md pages with the new content_hash.
+/cogni-knowledge:knowledge-ingest <project>
+```
+
+The Step 3.5 integrity sweep runs inside `knowledge-ingest`; a clean run (no
+`content_hash_mismatch`) confirms each page's `content_hash:` matches its
+freshly-stored normalized cache entry.
+
+## Verification
+
+- `fetch-cache.py stat --knowledge-root "$KROOT"` shows the evicted entries gone (then
+  repopulated after the re-curate).
+- The re-ingest summary reports **no** `integrity_mismatch` skips
+  (`reason: content_hash_mismatch` in particular).
+- Spot-check an affected `wiki/sources/<slug>.md`: its `content_hash:` matches the
+  cache entry for the same URL (`fetch-cache.py fetch --knowledge-root "$KROOT" --url
+  "<PDF_URL>"` reports the same hash).
+
+## Leaving it off
+
+Doing nothing is safe. With the flag off, the cache and pages stay byte-identical to
+today; this runbook is only needed when you deliberately want the cleaned body on a
+base whose PDFs predate the toggle.

--- a/cogni-knowledge/skills/knowledge-curate/SKILL.md
+++ b/cogni-knowledge/skills/knowledge-curate/SKILL.md
@@ -29,7 +29,7 @@ Read `${CLAUDE_PLUGIN_ROOT}/references/inverted-pipeline.md` §"Phase 2 — `kno
 | `--knowledge-root` | No | Override the default knowledge-base directory. |
 | `--sub-question-ids` | No | Comma-separated subset of sub-question ids to curate (e.g. `sq-01,sq-03`). Default: all from `plan.json`. Useful for resuming a partial curate. |
 | `--dry-run` | No | Print the dispatch plan without running curators. |
-| `--normalize-pdf-body` | No | Opt-in: thread `NORMALIZE_PDF_BODY=true` to every `source-curator` dispatch so the Phase-4 `pdf-extract.py` text-layer fallback stores a normalized body (NFKC-fold ligatures, map smart quotes/dashes to ASCII, rejoin hyphenated column-wrap breaks). Default off — the flag is not threaded, so the stored body / `content_hash` stay byte-identical. Applies only when `pypdf` is available and the Read tool cannot render the PDF. |
+| `--normalize-pdf-body` | No | Opt-in: thread `NORMALIZE_PDF_BODY=true` to every `source-curator` dispatch so the Phase-4 `pdf-extract.py` text-layer fallback stores a normalized body (NFKC-fold ligatures, map smart quotes/dashes to ASCII, rejoin hyphenated column-wrap breaks). Default off — the flag is not threaded, so the stored body / `content_hash` stay byte-identical. Applies only when `pypdf` is available and the Read tool cannot render the PDF. Enabling this on an **existing** base needs the affected raw-body PDF cache entries evicted first — see `references/normalize-pdf-body-runbook.md`. |
 
 ## Workflow
 

--- a/cogni-knowledge/skills/knowledge-ingest-source/SKILL.md
+++ b/cogni-knowledge/skills/knowledge-ingest-source/SKILL.md
@@ -60,7 +60,7 @@ more than one is an error.
 | `--sub-question-refs` | No | Comma-separated `sq-NN` ids to tag the page (carried to `claim-extractor` and the page frontmatter). Defaults to a single synthetic `sq-00` so the claim-extractor contract is satisfied; the standalone surface has no plan. |
 | `--theme` | No | Thematic index category (the `## <theme>` heading the source is filed under in `wiki/index.md`). Defaults to `Sources`. |
 | `--dry-run` | No | Print the resolved plan (URL, slug, dedup verdict) without fetching, writing, or indexing. |
-| `--normalize-pdf-body` | No | Opt-in: when the PDF text-layer fallback (`pdf-extract.py`, Step 1) runs, append `--normalize-pdf-body` to it so the stored body is cleaned (NFKC-fold ligatures, map smart quotes/dashes to ASCII, rejoin hyphenated column-wrap breaks). Default off — the flag is not appended, so the stored body / `content_hash` stay byte-identical. Applies only to the `pdf-extract.py` fallback path; the Read-tool page-loop path is unaffected. |
+| `--normalize-pdf-body` | No | Opt-in: when the PDF text-layer fallback (`pdf-extract.py`, Step 1) runs, append `--normalize-pdf-body` to it so the stored body is cleaned (NFKC-fold ligatures, map smart quotes/dashes to ASCII, rejoin hyphenated column-wrap breaks). Default off — the flag is not appended, so the stored body / `content_hash` stay byte-identical. Applies only to the `pdf-extract.py` fallback path; the Read-tool page-loop path is unaffected. Enabling this on an **existing** base needs the affected raw-body PDF cache entries evicted first — see `references/normalize-pdf-body-runbook.md`. |
 
 ## When to run
 


### PR DESCRIPTION
Closes #971.

## Summary
- Adds `cogni-knowledge/references/normalize-pdf-body-runbook.md` — the safe path to enable `--normalize-pdf-body` on an **existing** base.
- Documents the hazard: enabling the flag without evicting cached raw-body PDF entries is a no-op (the next ingest hits the cached raw body via a `fetch-cache.py fetch` cache hit, so the normalized body never lands), and the normalized body's `content_hash` diverges from the raw one.
- Documents the **actual** eviction surface (no per-URL / per-reason `evict` exists): `fetch-cache.py key --url <URL> --bare` to locate the entry file under `.cogni-knowledge/fetch-cache/<sha256>.json` and hand-delete it for surgical per-URL eviction, or `fetch-cache.py evict --older-than-days 0` for the documented full reset (`--dry-run` previews).
- Spells out the `content_hash` / Step 3.5 integrity-sweep (`ingest-integrity.py sweep`, reason `content_hash_mismatch`) implication: page frontmatter and cache entry must be regenerated together (evict → re-fetch → re-ingest); a fresh base is safe from day one.
- Adds minimal discoverability cross-links: from `references/fetch-cache-design.md`'s `## Eviction` section and the `--normalize-pdf-body` option rows of both `knowledge-curate` and `knowledge-ingest-source` SKILLs.
- Bumps the README references-tree count 20 → 21; bumps cogni-knowledge 1.0.62 → 1.0.63 (plugin.json + marketplace.json) + CHANGELOG.

## Scope decisions
- **In:** the runbook reference doc, three one-line cross-links, README count, CHANGELOG, version bump.
- **Out:** any change to `fetch-cache.py` — documentation-only operator guidance, per the issue. A per-URL / per-reason `evict` subcommand is an explicit future enhancement noted in `fetch-cache-design.md`; the runbook documents the hand-delete-via-`key` workaround rather than adding code.

## Test plan
- [x] Runbook references only commands that exist (`fetch-cache.py key/evict/stat`, `ingest-integrity.py sweep`) — no invented per-URL/per-reason `evict`.
- [x] `fetch-cache-design.md` `## Eviction` and both SKILL `--normalize-pdf-body` rows link to the runbook.
- [x] plugin.json + marketplace.json both at 1.0.63; CHANGELOG has a 1.0.63 entry; README references count = 21.
- [x] `check-breadcrumbs.py` passes clean (0 violations).
- [x] plugin.json + marketplace.json parse as valid JSON.