### PR TITLE
Add cogni-knowledge YouTube video script for consulting boutiques

### DIFF
--- a/docs/video-script-cogni-knowledge.md
+++ b/docs/video-script-cogni-knowledge.md
@@ -1,0 +1,174 @@
+# Video script — cogni-knowledge ("Research that compounds")
+
+> **Briefing for the presenter.** Two ready-to-shoot scripts for explaining the `cogni-knowledge` plugin to a consulting-boutique audience. **The Short Cut (~3 min)** is the trailer — drop it on LinkedIn or as a channel teaser. **The Deep Cut (~12 min)** is the explainer — the one a prospect watches before they install. Both stand on their own; cogni-knowledge is sold here on its own merits, not as a bolt-on to any other plugin.
+
+| Field | Value |
+|---|---|
+| **Subject** | `cogni-knowledge` — the wiki-first, compounding-knowledge research engine of insight-wave (v1.0.x, Released) |
+| **Target viewer** | The founder / principal of a small consulting boutique (2–20 people). Smart, time-poor, allergic to hype and vendor lock-in. Bills by the insight, not the hour. |
+| **Core promise** | "Stop throwing away the research under every report. Build a knowledge base that gets sharper — and cheaper to run — with every project." |
+| **Tone** | Confident, plain-spoken, lightly witty. Respect the viewer's intelligence. Show, don't gush. No buzzwords without a plain-language gloss. |
+| **One-line description** | A research engine that files every verified finding into a wiki your next project reads first — so your tenth deliverable stands on nine projects of checked, traceable evidence. |
+| **Suggested title** | *"Why your research keeps starting from zero (and the fix)"* |
+
+---
+
+## Script A — The Short Cut (~3 min · ~310 words VO + visual beats)
+
+| # | VISUAL / ON-SCREEN | NARRATION (VO) |
+|---|---|---|
+| A1 | Cold open. A polished PDF report slides across a desk. The instant it lands, it dissolves into pixels and blows away. Hard cut to black. | "You already paid to dig up the research behind that report. The moment it ships, it's gone — and in a few months, you'll pay to dig it all up again." |
+| A2 | Relatable scene: a consultant at 11pm, six browser tabs open, typing a search they *know* they ran last quarter. Title card: **"Re-researching. Again."** | "A related question lands. Six tabs open, re-running a search you *know* you ran last quarter. Worse — a client challenges a number, and you're spelunking through old chat logs trying to remember where it came from. That's not research. That's re-research — and you're paying for it twice." |
+| A3 | Logo: **cogni-knowledge**. Tagline animates in: *"Wiki-first research that compounds."* | "This is cogni-knowledge. It's a research engine built on one stubborn idea: research should compound — not evaporate." |
+| A4 | Animated diagram. A research run flows left-to-right; at the end, a verified page drops into a stack labelled **WIKI**. The *next* run starts by reading that stack *before* going to the web. | "Every run deposits its verified findings into a persistent wiki. And the next run reads that wiki first — before it ever touches the web. Run two stands on run one. Run ten stands on nine." |
+| A5 | Three clean cards snap in, one at a time. | "Three things that means for your boutique." |
+| A6 | Card 1: **COMPOUNDS** — a small wiki growing denser, project over project. | "One. Your knowledge base gets denser and more useful with every project — instead of resetting to empty." |
+| A7 | Card 2: **TRUSTED** — a sentence with a `[3]` citation; a checkmark snaps onto it. Subtitle: *"checked against its source — zero network calls."* | "Two. Every citation is checked for consistency against the source it came from — so your report can't drift from its own evidence. Not 'hope the model quoted it right' — checked, automatically. Anything unsupported gets revised before it ships." |
+| A8 | Card 3: **YOURS** — a folder of `.md` files opening in Obsidian; a git commit ticks by. Subtitle: *"No vector store. No lock-in."* | "Three. The whole base is plain markdown. No vector store, no embeddings, no lock-in. You read it, grep it, edit it, and version it in git. It's yours." |
+| A9 | Screen capture: `knowledge-setup` runs once; then `knowledge-run` drives the pipeline; at the end a synthesis file appears under `wiki/syntheses/`. | "Setting it up is one command. Then you point it at a topic and it runs the whole pipeline — plan, gather sources, verify, and file the result. At the end, a verified synthesis lands in your wiki, stamped with exactly which run produced it." |
+| A10 | Obsidian view: clicking a citation jumps to the source page. Text overlay: *"Defend any fact in one lookup."* | "So when someone asks 'where did this come from?' — it's one click, not an afternoon." |
+| A11 | End card: **cogni-knowledge** · *"Your tenth project, backed by nine."* · install line + channel handle. | "cogni-knowledge. Stop researching the same thing twice. Link's in the description — go build a base that compounds." |
+
+---
+
+## Script B — The Deep Cut (~12 min · ~1,300 words VO + visual beats)
+
+> Eight scenes. Times are cumulative targets. Keep the energy of the Short Cut; this version just earns the claims.
+
+### Scene 1 — The problem, dramatized (0:00–1:30)
+
+| # | VISUAL / ON-SCREEN | NARRATION (VO) |
+|---|---|---|
+| B1 | Same cold open as the trailer: the report lands, then dissolves and blows away. | "Let's start with the thing nobody puts in a sales deck. In most research workflows, every report you ship quietly throws away the research underneath it." |
+| B2 | Split screen builds into a table. Left header: **One-shot research tools.** Right header: **cogni-knowledge.** | "I want to show you a comparison — because this is really the whole pitch. On the left, how a typical one-shot research tool behaves. On the right, what we do differently." |
+| B3 | Row animates: *"Where do findings go after the report ships?"* → Left: **Lost to chat history.** Right: **Filed in a persistent wiki.** | "Where do your findings go after the report ships? In a chat-based tool — they're gone. Buried in scrollback. Here, they're filed in a persistent wiki." |
+| B4 | Row: *"Second run on a related topic?"* → Left: **Starts from zero.** Right: **Reads the wiki first.** | "Run a second project on a related topic? The one-shot tool starts from zero. Ours reads the wiki first." |
+| B5 | Row: *"Provenance of a stale fact?"* → Left: **Forgotten.** Right: **`derived_from_research:` traces it back.** | "Need to defend a number six months later? In one world it's forgotten. In ours, every page is stamped with the exact research run that produced it." |
+| B6 | Row: *"Trust in a cited number?"* → Left: **Hope it's right.** Right: **Checked against the source.** | "And trusting a citation? You can hope the model quoted the source correctly… or you can have it checked. We check." |
+| B7 | Hold on the full table. | "For a boutique, that left column isn't an inconvenience. It's billable hours you re-spend, and risk you carry into every client conversation. So let's pull the right column apart." |
+
+### Scene 2 — What it actually is (1:30–3:00)
+
+| # | VISUAL / ON-SCREEN | NARRATION (VO) |
+|---|---|---|
+| B8 | Define-card: **cogni-knowledge — a wiki-first research engine.** Two pillars slide in: **Compounding** and **Citation-consistent verification.** | "So what is it? cogni-knowledge is a wiki-first research engine, built on two pillars. One: compounding — research accumulates in a wiki instead of dying in chat history. Two: citation-consistent verification — every claim is checked against the source it came from, with zero network calls. I'll show you exactly what that means in a minute." |
+| B9 | File browser: a knowledge base folder. Highlight `wiki/` and `.cogni-knowledge/binding.json`. | "A knowledge base is just two things on disk: a wiki — plain markdown pages — and a small manifest called `binding.json` that records every research project you've deposited into it." |
+| B10 | Obsidian opens the same folder. The presenter clicks through `sources/`, `concepts/`, `syntheses/`. A wikilink jumps page to page. | "And because it's all markdown, you browse it in Obsidian, follow links between pages, and read every source, concept, and synthesis as plain text. No proprietary format. No database you can't open." |
+| B11 | Text overlay: *"The wiki engine ships inside the plugin. Nothing external to install."* | "The wiki engine is bundled inside the plugin — so there's nothing extra to install, and nothing phoning home. This runs as a self-contained thing you own." |
+| B11a | Quick cutaway (the payoff, before the machinery): a boutique's wiki labelled "DACH regulation" visibly thickening across three engagements. Text: *"By client #3, the background research is already done."* | "Before I show you the machinery — here's why you'd care. Build one base in your domain, and by your third client the background research is already there: checked, sourced, and ready to reuse. Keep that picture in mind. Now — how does it get there?" |
+
+### Scene 3 — The inverted pipeline, walked (3:00–5:30)
+
+| # | VISUAL / ON-SCREEN | NARRATION (VO) |
+|---|---|---|
+| B12 | Title: **The inverted pipeline.** A horizontal track of eight stations lights up as named: **plan · curate · fetch · ingest · (distill) · compose · verify · finalize.** | "When you research a topic, it runs through a pipeline. Eight steps. Don't worry about memorizing them — watch what each one *does*, because the order is the clever part." |
+| B13 | Station **plan** glows. A topic ("EU AI Act — Article 6 high-risk systems") fans into 3–7 sub-questions. | "**Plan** breaks your topic into three to seven sharp sub-questions. No web yet — just thinking about what you actually need to know." |
+| B14 | Station **curate**. Before searching, a check reads the existing wiki. Overlay: *"Read-before-web."* Then narrowed searches fire per sub-question. | "**Curate** is where the compounding starts paying off. Before it searches the web, it checks what your wiki *already* covers — read-before-web. So a question your base already answers narrows the search instead of re-crawling the whole internet. Then it searches, scores, and pulls the best sources." |
+| B15 | Stations **fetch** → **ingest**. Source bodies land as `wiki/sources/<slug>.md` pages; a `pre_extracted_claims:` block highlights in the frontmatter. Overlay: *"The wiki is populated BEFORE any draft is written."* | "**Fetch** and **ingest** save those sources into the wiki — and here's the key move: each source page is written with its claims *pre-extracted*, right in the page. The wiki is fully populated before a single word of the report is drafted. Remember that — it's what makes verification almost free in a minute." |
+| B16 | Station **distill** (dotted, labelled *optional*). Repeated facts from many sources merge into one concept page. | "**Distill** is optional — but it's where the compounding really happens. Recurring facts across sources get merged into concept pages — so the same fact across ten runs becomes *one* page that gets richer, not ten disconnected copies. That's the difference between a base that compounds and one that just piles up." |
+| B17 | Stations **compose** → **verify** → **finalize** light in sequence; a finished synthesis drops into `wiki/syntheses/`. | "**Compose** writes the draft — reading only what's in your wiki, so it can't cite a source the base hasn't filed. **Verify** checks it. And **finalize** deposits the finished, verified synthesis back into the wiki, where the next run will read it. The loop closes." |
+
+### Scene 4 — Verification: the trust story (5:30–7:15)
+
+| # | VISUAL / ON-SCREEN | NARRATION (VO) |
+|---|---|---|
+| B18 | Close-up: a draft sentence with a `[7]` marker. A line draws from `[7]` to a claim on the cited source page. A "verbatim" badge appears. | "Let's talk about trust. Here's a sentence in your draft, with citation seven. Verify takes that exact sentence and checks it against the claims on the page it cites — confirming your report stays faithful to its own sources, line by line. Worth being precise about what that is: it's a consistency check against the sources you captured, not a fact-check of the wider world. But it kills the most common failure — a report quietly drifting from what its sources actually said." |
+| B19 | Overlay, bold: **Zero network calls.** A little globe icon with a slash through it. | "And notice — it does this with zero network calls. It's not re-downloading anything. Remember, the claims were already pulled out and saved at ingest time. So checking every citation is fast and cheap — instead of a twenty-minute re-crawl of every URL." |
+| B20 | A sentence gets flagged **unsupported** (amber). A "revisor" pass rewrites it or re-points the citation. Counter: *"up to 2 passes."* | "If a sentence isn't actually supported by its source, it doesn't just ship with a warning. A revisor step re-points it to a claim that *does* back it — or rewrites it — automatically, up to two passes." |
+| B21 | The finished synthesis frontmatter shows `verification: citation_consistent_zero_network`. | "And the finished page records that it was verified this way. So 'trust me' becomes 'here's the receipt.'" |
+| B22 | Honest-broker beat. Small print card: *"Want to re-check against the live web later? `knowledge-refresh --resweep`."* | "One honest note: this checks that your report matches the sources you captured. If you want to re-check those sources against the live web weeks later — because pages change — there's an opt-in command for exactly that. It's your call, not a hidden background process." |
+
+### Scene 5 — Compounding: the money story (7:15–9:00)
+
+| # | VISUAL / ON-SCREEN | NARRATION (VO) |
+|---|---|---|
+| B23 | Timeline. **Project 1**: full pipeline, full web crawl. A synthesis lands in the wiki. | "Now the part that hits your P&L. Project one: you research a topic top to bottom. Full web crawl. A verified synthesis lands in your wiki." |
+| B24 | **Project 2** (weeks later) on an adjacent topic. The curate step lights up reading prior pages; far fewer new searches fire. Overlay: *"Reads the wiki first → searches only the gaps."* | "Project two, a few weeks later, on an adjacent topic. This time, curate reads what project one already filed — and only searches the genuine gaps. Less crawling. Faster. Better grounded, because it's building on checked work, not a blank page." |
+| B25 | A concept page visibly gains claims as **Project 3** and **Project 4** flow in. | "And those concept pages? Every run enriches them. By your tenth project, your base isn't a folder of old reports — it's an asset that makes every *new* project sharper." |
+| B26 | Client scene: someone asks "where's this from?" Cut to a one-click jump from the claim to `derived_from_research: <slug>` and the source. Overlay: *"Defend any fact in one lookup."* | "And defensibility comes for free. Every page carries a lineage stamp — the exact run that produced it. A client challenges a figure? One lookup, straight to the source. No archaeology." |
+
+### Scene 6 — Two boutique use cases (9:00–10:45)
+
+| # | VISUAL / ON-SCREEN | NARRATION (VO) |
+|---|---|---|
+| B27 | Use-case card 1: **The compliance base.** A boutique's wiki titled "DACH financial regulation" growing across engagements. | "Two ways boutiques actually use this. First — a standing knowledge base in your domain. Say you advise on DACH financial regulation. You build one base, and every engagement adds to it: MiFID II, ESG reporting, AML. By the third client, the background research is already there. You're not selling a one-off report — you've built an asset your firm owns." |
+| B28 | Map of Europe; sources highlight by country (DE, FR, IT, ES, NL, PL). A search shows German-language queries against German authority sources; the synthesis renders in German. | "And it's European-first. Bind a market, and research runs bilingually — local language *and* English — against curated regional authority sources. Research on a German topic actually reads German sources, not just English summaries — and the synthesis comes out in the language you work in, whether that's German, French, or English." |
+| B29 | Use-case card 2: **Source-verified thought leadership.** A LinkedIn-style article with checked citations. | "Second — thought leadership you can stand behind. Pull from a base where every statistic is sourced from a real authority and citation-checked. No invented numbers. When your post cites a figure, you can prove it. That's the difference between commentary and credibility." |
+
+### Scene 7 — Ownership, and where it fits (10:45–11:30)
+
+| # | VISUAL / ON-SCREEN | NARRATION (VO) |
+|---|---|---|
+| B30 | The `.md` files + git history again. Overlay: *"No vector store. No embeddings. No lock-in."* | "Let me hammer the ownership point, because it's rare. There's no vector store, no embeddings, no proprietary index. The whole base is markdown you read, grep, edit, and version in git. If you stopped using the tool tomorrow, you'd still have everything — readable." |
+| B31 | A light, single arrow from the cogni-knowledge wiki outward to generic "polish / visuals" icons — kept deliberately small. | "It's also the research backbone of a wider toolkit — verified findings can flow downstream into polished docs and visuals. But that's a bonus. On its own, cogni-knowledge already does the hard, valuable thing: research that's checked, traceable, and yours." |
+
+### Scene 8 — Close + CTA (11:30–12:00)
+
+| # | VISUAL / ON-SCREEN | NARRATION (VO) |
+|---|---|---|
+| B32 | Recap, three quick icons: **Compounds · Trusted · Yours.** | "So: research that compounds instead of evaporating. Citations checked against their sources, line by line. A base you fully own." |
+| B33 | End card: **cogni-knowledge** · *"Your tenth project, backed by nine."* · install link + handle. | "If your boutique runs serious research, stop paying for the same crawl twice. The link to install is below — go build a base that compounds. And if this was useful, subscribe; I'm walking through the whole toolkit next." |
+
+---
+
+## Appendix
+
+### On-screen commands (use real terminal captures)
+
+```bash
+# Set up a knowledge base (scaffolds the wiki + writes binding.json)
+/cogni-knowledge:knowledge-setup --knowledge-slug eu-ai-act --knowledge-title "EU AI Act knowledge base"
+
+# Plan a topic into 3–7 sub-questions
+/cogni-knowledge:knowledge-plan --knowledge-slug eu-ai-act --topic "EU AI Act Article 6 high-risk systems"
+
+# The pipeline (or drive it in one go with knowledge-run)
+/cogni-knowledge:knowledge-curate   --knowledge-slug eu-ai-act --project-path <project>
+/cogni-knowledge:knowledge-fetch    --knowledge-slug eu-ai-act --project-path <project>
+/cogni-knowledge:knowledge-ingest   --knowledge-slug eu-ai-act --project-path <project>
+/cogni-knowledge:knowledge-compose  --knowledge-slug eu-ai-act --project-path <project>
+/cogni-knowledge:knowledge-verify   --knowledge-slug eu-ai-act --project-path <project>
+/cogni-knowledge:knowledge-finalize --knowledge-slug eu-ai-act --project-path <project>
+
+# Ask the accumulated base in plain language (read-only, no web)
+/cogni-knowledge:knowledge-query --knowledge-slug eu-ai-act --question "what does the wiki say about foundation models?"
+
+# Status / next step at any time
+/cogni-knowledge:knowledge-resume --knowledge-slug eu-ai-act
+```
+
+The verified synthesis lands at `eu-ai-act/wiki/syntheses/<slug>.md` with a `derived_from_research:` lineage stamp.
+
+### B-roll shot list
+
+1. A PDF dissolving / blowing away (the throwaway-report metaphor) — Scene 1 cold open.
+2. Screen capture: the one-shot-vs-cogni-knowledge comparison table animating row by row.
+3. Obsidian: browsing `wiki/` — clicking from a synthesis to a source via a wikilink.
+4. Screen capture: a source page's frontmatter, highlighting `pre_extracted_claims:`.
+5. Animated pipeline track (eight stations) — reusable across Scenes 3 and 5.
+6. Close-up of a `[N]` citation being scored "verbatim" with a zero-network/globe-slash icon.
+7. Timeline montage of Projects 1→10, a concept page visibly gaining claims.
+8. Europe map with per-country authority sources lighting up; a bilingual (DE/EN) search.
+9. A `git log` / `git diff` over the wiki `.md` files (the ownership beat).
+
+### Thumbnail / title options
+
+| # | Title | Thumbnail concept |
+|---|---|---|
+| 1 | *"Why your research keeps starting from zero (and the fix)"* | A report dissolving into pixels; bold text "STARTING FROM ZERO?" |
+| 2 | *"Research that compounds: a knowledge base for consultants"* | A small wiki growing into a tall stack, arrow curving up. |
+| 3 | *"Every citation, checked. Zero network calls."* | A `[3]` citation with a green checkmark and a slashed globe icon. |
+
+---
+
+## Panel notes & revisions
+
+Before finalizing, both cuts were reviewed by a simulated 3-persona panel standing in for the target viewer (the repo's stakeholder-review pattern). Verdicts: **no fails** — *Mara* (solo founder) warn, *Dev* (research/delivery lead) accept, *Anja* (skeptical partner) warn. Highest-impact fixes applied:
+
+- **Verification claim was overstated** (Dev + Anja). "Checked against what the source says" risked implying a fact-check of reality. Reworded across **A7, B8, B18, B32** to *consistency against the sources you captured* — and B18 now states the limit out loud before B22's resweep beat reinforces it.
+- **Hook now leads with the money wound** (Mara). **A1–A2** open on "you're paying for it twice / re-research," not a metaphor.
+- **Accuracy of the trailer demo** (Dev). **A9** uses the real one-shot driver (`knowledge-setup` then `knowledge-run`) and shows the synthesis landing after the pipeline, matching B12 and the Appendix.
+- **Payoff surfaced earlier** (Mara). New cell **B11a** shows the boutique outcome before the pipeline machinery.
+- **Hype trimmed** (Anja). Cut "secret sauce" (**B16**) and "hold onto that phrase" (**B8**); removed a repeated "hope vs. check" beat (**B32**); the bald "16+ languages" line (**B28**) is now concrete (German/French/English) instead of a lone number.
+
+Open (non-blocking) note for production: keep on-screen code (`binding.json`, `pre_extracted_claims:`) as background texture, not focal text — Mara bounces off terminal UI; the narration's plain-language gloss carries the meaning.

--- a/docs/video-script-cogni-knowledge.md
+++ b/docs/video-script-cogni-knowledge.md
@@ -24,7 +24,7 @@
 | A5 | Three clean cards snap in, one at a time. | "Three things that means for your boutique." |
 | A6 | Card 1: **COMPOUNDS** — a small wiki growing denser, project over project. | "One. Your knowledge base gets denser and more useful with every project — instead of resetting to empty." |
 | A7 | Card 2: **TRUSTED** — a sentence with a `[3]` citation; a checkmark snaps onto it. Subtitle: *"checked + curated — conflicts surfaced."* | "Two. Every citation is checked for consistency against the source it came from — so your report can't drift from its own evidence. Anything unsupported gets revised before it ships. And when two sources disagree, it tells you — it doesn't quietly pick one. It's a base you curate, so it's one you can actually trust." |
-| A8 | Card 3: **YOURS** — a folder of `.md` files opening in Obsidian; a git commit ticks by. Subtitle: *"No vector store. No lock-in."* | "Three. The whole base is plain markdown. No vector store, no embeddings, no lock-in. You read it, grep it, edit it, and version it in git. It's yours." |
+| A8 | Card 3: **YOURS** — a folder of `.md` files opening in Obsidian; a git commit ticks by. Subtitle: *"No vector store. No lock-in."* | "Three. The whole base is plain markdown — your sourced research and your own client notes, together. No vector store, no embeddings, no lock-in. You read it, grep it, edit it, and version it in git. It's yours." |
 | A9 | Screen capture: `knowledge-setup` runs once; then `knowledge-run` drives the pipeline; at the end a synthesis file appears under `wiki/syntheses/`. | "Setting it up is one command. Then you point it at a topic and it runs the whole pipeline — plan, gather sources, verify, and file the result. At the end, a verified synthesis lands in your wiki, stamped with exactly which run produced it." |
 | A10 | Obsidian view: clicking a citation jumps to the source page. Text overlay: *"Defend any fact in one lookup."* | "So when someone asks 'where did this come from?' — it's one click, not an afternoon." |
 | A11 | End card: **cogni-knowledge** · *"Your tenth project, backed by nine."* · install line + channel handle. | "cogni-knowledge. Turn every report into knowledge your firm keeps. Link's in the description — go build a base that compounds." |
@@ -56,6 +56,7 @@
 | B9 | File browser: a knowledge base folder. Highlight `wiki/` and `.cogni-knowledge/binding.json`. | "A knowledge base is just two things on disk: a wiki — plain markdown pages — and a small manifest called `binding.json` that records every research project you've deposited into it." |
 | B10 | Obsidian opens the same folder. The presenter clicks through `sources/`, `concepts/`, `syntheses/`. A wikilink jumps page to page. | "And because it's all markdown, you browse it in Obsidian, follow links between pages, and read every source, concept, and synthesis as plain text. No proprietary format. No database you can't open." |
 | B11 | Text overlay: *"The wiki engine ships inside the plugin. Nothing external to install."* | "The wiki engine is bundled inside the plugin — so there's nothing extra to install, and nothing phoning home. This runs as a self-contained thing you own." |
+| B11b | A client interview note and a Word doc get dragged in; they land as wiki pages right beside the web sources. Overlay: *"Research **and** client material — one base."* | "And it's not only web research. You can bring your own material straight into the same base — a client interview note, a PDF, a Word doc, pasted text — and it's filed in the wiki alongside your sourced research. So the base is the whole picture: external evidence and your client work, in one place you own." |
 | B11a | Quick cutaway (the payoff, before the machinery): a boutique's wiki labelled "DACH regulation" visibly thickening across three engagements. Text: *"By client #3, the background research is already done."* | "Before I show you the machinery — here's why you'd care. Build one base in your domain, and by your third client the background research is already there: checked, sourced, and ready to reuse. Keep that picture in mind. Now — how does it get there?" |
 
 ### Scene 3 — The inverted pipeline, walked (3:00–5:30)
@@ -193,3 +194,10 @@ Owner follow-up: *"Consider trust in sources and claims; building a knowledge ba
 - **Comparison table** gains **B6a** — *"Two sources disagree?"* → one-shot tools hand you one answer silently; cogni-knowledge surfaces the contradiction with a severity.
 - **Short Cut A7** and **recap B32** enriched with the curate + conflict-honesty angle.
 - **Accuracy guardrail honored:** contradiction tripwires are framed as observability-only (no auto-resolution, clean runs silent) — no overclaim of live fact-checking.
+
+### Revision 4 — client-data ingestion (owner steer)
+
+Owner note: *"It's research and client data."* The base isn't web-only — it also holds the firm's own client material. Per owner direction, **show the ingestion** and **keep privacy light** (a passing mention, no privacy beat — the tool still processes content via Claude's API, so no airtight-confidentiality claim):
+
+- **Deep Cut B11b:** you can bring your own material into the same base — client interview notes, a PDF, a Word doc, pasted text (`knowledge-ingest-source`) — filed alongside sourced research. "One place you own" is the only ownership nod.
+- **Short Cut A8:** the "YOURS" card now says "your sourced research and your own client notes, together."

--- a/docs/video-script-cogni-knowledge.md
+++ b/docs/video-script-cogni-knowledge.md
@@ -6,7 +6,7 @@
 |---|---|
 | **Subject** | `cogni-knowledge` — the wiki-first, compounding-knowledge research engine of insight-wave (v1.0.x, Released) |
 | **Target viewer** | The founder / principal of a small consulting boutique (2–20 people). Smart, time-poor, allergic to hype and vendor lock-in. Bills by the insight, not the hour. |
-| **Core promise** | "Stop throwing away the research under every report. Build a knowledge base that gets sharper — and cheaper to run — with every project." |
+| **Core promise** | "Stop letting every report be a dead end. Turn each project's research into knowledge your firm keeps — and builds on." |
 | **Tone** | Confident, plain-spoken, lightly witty. Respect the viewer's intelligence. Show, don't gush. No buzzwords without a plain-language gloss. |
 | **One-line description** | A research engine that files every verified finding into a wiki your next project reads first — so your tenth deliverable stands on nine projects of checked, traceable evidence. |
 | **Suggested title** | *"Why your research keeps starting from zero (and the fix)"* |
@@ -17,8 +17,8 @@
 
 | # | VISUAL / ON-SCREEN | NARRATION (VO) |
 |---|---|---|
-| A1 | Cold open. A polished PDF report slides across a desk. The instant it lands, it dissolves into pixels and blows away. Hard cut to black. | "You already paid to dig up the research behind that report. The moment it ships, it's gone — and in a few months, you'll pay to dig it all up again." |
-| A2 | Relatable scene: a consultant at 11pm, six browser tabs open, typing a search they *know* they ran last quarter. Title card: **"Re-researching. Again."** | "A related question lands. Six tabs open, re-running a search you *know* you ran last quarter. Worse — a client challenges a number, and you're spelunking through old chat logs trying to remember where it came from. That's not research. That's re-research — and you're paying for it twice." |
+| A1 | Cold open. A polished PDF report slides across a desk. The instant it lands, it dissolves into pixels and blows away. Hard cut to black. | "Think about everything you learned researching your last report. The market, the regulations, the sources you vetted. The moment that report shipped… where did all of it go?" |
+| A2 | Relatable scene: a consultant at 11pm, six browser tabs open, re-finding a source they *know* they read last quarter. Title card: **"It never became knowledge."** | "Three months later, a related question lands — and you're starting from a blank page. Not because you never did the work. Because the work never turned into knowledge your firm could pick back up. Every report is a dead end. The research underneath it just… evaporates." |
 | A3 | Logo: **cogni-knowledge**. Tagline animates in: *"Wiki-first research that compounds."* | "This is cogni-knowledge. It's a research engine built on one stubborn idea: research should compound — not evaporate." |
 | A4 | Animated diagram. A research run flows left-to-right; at the end, a verified page drops into a stack labelled **WIKI**. The *next* run starts by reading that stack *before* going to the web. | "Every run deposits its verified findings into a persistent wiki. And the next run reads that wiki first — before it ever touches the web. Run two stands on run one. Run ten stands on nine." |
 | A5 | Three clean cards snap in, one at a time. | "Three things that means for your boutique." |
@@ -27,7 +27,7 @@
 | A8 | Card 3: **YOURS** — a folder of `.md` files opening in Obsidian; a git commit ticks by. Subtitle: *"No vector store. No lock-in."* | "Three. The whole base is plain markdown. No vector store, no embeddings, no lock-in. You read it, grep it, edit it, and version it in git. It's yours." |
 | A9 | Screen capture: `knowledge-setup` runs once; then `knowledge-run` drives the pipeline; at the end a synthesis file appears under `wiki/syntheses/`. | "Setting it up is one command. Then you point it at a topic and it runs the whole pipeline — plan, gather sources, verify, and file the result. At the end, a verified synthesis lands in your wiki, stamped with exactly which run produced it." |
 | A10 | Obsidian view: clicking a citation jumps to the source page. Text overlay: *"Defend any fact in one lookup."* | "So when someone asks 'where did this come from?' — it's one click, not an afternoon." |
-| A11 | End card: **cogni-knowledge** · *"Your tenth project, backed by nine."* · install line + channel handle. | "cogni-knowledge. Stop researching the same thing twice. Link's in the description — go build a base that compounds." |
+| A11 | End card: **cogni-knowledge** · *"Your tenth project, backed by nine."* · install line + channel handle. | "cogni-knowledge. Turn every report into knowledge your firm keeps. Link's in the description — go build a base that compounds." |
 
 ---
 
@@ -39,7 +39,7 @@
 
 | # | VISUAL / ON-SCREEN | NARRATION (VO) |
 |---|---|---|
-| B1 | Same cold open as the trailer: the report lands, then dissolves and blows away. | "Let's start with the thing nobody puts in a sales deck. In most research workflows, every report you ship quietly throws away the research underneath it." |
+| B1 | Same cold open as the trailer: the report lands, then dissolves and blows away. | "Let's start with the thing nobody puts in a sales deck. In most research workflows, every report you ship quietly throws away the research underneath it. Not the report — the *knowledge*. Everything you learned getting there. None of it becomes something your firm can reuse." |
 | B2 | Split screen builds into a table. Left header: **One-shot research tools.** Right header: **cogni-knowledge.** | "I want to show you a comparison — because this is really the whole pitch. On the left, how a typical one-shot research tool behaves. On the right, what we do differently." |
 | B3 | Row animates: *"Where do findings go after the report ships?"* → Left: **Lost to chat history.** Right: **Filed in a persistent wiki.** | "Where do your findings go after the report ships? In a chat-based tool — they're gone. Buried in scrollback. Here, they're filed in a persistent wiki." |
 | B4 | Row: *"Second run on a related topic?"* → Left: **Starts from zero.** Right: **Reads the wiki first.** | "Run a second project on a related topic? The one-shot tool starts from zero. Ours reads the wiki first." |
@@ -78,13 +78,13 @@
 | B21 | The finished synthesis frontmatter shows `verification: citation_consistent_zero_network`. | "And the finished page records that it was verified this way. So 'trust me' becomes 'here's the receipt.'" |
 | B22 | Honest-broker beat. Small print card: *"Want to re-check against the live web later? `knowledge-refresh --resweep`."* | "One honest note: this checks that your report matches the sources you captured. If you want to re-check those sources against the live web weeks later — because pages change — there's an opt-in command for exactly that. It's your call, not a hidden background process." |
 
-### Scene 5 — Compounding: the money story (7:15–9:00)
+### Scene 5 — Compounding: research becomes an asset (7:15–9:00)
 
 | # | VISUAL / ON-SCREEN | NARRATION (VO) |
 |---|---|---|
-| B23 | Timeline. **Project 1**: full pipeline, full web crawl. A synthesis lands in the wiki. | "Now the part that hits your P&L. Project one: you research a topic top to bottom. Full web crawl. A verified synthesis lands in your wiki." |
-| B24 | **Project 2** (weeks later) on an adjacent topic. The curate step lights up reading prior pages; far fewer new searches fire. Overlay: *"Reads the wiki first → searches only the gaps."* | "Project two, a few weeks later, on an adjacent topic. This time, curate reads what project one already filed — and only searches the genuine gaps. Less crawling. Faster. Better grounded, because it's building on checked work, not a blank page." |
-| B25 | A concept page visibly gains claims as **Project 3** and **Project 4** flow in. | "And those concept pages? Every run enriches them. By your tenth project, your base isn't a folder of old reports — it's an asset that makes every *new* project sharper." |
+| B23 | Timeline. **Project 1**: full pipeline. A verified synthesis lands in the wiki. | "Here's where it all pays off. Project one: you research a topic top to bottom. A verified synthesis lands in your wiki. So far, so normal — except this time, the work didn't evaporate. It's *filed*." |
+| B24 | A concept page visibly gains claims as **Project 2**, **3**, and **4** flow in. Overlay: *"One fact, enriched across runs — not ten copies."* | "Project two, three, four — each one enriches the same concept pages instead of duplicating them. By your tenth project, your base isn't a folder of old reports. It's an asset: institutional knowledge your firm owns, that makes every *new* project sharper. That's the thing the dead-end report could never give you." |
+| B25 | **Project 2** (weeks later) on an adjacent topic. The curate step lights up reading prior pages; far fewer new searches fire. Overlay: *"Reads the wiki first → searches only the gaps."* | "And there's a nice side effect. Because each run reads the wiki before it searches, an adjacent topic only hunts for the genuine gaps — not the ground you already covered. Faster, and better grounded, because it's standing on checked work instead of a blank page." |
 | B26 | Client scene: someone asks "where's this from?" Cut to a one-click jump from the claim to `derived_from_research: <slug>` and the source. Overlay: *"Defend any fact in one lookup."* | "And defensibility comes for free. Every page carries a lineage stamp — the exact run that produced it. A client challenges a figure? One lookup, straight to the source. No archaeology." |
 
 ### Scene 6 — Two boutique use cases (9:00–10:45)
@@ -107,7 +107,7 @@
 | # | VISUAL / ON-SCREEN | NARRATION (VO) |
 |---|---|---|
 | B32 | Recap, three quick icons: **Compounds · Trusted · Yours.** | "So: research that compounds instead of evaporating. Citations checked against their sources, line by line. A base you fully own." |
-| B33 | End card: **cogni-knowledge** · *"Your tenth project, backed by nine."* · install link + handle. | "If your boutique runs serious research, stop paying for the same crawl twice. The link to install is below — go build a base that compounds. And if this was useful, subscribe; I'm walking through the whole toolkit next." |
+| B33 | End card: **cogni-knowledge** · *"Your tenth project, backed by nine."* · install link + handle. | "If your boutique runs serious research, stop letting it die in the report. Turn it into knowledge your firm keeps. The link to install is below — go build a base that compounds. And if this was useful, subscribe; I'm walking through the whole toolkit next." |
 
 ---
 
@@ -172,3 +172,11 @@ Before finalizing, both cuts were reviewed by a simulated 3-persona panel standi
 - **Hype trimmed** (Anja). Cut "secret sauce" (**B16**) and "hold onto that phrase" (**B8**); removed a repeated "hope vs. check" beat (**B32**); the bald "16+ languages" line (**B28**) is now concrete (German/French/English) instead of a lone number.
 
 Open (non-blocking) note for production: keep on-screen code (`binding.json`, `pre_extracted_claims:`) as background texture, not focal text — Mara bounces off terminal UI; the narration's plain-language gloss carries the meaning.
+
+### Revision 2 — core pain reframed (owner steer)
+
+Product-owner feedback after round 1: *"the pain is not about paying for research that dissolves — it's about research that never turns into project knowledge."* This **supersedes** Mara's round-1 "lead with the money" note. The central wound is now **knowledge loss**, not cost:
+
+- **Hook (A1–A2, B1)** rewritten around "everything you learned never became knowledge your firm can reuse"; A2 title card is now **"It never became knowledge."** The "paying for it twice" framing is gone.
+- **Core promise** and both CTAs (**A11, B33**) re-pointed from cost ("stop paying for the same crawl twice") to knowledge ("turn every report into knowledge your firm keeps").
+- **Scene 5** renamed *"Compounding: the money story" → "research becomes an asset"* and reordered so the institutional-knowledge-asset beat leads; the cost/efficiency benefit (read-before-web) is kept but demoted to a supporting side-effect, not the headline.

--- a/docs/video-script-cogni-knowledge.md
+++ b/docs/video-script-cogni-knowledge.md
@@ -23,7 +23,7 @@
 | A4 | Animated diagram. A research run flows left-to-right; at the end, a verified page drops into a stack labelled **WIKI**. The *next* run starts by reading that stack *before* going to the web. | "Every run deposits its verified findings into a persistent wiki. And the next run reads that wiki first — before it ever touches the web. Run two stands on run one. Run ten stands on nine." |
 | A5 | Three clean cards snap in, one at a time. | "Three things that means for your boutique." |
 | A6 | Card 1: **COMPOUNDS** — a small wiki growing denser, project over project. | "One. Your knowledge base gets denser and more useful with every project — instead of resetting to empty." |
-| A7 | Card 2: **TRUSTED** — a sentence with a `[3]` citation; a checkmark snaps onto it. Subtitle: *"checked against its source — zero network calls."* | "Two. Every citation is checked for consistency against the source it came from — so your report can't drift from its own evidence. Not 'hope the model quoted it right' — checked, automatically. Anything unsupported gets revised before it ships." |
+| A7 | Card 2: **TRUSTED** — a sentence with a `[3]` citation; a checkmark snaps onto it. Subtitle: *"checked + curated — conflicts surfaced."* | "Two. Every citation is checked for consistency against the source it came from — so your report can't drift from its own evidence. Anything unsupported gets revised before it ships. And when two sources disagree, it tells you — it doesn't quietly pick one. It's a base you curate, so it's one you can actually trust." |
 | A8 | Card 3: **YOURS** — a folder of `.md` files opening in Obsidian; a git commit ticks by. Subtitle: *"No vector store. No lock-in."* | "Three. The whole base is plain markdown. No vector store, no embeddings, no lock-in. You read it, grep it, edit it, and version it in git. It's yours." |
 | A9 | Screen capture: `knowledge-setup` runs once; then `knowledge-run` drives the pipeline; at the end a synthesis file appears under `wiki/syntheses/`. | "Setting it up is one command. Then you point it at a topic and it runs the whole pipeline — plan, gather sources, verify, and file the result. At the end, a verified synthesis lands in your wiki, stamped with exactly which run produced it." |
 | A10 | Obsidian view: clicking a citation jumps to the source page. Text overlay: *"Defend any fact in one lookup."* | "So when someone asks 'where did this come from?' — it's one click, not an afternoon." |
@@ -31,7 +31,7 @@
 
 ---
 
-## Script B — The Deep Cut (~12 min · ~1,300 words VO + visual beats)
+## Script B — The Deep Cut (~12–13 min · ~1,600 words VO + visual beats)
 
 > Eight scenes. Times are cumulative targets. Keep the energy of the Short Cut; this version just earns the claims.
 
@@ -45,6 +45,7 @@
 | B4 | Row: *"Second run on a related topic?"* → Left: **Starts from zero.** Right: **Reads the wiki first.** | "Run a second project on a related topic? The one-shot tool starts from zero. Ours reads the wiki first." |
 | B5 | Row: *"Provenance of a stale fact?"* → Left: **Forgotten.** Right: **`derived_from_research:` traces it back.** | "Need to defend a number six months later? In one world it's forgotten. In ours, every page is stamped with the exact research run that produced it." |
 | B6 | Row: *"Trust in a cited number?"* → Left: **Hope it's right.** Right: **Checked against the source.** | "And trusting a citation? You can hope the model quoted the source correctly… or you can have it checked. We check." |
+| B6a | Row: *"Two sources disagree?"* → Left: **You get one answer, silently.** Right: **The contradiction is surfaced — with a severity.** | "And when two of your sources flatly disagree? A one-shot tool hands you one answer and never tells you the other existed. We flag the conflict — so you decide, instead of trusting a coin-flip you never saw." |
 | B7 | Hold on the full table. | "For a boutique, that left column isn't an inconvenience. It's billable hours you re-spend, and risk you carry into every client conversation. So let's pull the right column apart." |
 
 ### Scene 2 — What it actually is (1:30–3:00)
@@ -68,17 +69,20 @@
 | B16 | Station **distill** (dotted, labelled *optional*). Repeated facts from many sources merge into one concept page. | "**Distill** is optional — but it's where the compounding really happens. Recurring facts across sources get merged into concept pages — so the same fact across ten runs becomes *one* page that gets richer, not ten disconnected copies. That's the difference between a base that compounds and one that just piles up." |
 | B17 | Stations **compose** → **verify** → **finalize** light in sequence; a finished synthesis drops into `wiki/syntheses/`. | "**Compose** writes the draft — reading only what's in your wiki, so it can't cite a source the base hasn't filed. **Verify** checks it. And **finalize** deposits the finished, verified synthesis back into the wiki, where the next run will read it. The loop closes." |
 
-### Scene 4 — Verification: the trust story (5:30–7:15)
+### Scene 4 — Trust: checked, curated, honest about conflict (5:30–7:45)
 
 | # | VISUAL / ON-SCREEN | NARRATION (VO) |
 |---|---|---|
 | B18 | Close-up: a draft sentence with a `[7]` marker. A line draws from `[7]` to a claim on the cited source page. A "verbatim" badge appears. | "Let's talk about trust. Here's a sentence in your draft, with citation seven. Verify takes that exact sentence and checks it against the claims on the page it cites — confirming your report stays faithful to its own sources, line by line. Worth being precise about what that is: it's a consistency check against the sources you captured, not a fact-check of the wider world. But it kills the most common failure — a report quietly drifting from what its sources actually said." |
 | B19 | Overlay, bold: **Zero network calls.** A little globe icon with a slash through it. | "And notice — it does this with zero network calls. It's not re-downloading anything. Remember, the claims were already pulled out and saved at ingest time. So checking every citation is fast and cheap — instead of a twenty-minute re-crawl of every URL." |
 | B20 | A sentence gets flagged **unsupported** (amber). A "revisor" pass rewrites it or re-points the citation. Counter: *"up to 2 passes."* | "If a sentence isn't actually supported by its source, it doesn't just ship with a warning. A revisor step re-points it to a claim that *does* back it — or rewrites it — automatically, up to two passes." |
+| B20a | New visual: two source cards side by side with conflicting figures; a flag pops between them tagged **contradiction · high**. Overlay: *"surfaced, not silently resolved."* | "But here's the trust feature I'd actually put on the box. Real research is full of sources that disagree. When a new source contradicts what your base already says — or your draft drifts from a source, or even contradicts a synthesis from a *previous* project — it gets flagged, with a severity. High, medium, low." |
+| B20b | The flag expands to show both claims; a human cursor hovers, choosing. The tool does **not** auto-pick. Text: *"You decide."* | "And — this is the important part — it does *not* pick a winner for you. It surfaces the conflict and leaves the call to you. That's the difference between a tool that launders disagreement into one confident-sounding answer, and one that's honest enough to say 'these two don't agree — your move.' A base you can trust is one that tells you when it's unsure." |
 | B21 | The finished synthesis frontmatter shows `verification: citation_consistent_zero_network`. | "And the finished page records that it was verified this way. So 'trust me' becomes 'here's the receipt.'" |
+| B21a | Obsidian: a human edits a page; a diff appears; a small prompt asks for a source citation on a new claim. Human `## Notes` stay untouched. Overlay: *"A base you curate."* | "One more thing that earns trust: this is a base you *curate*. You decide what goes in. When you revise a page, it shows you the diff first and asks for a source on anything new. Your own notes are preserved. It's your judgment in the loop — not a black box you hope is right." |
 | B22 | Honest-broker beat. Small print card: *"Want to re-check against the live web later? `knowledge-refresh --resweep`."* | "One honest note: this checks that your report matches the sources you captured. If you want to re-check those sources against the live web weeks later — because pages change — there's an opt-in command for exactly that. It's your call, not a hidden background process." |
 
-### Scene 5 — Compounding: research becomes an asset (7:15–9:00)
+### Scene 5 — Compounding: research becomes an asset (7:45–9:15)
 
 | # | VISUAL / ON-SCREEN | NARRATION (VO) |
 |---|---|---|
@@ -87,7 +91,7 @@
 | B25 | **Project 2** (weeks later) on an adjacent topic. The curate step lights up reading prior pages; far fewer new searches fire. Overlay: *"Reads the wiki first → searches only the gaps."* | "And there's a nice side effect. Because each run reads the wiki before it searches, an adjacent topic only hunts for the genuine gaps — not the ground you already covered. Faster, and better grounded, because it's standing on checked work instead of a blank page." |
 | B26 | Client scene: someone asks "where's this from?" Cut to a one-click jump from the claim to `derived_from_research: <slug>` and the source. Overlay: *"Defend any fact in one lookup."* | "And defensibility comes for free. Every page carries a lineage stamp — the exact run that produced it. A client challenges a figure? One lookup, straight to the source. No archaeology." |
 
-### Scene 6 — Two boutique use cases (9:00–10:45)
+### Scene 6 — Two boutique use cases (9:15–11:00)
 
 | # | VISUAL / ON-SCREEN | NARRATION (VO) |
 |---|---|---|
@@ -95,18 +99,18 @@
 | B28 | Map of Europe; sources highlight by country (DE, FR, IT, ES, NL, PL). A search shows German-language queries against German authority sources; the synthesis renders in German. | "And it's European-first. Bind a market, and research runs bilingually — local language *and* English — against curated regional authority sources. Research on a German topic actually reads German sources, not just English summaries — and the synthesis comes out in the language you work in, whether that's German, French, or English." |
 | B29 | Use-case card 2: **Source-verified thought leadership.** A LinkedIn-style article with checked citations. | "Second — thought leadership you can stand behind. Pull from a base where every statistic is sourced from a real authority and citation-checked. No invented numbers. When your post cites a figure, you can prove it. That's the difference between commentary and credibility." |
 
-### Scene 7 — Ownership, and where it fits (10:45–11:30)
+### Scene 7 — Ownership, and where it fits (11:00–11:45)
 
 | # | VISUAL / ON-SCREEN | NARRATION (VO) |
 |---|---|---|
 | B30 | The `.md` files + git history again. Overlay: *"No vector store. No embeddings. No lock-in."* | "Let me hammer the ownership point, because it's rare. There's no vector store, no embeddings, no proprietary index. The whole base is markdown you read, grep, edit, and version in git. If you stopped using the tool tomorrow, you'd still have everything — readable." |
 | B31 | A light, single arrow from the cogni-knowledge wiki outward to generic "polish / visuals" icons — kept deliberately small. | "It's also the research backbone of a wider toolkit — verified findings can flow downstream into polished docs and visuals. But that's a bonus. On its own, cogni-knowledge already does the hard, valuable thing: research that's checked, traceable, and yours." |
 
-### Scene 8 — Close + CTA (11:30–12:00)
+### Scene 8 — Close + CTA (11:45–12:30)
 
 | # | VISUAL / ON-SCREEN | NARRATION (VO) |
 |---|---|---|
-| B32 | Recap, three quick icons: **Compounds · Trusted · Yours.** | "So: research that compounds instead of evaporating. Citations checked against their sources, line by line. A base you fully own." |
+| B32 | Recap, three quick icons: **Compounds · Trusted · Yours.** | "So: research that compounds instead of evaporating. Citations checked against their sources — and honest with you when sources disagree. A base you curate, and fully own." |
 | B33 | End card: **cogni-knowledge** · *"Your tenth project, backed by nine."* · install link + handle. | "If your boutique runs serious research, stop letting it die in the report. Turn it into knowledge your firm keeps. The link to install is below — go build a base that compounds. And if this was useful, subscribe; I'm walking through the whole toolkit next." |
 
 ---
@@ -180,3 +184,12 @@ Product-owner feedback after round 1: *"the pain is not about paying for researc
 - **Hook (A1–A2, B1)** rewritten around "everything you learned never became knowledge your firm can reuse"; A2 title card is now **"It never became knowledge."** The "paying for it twice" framing is gone.
 - **Core promise** and both CTAs (**A11, B33**) re-pointed from cost ("stop paying for the same crawl twice") to knowledge ("turn every report into knowledge your firm keeps").
 - **Scene 5** renamed *"Compounding: the money story" → "research becomes an asset"* and reordered so the institutional-knowledge-asset beat leads; the cost/efficiency benefit (read-before-web) is kept but demoted to a supporting side-effect, not the headline.
+
+### Revision 3 — trust story strengthened (owner steer)
+
+Owner follow-up: *"Consider trust in sources and claims; building a knowledge base you curate and can trust, and contradictions are transparently surfaced."* Broadened the trust story and added the contradiction-surfacing feature (previously omitted):
+
+- **Deep Cut Scene 4** renamed *"Verification: the trust story" → "Trust: checked, curated, honest about conflict,"* with two new beats: **B20a/B20b** (contradictions flagged with a severity at ingest and at synthesis time — *surfaced, never auto-resolved; you decide*) and **B21a** (a base you *curate*: diff-before-write, a source required per new claim, your notes preserved).
+- **Comparison table** gains **B6a** — *"Two sources disagree?"* → one-shot tools hand you one answer silently; cogni-knowledge surfaces the contradiction with a severity.
+- **Short Cut A7** and **recap B32** enriched with the curate + conflict-honesty angle.
+- **Accuracy guardrail honored:** contradiction tripwires are framed as observability-only (no auto-resolution, clean runs silent) — no overclaim of live fact-checking.


### PR DESCRIPTION
## Description

Adds a ready-to-shoot YouTube video script that explains the **cogni-knowledge** plugin to a consulting-boutique audience. The deliverable lives at `docs/video-script-cogni-knowledge.md` and contains two cuts so the same material works as both a teaser and an explainer. cogni-knowledge is framed on its own merits (compounding wiki, citation-consistent verification, plain-markdown ownership) and is intentionally independent of cogni-consult.

## Changes

- New `docs/video-script-cogni-knowledge.md` with:
  - A presenter briefing header (target viewer, core promise, tone, suggested title/description).
  - **Script A — The Short Cut (~3 min)**: two-column shooting script (visual cues | narration).
  - **Script B — The Deep Cut (~12 min)**: 8-scene two-column shooting script walking the inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize), the zero-network verification story, the compounding "money story," and two standalone boutique use cases.
  - Appendix: real on-screen commands, a B-roll shot list, and thumbnail/title options.
  - A "Panel notes & revisions" section recording the goal-test feedback and what changed.

## Testing

- Cross-checked every command, skill name, file path, and quoted phrase against `cogni-knowledge/README.md` and `cogni-knowledge/CLAUDE.md` — no invented features.
- Validated table structure (all script rows have correct column counts) and measured VO word counts against runtime targets.
- Goal test: ran a 3-persona simulated-viewer panel (solo founder, research/delivery lead, skeptical partner). Verdicts: no fails (warn / accept / warn). Revised both cuts to correct an overstated verification claim (now scoped to consistency against captured sources), lead the hook with the cost angle, fix the trailer demo to use the real one-shot driver, and trim hype.

## Checklist

- [ ] I have read and agree to the [Contributor License Agreement](../CLA.md)
- [x] My changes follow the existing code style
- [x] I have updated documentation where applicable
- [x] I have tested my changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WQq9zbqk5eDjVJoFaTzL4R

---
_Generated by [Claude Code](https://claude.ai/code/session_01WQq9zbqk5eDjVJoFaTzL4R)_