### PR TITLE
cogni-consult: single-owner persona-challenge via consult-personas fan-out

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -35,7 +35,7 @@
     {
       "name": "cogni-consult",
       "source": "./cogni-consult",
-      "version": "0.1.46",
+      "version": "0.1.47",
       "maturity": "preview",
       "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
       "keywords": [

--- a/cogni-consult/.claude-plugin/plugin.json
+++ b/cogni-consult/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-consult",
-  "version": "0.1.46",
+  "version": "0.1.47",
   "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-consult/README.md
+++ b/cogni-consult/README.md
@@ -148,6 +148,7 @@ Publishing is **consultant-elected and never automatic** — it does not fire at
 | `consult-dashboard` | Skill | Themed HTML engagement dashboard: action-field WBS, deliverable state, design-thinking stage, persona-review progress |
 | `consult-dashboard-refresher` | Agent | Regenerate the engagement dashboard HTML at a milestone (haiku, read-only, no theme prompt) |
 | `consult-framework-adherence-reviewer` | Agent | Score a completed deliverable against its stored `chosen_framework` and report structural drift (sonnet, read-only) — the framework-adherence rung of the design-thinking Test gate |
+| `consult-persona-challenger` | Agent | Challenge a deliverable as one acting stakeholder persona in voice and return a structured objection envelope (sonnet, read-only) — the per-persona fan-out consult-personas merges at the design-thinking Test gate |
 | `engagement-init.sh` | Script | Create the engagement directory skeleton + `consult-project.json` |
 | `engagement-status.sh` | Script | Derive field/deliverable rollups from `field.json` files → JSON |
 | `discover-projects.sh` | Script | Engagement discovery (delegates to the cogni-workspace helper) |
@@ -170,11 +171,13 @@ cogni-consult/
 │   ├── methods/                   Stage methods (scope dimensions, empathy mapping,
 │   │                              HMW synthesis, guided ideation)
 │   └── orchestration/             DT orchestration contracts (Empathize intake,
-│                                  Test provenance gate + adherence review,
-│                                  Close KB deposit)
+│                                  Test provenance gate + adherence review +
+│                                  persona challenge, Close KB deposit)
 ├── agents/                        consult-dashboard-refresher (milestone HTML refresh),
 │                                  consult-framework-adherence-reviewer (Test-stage
-│                                  framework drift)
+│                                  framework drift),
+│                                  consult-persona-challenger (per-persona Test
+│                                  challenge fan-out)
 ├── scripts/                       Engagement init/status/discovery (stdlib-only)
 └── skills/                        The seven skills listed under Components
                                    (consult-dashboard bundles its generator + theme schema)

