### PR TITLE
cogni-consult: seed default personas at scaffold + personas_gate rollup

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -35,7 +35,7 @@
     {
       "name": "cogni-consult",
       "source": "./cogni-consult",
-      "version": "0.1.39",
+      "version": "0.1.40",
       "maturity": "preview",
       "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
       "keywords": [

--- a/cogni-consult/.claude-plugin/plugin.json
+++ b/cogni-consult/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-consult",
-  "version": "0.1.39",
+  "version": "0.1.40",
   "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-consult/scripts/engagement-init.sh
+++ b/cogni-consult/scripts/engagement-init.sh
@@ -20,6 +20,19 @@ fi
 
 mkdir -p "$BASE_DIR"/{scope,action-fields,personas,sources,.metadata}
 
+# Seed the two default advisor personas at scaffold time so personas/ is never
+# empty — an empty personas/ silently degrades the design-thinking Empathize and
+# Test stages to consultant-direct fallback. Idempotent: cp -n never overwrites
+# an enriched file, the same guarantee consult-personas holds. These templates
+# carry source:"setup-default", so they do NOT satisfy the personas_gate; that
+# gate tracks scope-seeded personas (or a .gate-waiver marker) and is derived in
+# engagement-status.sh. Templates are resolved relative to this script, not CWD.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PERSONA_TEMPLATES="$SCRIPT_DIR/../references/personas"
+for advisor in consulting-partner project-manager; do
+  cp -n "$PERSONA_TEMPLATES/$advisor.json" "$BASE_DIR/personas/$advisor.json"
+done
+
 SLUG="$SLUG" NAME="$NAME" BASE_DIR="$BASE_DIR" python3 - <<'PY'
 import json, os, datetime
 

--- a/cogni-consult/scripts/engagement-status.sh
+++ b/cogni-consult/scripts/engagement-status.sh
@@ -74,9 +74,36 @@ try:
             fields.append({"slug": slug, "state": "unreadable", "deliverables": []})
             warnings.append(f"unreadable field file: {field_path}: {exc}")
 
+    # personas_gate: derived at read time (no stored field), consistent with
+    # scope_state and the field rollups above. "satisfied" when a scope-seeded
+    # stakeholder persona exists (a personas/*.json with source == "scope-seeded")
+    # OR an explicit personas/.gate-waiver marker is present; otherwise "pending".
+    # The shipped setup-default advisors alone never satisfy it. Fail-soft: a
+    # missing or unreadable personas dir / persona file degrades to "pending",
+    # never raises.
+    personas_gate = "pending"
+    personas_dir = os.path.join(engagement_dir, "personas")
+    if os.path.exists(os.path.join(personas_dir, ".gate-waiver")):
+        personas_gate = "satisfied"
+    else:
+        try:
+            for name in os.listdir(personas_dir):
+                if not name.endswith(".json"):
+                    continue
+                try:
+                    with open(os.path.join(personas_dir, name)) as pf:
+                        if json.load(pf).get("source") == "scope-seeded":
+                            personas_gate = "satisfied"
+                            break
+                except (json.JSONDecodeError, OSError):
+                    continue
+        except OSError:
+            pass
+
     data = {
         **{k: project.get(k) for k in ("slug", "name", "language", "key_question", "updated")},
         "scope_state": (project.get("workflow_state") or {}).get("scope", "pending"),
+        "personas_gate": personas_gate,
         "action_fields": fields,
         "plugin_refs": project.get("plugin_refs") or {},
         "warnings": warnings,

--- a/cogni-consult/skills/consult-setup/SKILL.md
+++ b/cogni-consult/skills/consult-setup/SKILL.md
@@ -18,7 +18,7 @@ allowed-tools: Read, Write, Edit, Bash, Glob, Grep, Skill
 
 Initialize a cogni-consult engagement: frame the desired outcome with the consultant, scaffold the action-fields-WBS directory structure, bind the one cogni-knowledge base the whole engagement compounds research into, and register the engagement for cross-session discovery. This is the entry point — without it, no later skill has a project to write to.
 
-Setup deliberately stays light: it captures the outcome and the research spine, nothing more. The SMART key question, the five scoping dimensions, and the 3-6 action fields are `consult-scope`'s job; personas ship with `consult-personas`; deliverables emerge inside action fields. If an engagement already exists for this client/topic, do not create a duplicate — dispatch `Skill("cogni-consult:consult-resume")` to re-enter it.
+Setup deliberately stays light: it captures the outcome and the research spine, nothing more. The SMART key question, the five scoping dimensions, and the 3-6 action fields are `consult-scope`'s job; the two default advisor personas (`consulting-partner`, `project-manager`) now ship at scaffold so `personas/` is never empty, while engagement-specific scope-seeded stakeholder personas still come from `consult-personas`; deliverables emerge inside action fields. If an engagement already exists for this client/topic, do not create a duplicate — dispatch `Skill("cogni-consult:consult-resume")` to re-enter it.
 
 ## Workflow
 
@@ -46,7 +46,7 @@ Run the init script from the workspace root:
 bash $CLAUDE_PLUGIN_ROOT/scripts/engagement-init.sh "<engagement-slug>" "<engagement-name>"
 ```
 
-The script creates `cogni-consult/<slug>/{scope,action-fields,personas,sources,.metadata}/`, writes the three `.metadata/` logs, writes a `sources/README.md` (the `sources/` directory is the engagement's **source inbox** — the documented drop location for raw material to ground a deliverable; see `$CLAUDE_PLUGIN_ROOT/references/data-model.md`), and writes `consult-project.json` last (its existence is the idempotency key). On `"success": false` with `"engagement already initialized"`, stop and route to the existing engagement via `consult-resume` — never overwrite.
+The script creates `cogni-consult/<slug>/{scope,action-fields,personas,sources,.metadata}/`, seeds the two default advisor personas (`consulting-partner.json`, `project-manager.json`) into `personas/` (idempotent — never overwrites an enriched file), writes the three `.metadata/` logs, writes a `sources/README.md` (the `sources/` directory is the engagement's **source inbox** — the documented drop location for raw material to ground a deliverable; see `$CLAUDE_PLUGIN_ROOT/references/data-model.md`), and writes `consult-project.json` last (its existence is the idempotency key). On `"success": false` with `"engagement already initialized"`, stop and route to the existing engagement via `consult-resume` — never overwrite.
 
 Then enrich `consult-project.json` with `Edit` — never rewrite the file (the `created`/`updated` timestamps the script set must survive):
 


### PR DESCRIPTION
Closes #986.

Foundation (phase 1) of the seeded-personas-gate epic #991. Defines the machine-readable `personas_gate` signal every other child reads, and makes `personas/` non-empty from scaffold.

## Summary
- `engagement-init.sh` now seeds the two default advisors (`consulting-partner.json`, `project-manager.json`) into `personas/` at scaffold time (via a CWD-independent `SCRIPT_DIR`-relative path), so `personas/` is never empty. Copy is idempotent (`cp -n`) and never overwrites an enriched file — the same guarantee `consult-personas` holds.
- `engagement-status.sh` derives a new read-time `personas_gate` rollup: `satisfied` when a persona carries `source: "scope-seeded"` **OR** a `personas/.gate-waiver` marker exists, else `pending`. Fail-soft: a missing/unreadable personas dir or persona json degrades to `pending`, never raises. No new stored field in `consult-project.json` — consistent with how `scope_state` and the field/deliverable rollups are derived.
- `consult-setup/SKILL.md` updated to reflect that the two default advisors now ship at scaffold, while engagement-specific scope-seeded stakeholder personas still come from `consult-personas`.
- Patch version bump to `0.1.40` in `plugin.json`, mirrored in root `marketplace.json`.

## Scope decisions
- Full scope of #986 in one PR. The seeded defaults carry `source: "setup-default"`, **not** `scope-seeded`, so a fresh scaffold reports `personas_gate: "pending"` even with both defaults present — exactly the AC (`pending — otherwise (only the shipped defaults exist, no waiver)`). Only a `consult-personas` define-mode persona (`source: "scope-seeded"`) or an explicit `.gate-waiver` flips it to `satisfied`. This deliberate two-tier design is why child #987 satisfies the gate on scope-seed or a defaults-only waiver.
- No change to `consult-personas`: it already copies these same templates idempotently, so it stays a harmless no-op after scaffold.
- No `consult-project.json` schema change — the rollup is derived at read time.

## Verified locally (all acceptance criteria)
- ✅ Fresh `engagement-init.sh` → both default advisors present in `personas/`.
- ✅ Re-run never overwrites: manifest short-circuit AND `cp -n` both preserve an enriched/scope-seeded file; a missing sibling default is still seeded.
- ✅ Fresh engagement → `personas_gate: "pending"`.
- ✅ A `source:"scope-seeded"` persona → `satisfied`; a `personas/.gate-waiver` marker → `satisfied`.
- ✅ Missing `personas/` dir → `pending`, no raise (fail-soft).
- ✅ `plugin.json` and `marketplace.json` both read `0.1.40`.
- ✅ `bash -n` syntax check on both scripts.