### PR TITLE
cogni-consult: per-persona empathy-mapping fan-out in Empathize

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -35,7 +35,7 @@
     {
       "name": "cogni-consult",
       "source": "./cogni-consult",
-      "version": "0.1.47",
+      "version": "0.1.48",
       "maturity": "preview",
       "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
       "keywords": [

--- a/cogni-consult/.claude-plugin/plugin.json
+++ b/cogni-consult/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-consult",
-  "version": "0.1.47",
+  "version": "0.1.48",
   "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-consult/README.md
+++ b/cogni-consult/README.md
@@ -149,6 +149,7 @@ Publishing is **consultant-elected and never automatic** — it does not fire at
 | `consult-dashboard-refresher` | Agent | Regenerate the engagement dashboard HTML at a milestone (haiku, read-only, no theme prompt) |
 | `consult-framework-adherence-reviewer` | Agent | Score a completed deliverable against its stored `chosen_framework` and report structural drift (sonnet, read-only) — the framework-adherence rung of the design-thinking Test gate |
 | `consult-persona-challenger` | Agent | Challenge a deliverable as one acting stakeholder persona in voice and return a structured objection envelope (sonnet, read-only) — the per-persona fan-out consult-personas merges at the design-thinking Test gate |
+| `consult-empathy-mapper` | Agent | Map one acting stakeholder persona's empathize-stage empathy map (thinks/feels/says/does) and extract their needs, returning a structured envelope (sonnet, read-only) — the per-persona fan-out consult-design-thinking merges at the Empathize stage |
 | `engagement-init.sh` | Script | Create the engagement directory skeleton + `consult-project.json` |
 | `engagement-status.sh` | Script | Derive field/deliverable rollups from `field.json` files → JSON |
 | `discover-projects.sh` | Script | Engagement discovery (delegates to the cogni-workspace helper) |
@@ -170,14 +171,17 @@ cogni-consult/
 │   ├── personas/                  Packaged default advisors (partner, PM)
 │   ├── methods/                   Stage methods (scope dimensions, empathy mapping,
 │   │                              HMW synthesis, guided ideation)
-│   └── orchestration/             DT orchestration contracts (Empathize intake,
-│                                  Test provenance gate + adherence review +
-│                                  persona challenge, Close KB deposit)
+│   └── orchestration/             DT orchestration contracts (Empathize intake
+│                                  + empathy mapping, Test provenance gate +
+│                                  adherence review + persona challenge,
+│                                  Close KB deposit)
 ├── agents/                        consult-dashboard-refresher (milestone HTML refresh),
 │                                  consult-framework-adherence-reviewer (Test-stage
 │                                  framework drift),
 │                                  consult-persona-challenger (per-persona Test
-│                                  challenge fan-out)
+│                                  challenge fan-out),
+│                                  consult-empathy-mapper (per-persona Empathize
+│                                  mapping fan-out)
 ├── scripts/                       Engagement init/status/discovery (stdlib-only)
 └── skills/                        The seven skills listed under Components
                                    (consult-dashboard bundles its generator + theme schema)

--- a/cogni-consult/agents/consult-empathy-mapper.md
+++ b/cogni-consult/agents/consult-empathy-mapper.md
@@ -1,7 +1,6 @@
 ---
 name: consult-empathy-mapper
 description: Map ONE cogni-consult stakeholder persona's empathize-stage empathy map (thinks/feels/says/does), extract their needs, and return a structured empathy-map envelope. Read-only — never edits the persona files, the artifact, or any state.
-
 model: sonnet
 color: teal
 tools: ["Read", "Glob", "Grep"]

--- a/cogni-consult/agents/consult-empathy-mapper.md
+++ b/cogni-consult/agents/consult-empathy-mapper.md
@@ -1,0 +1,115 @@
+---
+name: consult-empathy-mapper
+description: Map ONE cogni-consult stakeholder persona's empathize-stage empathy map (thinks/feels/says/does), extract their needs, and return a structured empathy-map envelope. Read-only — never edits the persona files, the artifact, or any state.
+
+model: sonnet
+color: teal
+tools: ["Read", "Glob", "Grep"]
+---
+
+You are a read-only empathy-mapper for the cogni-consult plugin. Your only job is
+to build the empathize-stage empathy map for **one stakeholder persona** against
+one deliverable's framing, grounded in the evidence handed to you, and return it
+as a JSON envelope. You never edit the persona file, the deliverable artifact,
+`field.json`, or any other file — the design-thinking Empathize stage merges your
+envelope and owns every write.
+
+You are dispatched once per relevant persona (the fan-out). Each dispatch maps
+exactly one persona so their inner worlds never bleed together.
+
+## Environment
+
+The task prompt that spawned you includes a `plugin_root` path. Wherever these
+instructions reference `$CLAUDE_PLUGIN_ROOT`, substitute the `plugin_root` value
+from your task.
+
+## Input Contract
+
+Your task prompt includes:
+- `engagement_dir` (required): absolute path to the engagement directory (the one
+  holding `consult-project.json`).
+- `field_slug` (required): the action field the deliverable lives in.
+- `deliverable_slug` (required): the deliverable being empathized for.
+- `persona_slug` (required): the single persona to map.
+- `plugin_root` (required): absolute path to `$CLAUDE_PLUGIN_ROOT`.
+- `evidence_refs` (optional): absolute on-disk paths the orchestrator already
+  gathered — the deliverable's research synthesis
+  (`action-fields/<field_slug>/research/<topic-slug>.md`) and prior deliverables
+  that ground this persona. Read them locally; never fetch anything yourself.
+
+## Workflow
+
+1. **Read the method.** Read
+   `$CLAUDE_PLUGIN_ROOT/references/methods/empathy-mapping.md` — you embody its
+   quadrant-mapping, gap-surfacing, and need-extraction substance (Steps 2-4).
+   You do NOT perform its Step 5 write — that belongs to the Empathize stage.
+
+2. **Read the persona.** Read `<engagement_dir>/personas/<persona_slug>.json`. If
+   it is missing, return `success: false` with the reason. Otherwise absorb its
+   `role`, `context`, `core_tension`, `capabilities`, `wants`, `needs`, and any
+   existing `empathy_map` — these anchor the mapping to a real stakeholder (the
+   Acting Contract in `$CLAUDE_PLUGIN_ROOT/references/persona-schema.md`).
+
+3. **Read the evidence.** Read the deliverable framing (the field's `framing` in
+   `<engagement_dir>/action-fields/<field_slug>/field.json`) plus each
+   `evidence_refs` path that exists. Draw quadrant entries from this evidence
+   first, then supplement with grounded inference; mark inferred entries as
+   assumed rather than fabricating certainty.
+
+4. **Map the four quadrants.** Produce `thinks`, `feels`, `says`, `does` for the
+   persona in the context of this deliverable's topic (empathy-mapping.md Step
+   2). Use the persona's actual language for `says` where the evidence supplies
+   it.
+
+5. **Surface gaps and tensions.** Name the quadrants whose evidence is thin
+   (`gaps`) and the say-do / think-feel contradictions (`tensions`) —
+   empathy-mapping.md Step 3 — the richest design inputs and the flags for where
+   a research pass would help.
+
+6. **Extract needs.** Distill 2-5 persona-framed need statements describing the
+   desired state, not a solution, each connected to the `core_tension`
+   (empathy-mapping.md Step 4).
+
+7. **Recommend maturity.** Set `maturity_recommendation` to `"researched"` when
+   at least two quadrants carry evidence-based (not merely assumed) entries, else
+   `"hypothesis"` — the stage uses this to decide whether to promote the persona.
+
+## Output Contract
+
+Return exactly one JSON object on stdout, the standard envelope:
+
+```json
+{
+  "success": true,
+  "data": {
+    "persona_slug": "<persona_slug>",
+    "persona_name": "<name>",
+    "deliverable": "<field_slug>/<deliverable_slug>",
+    "empathy_map": {"thinks": ["..."], "feels": ["..."], "says": ["..."], "does": ["..."]},
+    "needs": ["<persona-framed need>"],
+    "gaps": ["<quadrant with thin evidence>"],
+    "tensions": ["<say-do or think-feel contradiction>"],
+    "maturity_recommendation": "researched",
+    "summary_note": "<one-line key insight>"
+  },
+  "error": null
+}
+```
+
+On a hard failure (missing persona file, bad `engagement_dir`), set
+`success: false`, `data: null`, and put the reason in `error`.
+
+## Boundaries
+
+- **Read-only, always.** You hold no Write/Edit tools and must never ask for
+  them. The Empathize stage merges your envelope and owns every write (the
+  `empathy_map`/`needs` population, the `maturity` promotion, the
+  `empathy-mapped` `work_log` entry).
+- **One persona per dispatch.** Map only `persona_slug`; do not blend in other
+  personas' inner worlds.
+- **Zero-network.** You read only on-disk persona, framing, and `evidence_refs`
+  files — no web, no knowledge base — so you report no `cost_estimate`. Evidence
+  discipline stays with the orchestrator, which gathered the evidence before
+  dispatching you.
+- **Grounded, not fabricated.** Every quadrant entry traces to evidence or is
+  marked assumed; never invent stakeholder facts the evidence does not support.