--- a/cogni-consult/agents/consult-persona-challenger.md
+++ b/cogni-consult/agents/consult-persona-challenger.md
@@ -1,0 +1,99 @@
+---
+name: consult-persona-challenger
+description: Challenge a cogni-consult deliverable as ONE acting stakeholder persona, in that persona's voice, and return a structured objection envelope. Read-only — never edits the artifact, persona files, or any state.
+
+model: sonnet
+color: orange
+tools: ["Read", "Glob", "Grep"]
+---
+
+You are a read-only acting-persona challenger for the cogni-consult plugin. Your
+only job is to challenge one finished-enough deliverable draft **as a single
+stakeholder persona**, in that persona's own voice, and return the structured
+objection as a JSON envelope. You never edit the deliverable, the persona file,
+`field.json`, or any other file — the challenge informs; the consultant decides
+what to revise, and `consult-personas` owns every write.
+
+You are dispatched once per relevant persona (the fan-out). Each dispatch speaks
+for exactly one persona so voices never bleed together.
+
+## Environment
+
+The task prompt that spawned you includes a `plugin_root` path. Wherever these
+instructions reference `$CLAUDE_PLUGIN_ROOT`, substitute the `plugin_root` value
+from your task.
+
+## Input Contract
+
+Your task prompt includes:
+- `engagement_dir` (required): absolute path to the engagement directory (the one
+  holding `consult-project.json`).
+- `field_slug` (required): the action field the deliverable lives in.
+- `deliverable_slug` (required): the deliverable to challenge.
+- `persona_slug` (required): the single persona to act as.
+- `plugin_root` (required): absolute path to `$CLAUDE_PLUGIN_ROOT`.
+
+## Workflow
+
+1. **Read the persona.** Read `<engagement_dir>/personas/<persona_slug>.json`. If
+   it is missing, return `success: false` with the reason. Otherwise absorb its
+   `voice`, `role`, `capabilities`, `wants`, `needs`, `core_tension`, and
+   `empathy_map` — these bound and color the challenge (the Acting Contract in
+   `$CLAUDE_PLUGIN_ROOT/references/persona-schema.md`).
+
+2. **Read the artifact.** Read the deliverable artifact at
+   `<engagement_dir>/action-fields/<field_slug>/<deliverable_slug>.md`. If it does
+   not exist yet (nothing to challenge), return `success: true` with empty
+   `missing`/`pushbacks`/`acceptance_bar` and a `voice_note` saying there is no
+   draft to challenge yet.
+
+3. **Challenge in voice.** Adopt the persona: speak as its `voice`, demand only
+   what its `capabilities` can credibly demand, aim at its `wants`, hold the work
+   to its `needs`, and let its `core_tension` and `empathy_map` shape *how* it
+   pushes back. Produce the structured challenge — never free-form prose:
+   - **What's missing** — the gaps this persona spots first.
+   - **Push-backs** — claims or choices it would contest, each with why.
+   - **Acceptance bar** — what would make this persona accept the deliverable.
+
+4. **Ground it.** Every demand must trace to a persona field — do not invent
+   authority the persona lacks or objections outside its stake. If the artifact
+   already satisfies this persona, say so plainly rather than manufacturing
+   friction.
+
+## Output Contract
+
+Return exactly one JSON object on stdout, the standard envelope:
+
+```json
+{
+  "success": true,
+  "data": {
+    "persona_slug": "<persona_slug>",
+    "persona_name": "<name>",
+    "deliverable": "<field_slug>/<deliverable_slug>",
+    "missing": ["<gap>"],
+    "pushbacks": [{"claim": "<what they contest>", "why": "<grounded reason>"}],
+    "acceptance_bar": ["<what would earn this persona's acceptance>"],
+    "voice_note": "<one-line in-character summary>"
+  },
+  "error": null
+}
+```
+
+On a recoverable empty case (no draft yet), set `success: true` with empty arrays
+and an explanatory `voice_note`. On a hard failure (missing persona file, bad
+`engagement_dir`), set `success: false`, `data: null`, and put the reason in
+`error`.
+
+## Boundaries
+
+- **Read-only, always.** You hold no Write/Edit tools and must never ask for
+  them. `consult-personas` merges your envelope and owns every write (the
+  `work_log` entry, the `## Persona Challenges` section, the `persona_review`
+  advance).
+- **One persona per dispatch.** Speak only for `persona_slug`; do not blend in
+  other personas' concerns.
+- **Advisory, never gating.** You report objections; you never revise the
+  artifact and never block completion.
+- **No research.** You read only on-disk persona and artifact files — no web, no
+  knowledge base — so you report no `cost_estimate`.

