### PR TITLE
cogni-consult: personas-gate satisfaction — scope-seed or defaults-only waiver

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -35,7 +35,7 @@
     {
       "name": "cogni-consult",
       "source": "./cogni-consult",
-      "version": "0.1.40",
+      "version": "0.1.41",
       "maturity": "preview",
       "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
       "keywords": [

--- a/cogni-consult/.claude-plugin/plugin.json
+++ b/cogni-consult/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-consult",
-  "version": "0.1.40",
+  "version": "0.1.41",
   "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-consult/skills/consult-personas/SKILL.md
+++ b/cogni-consult/skills/consult-personas/SKILL.md
@@ -74,8 +74,48 @@ hypothesis. Confirm with the consultant (names, count, tensions), then
 `maturity: "hypothesis"`, `source: "scope-seeded"`, a drafted `role` and
 `voice`, empty `empathy_map`/`capabilities`/`wants`/`needs`/`work_log`.
 
-When scope is not complete, say so and offer the defaults-only path — do not
-dispatch consult-scope unless the consultant wants to scope now.
+Writing at least one `source: "scope-seeded"` persona satisfies the
+engagement's `personas_gate` (derived by `engagement-status.sh`) — tell the
+consultant the gate has flipped to `satisfied`, so the first design-thinking
+deliverable is unblocked.
+
+When scope is not complete, say so and offer the **defaults-only waiver**
+(step 3a) — do not dispatch consult-scope unless the consultant wants to scope
+now.
+
+### 3a. Defaults-Only Waiver Path (mode: waive)
+
+Some engagements have no external stakeholders worth modelling — the two
+shipped advisors are enough. For these, seeding scope personas would only
+invent fiction, yet the `personas_gate` still needs a legitimate way to reach
+`satisfied` so the first design-thinking deliverable is not deadlocked. The
+waiver is that escape, and it is a deliberate, confirmed decision — never a
+silent default.
+
+Only take this path when the consultant explicitly confirms it. Ask, in the
+resolved interaction language (see step 1), whether the engagement genuinely
+has no external stakeholders to model beyond the shipped advisors. Do **not**
+write the marker on silence, on ambiguity, or as a fallback when scope-seeding
+merely hasn't happened yet — a *pending* gate and a *waived* gate are
+different states.
+
+On explicit confirmation, `Write` a `personas/.gate-waiver` marker under the
+engagement's `personas/` directory — a small JSON stamp recording who waived,
+when, and why:
+
+```json
+{
+  "waived_by": "<consultant name or handle>",
+  "waived_at": "<ISO date>",
+  "reason": "No external stakeholders to model; the shipped advisors suffice."
+}
+```
+
+The gate keys on the marker's **presence** (`engagement-status.sh` does not
+parse its contents), so any valid stamp satisfies it — the fields are for the
+human audit trail. Never overwrite an existing `.gate-waiver` or persona file,
+and never invent a persona to stand in for the waiver. Confirm to the
+consultant that `personas_gate` is now `satisfied`.
 
 ### 4. Enrich a Persona (mode: enrich)
 
@@ -138,6 +178,13 @@ the next step.
 - **State ownership**: persona files own persona state; deliverable state
   stays in the field's `field.json`. This skill never edits
   `consult-project.json`.
+- **Personas gate**: writing any `source: "scope-seeded"` persona (step 3) or
+  an explicit `personas/.gate-waiver` marker (step 3a) satisfies the
+  engagement's `personas_gate`; the two shipped advisors alone never do. The
+  waiver is the deliberate alternative for engagements with no external
+  stakeholders — it distinguishes a gate that is *pending* (not seeded, no
+  waiver) from one *deliberately waived*. Like every write here, the marker
+  lives under `personas/`, never in `consult-project.json`.
 - **WBS coordinates everywhere**: `work_log` entries are addressed by
   `action_field` + `deliverable`, like every log in the plugin — there are
   no phases.

--- a/cogni-consult/skills/consult-personas/SKILL.md
+++ b/cogni-consult/skills/consult-personas/SKILL.md
@@ -27,6 +27,8 @@ templates live in `$CLAUDE_PLUGIN_ROOT/references/personas/`.
 
 ## Workflow
 
+Modes: define (step 3), waive (step 3a), enrich (step 4), challenge (step 5).
+
 ### 1. Prerequisite Gate
 
 When arriving via an in-session handoff (e.g. a design-thinking test stage
@@ -113,8 +115,11 @@ when, and why:
 
 The gate keys on the marker's **presence** (`engagement-status.sh` does not
 parse its contents), so any valid stamp satisfies it — the fields are for the
-human audit trail. Never overwrite an existing `.gate-waiver` or persona file,
-and never invent a persona to stand in for the waiver. Confirm to the
+human audit trail. The extensionless `.gate-waiver` name is deliberate: it is a
+presence marker, not a parsed persona file, so it is never mistaken for a
+persona slug when scanning `personas/` — keep the literal name (the gate
+contract keys on it exactly). Never overwrite an existing `.gate-waiver` or
+persona file, and never invent a persona to stand in for the waiver. Confirm to the
 consultant that `personas_gate` is now `satisfied`.
 
 ### 4. Enrich a Persona (mode: enrich)


### PR DESCRIPTION
Closes #987.

Depends on #986 (personas-gate contract, script side — MERGED via #992).

## Summary
- Adds an explicit **defaults-only waiver path** to `consult-personas`: on explicit consultant confirmation that the scope has no external stakeholders worth modelling, the skill writes a `personas/.gate-waiver` marker (small JSON who/when/why stamp) that satisfies the personas gate without inventing personas.
- Wires gate-satisfaction wording into Step 3 so completing define-mode seeding (which already writes `source:"scope-seeded"` personas) tells the consultant the gate flipped to `satisfied`.
- Fleshes out the previously-dangling "defaults-only path" phrase into a real `### 3a. Defaults-Only Waiver Path` subsection.
- Adds an Important Notes bullet distinguishing "gate pending (not seeded, no waiver)" from "gate deliberately waived".
- Patch-bumps cogni-consult `0.1.40 → 0.1.41` in `plugin.json` and `marketplace.json`.

## Scope decisions
- **In scope:** the SKILL.md authoring side (waiver path + gate-satisfaction wording) plus the version bumps — one coherent change (`change-impl`, not decompose).
- **Already done / out of scope:** the script-side gate contract (`engagement-status.sh` deriving `personas_gate` from a `.gate-waiver` marker OR a `scope-seeded` persona) landed in #986 and is intentionally untouched here.
- **No schema change:** the waiver is a separate marker file, not a persona `source` value, so `references/persona-schema.md` stays as-is.
- **Domain ownership preserved:** writes only under `personas/`, never `consult-project.json`.

## Test plan
- [ ] In an engagement with a completed scope, run define-mode seeding; confirm ≥1 `personas/<slug>.json` with `source:"scope-seeded"` and `engagement-status.sh` reports `personas_gate:"satisfied"`.
- [ ] With no scope-seeded personas, exercise the waiver path; confirm explicit confirmation is required, then `personas/.gate-waiver` is written and the gate reports `satisfied`.
- [ ] Confirm the waiver is never written without confirmation and existing persona files are never overwritten.
- [ ] `plugin.json` and the marketplace entry both read `0.1.41`.