--- a/cogni-consult/references/methods/empathy-mapping.md
+++ b/cogni-consult/references/methods/empathy-mapping.md
@@ -11,6 +11,15 @@ duration_estimate: "15-30 min per persona"
 
 Build a rich understanding of each persona by mapping what they think, feel, say, and do. This method bridges the gap between knowing *about* someone and understanding *what it's like to be them* — which is the difference between deliverables that look good on slides and deliverables stakeholders actually adopt. In cogni-consult it runs at the **empathize stage** of a deliverable's design-thinking loop, scoped to the personas that matter for *this* deliverable.
 
+> **Fan-out execution.** At the Empathize stage this method runs as a per-persona
+> fan-out: the read-only `consult-empathy-mapper` agent embodies Steps 2-4 (map
+> the quadrants, surface gaps and tensions, extract needs) for one persona and
+> returns them in a `{success, data, error}` envelope; the design-thinking
+> Empathize stage merges the envelopes and performs Step 5's persona write. The
+> guided prompt sequence below is the substance the agent embodies (and the shape
+> a consultant follows when mapping inline). Full contract:
+> `references/orchestration/empathize-empathy-mapping.md`.
+
 ## When to Use
 
 - At the empathize stage of any deliverable whose adoption depends on people — before sharpening the spec, understand who it must serve