--- a/cogni-consult/references/orchestration/test-persona-challenge.md
+++ b/cogni-consult/references/orchestration/test-persona-challenge.md
@@ -1,0 +1,80 @@
+# Test-Stage Persona Challenge — Fan-Out + Merge
+
+The persona-challenge contract for the design-thinking Test stage. The
+design-thinking loop delegates the challenge here rather than reimplementing it,
+and `consult-personas` (mode: challenge) executes it — so the persona-challenge
+write contract lives in exactly one owner. This document is authoritative for the
+*fan-out, envelope, and merge* mechanics; the *writes* are owned by
+`consult-personas` step 5 (Act as a Persona).
+
+## Who owns what
+
+- **`consult-design-thinking` Test stage** dispatches
+  `Skill("cogni-consult:consult-personas")` in challenge mode as an in-session
+  handoff naming the deliverable. It does not reimplement any persona write.
+- **`consult-personas` step 5** runs the fan-out below, merges the results, and
+  performs the three writes (the single write owner).
+- **`consult-persona-challenger` agent** generates one persona's objections,
+  read-only, and returns them in the standard `{success, data, error}` envelope.
+
+## Fan-out
+
+Determine the relevant personas: both shipped advisors
+(`consulting-partner`, `project-manager`) plus any persona whose `context`
+touches the deliverable's topic. Dispatch the read-only
+`consult-persona-challenger` agent **once per relevant persona** (the fan-out),
+passing `engagement_dir`, `field_slug`, `deliverable_slug`, `persona_slug`, and
+`plugin_root`. Each dispatch speaks for exactly one persona so voices stay
+distinct.
+
+## Envelope + merge
+
+Each dispatch returns the standard envelope with `data.missing[]`,
+`data.pushbacks[]`, and `data.acceptance_bar[]` for its persona. Merge the
+per-persona envelopes into one consolidated result: a single
+`## Persona Challenges` section (one block per persona) and one `work_log` append
+per persona. This per-persona-dispatch → envelope → merge convention is the one
+later per-persona fan-outs (e.g. Empathize per-persona empathy mapping) reuse.
+
+## The write contract (owned by consult-personas step 5)
+
+After the merge, `consult-personas` applies exactly these writes:
+
+- Append one `work_log` entry per persona challenged to that persona's
+  `personas/<slug>.json` `work_log` array via `Edit`
+  (`{"action_field", "deliverable", "action": "challenged", "date"}`).
+- Append (or update) a consolidated `## Persona Challenges` section in the
+  deliverable artifact summarizing each persona's challenge and the consultant's
+  disposition (accepted / revised / rejected with reason).
+- When the field's manifest entry carries a `persona_review` field, advance it
+  (`pending` → `in-progress` when challenges start, → `complete` only once every
+  challenge is dispositioned); when it doesn't, the `work_log` entries and the
+  artifact section are the record — never create the field on an entry lacking
+  it.
+
+## Idempotency (the loop may re-enter Test)
+
+- **`work_log`:** before appending, scan the persona's `work_log` for a
+  `challenged` entry matching these `(action_field, deliverable)` coordinates;
+  append only when none exists, so a re-entry does not double-record.
+- **`## Persona Challenges`:** append-or-update the section rather than stacking
+  duplicate sections.
+- **`persona_review`:** advance via idempotent read-modify-write; a same-state
+  re-set is a no-op.
+
+## Advisory + consultant-interactive
+
+The challenge informs — it never blocks completion. In auto-walk mode, run the
+fan-out, apply the writes, and surface the merged challenges without pausing. In
+interactive mode, the Test stage surfaces the persona dispositions before the
+challenge runs (its interactive gate), and the consultant steers before and
+disposition-decides after; electing to complete is always available. The
+consultant decides what to revise — revision belongs to the deliverable's
+producing route.
+
+## Zero personas on disk
+
+When no persona files exist at all (the shipped-advisor seeding normally prevents
+this), skip the fan-out and challenge the consultant directly ("what would your
+engagement partner push back on?"), noting the acting-persona pass deepens once
+personas exist.

--- a/cogni-consult/references/orchestration/test-persona-challenge.md
+++ b/cogni-consult/references/orchestration/test-persona-challenge.md
@@ -30,7 +30,11 @@ distinct.
 ## Envelope + merge
 
 Each dispatch returns the standard envelope with `data.missing[]`,
-`data.pushbacks[]`, and `data.acceptance_bar[]` for its persona. Merge the
+`data.pushbacks[]`, and `data.acceptance_bar[]` for its persona. Merge only the
+`success: true` envelopes: a `success: false` envelope is surfaced to the
+consultant as a dispatch error and its persona is excluded from every write,
+and a no-draft envelope (`success: true` with empty arrays) produces no writes
+at all — nothing was challenged. Merge the surviving
 per-persona envelopes into one consolidated result: a single
 `## Persona Challenges` section (one block per persona) and one `work_log` append
 per persona. This per-persona-dispatch → envelope → merge convention is the one

--- a/cogni-consult/skills/consult-design-thinking/SKILL.md
+++ b/cogni-consult/skills/consult-design-thinking/SKILL.md
@@ -328,8 +328,11 @@ Every evidence-backed claim carries a `sources[]` entry. Then advance
 ### 7. Test
 
 **Interactive mode:** before challenging, surface the persona dispositions you
-intend to apply — which personas will challenge and the objections each is likely
-to raise — so the consultant can steer the challenge before it runs; then proceed.
+intend to apply — which personas will challenge (per the relevance rule in
+`$CLAUDE_PLUGIN_ROOT/references/orchestration/test-persona-challenge.md`:
+shipped advisors plus context-matching personas) and the objections each is
+likely to raise — so the consultant can steer the challenge before it runs;
+then proceed.
 
 Challenge the draft as the stakeholder personas by **delegating to the
 write-contract owner** — do not reimplement the persona-challenge writes inline
@@ -391,7 +394,8 @@ unstarted deliverable in the WBS (via the WBS dashboard skill when present in
 the plugin, or by reading the field manifests directly).
 
 **Milestone dashboard refresh.** When this session moved the deliverable's
-`state` to `"complete"` (or closed its `persona_review`), the engagement's
+`state` to `"complete"` (or the delegated persona challenge closed its
+`persona_review`), the engagement's
 status changed — offer the consultant a fresh visual dashboard. If the
 engagement already has `output/design-variables.json` (a prior
 `consult-dashboard` run set up a theme), regenerate the HTML without prompting

--- a/cogni-consult/skills/consult-design-thinking/SKILL.md
+++ b/cogni-consult/skills/consult-design-thinking/SKILL.md
@@ -331,21 +331,20 @@ Every evidence-backed claim carries a `sources[]` entry. Then advance
 intend to apply — which personas will challenge and the objections each is likely
 to raise — so the consultant can steer the challenge before it runs; then proceed.
 
-Challenge the draft as the stakeholder personas, in their voice: for each
-relevant `personas/*.json`, pose the objections that persona's `role`,
-`core_tension`, and `empathy_map` imply, and revise the artifact where a
-challenge lands. Append one `work_log` entry per persona challenged to that
-persona's `personas/<persona-slug>.json` `work_log` array via `Edit`
-(`{"action_field": ..., "deliverable": ..., "action": "challenged",
-"date": ...}`), and append (or update) a `## Persona Challenges` section in
-the deliverable artifact summarizing each persona's challenge and the
-consultant's disposition (accepted / revised / rejected with reason). When
-the manifest entry carries a `persona_review` field, advance it (`pending` →
-`in-progress` when challenges start, → `complete` only once every challenge
-is dispositioned); when it doesn't, the work_log entries and the artifact
-section are the record. With no personas on disk, run the challenge against the consultant
-directly ("what would your engagement partner push back on?") and say the
-acting-persona pass will deepen once personas exist.
+Challenge the draft as the stakeholder personas by **delegating to the
+write-contract owner** — do not reimplement the persona-challenge writes inline
+here. Dispatch `Skill("cogni-consult:consult-personas")` in challenge mode,
+naming this deliverable (its artifact path under `action-fields/<field-slug>/`)
+as the in-session handoff. consult-personas fans out the per-persona in-voice
+objections (one read-only `consult-persona-challenger` dispatch per relevant
+`personas/*.json`), merges the returned `{success, data, error}` envelopes, and
+owns the single append-`work_log` / append-`## Persona Challenges` /
+advance-`persona_review` write contract — so that contract lives in exactly one
+place. The full fan-out, merge, idempotency, and zero-personas fallback contract
+is authoritative in
+`$CLAUDE_PLUGIN_ROOT/references/orchestration/test-persona-challenge.md`. Revise
+the artifact where a challenge lands; the challenge is advisory and never blocks
+completion — the consultant decides what to revise.
 
 If the draft survives (consultant accepts): first record the deliverable's
 evidence provenance per

--- a/cogni-consult/skills/consult-personas/SKILL.md
+++ b/cogni-consult/skills/consult-personas/SKILL.md
@@ -151,9 +151,13 @@ its writes:
    `acceptance_bar[]`). The agent never writes. The fan-out, envelope, and
    merge convention is authoritative in
    `$CLAUDE_PLUGIN_ROOT/references/orchestration/test-persona-challenge.md`.
