### PR TITLE
cogni-consult: proactive persona-seed routing before first deliverable

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -35,7 +35,7 @@
     {
       "name": "cogni-consult",
       "source": "./cogni-consult",
-      "version": "0.1.42",
+      "version": "0.1.43",
       "maturity": "preview",
       "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
       "keywords": [

--- a/cogni-consult/.claude-plugin/plugin.json
+++ b/cogni-consult/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-consult",
-  "version": "0.1.42",
+  "version": "0.1.43",
   "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-consult/skills/consult-resume/SKILL.md
+++ b/cogni-consult/skills/consult-resume/SKILL.md
@@ -56,8 +56,10 @@ bash $CLAUDE_PLUGIN_ROOT/scripts/engagement-status.sh <engagement-path>
 ```
 
 `<engagement-path>` is the `path` field from discovery. The script derives
-the rollups at read time: `scope_state`, and per field its `state` plus each
-deliverable's `state`, `dt_stage`, `producing_route`, and `persona_review`.
+the rollups at read time: `scope_state`, an engagement-level `personas_gate`
+(`satisfied` once a scope-seeded persona or a `.gate-waiver` marker exists,
+else `pending`), and per field its `state` plus each deliverable's `state`,
+`dt_stage`, `producing_route`, and `persona_review`.
 Surface any `warnings[]` verbatim (an `unreadable` field manifest is a
 problem for the consultant to see, not to paper over).
 
@@ -123,6 +125,19 @@ Branch on the derived state, first match wins, and say *why*:
   once the layer above it has been. Route to `knowledge-refresh` for the
   research, then `consult-design-thinking` to re-run that deliverable's loop.
   Never recommend refreshing a dependent before its upstream dependency.
+- **`scope_state` is `complete` AND `personas_gate` is `"pending"`** (no
+  scope-seeded persona and no `.gate-waiver` marker yet) → the first
+  design-thinking deliverable's empathize and test stages would run on degraded
+  fallback, and the hard gate blocks a not-yet-started deliverable until personas
+  are seeded. Recommend `consult-personas` to seed acting personas from the
+  scope's Stakeholder dimension (or waive to defaults) *before* recommending any
+  deliverable work. Placed after the scope/unreadable/stale checks so it never
+  masks a broken manifest or a stale set, but ahead of the pending-deliverable
+  recommendation so it front-runs the first deliverable. Read `personas_gate`
+  from the `engagement-status.sh` rollup already fetched above; this stays a
+  read-only route — never write persona state here. (This gate is naturally
+  once-per-engagement: once satisfied it stays satisfied, and it never fires
+  for an `in-progress` or resumed deliverable, which the branches below own.)
 - **A deliverable is `in-progress`** → resume it where it stands; recommend
   `consult-design-thinking` naming the field, the deliverable, and its
   `dt_stage` ("competitor-map is mid-ideate — pick the loop back up there").

--- a/cogni-consult/skills/consult-scope/SKILL.md
+++ b/cogni-consult/skills/consult-scope/SKILL.md
@@ -108,7 +108,11 @@ Skip the cascade-stale silently when `diagnostic-as-is/field.json` `deliverables
 
 ### 6. Close the Scope
 
-`Edit` `consult-project.json`: set `workflow_state.scope` to `"complete"` and `updated` to today's ISO date. Summarize what now exists — the key question, one line per dimension, and the action-field WBS. Then recommend planning the first action field's deliverables as the next step and dispatch `Skill("cogni-consult:consult-action-fields")` to plan each field's deliverable set and pick the next deliverable.
+`Edit` `consult-project.json`: set `workflow_state.scope` to `"complete"` and `updated` to today's ISO date. Summarize what now exists — the key question, one line per dimension, and the action-field WBS.
+
+Then, **when the `## Stakeholder` dimension is populated**, recommend seeding acting personas from scope as the natural first next step — dispatch `Skill("cogni-consult:consult-personas")` — *before* planning deliverables. The Stakeholder dimension is the exact source for scope-seeded personas and is freshest right now, and the first design-thinking deliverable's empathize and test stages consume those personas: seeding here turns a later hard-gate stop into an on-rails step. Stay a read-only router — recommend/dispatch only; never write persona state here (`consult-personas` owns that). Skip the persona recommendation when the Stakeholder dimension is empty.
+
+Finally, recommend planning the first action field's deliverables and dispatch `Skill("cogni-consult:consult-action-fields")` to plan each field's deliverable set and pick the next deliverable.
 
 ## Important Notes
 


### PR DESCRIPTION
Closes #989.

## Summary
- **consult-scope "### 6. Close the Scope":** when the `## Stakeholder` dimension is populated, recommend seeding personas via `consult-personas` as a next step alongside (before) planning the first field's deliverables. Stays a read-only recommendation — no persona state is written. Skips the recommendation when the Stakeholder dimension is empty.
- **consult-resume "### 5. Recommend the Next Action":** insert a new first-match branch — `scope_state` complete AND `personas_gate` is `"pending"` → recommend `consult-personas` (seed). Placed after the scope/unreadable/stale checks and before the pending-deliverable recommendation, so it front-runs the first deliverable without masking a broken manifest or stale set. Step 3's rollup field list now documents `personas_gate` where the script output is described.
- The reactive post-completion `persona_review` branch is left exactly as-is.
- Patch bump cogni-consult 0.1.42 → 0.1.43 in `plugin.json` and mirrored in `marketplace.json`.

## Scope decisions
- **In:** all three acceptance criteria (scope handoff, resume Step 5 seed branch, version bump). Both surfaces remain read-only routers.
- **Insertion point in Step 5:** after the stale branch, before the in-progress branch — satisfies the issue's ordering constraint ("after scope/unreadable/stale, before a new pending deliverable"). Ordering vs the in-progress and reactive `persona_review` branches is not load-bearing because `personas_gate` cannot be `"pending"` once a deliverable is in-progress or a persona_review exists (the personas-gate contract), but the reactive branch is preserved verbatim regardless.
- **Out:** no persona-state writes, no `engagement-status.sh` change (it already derives `personas_gate` at read time). Nothing deferred.

## Test plan
- [ ] On an engagement with scope complete and a populated `## Stakeholder` dimension, run consult-scope to completion and confirm the closing handoff names persona-seeding before planning deliverables.
- [ ] On an engagement with `scope_state: complete` and `personas_gate: pending`, run consult-resume and confirm Step 5 recommends `consult-personas` (seed) before any consult-action-fields / consult-design-thinking recommendation.
- [ ] Confirm a `complete` deliverable with `persona_review: pending` still routes to `consult-personas` via the unchanged reactive branch.
- [ ] Confirm `personas_gate: satisfied` (a scope-seeded persona or `.gate-waiver` marker present) does NOT trigger the new seed branch.
- [ ] `git grep` confirms plugin.json and marketplace.json both read 0.1.43 for cogni-consult.

## Review notes
- Skill-quality gate: consult-scope **pass**; consult-resume **needs_revision** → the single auto-fixable finding (Step 3 field list omitted `personas_gate`) was fixed in-pipeline before commit.