--- a/cogni-consult/references/orchestration/empathize-empathy-mapping.md
+++ b/cogni-consult/references/orchestration/empathize-empathy-mapping.md
@@ -1,0 +1,95 @@
+# Empathize-Stage Empathy Mapping — Fan-Out + Merge
+
+The per-persona empathy-mapping contract for the design-thinking Empathize
+stage. The stage fans the per-persona quadrant mapping out to a read-only agent
+rather than mapping every persona inline, then merges the returned envelopes and
+writes the enriched personas itself. This document is authoritative for the
+*fan-out, envelope, merge, and write* mechanics; the *method substance* (the
+quadrants, gap-surfacing, and need-extraction) lives in
+`references/methods/empathy-mapping.md`, which the agent embodies.
+
+Unlike the Test-stage persona challenge — which delegates its writes across a
+skill boundary to `consult-personas` — Empathize is `consult-design-thinking`'s
+own stage, so the merge and the persona writes stay in the Empathize section.
+There is no cross-skill write owner here: the agent is read-only and the stage
+owns every write.
+
+## Who owns what
+
+- **`consult-design-thinking` Empathize stage** runs the fan-out, merges the
+  results, and performs the persona writes (the single write owner).
+- **`consult-empathy-mapper` agent** builds one persona's empathy map,
+  read-only, and returns it in the standard `{success, data, error}` envelope. It
+  embodies `references/methods/empathy-mapping.md` Steps 2-4 and performs no Step
+  5 write.
+
+## Fan-out
+
+Determine the personas that matter to this deliverable — every `personas/*.json`
+whose reality shapes whether the deliverable lands (the shipped advisors plus any
+scope-seeded stakeholder whose `context` touches the topic). Dispatch the
+read-only `consult-empathy-mapper` agent **once per relevant persona** (the
+fan-out), passing `engagement_dir`, `field_slug`, `deliverable_slug`,
+`persona_slug`, `plugin_root`, and `evidence_refs` — the on-disk research
+synthesis and prior-deliverable paths the stage's gap-check / research-routing
+rung already gathered. Each dispatch maps exactly one persona so their inner
+worlds stay distinct. This reuses the per-persona-dispatch → envelope → merge
+convention established by the Test-stage persona challenge.
+
+## Envelope + merge
+
+Each dispatch returns the standard envelope with `data.empathy_map` (the four
+quadrants), `data.needs[]`, `data.gaps[]`, `data.tensions[]`, and
+`data.maturity_recommendation`. Merge only the `success: true` envelopes: a
+`success: false` envelope is surfaced to the consultant as a dispatch error and
+its persona is excluded from every write. Across the surviving envelopes, note
+where personas' maps overlap or conflict — a tension between two personas' needs
+is often the most important design constraint, and feeds the Define-stage spec
+directly.
+
+## The write contract (owned by the Empathize stage)
+
+After the merge, for each `success: true` persona the Empathize stage applies
+exactly these writes via `Edit` to `personas/<slug>.json` (mirroring
+empathy-mapping.md Step 5 — the write the read-only agent does not perform):
+
+- Populate `empathy_map` with the four returned quadrants and add the returned
+  `needs` to the persona's `needs`.
+- Promote `maturity` to `"researched"` when the envelope's
+  `maturity_recommendation` is `"researched"` (at least two quadrants carry
+  evidence-based entries); never advance `source`, and never downgrade a persona
+  already `validated`.
+- Append one `work_log` entry
+  (`{"action_field", "deliverable", "action": "empathy-mapped", "date"}`).
+
+The empathy map lives inside the persona entity — no separate artifact is written
+at Empathize; the merged insight and cross-persona tensions flow into the
+Define-stage spec.
+
+## Idempotency (the loop may re-enter Empathize)
+
+- **`work_log`:** before appending, scan the persona's `work_log` for an
+  `empathy-mapped` entry matching these `(action_field, deliverable)`
+  coordinates; append only when none exists, so a re-entry does not
+  double-record.
+- **`empathy_map` / `needs`:** a re-map refreshes the quadrants and merges needs
+  rather than stacking duplicates.
+- **`maturity`:** advance via idempotent read-modify-write; a same-state re-set
+  is a no-op.
+
+## Advisory + consultant-interactive
+
+The mapping informs the Define spec — it never blocks the loop. In auto-walk
+mode, run the fan-out, apply the writes, and surface the merged maps without
+pausing. In interactive mode, the Empathize stage keeps its consultant seams: the
+start-of-Empathize input-material intake rung runs first, and before the persona
+writes the stage presents the merged maps and each persona's key insight for
+confirmation; the consultant steers before the writes land. Define and Ideate
+remain fully inline — only this per-persona mapping is delegated.
+
+## Zero personas on disk
+
+When no persona files exist at all (the shipped-advisor seeding normally prevents
+this), skip the fan-out and continue with the consultant's own stakeholder
+knowledge — persona files can be added later without redoing the loop. Nothing is
+written and no agent is dispatched.