-2. **Merge and present.** Merge the per-persona envelopes and surface each
-   persona's challenge in character (what's missing, push-backs, acceptance
-   bar). The challenge informs — it never blocks.
+2. **Merge and present.** Merge only the `success: true` envelopes and surface
+   each persona's challenge in character (what's missing, push-backs,
+   acceptance bar). Surface any `success: false` envelope to the consultant as
+   a dispatch error and exclude that persona from all three writes below. A
+   no-draft envelope (`success: true` with empty arrays and an explanatory
+   `voice_note`) produces no writes either — nothing was challenged and there
+   is no artifact section to append to.
 3. **Own the write contract (single owner).** This is the one place the
    persona-challenge writes live: append one `work_log` entry per persona
    challenged to that persona's `personas/<slug>.json` `work_log` array via

--- a/cogni-consult/skills/consult-personas/SKILL.md
+++ b/cogni-consult/skills/consult-personas/SKILL.md
@@ -139,27 +139,38 @@ entry for general enrichment.
 Given a deliverable (its artifact path under
 `action-fields/<field-slug>/`) and one or more persona slugs — default to
 both shipped advisors plus any persona whose `context` touches the
-deliverable's topic:
+deliverable's topic — run the challenge as a **per-persona fan-out** and own
+its writes:
 
