### PR TITLE
cogni-consult: personas-gate hard-block on fresh deliverable start

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -35,7 +35,7 @@
     {
       "name": "cogni-consult",
       "source": "./cogni-consult",
-      "version": "0.1.41",
+      "version": "0.1.42",
       "maturity": "preview",
       "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
       "keywords": [

--- a/cogni-consult/.claude-plugin/plugin.json
+++ b/cogni-consult/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-consult",
-  "version": "0.1.41",
+  "version": "0.1.42",
   "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-consult/skills/consult-design-thinking/SKILL.md
+++ b/cogni-consult/skills/consult-design-thinking/SKILL.md
@@ -7,7 +7,10 @@ description: |
   field. Trigger on: "work the deliverable", "run design thinking on
   <deliverable>", "produce the <deliverable> deliverable", "start the DT loop",
   "draft the deliverable", "continue the deliverable", or when a WBS
-  dashboard recommendation hands off the next unstarted deliverable. Global
+  dashboard recommendation hands off the next unstarted deliverable. Starting
+  a fresh (not-yet-in-progress) deliverable requires a satisfied personas gate:
+  when it is unsatisfied the loop routes to consult-personas first before
+  opening, so a fresh start may bounce to persona seeding or a waiver. Global
   phase phrasing ("discover phase", "develop phase", "diamond") refers to a
   legacy engagement model no longer in the ecosystem — do not run
   this loop against legacy engagement directories; cogni-consult has no

--- a/cogni-consult/skills/consult-design-thinking/SKILL.md
+++ b/cogni-consult/skills/consult-design-thinking/SKILL.md
@@ -141,6 +141,36 @@ default, overridden by the user's message language) — independent of the
 engagement's `language` field, which is the deliverable axis. See
 `$CLAUDE_PLUGIN_ROOT/references/interaction-language.md`.
 
+**Personas gate (fresh starts only).** Before opening the loop for a deliverable
+whose `state` is `pending` (a fresh start — not a resume or rework), the
+engagement's personas gate must be satisfied, so Empathize (which maps personas)
+and Test (which challenges *as* personas) operate on real stakeholders rather
+than the degraded fallback. Read the derived rollup — this gate does not
+otherwise call it:
+
+```bash
+bash $CLAUDE_PLUGIN_ROOT/scripts/engagement-status.sh <engagement-dir>
+```
+
+and branch on `data.personas_gate`:
+
+- If `"pending"` (no `source: "scope-seeded"` persona and no
+  `personas/.gate-waiver` marker — the seeded default advisors alone do not
+  satisfy it): do **not** open the loop. Dispatch
+  `Skill("cogni-consult:consult-personas")` and stop — write nothing. Explain
+  that the engagement's personas gate is unsatisfied, and that it flips to
+  `satisfied` once scope-specific stakeholders are seeded (define mode) or an
+  explicit waiver is recorded (for engagements with no external stakeholders);
+  the consultant returns here once it is satisfied.
+- If `"satisfied"`: proceed to *Open the Loop* as usual.
+
+This guard applies only to the `pending` (fresh-start) branch below. A
+deliverable that is already `in-progress` (resume) or being reopened from
+`complete` (rework) is never blocked — the gate is a start-of-loop check, and
+once satisfied it stays satisfied, so in practice it only ever gates the
+engagement's first deliverable. The Empathize/Test fallbacks remain as a
+last-resort safety net but do not trigger for the scope-seeded flow.
+
 ### 2. Open the Loop
 
 If the deliverable's `state` is `pending`: one `Edit` of `field.json` sets it


### PR DESCRIPTION
Closes #988.

## Summary
- Insert a personas-gate hard-block into `consult-design-thinking`'s Prerequisite Gate: after the deliverable-entry check and before "Open the Loop", when the deliverable `state` is `pending` (a fresh start), call `bash $CLAUDE_PLUGIN_ROOT/scripts/engagement-status.sh <engagement-dir>` and read `data.personas_gate` (the gate did not previously call it).
- If `pending` → dispatch `Skill("cogni-consult:consult-personas")` (define/waive mode, self-selected from context) and stop, writing nothing; explain personas must be seeded or explicitly waived.
- If `satisfied` → proceed into the loop as today.
- In-progress (resume) and complete→rework deliverables are never gated — the guard is scoped to the `pending` branch only, so in practice it only ever gates the engagement's first deliverable. The Empathize/Test persona fallbacks remain as the last-resort safety net.
- Bump cogni-consult 0.1.41 → 0.1.42 in `plugin.json` and `marketplace.json`.

## Scope
Full scope for the issue's acceptance criteria (enforcement half of the personas gate, building on the merged #986 contract). SKILL.md prose plus the two version mirrors; no script or fixture change — no existing tests exercise the gate, and all three cogni-consult test suites stay green.

## Test plan
- [ ] Fresh `pending` deliverable + `personas_gate` `pending` (only default advisors, no `.gate-waiver`): loop halts and routes to consult-personas; does NOT enter empathize or flip state to in-progress.
- [ ] Gate `satisfied` (scope-seeded persona or `personas/.gate-waiver`): the same deliverable enters empathize with personas present.
- [ ] Resume an already `in-progress` deliverable while gate `pending`: not blocked.
- [ ] Re-enter a `complete` deliverable for rework while gate `pending`: not blocked.
- [ ] `plugin.json` and the `marketplace.json` cogni-consult entry both read `0.1.42`.