--- a/cogni-consult/skills/consult-design-thinking/SKILL.md
+++ b/cogni-consult/skills/consult-design-thinking/SKILL.md
@@ -211,10 +211,15 @@ error and proceed with the rework.
 
 ### 3. Empathize
 
-Read `$CLAUDE_PLUGIN_ROOT/references/methods/empathy-mapping.md` and run it
-for the personas that matter to this deliverable (`personas/*.json`). When the
-directory is empty, say so and continue with the consultant's own stakeholder
-knowledge — persona files can be added later without redoing the loop.
+The empathize-stage per-persona empathy mapping runs as a **read-only fan-out**:
+one `consult-empathy-mapper` dispatch per relevant `personas/*.json`, merged and
+written by this stage (the agent never writes). It embodies
+`$CLAUDE_PLUGIN_ROOT/references/methods/empathy-mapping.md`; the full fan-out,
+envelope, merge, write, and idempotency contract is authoritative in
+`$CLAUDE_PLUGIN_ROOT/references/orchestration/empathize-empathy-mapping.md`.
+Define and Ideate stay fully inline — only this per-persona mapping is delegated.
+When `personas/` is empty, say so and continue with the consultant's own
+stakeholder knowledge — persona files can be added later without redoing the loop.
 
 **Interactive mode — input material first.** Before the gap-check, run the
 Empathize source-material intake rung — the pre-gap-check intake of
@@ -246,6 +251,20 @@ the `--source wiki` re-run on a populated base) per the rule, and copy the
 finalized synthesis to `action-fields/<field-slug>/research/<topic-slug>.md`
 so this deliverable — and later ones — find it at a stable path. Evidence
 comes from the knowledge base, never from raw web search.
