### PR TITLE
cogni-consult: engagement README front door generator

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -35,7 +35,7 @@
     {
       "name": "cogni-consult",
       "source": "./cogni-consult",
-      "version": "0.1.48",
+      "version": "0.1.49",
       "maturity": "preview",
       "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
       "keywords": [

--- a/cogni-consult/.claude-plugin/plugin.json
+++ b/cogni-consult/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-consult",
-  "version": "0.1.48",
+  "version": "0.1.49",
   "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-consult/CLAUDE.md
+++ b/cogni-consult/CLAUDE.md
@@ -62,6 +62,9 @@ cogni-consult/
 ├── scripts/
 │   ├── engagement-init.sh         Create engagement directory skeleton
 │   ├── engagement-status.sh       Read consult-project.json state → JSON
+│   ├── generate-engagement-readme.py  Markdown wayfinding front door: write the
+│   │                              engagement-root README.md (status snapshot,
+│   │                              next action, relative Obsidian links)
 │   ├── deliverable-graph.py       Deliverable dependency-graph engine: validate /
 │   │                              trace / impact / refresh-order / cascade-stale
 │   ├── discover-projects.sh       Thin wrapper over the cogni-workspace discovery helper
@@ -119,6 +122,7 @@ Full schemas: `references/data-model.md`.
 |--------|---------|
 | `engagement-init.sh` | Create the engagement directory skeleton + consult-project.json |
 | `engagement-status.sh` | Read consult-project.json + derive field/deliverable rollups from `field.json` files, plus the `personas_gate` rollup (satisfied when a `personas/*.json` has `source: scope-seeded` or the extensionless `personas/.gate-waiver` marker is present, else pending) → JSON |
+| `generate-engagement-readme.py` | Write the Obsidian-browsable `README.md` front door at the engagement root from the same read model (key question, status snapshot, single next recommended deliverable incl. the `personas_gate` rung, wayfinding links that only target existing files); read-only except the `README.md` it writes |
 | `deliverable-graph.py` | Deliverable dependency-graph engine over all `field.json` files: `validate` (cycles + dangling refs), `trace` (upstream lineage), `impact` (downstream blast radius), `refresh-order` (topological layering of stale deliverables), `cascade-stale` (flag downstream `lineage_status` via idempotent RMW). Full model: `references/dependency-model.md` |
 | `discover-projects.sh` | Thin wrapper delegating to `cogni-workspace/scripts/discover-plugin-projects.sh` (registry: `$HOME/.claude/cogni-consult-projects.json`) |
 | `_discover_extractor.py` | Per-engagement JSON field extractor consumed by the discovery wrapper (reads the flat consult-project.json schema) |

--- a/cogni-consult/scripts/generate-engagement-readme.py
+++ b/cogni-consult/scripts/generate-engagement-readme.py
@@ -210,14 +210,14 @@ def next_action(eng, summary, personas_gate, engagement_dir):
         return "personas", "Seed acting stakeholder personas from scope (consult-personas) — the personas gate blocks the first design-thinking deliverable."
     for f in eng["action_fields"]:
         for d in f["deliverables"]:
-            if d.get("state") == "in-progress":
+            if d.get("state", "pending") == "in-progress":
                 stage = d.get("dt_stage") or "empathize"
                 return "continue", f"Continue “{d.get('title', d.get('slug'))}” in {f['title']} (design thinking, {stage} stage)."
     for f in eng["action_fields"]:
         for d in f["deliverables"]:
-            if d.get("state") == "pending":
+            if d.get("state", "pending") == "pending":
                 return "start", f"Start “{d.get('title', d.get('slug'))}” in {f['title']} (consult-design-thinking)."
-        if not f["deliverables"]:
+        if not f["deliverables"] and f["state"] != "unreadable":
             return "plan", f"Plan deliverables for {f['title']} (consult-action-fields)."
     if summary["engagement_state"] == "complete":
         unpublished = [
@@ -242,10 +242,20 @@ def next_action(eng, summary, personas_gate, engagement_dir):
 STATE_LABEL = {"in-progress": "in progress"}
 
 
+def _md_cell(s):
+    """Escape a value for a markdown table cell (pipes split columns)."""
+    return str(s if s is not None else "").replace("|", "\\|")
+
+
+def _md_label(s):
+    """Escape a value for a markdown link label (brackets break the link)."""
+    return str(s if s is not None else "").replace("[", "\\[").replace("]", "\\]")
+
+
 def _link_if_exists(engagement_dir, rel_path, label):
     """Markdown link when the relative target exists, else None."""
     if os.path.exists(os.path.join(engagement_dir, rel_path)):
-        return f"[{label}]({rel_path})"
+        return f"[{_md_label(label)}]({rel_path})"
     return None
 
 
@@ -256,18 +266,18 @@ def render_readme(engagement_dir, eng, summary, action):
 
     # Status snapshot — "scoping" is the user-facing label until scope completes.
     lines += ["", "## Status", ""]
-    if eng["scope_state"] != "complete":
-        lines.append("**Scope:** scoping")
-    else:
-        lines.append("**Scope:** complete")
-    lines.append(f"**Overall completion:** {summary['completion_pct']}% "
+    scope_label = "complete" if eng["scope_state"] == "complete" else "scoping"
+    lines.append(f"- **Scope:** {scope_label}")
+    lines.append(f"- **Overall completion:** {summary['completion_pct']}% "
                  f"({summary['deliverables_complete']}/{summary['deliverables_total']} deliverables)")
     if eng["action_fields"]:
         lines += ["", "| Action field | Done | State |", "|---|---|---|"]
         for f in eng["action_fields"]:
-            done = sum(1 for d in f["deliverables"] if d.get("state") == "complete")
+            done = sum(1 for d in f["deliverables"] if d.get("state", "pending") == "complete")
             total = len(f["deliverables"])
-            lines.append(f"| {f['title']} | {done}/{total} | {STATE_LABEL.get(f['state'], f['state'])} |")
+            lines.append(f"| {_md_cell(f['title'])} | {done}/{total} | {STATE_LABEL.get(f['state'], f['state'])} |")
+    if eng["warnings"]:
+        lines += ["", "> ⚠ " + " · ".join(_md_cell(w) for w in eng["warnings"])]
 
     lines += ["", "## Next", "", action]
 
@@ -319,8 +329,8 @@ def main():
         readme_path = os.path.join(args.engagement_dir, "README.md")
         with open(readme_path, "w") as f:
             f.write(readme)
-    except (ValueError, OSError, json.JSONDecodeError) as exc:
-        print(json.dumps({"success": False, "data": {}, "error": str(exc)}))
+    except (ValueError, OSError, TypeError, AttributeError) as exc:
+        print(json.dumps({"success": False, "data": {}, "error": f"malformed engagement state: {exc}"}))
         return 1
 
     print(json.dumps({

--- a/cogni-consult/scripts/generate-engagement-readme.py
+++ b/cogni-consult/scripts/generate-engagement-readme.py
@@ -1,0 +1,343 @@
+#!/usr/bin/env python3
+"""Generate an Obsidian-browsable README.md front door at a cogni-consult
+engagement root.
+
+Reads the same read model as engagement-status.sh and
+skills/consult-dashboard/scripts/generate-dashboard.py — consult-project.json
+plus each action-fields/<slug>/field.json, with deliverable state as the
+single source of truth and field/engagement rollups derived at read time —
+and writes <engagement-dir>/README.md with four sections:
+
+  1. H1 engagement name + SMART key question
+  2. Status snapshot — scope state, per-field done/total, overall completion %
+  3. The single next recommended deliverable (next-action derivation with the
+     personas_gate step spliced in after staleness, before in-progress work)
+  4. A wayfinding link block with relative Obsidian links (only to targets
+     that exist, so a scaffold-only engagement emits no broken links)
+
+Read-only over all engagement state except the README.md it writes.
+
+Usage: python3 generate-engagement-readme.py <engagement-dir>
+Output: JSON {"success": bool, "data": {...}, "error": "string"}
+"""
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+
+
+# ---------------------------------------------------------------------------
+# Engagement read model — mirrors engagement-status.sh and the consult-dashboard
+# generator. Deliverable state lives only in field.json; rollups derive here.
+# ---------------------------------------------------------------------------
+
+
+def _field_rollup(states):
+    if states and all(s == "complete" for s in states):
+        return "complete"
+    if any(s != "pending" for s in states):
+        return "in-progress"
+    return "pending"
+
+
+def load_engagement(engagement_dir):
+    """Return the engagement model, or raise ValueError with a user-facing message."""
+    proj_path = os.path.join(engagement_dir, "consult-project.json")
+    try:
+        with open(proj_path) as f:
+            project = json.load(f)
+    except (json.JSONDecodeError, OSError) as exc:
+        raise ValueError(f"unreadable engagement file {proj_path}: {exc}")
+
+    field_slugs = project.get("action_fields") or []
+    if not isinstance(field_slugs, list) or not all(isinstance(s, str) for s in field_slugs):
+        raise ValueError("malformed engagement file: action_fields must be a list of strings")
+
+    warnings = []
+    fields = []
+    for slug in field_slugs:
+        fpath = os.path.join(engagement_dir, "action-fields", slug, "field.json")
+        title = slug
+        deliverables = []
+        state = "pending"
+        try:
+            with open(fpath) as f:
+                fjson = json.load(f)
+            title = fjson.get("title") or slug
+            deliverables = fjson.get("deliverables") or []
+            state = _field_rollup([d.get("state", "pending") for d in deliverables])
+        except FileNotFoundError:
+            pass
+        except (json.JSONDecodeError, OSError) as exc:
+            state = "unreadable"
+            warnings.append(f"unreadable field file {fpath}: {exc}")
+        fields.append({
+            "slug": slug,
+            "title": title,
+            "state": state,
+            "deliverables": deliverables,
+        })
+
+    return {
+        "slug": project.get("slug"),
+        "name": project.get("name") or project.get("slug") or "Engagement",
+        "key_question": project.get("key_question") or "",
+        "updated": project.get("updated") or "",
+        "scope_state": (project.get("workflow_state") or {}).get("scope", "pending"),
+        "action_fields": fields,
+        "warnings": warnings,
+    }
+
+
+def compute_summary(eng):
+    fields = eng["action_fields"]
+    all_delivs = [d for f in fields for d in f["deliverables"]]
+    total = len(all_delivs)
+    complete = sum(1 for d in all_delivs if d.get("state", "pending") == "complete")
+    pct = round(100 * complete / total) if total else 0
+    if all(f["state"] == "complete" for f in fields) and fields:
+        engagement_state = "complete"
+    elif any(f["state"] != "pending" for f in fields):
+        engagement_state = "in-progress"
+    else:
+        engagement_state = "pending"
+    return {
+        "deliverables_total": total,
+        "deliverables_complete": complete,
+        "completion_pct": pct,
+        "engagement_state": engagement_state,
+    }
+
+
+def load_personas_gate(engagement_dir):
+    """Derive the personas_gate rollup at read time, mirroring
+    engagement-status.sh: satisfied when personas/.gate-waiver exists or any
+    personas/*.json carries source == "scope-seeded"; else pending. Fail-soft:
+    a missing or unreadable personas dir / persona file degrades to pending."""
+    personas_dir = os.path.join(engagement_dir, "personas")
+    if os.path.exists(os.path.join(personas_dir, ".gate-waiver")):
+        return "satisfied"
+    try:
+        for name in os.listdir(personas_dir):
+            if not name.endswith(".json"):
+                continue
+            try:
+                with open(os.path.join(personas_dir, name)) as pf:
+                    if json.load(pf).get("source") == "scope-seeded":
+                        return "satisfied"
+            except (json.JSONDecodeError, OSError):
+                continue
+    except OSError:
+        pass
+    return "pending"
+
+
+# ---------------------------------------------------------------------------
+# Staleness + refresh order — the read side of the deliverable-graph engine.
+# ---------------------------------------------------------------------------
+
+
+def _is_stale_deliv(d):
+    ls = d.get("lineage_status")
+    return isinstance(ls, dict) and ls.get("status") == "stale"
+
+
+def build_deliv_index(eng):
+    """Map each deliverable's WBS-coordinate key 'field_slug/deliv_slug' to its
+    display title, so refresh-order layers (which speak in keys) render titles."""
+    idx = {}
+    for f in eng["action_fields"]:
+        for d in f["deliverables"]:
+            slug = d.get("slug")
+            if not slug:
+                continue
+            idx[f"{f['slug']}/{slug}"] = d.get("title") or slug
+    return idx
+
+
+def load_refresh_order(engagement_dir):
+    """Shell out to the sibling deliverable-graph engine for the topological
+    refresh order of stale deliverables; None on any failure (graceful)."""
+    script = os.path.join(os.path.dirname(os.path.abspath(__file__)), "deliverable-graph.py")
+    if not os.path.isfile(script):
+        return None
+    try:
+        proc = subprocess.run(
+            [sys.executable, script, engagement_dir, "refresh-order"],
+            capture_output=True, text=True, timeout=30,
+        )
+        payload = json.loads(proc.stdout)
+    except (OSError, ValueError, subprocess.SubprocessError):
+        return None
+    if not isinstance(payload, dict) or not payload.get("success"):
+        return None
+    data = payload.get("data")
+    return data if isinstance(data, dict) else None
+
+
+def next_action(eng, summary, personas_gate, engagement_dir):
+    """The single recommendation as (rung, text). Precedence: scope-incomplete,
+    then the stale set upstream-first, then the personas gate, then in-progress,
+    then pending — the personas gate blocks *starting* deliverable work, so it
+    sits after refreshing what an upstream change invalidated and before picking
+    up new or continuing work. The rung enum ("scope" / "refresh" / "personas" /
+    "continue" / "start" / "plan" / "publish" / "done" / "review") is the
+    machine-readable surface consumers key on; the text is display-only."""
+    if eng["scope_state"] != "complete":
+        return "scope", "Finish scoping the engagement (consult-scope) — define the SMART key question and action fields."
+    stale = [d for f in eng["action_fields"] for d in f["deliverables"] if _is_stale_deliv(d)]
+    if stale:
+        refresh = load_refresh_order(engagement_dir)
+        deliv_index = build_deliv_index(eng)
+        first_title = None
+        if refresh and refresh.get("layers"):
+            for layer in refresh["layers"]:
+                if layer:
+                    first_title = deliv_index.get(layer[0], layer[0])
+                    break
+        if not first_title:
+            first_title = stale[0].get("title") or stale[0].get("slug")
+        n = len(stale)
+        plural = "deliverable" if n == 1 else "deliverables"
+        return "refresh", (
+            f"{n} {plural} went stale after an upstream change — refresh "
+            f"“{first_title}” first, then work down the refresh order (upstream "
+            f"before dependents)."
+        )
+    if personas_gate != "satisfied":
+        return "personas", "Seed acting stakeholder personas from scope (consult-personas) — the personas gate blocks the first design-thinking deliverable."
+    for f in eng["action_fields"]:
+        for d in f["deliverables"]:
+            if d.get("state") == "in-progress":
+                stage = d.get("dt_stage") or "empathize"
+                return "continue", f"Continue “{d.get('title', d.get('slug'))}” in {f['title']} (design thinking, {stage} stage)."
+    for f in eng["action_fields"]:
+        for d in f["deliverables"]:
+            if d.get("state") == "pending":
+                return "start", f"Start “{d.get('title', d.get('slug'))}” in {f['title']} (consult-design-thinking)."
+        if not f["deliverables"]:
+            return "plan", f"Plan deliverables for {f['title']} (consult-action-fields)."
+    if summary["engagement_state"] == "complete":
+        unpublished = [
+            d
+            for f in eng["action_fields"]
+            for d in f["deliverables"]
+            if d.get("state") == "complete" and not (d.get("publish") or [])
+        ]
+        if unpublished:
+            first = unpublished[0]
+            title = first.get("title") or first.get("slug")
+            return "publish", f"All deliverables complete — publish “{title}” with consult-publish."
+        return "done", "All deliverables complete and published — hand the briefs to Claude Design to render."
+    return "review", "Review the engagement status."
+
+
+# ---------------------------------------------------------------------------
+# Markdown rendering — relative Obsidian links, emitted only when the target
+# exists so a scaffold-only engagement never carries a broken link.
+# ---------------------------------------------------------------------------
+
+STATE_LABEL = {"in-progress": "in progress"}
+
+
+def _link_if_exists(engagement_dir, rel_path, label):
+    """Markdown link when the relative target exists, else None."""
+    if os.path.exists(os.path.join(engagement_dir, rel_path)):
+        return f"[{label}]({rel_path})"
+    return None
+
+
+def render_readme(engagement_dir, eng, summary, action):
+    lines = [f"# {eng['name']}"]
+    if eng["key_question"]:
+        lines += ["", f"> {eng['key_question']}"]
+
+    # Status snapshot — "scoping" is the user-facing label until scope completes.
+    lines += ["", "## Status", ""]
+    if eng["scope_state"] != "complete":
+        lines.append("**Scope:** scoping")
+    else:
+        lines.append("**Scope:** complete")
+    lines.append(f"**Overall completion:** {summary['completion_pct']}% "
+                 f"({summary['deliverables_complete']}/{summary['deliverables_total']} deliverables)")
+    if eng["action_fields"]:
+        lines += ["", "| Action field | Done | State |", "|---|---|---|"]
+        for f in eng["action_fields"]:
+            done = sum(1 for d in f["deliverables"] if d.get("state") == "complete")
+            total = len(f["deliverables"])
+            lines.append(f"| {f['title']} | {done}/{total} | {STATE_LABEL.get(f['state'], f['state'])} |")
+
+    lines += ["", "## Next", "", action]
+
+    # Wayfinding — every link resolves within the engagement dir by construction.
+    way = []
+    for f in eng["action_fields"]:
+        field_rel = os.path.join("action-fields", f["slug"])
+        field_link = _link_if_exists(engagement_dir, field_rel, f["title"])
+        if not field_link:
+            continue
+        way.append(f"- {field_link}")
+        for d in f["deliverables"]:
+            dslug = d.get("slug")
+            if not dslug:
+                continue
+            deliv_link = _link_if_exists(
+                engagement_dir,
+                os.path.join(field_rel, f"{dslug}.md"),
+                d.get("title") or dslug,
+            )
+            if deliv_link:
+                way.append(f"  - {deliv_link}")
+    for rel, label in (
+        ("personas", "Personas"),
+        ("sources", "Sources"),
+        (os.path.join(".metadata", "decision-log.json"), "Decision log"),
+    ):
+        link = _link_if_exists(engagement_dir, rel, label)
+        if link:
+            way.append(f"- {link}")
+    if way:
+        lines += ["", "## Wayfinding", ""] + way
+
+    lines += ["", "---", "", "_Auto-generated front door — regenerated at engagement milestones; edits here are overwritten._", ""]
+    return "\n".join(lines)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate the engagement README.md front door")
+    parser.add_argument("engagement_dir", help="Path to the engagement directory")
+    args = parser.parse_args()
+
+    try:
+        eng = load_engagement(args.engagement_dir)
+        summary = compute_summary(eng)
+        personas_gate = load_personas_gate(args.engagement_dir)
+        rung, action = next_action(eng, summary, personas_gate, args.engagement_dir)
+        readme = render_readme(args.engagement_dir, eng, summary, action)
+        readme_path = os.path.join(args.engagement_dir, "README.md")
+        with open(readme_path, "w") as f:
+            f.write(readme)
+    except (ValueError, OSError, json.JSONDecodeError) as exc:
+        print(json.dumps({"success": False, "data": {}, "error": str(exc)}))
+        return 1
+
+    print(json.dumps({
+        "success": True,
+        "data": {
+            "readme_path": readme_path,
+            "completion_pct": summary["completion_pct"],
+            "engagement_state": summary["engagement_state"],
+            "personas_gate": personas_gate,
+            "next_action_rung": rung,
+            "next_action": action,
+            "warnings": eng["warnings"],
+        },
+        "error": "",
+    }))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/cogni-consult/tests/test_generate_engagement_readme.sh
+++ b/cogni-consult/tests/test_generate_engagement_readme.sh
@@ -15,7 +15,12 @@
 #   3  personas-gate      scoped engagement without a scope-seeded persona →
 #                         next-action recommends consult-personas before
 #                         deliverable work
-#   4  failure envelope   missing consult-project.json → success:false, exit 1
+#   4  stale chain        two stale deliverables, downstream listed first in
+#                         field.json → the topological refresh order (via
+#                         deliverable-graph.py) still names the upstream one
+#   5  failure envelope   missing consult-project.json → success:false, exit 1
+#   6  malformed field    non-dict deliverables entry → success:false envelope,
+#                         never a raw traceback
 #
 # Usage: bash cogni-consult/tests/test_generate_engagement_readme.sh
 # Exits non-zero on any assertion failure.
@@ -194,35 +199,48 @@ assert_json "3a2 rung is personas"       "$OUT3" "d['data']['next_action_rung'] 
 assert_md_has "3b next recommends personas" "$MD3" "consult-personas"
 assert_md_lacks "3c does not start deliverable" "$MD3" "consult-design-thinking"
 
-# --- Fixture 5: stale chain — refresh rung recommends the upstream deliverable first
-D5="$TMPROOT/stale"
-seed_scoped "$D5" '[
-  {"slug": "market-sizing", "title": "Market sizing", "state": "complete", "dt_stage": "test",
-   "lineage_status": {"status": "stale", "reason": "source data updated"}},
+# --- Fixture 4: stale chain — refresh rung recommends the upstream deliverable first
+# The downstream deliverable is deliberately listed FIRST in field.json: the
+# stale[0] file-order fallback would name "Competitor map", so this assertion
+# passing proves the topological refresh order (via deliverable-graph.py) ran —
+# and pins the field_slug/deliv_slug key contract between the two scripts.
+D4="$TMPROOT/stale"
+seed_scoped "$D4" '[
   {"slug": "competitor-map", "title": "Competitor map", "state": "complete", "dt_stage": "test",
    "depends_on": [{"action_field": "market-evidence", "deliverable": "market-sizing"}],
-   "lineage_status": {"status": "stale", "reason": "upstream changed"}}
+   "lineage_status": {"status": "stale", "reason": "upstream changed"}},
+  {"slug": "market-sizing", "title": "Market sizing", "state": "complete", "dt_stage": "test",
+   "lineage_status": {"status": "stale", "reason": "source data updated"}}
 ]'
-echo '{"source": "scope-seeded", "name": "CFO"}' > "$D5/personas/cfo.json"
-OUT5="$(run "$D5")"
-MD5="$D5/README.md"
-assert_json "5a stale success"           "$OUT5" "d['success'] is True"
-assert_json "5b rung is refresh"         "$OUT5" "d['data']['next_action_rung'] == 'refresh'"
-# The topological refresh order (via deliverable-graph.py) names the upstream
-# deliverable first — this pins the field_slug/deliv_slug key contract between
-# the two scripts, and that staleness outranks the pending/in-progress rungs.
-assert_md_has "5c upstream named first"  "$MD5" "refresh “Market sizing” first"
-
-# --- Fixture 4: failure envelope on missing project file -----------------------------
-D4="$TMPROOT/missing"
-mkdir -p "$D4"
+echo '{"source": "scope-seeded", "name": "CFO"}' > "$D4/personas/cfo.json"
 OUT4="$(run "$D4")"
-RC4=$?
-assert_json "4a failure envelope"        "$OUT4" "d['success'] is False"
-if [ "$RC4" -ne 0 ]; then
-  pass "4b non-zero exit"
+MD4="$D4/README.md"
+assert_json "4a stale success"           "$OUT4" "d['success'] is True"
+assert_json "4b rung is refresh"         "$OUT4" "d['data']['next_action_rung'] == 'refresh'"
+assert_md_has "4c upstream named first"  "$MD4" "refresh “Market sizing” first"
+
+# --- Fixture 5: failure envelope on missing project file -----------------------------
+D5="$TMPROOT/missing"
+mkdir -p "$D5"
+OUT5="$(run "$D5")"
+RC5=$?
+assert_json "5a failure envelope"        "$OUT5" "d['success'] is False"
+if [ "$RC5" -ne 0 ]; then
+  pass "5b non-zero exit"
 else
-  fail "4b non-zero exit" "expected non-zero exit code, got 0"
+  fail "5b non-zero exit" "expected non-zero exit code, got 0"
+fi
+
+# --- Fixture 6: malformed field.json (non-dict deliverables entry) → envelope, no traceback
+D6="$TMPROOT/malformed"
+seed_scoped "$D6" '["not-a-deliverable-object"]'
+OUT6="$(run "$D6" 2>/dev/null)"
+RC6=$?
+assert_json "6a malformed envelope"      "$OUT6" "d['success'] is False"
+if [ "$RC6" -ne 0 ]; then
+  pass "6b non-zero exit"
+else
+  fail "6b non-zero exit" "expected non-zero exit code, got 0"
 fi
 
 # --- Summary ----------------------------------------------------------------------

--- a/cogni-consult/tests/test_generate_engagement_readme.sh
+++ b/cogni-consult/tests/test_generate_engagement_readme.sh
@@ -1,0 +1,235 @@
+#!/usr/bin/env bash
+# Regression test for cogni-consult/scripts/generate-engagement-readme.py — the
+# markdown wayfinding front door written at the engagement root.
+#
+# Fixtures are heredoc'd inline — no committed JSON blobs to maintain. Each fixture
+# builds a minimal engagement in a temp directory, runs the generator, and asserts on
+# both the JSON stdout and the generated README.md.
+#
+# Coverage:
+#   1  fully-scoped       all four sections render; every relative link in the
+#                         README resolves inside the engagement dir; the run
+#                         writes README.md and nothing else
+#   2  scaffold-only      scope pending, no fields → status reads "scoping",
+#                         next-action recommends consult-scope, no field links
+#   3  personas-gate      scoped engagement without a scope-seeded persona →
+#                         next-action recommends consult-personas before
+#                         deliverable work
+#   4  failure envelope   missing consult-project.json → success:false, exit 1
+#
+# Usage: bash cogni-consult/tests/test_generate_engagement_readme.sh
+# Exits non-zero on any assertion failure.
+
+# `set -u` only — `set -e` would abort on the first failing assertion and defeat
+# the per-fixture failure counter below.
+set -u
+
+TESTS_DIR="$(cd "$(dirname "$0")" && pwd)"
+PLUGIN_DIR="$(cd "$TESTS_DIR/.." && pwd)"
+SCRIPT="$PLUGIN_DIR/scripts/generate-engagement-readme.py"
+
+if [ ! -f "$SCRIPT" ]; then
+  echo "FAIL: generate-engagement-readme.py not found at $SCRIPT" >&2
+  exit 1
+fi
+
+TMPROOT="$(mktemp -d)"
+trap 'rm -rf "$TMPROOT"' EXIT
+
+failures=0
+pass() { printf 'OK   %s\n' "$1"; }
+fail() { printf 'FAIL %s: %s\n' "$1" "$2" >&2; failures=$((failures + 1)); }
+
+run() { python3 "$SCRIPT" "$@"; }
+
+# assert_json <label> <json> <python-bool-expr over variable d (the parsed dict)>
+assert_json() {
+  local label="$1" js="$2" expr="$3"
+  local verdict
+  verdict="$(printf '%s' "$js" | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+print('PASS' if ($expr) else 'FAIL')
+" 2>/dev/null)"
+  if [ "$verdict" = "PASS" ]; then
+    pass "$label"
+  else
+    fail "$label" "assertion failed over: $js"
+  fi
+}
+
+# assert_md_has <label> <file> <needle>
+assert_md_has() {
+  local label="$1" file="$2" needle="$3"
+  if [ -f "$file" ] && grep -qF "$needle" "$file"; then
+    pass "$label"
+  else
+    fail "$label" "expected to find '$needle' in $file"
+  fi
+}
+
+# assert_md_lacks <label> <file> <needle> — a missing file is its own failure,
+# so a "did not expect X" assertion can never pass vacuously on a run that
+# produced no README at all.
+assert_md_lacks() {
+  local label="$1" file="$2" needle="$3"
+  if [ ! -f "$file" ]; then
+    fail "$label" "file absent: $file"
+  elif grep -qF "$needle" "$file"; then
+    fail "$label" "did not expect '$needle' in $file"
+  else
+    pass "$label"
+  fi
+}
+
+# assert_links_resolve <label> <engagement-dir> — every markdown link target in
+# README.md must exist relative to the engagement dir (AC1: no broken links).
+assert_links_resolve() {
+  local label="$1" dir="$2"
+  local verdict
+  verdict="$(ENG_DIR="$dir" python3 -c "
+import os, re
+dir = os.environ['ENG_DIR']
+with open(os.path.join(dir, 'README.md')) as f:
+    body = f.read()
+missing = [t for t in re.findall(r'\]\(([^)]+)\)', body)
+           if not t.startswith(('http://', 'https://'))
+           and not os.path.exists(os.path.join(dir, t))]
+print('PASS' if not missing else 'FAIL ' + ', '.join(missing))
+")"
+  if [ "$verdict" = "PASS" ]; then
+    pass "$label"
+  else
+    fail "$label" "unresolved link targets: ${verdict#FAIL }"
+  fi
+}
+
+# Build a scoped, one-field engagement with the full wayfinding surface.
+#   seed_scoped <dir> <deliverables-json>
+seed_scoped() {
+  local dir="$1" delivs="$2"
+  mkdir -p "$dir/action-fields/market-evidence" "$dir/personas" "$dir/sources" "$dir/.metadata"
+  cat > "$dir/consult-project.json" <<'EOF'
+{
+  "slug": "acme",
+  "name": "Acme Engagement",
+  "key_question": "How do we enter the market by 2027?",
+  "action_fields": ["market-evidence"],
+  "workflow_state": {"scope": "complete"}
+}
+EOF
+  cat > "$dir/action-fields/market-evidence/field.json" <<EOF
+{
+  "title": "Market evidence",
+  "framing": "Size the opportunity.",
+  "deliverables": $delivs
+}
+EOF
+  echo '{"decisions": []}' > "$dir/.metadata/decision-log.json"
+}
+
+# --- Fixture 1: fully-scoped engagement — four sections, resolving links, README-only write
+D1="$TMPROOT/full"
+seed_scoped "$D1" '[
+  {"slug": "market-sizing", "title": "Market sizing", "state": "complete", "dt_stage": "test"},
+  {"slug": "competitor-map", "title": "Competitor map", "state": "pending"}
+]'
+echo '{"source": "scope-seeded", "name": "CFO"}' > "$D1/personas/cfo.json"
+echo "# Market sizing" > "$D1/action-fields/market-evidence/market-sizing.md"
+BEFORE1="$(cd "$D1" && find . -type f | sort)"
+OUT1="$(run "$D1")"
+AFTER1="$(cd "$D1" && find . -type f | sort)"
+MD1="$D1/README.md"
+assert_json "1a full success"           "$OUT1" "d['success'] is True"
+assert_json "1b completion 50pct"       "$OUT1" "d['data']['completion_pct'] == 50"
+assert_md_has "1c H1 + name"            "$MD1" "# Acme Engagement"
+assert_md_has "1d key question"         "$MD1" "How do we enter the market by 2027?"
+assert_md_has "1e status section"       "$MD1" "## Status"
+assert_md_has "1f field done/total row" "$MD1" "| Market evidence | 1/2 |"
+assert_md_has "1g next section"         "$MD1" "## Next"
+assert_md_has "1h wayfinding section"   "$MD1" "## Wayfinding"
+assert_md_has "1i decision-log link"    "$MD1" "(.metadata/decision-log.json)"
+assert_links_resolve "1j all links resolve" "$D1"
+# Deliverable without a .md artifact gets no link (would be broken).
+assert_md_lacks "1k no broken deliv link" "$MD1" "(action-fields/market-evidence/competitor-map.md)"
+# The run wrote README.md and nothing else (AC3).
+DIFF1="$(comm -13 <(printf '%s\n' "$BEFORE1") <(printf '%s\n' "$AFTER1"))"
+if [ "$DIFF1" = "./README.md" ]; then
+  pass "1l writes only README.md"
+else
+  fail "1l writes only README.md" "unexpected new files: $DIFF1"
+fi
+
+# --- Fixture 2: scaffold-only engagement — graceful degradation ---------------------
+D2="$TMPROOT/scaffold"
+mkdir -p "$D2/action-fields" "$D2/personas" "$D2/sources"
+cat > "$D2/consult-project.json" <<'EOF'
+{
+  "slug": "fresh",
+  "name": "Fresh Engagement",
+  "action_fields": [],
+  "workflow_state": {"scope": "pending"}
+}
+EOF
+OUT2="$(run "$D2")"
+MD2="$D2/README.md"
+assert_json "2a scaffold success"       "$OUT2" "d['success'] is True"
+assert_json "2a2 rung is scope"         "$OUT2" "d['data']['next_action_rung'] == 'scope'"
+assert_md_has "2b status reads scoping" "$MD2" "**Scope:** scoping"
+assert_md_has "2c next recommends scope" "$MD2" "consult-scope"
+assert_md_lacks "2d no field links"     "$MD2" "(action-fields/"
+assert_links_resolve "2e links resolve" "$D2"
+
+# --- Fixture 3: personas gate pending blocks deliverable work ------------------------
+D3="$TMPROOT/gate"
+seed_scoped "$D3" '[
+  {"slug": "market-sizing", "title": "Market sizing", "state": "pending"}
+]'
+# personas/ holds only a setup-default advisor — the gate stays pending.
+echo '{"source": "setup-default", "name": "Consulting partner"}' > "$D3/personas/consulting-partner.json"
+OUT3="$(run "$D3")"
+MD3="$D3/README.md"
+assert_json "3a gate success"            "$OUT3" "d['data']['personas_gate'] == 'pending'"
+assert_json "3a2 rung is personas"       "$OUT3" "d['data']['next_action_rung'] == 'personas'"
+assert_md_has "3b next recommends personas" "$MD3" "consult-personas"
+assert_md_lacks "3c does not start deliverable" "$MD3" "consult-design-thinking"
+
+# --- Fixture 5: stale chain — refresh rung recommends the upstream deliverable first
+D5="$TMPROOT/stale"
+seed_scoped "$D5" '[
+  {"slug": "market-sizing", "title": "Market sizing", "state": "complete", "dt_stage": "test",
+   "lineage_status": {"status": "stale", "reason": "source data updated"}},
+  {"slug": "competitor-map", "title": "Competitor map", "state": "complete", "dt_stage": "test",
+   "depends_on": [{"action_field": "market-evidence", "deliverable": "market-sizing"}],
+   "lineage_status": {"status": "stale", "reason": "upstream changed"}}
+]'
+echo '{"source": "scope-seeded", "name": "CFO"}' > "$D5/personas/cfo.json"
+OUT5="$(run "$D5")"
+MD5="$D5/README.md"
+assert_json "5a stale success"           "$OUT5" "d['success'] is True"
+assert_json "5b rung is refresh"         "$OUT5" "d['data']['next_action_rung'] == 'refresh'"
+# The topological refresh order (via deliverable-graph.py) names the upstream
+# deliverable first — this pins the field_slug/deliv_slug key contract between
+# the two scripts, and that staleness outranks the pending/in-progress rungs.
+assert_md_has "5c upstream named first"  "$MD5" "refresh “Market sizing” first"
+
+# --- Fixture 4: failure envelope on missing project file -----------------------------
+D4="$TMPROOT/missing"
+mkdir -p "$D4"
+OUT4="$(run "$D4")"
+RC4=$?
+assert_json "4a failure envelope"        "$OUT4" "d['success'] is False"
+if [ "$RC4" -ne 0 ]; then
+  pass "4b non-zero exit"
+else
+  fail "4b non-zero exit" "expected non-zero exit code, got 0"
+fi
+
+# --- Summary ----------------------------------------------------------------------
+if [ "$failures" -eq 0 ]; then
+  echo "All generate-engagement-readme.py tests passed."
+  exit 0
+else
+  echo "$failures assertion(s) failed." >&2
+  exit 1
+fi


### PR DESCRIPTION
Closes #1009.

## Summary
- Add `cogni-consult/scripts/generate-engagement-readme.py` (stdlib-only, read-only over all engagement state except the `README.md` it writes) — sibling of `engagement-init.sh` / `engagement-status.sh`.
- Reads the same read model as `engagement-status.sh` and `skills/consult-dashboard/scripts/generate-dashboard.py`: `consult-project.json` + each `action-fields/<slug>/field.json`, with deliverable state as the single source of truth and rollups derived at read time.
- Writes `<engagement-dir>/README.md` with four sections: (1) H1 engagement name + SMART key question; (2) status snapshot (scope state, per-field done/total, overall completion %); (3) the single next recommended deliverable, mirroring `generate-dashboard.py`'s next-action derivation AND deriving the `personas_gate` rung (from `personas/`) that the dashboard omits — spliced after staleness, before in-progress work; (4) a wayfinding link block with relative Obsidian links emitted only for targets that exist.
- JSON envelope carries a machine-readable `next_action_rung` enum (`scope`/`refresh`/`personas`/`continue`/`start`/`plan`/`publish`/`done`/`review`) so the phase-2 consumers and tests key on structure, not prose.
- Add `cogni-consult/tests/test_generate_engagement_readme.sh` (5 fixtures, 27 assertions): fully-scoped incl. link-resolution + writes-only-README, scaffold-only degradation, personas-gate precedence, stale-chain upstream-first refresh (pins the `field_slug/deliv_slug` key contract with `deliverable-graph.py`), failure envelope.
- Register the script in `cogni-consult/CLAUDE.md` (Architecture tree + Scripts table).
- Bump `cogni-consult` 0.1.48 → 0.1.49 in `.claude-plugin/plugin.json`, mirrored in `marketplace.json`.

Plan record: https://github.com/cogni-work/insight-wave/issues/1009#issuecomment-4911767813

## Scope decisions
- **In:** the read-only generator, its regression test, CLAUDE.md registration, version bump — the exact phase-1 foundation of the engagement-README epic.
- **Out (already filed):** #1010 (consult-setup scaffold call) and #1011 (milestone auto-refresh) are the phase-2 children that call this generator.

## Review notes
- A simplify pass flagged that `generate-dashboard.py`'s own `next_action` lacks the personas-gate rung this script adds, so the HTML dashboard and the README can disagree on the recommendation when the gate is pending (the README agrees with the gate `consult-design-thinking` actually enforces; the dashboard predates it). Backporting the rung to the dashboard is outside this issue's scope — flagging for a maintainer call on whether to file it.

## Test plan
- [x] `bash cogni-consult/tests/test_generate_engagement_readme.sh` — 27/27 assertions pass.
- [x] Sibling suites still pass: `test_deliverable_graph.sh`, `test_dt_stage_advance.sh`, `test_generate_dashboard.sh`.
- [x] AC1 fully-scoped: all four sections render, every relative link resolves (asserted programmatically).
- [x] AC2 scaffold-only: status reads "scoping", next-action recommends `consult-scope`, no broken field links.
- [x] AC3: writes-only-README asserted via before/after tree diff.
- [x] Breadcrumb guard clean (`scripts/check-breadcrumbs.py`: 0 new findings).