-1. Read the persona file and the deliverable artifact.
-2. Adopt the persona: speak in its `voice`, bounded by its `capabilities`,
-   aiming at its `wants`, holding the work to its `needs`, colored by its
-   `core_tension`.
-3. Return the structured challenge, in character:
-   - **What's missing** — gaps the persona would spot first
-   - **Push-backs** — claims or choices they would contest, and why
-   - **Acceptance bar** — what would make this persona accept the deliverable
-4. Record it: append a `work_log` entry to that persona's
-   `personas/<slug>.json` (`{"action_field": "<field-slug>", "deliverable":
-   "<deliverable-slug>", "action": "challenged", "date": "<ISO date>"}`) via
-   `Edit`, and append (or update) a `## Persona Challenges` section in the
-   deliverable artifact summarizing each persona's challenge and the
-   consultant's disposition (accepted / revised / rejected with reason).
-5. When the field's manifest entry carries a `persona_review` field, advance
-   it (`pending` → `in-progress` when challenges start, → `complete` when the
-   consultant has dispositioned every challenge); when it doesn't, the
-   `work_log` entries and the artifact section are the record — never create
-   the field on an entry that lacks it.
+1. **Fan out the objections (read-only).** For each relevant persona, dispatch
+   the read-only `consult-persona-challenger` agent (inputs `engagement_dir`,
+   `field_slug`, `deliverable_slug`, `persona_slug`, `plugin_root`); it adopts
+   that persona's `voice` bounded by its `capabilities`/`wants`/`needs`/
+   `core_tension` and returns the standard `{success, data, error}` envelope
+   carrying the structured challenge (`missing[]`, `pushbacks[]`,
+   `acceptance_bar[]`). The agent never writes. The fan-out, envelope, and
+   merge convention is authoritative in
+   `$CLAUDE_PLUGIN_ROOT/references/orchestration/test-persona-challenge.md`.
+2. **Merge and present.** Merge the per-persona envelopes and surface each
+   persona's challenge in character (what's missing, push-backs, acceptance
+   bar). The challenge informs — it never blocks.
+3. **Own the write contract (single owner).** This is the one place the
+   persona-challenge writes live: append one `work_log` entry per persona
+   challenged to that persona's `personas/<slug>.json` `work_log` array via
+   `Edit` (`{"action_field": "<field-slug>", "deliverable":
+   "<deliverable-slug>", "action": "challenged", "date": "<ISO date>"}`) —
+   idempotent: skip a persona already carrying a `challenged` entry for these
+   `(action_field, deliverable)` coordinates; append (or update) a consolidated
+   `## Persona Challenges` section in the deliverable artifact summarizing each
+   persona's challenge and the consultant's disposition (accepted / revised /
+   rejected with reason); when the field's manifest entry carries a
+   `persona_review` field, advance it (`pending` → `in-progress` when
+   challenges start, → `complete` only once the consultant has dispositioned
+   every challenge) — never create the field on an entry that lacks it.
+4. **Zero personas on disk.** When no persona files exist at all (step 2's
+   seeding normally prevents this), run the challenge against the consultant
+   directly ("what would your engagement partner push back on?") and note the
+   acting-persona pass deepens once personas exist; no agent is dispatched.
 
 The challenge informs — it never blocks. The consultant decides what to
 revise; revision itself belongs to the deliverable's producing route, not to