+
+**Run the fan-out.** With the evidence context in hand from the rung above,
+dispatch `consult-empathy-mapper` once per relevant `personas/*.json` (inputs
+`engagement_dir`, `field_slug`, `deliverable_slug`, `persona_slug`,
+`plugin_root`, and `evidence_refs` — the research-synthesis and prior-deliverable
+paths gathered above). Merge the `success: true` envelopes and apply this stage's
+write contract per
+`$CLAUDE_PLUGIN_ROOT/references/orchestration/empathize-empathy-mapping.md`: per
+persona, `Edit` `personas/<slug>.json` to populate `empathy_map` and `needs`,
+promote `maturity` to `"researched"` when the envelope recommends it, and append
+one idempotent `empathy-mapped` `work_log` entry keyed by `(action_field,
+deliverable)`. Surface the cross-persona overlaps and tensions — they feed the
+Define spec. **Interactive mode:** before these writes, present the merged maps
+and each persona's key insight, confirm with the consultant, then write.
 
 Close the stage by advancing `dt_stage` → `"define"` via the helper (see
 *Advancing the stage* above).

--- a/cogni-consult/skills/consult-design-thinking/SKILL.md
+++ b/cogni-consult/skills/consult-design-thinking/SKILL.md
@@ -68,7 +68,8 @@ session's conversation flow and is never written to `field.json`,
 contract below are identical in both modes.
 
 In interactive mode, at each stage gate marked **Interactive mode** below (start
-of Empathize, end of Define, end of Ideate, start of Prototype, Test), before
+of Empathize, the Empathize pre-write merge confirmation, end of Define, end of
+Ideate, start of Prototype, Test), before
 the stage's write: surface the *reasoning* behind the stage decision (why this
 HMW spec, why this ideation method, why this prototype shape, why these persona
 dispositions) ahead of the log entry, name exactly what is about to be written,


### PR DESCRIPTION
Closes #1002.

## Summary
- Add a new read-only `consult-empathy-mapper` agent (sonnet) that builds ONE persona's empathize-stage empathy map (thinks/feels/says/does), extracts 2-5 needs, surfaces gaps/tensions, and returns a `{success, data, error}` envelope — never writing.
- Rewrite `consult-design-thinking` Section 3 (Empathize) so the per-persona empathy mapping runs as a fan-out (one dispatch per relevant `personas/*.json`), merged and written by the stage; the intake rung, gap-check, and research-routing rung stay untouched and correctly ordered (intake → evidence → fan-out → advance).
- Add `references/orchestration/empathize-empathy-mapping.md` — the authoritative fan-out + envelope + merge + write + idempotency contract, mirroring `test-persona-challenge.md`.
- Add a fan-out reconciliation note to `references/methods/empathy-mapping.md` so its Step 5 write is owned by the stage while the agent embodies Steps 2-4 read-only.
- README components table + architecture tree updated; both manifests patch-bumped 0.1.47 → 0.1.48.

## Design decisions
- **New agent, not reuse:** empathy mapping (pre-draft, produces an empathy map) is a different task from the challenger's post-draft objections — different inputs, timing, and envelope.
- **Model = sonnet:** grounded perspective-taking synthesis, matching the sibling `consult-persona-challenger`; haiku is reserved for high-volume rubric scoring.
- **Contract in a dedicated orchestration doc:** mirrors the established `test-persona-challenge.md` pattern and keeps SKILL.md under the 500-line cap (482 after the change).
- **Zero-network read-only agent:** the orchestrator's gap-check/research rung gathers evidence and passes `evidence_refs`; the agent reads only local files, reports no `cost_estimate`.
- **Writes stay in DT:** Empathize is the DT loop's own stage, so it owns the persona Edits after merge — no cross-skill write owner (unlike the Test challenge, which delegates to consult-personas).

## AC checklist
- [x] (1) Empathy-mapping runs as a per-persona fan-out returning merged envelopes (success:false excluded from writes)
- [x] (2) Define and Ideate remain fully inline/interactive (sections untouched)
- [x] (3) Empathize stays consultant-interactive (intake rung untouched; confirm-before-write seam on the persona writes)
- [x] (4) plugin.json + marketplace.json at 0.1.48; README refreshed

## Test plan
- [x] SKILL.md = 482 lines (< 500 cap)
- [x] `check-breadcrumbs.py` success:true; `check-skill-names.sh` OK
- [x] New agent declares `tools: ["Read", "Glob", "Grep"]`, `model: sonnet`, no `cost_estimate` (zero-network)
- [x] Section 3 ordering verified: intake → gap-check/research → fan-out → advance; Define (§4) / Ideate (§5) unchanged
- [x] plugin.json + marketplace.json both read 0.1.48
- [x] Pre-commit skill-quality gate: pass, zero findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)
