### PR TITLE
cogni-consult: document personas gate in lifecycle docs + version bump

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -35,7 +35,7 @@
     {
       "name": "cogni-consult",
       "source": "./cogni-consult",
-      "version": "0.1.43",
+      "version": "0.1.44",
       "maturity": "preview",
       "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
       "keywords": [

--- a/cogni-consult/.claude-plugin/plugin.json
+++ b/cogni-consult/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-consult",
-  "version": "0.1.43",
+  "version": "0.1.44",
   "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-consult/CLAUDE.md
+++ b/cogni-consult/CLAUDE.md
@@ -65,7 +65,7 @@ cogni-consult/
 
 - **Action fields as WBS** — scoping derives 3-6 action fields from the key question; every deliverable lives inside exactly one field. Progress is tracked per deliverable, not per global phase
 - **Design thinking per deliverable** — each deliverable iterates empathize→define→ideate→prototype→test on its own clock; fields complete when their deliverables do
-- **Acting personas** — stakeholder personas (shipped defaults: consulting partner, project manager) actively challenge deliverable work in their voice, not just describe users
+- **Acting personas as a seed-from-scope gate** — stakeholder personas are seeded from the engagement scope *before* the first design-thinking deliverable can start, then actively challenge deliverable work in their voice (not just describe users). The seed is a gate, not a suggestion: `consult-design-thinking` hard-blocks a not-started deliverable and `consult-resume` routes to persona-seeding first, until the gate is satisfied. The two shipped setup-default advisors (consulting partner, project manager; `source: setup-default`) do **not** satisfy it. The gate is the derived `personas_gate` rollup: **satisfied** when any `personas/*.json` carries `source: scope-seeded` **or** the extensionless `personas/.gate-waiver` marker is present, else **pending**. The waiver is the defaults-only escape — when no external stakeholders are worth modelling, `consult-personas` (mode: waive) writes `.gate-waiver` on explicit confirmation, moving the gate to satisfied without seeding a persona
 - **Knowledge base as the research spine** — one cogni-knowledge base bound at setup (`plugin_refs.knowledge_base`); all deliverable research runs through it and compounds
 - **Orchestrator, not producer** — manages engagement state; content work dispatches to existing plugins
 - **Path references, not data copies** — cross-references via slugs/paths, no shared DB
@@ -88,7 +88,7 @@ Full schemas: `references/data-model.md`.
 | Script | Purpose |
 |--------|---------|
 | `engagement-init.sh` | Create the engagement directory skeleton + consult-project.json |
-| `engagement-status.sh` | Read consult-project.json + derive field/deliverable rollups from `field.json` files → JSON |
+| `engagement-status.sh` | Read consult-project.json + derive field/deliverable rollups from `field.json` files, plus the `personas_gate` rollup (satisfied when a `personas/*.json` has `source: scope-seeded` or the extensionless `personas/.gate-waiver` marker is present, else pending) → JSON |
 | `deliverable-graph.py` | Deliverable dependency-graph engine over all `field.json` files: `validate` (cycles + dangling refs), `trace` (upstream lineage), `impact` (downstream blast radius), `refresh-order` (topological layering of stale deliverables), `cascade-stale` (flag downstream `lineage_status` via idempotent RMW). Full model: `references/dependency-model.md` |
 | `discover-projects.sh` | Thin wrapper delegating to `cogni-workspace/scripts/discover-plugin-projects.sh` (registry: `$HOME/.claude/cogni-consult-projects.json`) |
 | `_discover_extractor.py` | Per-engagement JSON field extractor consumed by the discovery wrapper (reads the flat consult-project.json schema) |
@@ -101,6 +101,7 @@ All scripts are stdlib-only (bash + python3, no pip dependencies).
 - Engagement and entity slugs in kebab-case, derived from names
 - Workflow state per deliverable: `pending` → `in-progress` → `complete` (→ `in-progress` on iteration re-entry); stored only in `field.json`, field and engagement completion derived at read time
 - `dt_stage` tracks the design-thinking stage per deliverable (`empathize`/`define`/`ideate`/`prototype`/`test`)
+- `personas_gate` is a **derived** rollup (never stored): `engagement-status.sh` computes it at read time from the `personas/` directory — **satisfied** when any `personas/*.json` carries `source: scope-seeded` or the extensionless `personas/.gate-waiver` marker exists, else **pending**. It gates the first design-thinking deliverable (seed personas from scope, or take the defaults-only waiver, before deliverable work starts)
 - Entity outputs are Obsidian-browsable markdown with YAML frontmatter; state files are plain JSON
 - `language` field in consult-project.json is the deliverable/output language for artifacts (technical terms stay English); the user-facing interaction language is a separate, runtime-derived axis (workspace default + message-detection override, never stored) — see `references/interaction-language.md`
 - **Research routing**: every research run goes through the engagement's bound knowledge base per `references/research-routing.md` — the canonical rule all deliverable-producing skills point at (binding via `plugin_refs.knowledge_base`, pipeline rungs, depth framing, syntheses copied to `action-fields/<field-slug>/research/<topic-slug>.md`); raw WebSearch only for a single trivial fact-check

--- a/cogni-consult/README.md
+++ b/cogni-consult/README.md
@@ -29,7 +29,7 @@ A consulting engagement orchestrator that treats action fields as the work-break
 2. **Scope the engagement** — frame the SMART key question, work the five scoping dimensions, derive 3-6 action fields as the WBS (`consult-scope`)
 3. **Manage the WBS** — per-field deliverable manifests, a fields × deliverables dashboard, next-deliverable recommendations, add/split/merge fields (`consult-action-fields`)
 4. **Produce deliverables** — run the empathize→define→ideate→prototype→test loop on one deliverable at a time, with evidence from the bound knowledge base (`consult-design-thinking`)
-5. **Challenge with acting personas** — define stakeholder personas from the scope, enrich them with evidence, and have them push back on deliverables in their own voice (`consult-personas`)
+5. **Seed and challenge with acting personas** — seed stakeholder personas from the scope *before* the first deliverable starts (the `personas_gate`), enrich them with evidence, and have them push back on deliverables in their own voice; when there are no external stakeholders worth modelling, take the defaults-only waiver instead (`consult-personas`)
 6. **Resume across sessions** — discover engagements, show WBS progress, and route to the most valuable next action (`consult-resume`)
 7. **See engagement status visually** — generate a themed, browsable HTML dashboard of the action-field WBS, deliverable states, design-thinking stages, and persona-review progress (`consult-dashboard`)
 
@@ -37,7 +37,7 @@ A consulting engagement orchestrator that treats action fields as the work-break
 
 - **Compound your research instead of repeating it.** Every deliverable's evidence lands in one refinable cogni-knowledge base, so the tenth deliverable starts from what the first nine already found instead of re-running the same searches.
 - **Move ready work without waiting on a phase gate.** Deliverable-level state across the engagement's 3-6 action fields shows what is mid-loop, what awaits persona review, and what to pick up next — no deliverable stalls behind an unrelated one.
-- **Catch objections while change is cheap.** Two acting personas push back on each deliverable in their own voice at the prototype stage, surfacing concerns that otherwise land at the final readout.
+- **Catch objections while change is cheap.** Acting personas are seeded from the scope before the first deliverable begins — a gate, not an afterthought — then push back on each deliverable in their own voice, surfacing concerns that otherwise land at the final readout. No external stakeholders to model? A one-step defaults-only waiver clears the gate.
 - **Resume across sessions without re-briefing.** `consult-resume` rebuilds engagement status and routes to the next action, so a multi-week engagement never loses its thread between sessions.
 
 ## Install
@@ -109,20 +109,21 @@ Field and engagement completion are derived at read time — never stored. Full 
 Setup comes first because everything downstream is path-addressed against the engagement skeleton it writes, and the knowledge base it binds is the spine every later research run reaches. Scoping then converts one SMART key question into 3-6 action fields — the work-breakdown-structure — so the rest of the engagement is organized by *what the work is about*, not by which process phase it sits in.
 
 ```
-consult-setup ──→ consult-scope ──→ consult-action-fields ──→ consult-design-thinking
- (scaffold +        (key question +     (plan deliverable        (empathize→define→ideate
-  kb binding)        5 dimensions +      sets, pick next)          →prototype→test per
-                     3-6 action fields)        │                    deliverable)
-                                               │                         │
-                                               ▼                         ▼
-                                        consult-resume  ←──────  consult-personas
-                                        (re-entry: dashboard      (acting personas
-                                         + next action)            challenge the draft)
+consult-setup ─→ consult-scope ─→ consult-personas ─→ consult-action-fields ─→ consult-design-thinking
+ (scaffold +      (key question +   (seed from scope:       (plan deliverable       (empathize→define→ideate
+  kb binding)      5 dimensions +    personas_gate, or       sets, pick next)         →prototype→test; the
+                   3-6 action        defaults-only waiver          │                  seeded personas challenge
+                   fields)           — gates deliverable 1)        │                  each draft in their voice)
+                                                                   ▼
+                                                            consult-resume
+                                                            (re-entry: dashboard + next
+                                                             action; routes to persona-
+                                                             seeding before deliverable 1)
 
 cogni-knowledge (bound once at setup) ←── every research run, per references/research-routing.md
 ```
 
-Each deliverable then runs its own empathize→define→ideate→prototype→test loop on its own clock — a field completes when its deliverables do, and the engagement completes by derivation rather than by a global gate. That is why ready work never blocks: deliverable state lives in each `field.json`, and completion is computed at read time, never stored. Acting personas enter at the prototype stage so objections surface while the draft is still cheap to change.
+Acting personas gate the first deliverable: before design thinking starts, personas are seeded from the scope (or the defaults-only waiver is taken) so the stakeholder voices that will challenge the work are in place from the outset — `consult-design-thinking` hard-blocks a not-started deliverable and `consult-resume` routes to persona-seeding first until the `personas_gate` is satisfied. Each deliverable then runs its own empathize→define→ideate→prototype→test loop on its own clock — a field completes when its deliverables do, and the engagement completes by derivation rather than by a global gate. That is why ready work never blocks: deliverable state lives in each `field.json`, and completion is computed at read time, never stored. The seeded personas push back on each draft in their own voice while it is still cheap to change.
 
 Research never goes to raw web search: the engagement's bound knowledge base serves quick gap-checks (`knowledge-query`), full inverted-pipeline runs for new topics, and `--source wiki` re-runs on covered topics — with finalized syntheses copied to the owning action field's `research/` directory. Routing every run through one base is what lets later deliverables build on earlier findings instead of paying to rediscover them.
 


### PR DESCRIPTION
Closes #990.

## Summary
- **CLAUDE.md Design Principles:** rewrote the "Acting personas" bullet so personas are seeded from scope *before* the first design-thinking deliverable (a gate), documenting the `personas_gate` derived rollup and the defaults-only waiver escape.
- **CLAUDE.md Scripts table + Key Conventions:** the `engagement-status.sh` row now names the `personas_gate` rollup it derives, and a Key Conventions entry defines the rollup (satisfied on a `source: scope-seeded` persona or the extensionless `personas/.gate-waiver`, else pending) — keeping the doc internally consistent.
- **README.md:** aligned the "What it does" item 5, "What it means for you", and "How it works" (diagram + prose) so the personas gate reads as gating the first deliverable via seed-from-scope, not only challenging at the prototype stage.
- **Version:** bumped `cogni-consult/.claude-plugin/plugin.json` 0.1.43 → 0.1.44 and mirrored it in the root `.claude-plugin/marketplace.json` entry.

## Scope decisions
- Docs-only reconciliation of behavior already shipped by the three prior children (seed/hard-block/route-to-seeding); no code change here.
- Version base on `origin/main` was already 0.1.43 (prior children merged), so the bump target is 0.1.44 — not the pre-merge number in the original issue.
- Nothing deferred — single coherent reconciliation, one reviewable PR.

## Test plan
- [x] `plugin.json` version == 0.1.44; `marketplace.json` cogni-consult entry == 0.1.44.
- [x] `personas_gate` + defaults-only waiver documented in CLAUDE.md (Design Principles, Scripts row, Key Conventions).
- [x] README no longer claims personas enter *only* at the prototype stage.
- [x] `scripts/check-breadcrumbs.py` passes (no new issue refs introduced in the edited docs).