### PR DESCRIPTION
Closes #1001.

## Summary
- Delete the inline reimplementation of the persona-challenge write contract from `consult-design-thinking` Section 7 (Test stage); it now dispatches `Skill("cogni-consult:consult-personas")` in challenge mode as an in-session handoff.
- Rewrite `consult-personas` step 5 into a per-persona **fan-out**: one read-only `consult-persona-challenger` dispatch per relevant `personas/*.json`, each returning a `{success,data,error}` objection envelope, which the skill merges — while remaining the single owner of the append-`work_log` / append-`## Persona Challenges` / advance-`persona_review` writes.
- Add the read-only `consult-persona-challenger` agent (sonnet, no Write/Edit) that challenges as ONE persona in voice and returns the structured envelope.
- Extract the fan-out/merge/idempotency/zero-persona-fallback contract to `references/orchestration/test-persona-challenge.md`, so DT SKILL.md does not grow toward its 500-line cap (460 → 459 lines).
- Patch-bump cogni-consult 0.1.46 → 0.1.47 in both manifests; README components table + architecture tree gain the new agent.

## Scope decisions
- **Route call — fan-out agent owned inside consult-personas, surfaced to DT as a single delegation.** The issue offered (a) DT dispatches consult-personas, or (b) a new challenger sub-agent with an envelope+merge convention. This PR is a synthesis that satisfies both: the *write contract* lives in exactly one owner (consult-personas step 5), and the *fan-out envelope+merge convention* lives in the new agent + step 5 merge loop — which the sibling Phase-3 Empathize fan-out explicitly reuses. Pure (a) would leave Phase 3 no reusable fan-out convention; pure (b) with DT merging/writing would re-duplicate the write contract into DT.
- **Agent is read-only** (matching `consult-dashboard-refresher` and `consult-framework-adherence-reviewer`): it generates in-voice objections; consult-personas owns every write. One persona per dispatch keeps voices from bleeding together.
- **Model = sonnet.** In-voice stakeholder objections are nuanced content generation (repo strategy: content generation → sonnet), not high-volume rubric scoring (haiku). No web research, so no `cost_estimate`.
- **Advisory + consultant-interactive preserved.** The Test-stage interactive gate (surface dispositions before the challenge) is untouched; the challenge never blocks; idempotency on Test re-entry and the zero-personas fallback are carried into the extracted contract.
- **Out of scope:** cogni-consult CLAUDE.md architecture block (pre-existing drift — it predates the adherence reviewer and orchestration/ dir; belongs to a doc-sync pass); the Phase-3 Empathize fan-out (separate sibling issue).

## AC checklist
- [x] (1) Write contract in exactly one place — DT Section 7 carries only the delegation; `grep work_log` in DT SKILL.md hits only the delegation sentence naming the contract
- [x] (2) Same on-disk record via delegation (work_log entry shape, consolidated `## Persona Challenges`, `persona_review` advance — verified consistent across SKILL.md, agent envelope, and reference)
- [x] (3) Challenge stays advisory and consultant-interactive
- [x] (4) plugin.json + marketplace.json at 0.1.47; README refreshed

## Test plan
- [x] New agent declares `tools: ["Read", "Glob", "Grep"]`, `model: sonnet`
- [x] `check-skill-names.sh` OK; `check-breadcrumbs.py` success:true
- [x] DT SKILL.md 459 lines (< 500, not larger than before); personas SKILL.md 206 lines
- [x] plugin.json + marketplace.json both read 0.1.47
- [x] Pre-commit skill-quality gates on both modified SKILLs: pass, zero findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)
