### PR TITLE
cogni-consult: scaffold engagement README front door at setup

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -35,7 +35,7 @@
     {
       "name": "cogni-consult",
       "source": "./cogni-consult",
-      "version": "0.1.49",
+      "version": "0.1.50",
       "maturity": "preview",
       "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
       "keywords": [

--- a/cogni-consult/.claude-plugin/plugin.json
+++ b/cogni-consult/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-consult",
-  "version": "0.1.49",
+  "version": "0.1.50",
   "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-consult/CLAUDE.md
+++ b/cogni-consult/CLAUDE.md
@@ -61,6 +61,7 @@ cogni-consult/
 │                                  the Empathize stage merges + writes)
 ├── scripts/
 │   ├── engagement-init.sh         Create engagement directory skeleton
+│   │                              + README front door (final, non-fatal step)
 │   ├── engagement-status.sh       Read consult-project.json state → JSON
 │   ├── generate-engagement-readme.py  Markdown wayfinding front door: write the
 │   │                              engagement-root README.md (status snapshot,
@@ -120,7 +121,7 @@ Full schemas: `references/data-model.md`.
 
 | Script | Purpose |
 |--------|---------|
-| `engagement-init.sh` | Create the engagement directory skeleton + consult-project.json |
+| `engagement-init.sh` | Create the engagement directory skeleton + consult-project.json, then write the engagement-root `README.md` front door via `generate-engagement-readme.py` (final step, non-fatal — a generator failure degrades to a stderr warning) |
 | `engagement-status.sh` | Read consult-project.json + derive field/deliverable rollups from `field.json` files, plus the `personas_gate` rollup (satisfied when a `personas/*.json` has `source: scope-seeded` or the extensionless `personas/.gate-waiver` marker is present, else pending) → JSON |
 | `generate-engagement-readme.py` | Write the Obsidian-browsable `README.md` front door at the engagement root from the same read model (key question, status snapshot, single next recommended deliverable incl. the `personas_gate` rung, wayfinding links that only target existing files); read-only except the `README.md` it writes |
 | `deliverable-graph.py` | Deliverable dependency-graph engine over all `field.json` files: `validate` (cycles + dangling refs), `trace` (upstream lineage), `impact` (downstream blast radius), `refresh-order` (topological layering of stale deliverables), `cascade-stale` (flag downstream `lineage_status` via idempotent RMW). Full model: `references/dependency-model.md` |

--- a/cogni-consult/scripts/engagement-init.sh
+++ b/cogni-consult/scripts/engagement-init.sh
@@ -84,3 +84,14 @@ with open(os.path.join(base, "consult-project.json"), "w") as f:
 
 print(json.dumps({"success": True, "data": {"path": base, "slug": project["slug"]}, "error": ""}))
 PY
+
+# Front door: write the engagement-root README as the final step, after
+# consult-project.json, so a consultant opening the directory always finds a
+# wayfinding page (the generator's graceful-degradation branch renders the
+# scaffold-only state). The generator prints its own JSON envelope on both
+# success and failure, so its stdout is redirected to preserve this script's
+# single-JSON-line output contract; failure degrades to a stderr warning —
+# the front door is a convenience, never a scaffold gate.
+if ! python3 "$SCRIPT_DIR/generate-engagement-readme.py" "$BASE_DIR" >/dev/null; then
+  echo "warning: engagement README front door generation failed; scaffold is otherwise complete" >&2
+fi

--- a/cogni-consult/skills/consult-setup/SKILL.md
+++ b/cogni-consult/skills/consult-setup/SKILL.md
@@ -46,7 +46,7 @@ Run the init script from the workspace root:
 bash $CLAUDE_PLUGIN_ROOT/scripts/engagement-init.sh "<engagement-slug>" "<engagement-name>"
 ```
 
-The script creates `cogni-consult/<slug>/{scope,action-fields,personas,sources,.metadata}/`, seeds the two default advisor personas (`consulting-partner.json`, `project-manager.json`) into `personas/` (idempotent — never overwrites an enriched file), writes the three `.metadata/` logs, writes a `sources/README.md` (the `sources/` directory is the engagement's **source inbox** — the documented drop location for raw material to ground a deliverable; see `$CLAUDE_PLUGIN_ROOT/references/data-model.md`), and writes `consult-project.json` last (its existence is the idempotency key). On `"success": false` with `"engagement already initialized"`, stop and route to the existing engagement via `consult-resume` — never overwrite.
+The script creates `cogni-consult/<slug>/{scope,action-fields,personas,sources,.metadata}/`, seeds the two default advisor personas (`consulting-partner.json`, `project-manager.json`) into `personas/` (idempotent — never overwrites an enriched file), writes the three `.metadata/` logs, writes a `sources/README.md` (the `sources/` directory is the engagement's **source inbox** — the documented drop location for raw material to ground a deliverable; see `$CLAUDE_PLUGIN_ROOT/references/data-model.md`), writes `consult-project.json` (its existence is the idempotency key), and finishes by writing the engagement-root `README.md` front door via `generate-engagement-readme.py` — the generator's graceful-degradation branch renders the scaffold-only state, so the consultant finds a wayfinding page from the first moment (a README-generation failure degrades to a stderr warning and never blocks init). On `"success": false` with `"engagement already initialized"`, stop and route to the existing engagement via `consult-resume` — never overwrite.
 
 Then enrich `consult-project.json` with `Edit` — never rewrite the file (the `created`/`updated` timestamps the script set must survive):
 
@@ -92,7 +92,7 @@ The wrapper delegates to the cogni-workspace discovery helper with the cogni-con
 
 ### 6. Recommend the Next Step
 
-Close by confirming what exists (engagement directory, bound knowledge base, registry entry) and recommend `consult-scope` as the next step — the SMART key question and five scoping dimensions anchor the engagement before any action field is derived. When the user wants to continue immediately, dispatch `Skill("cogni-consult:consult-scope")` in the same session; otherwise stop here and report that the engagement is ready for scoping.
+Close by confirming what exists (engagement directory, bound knowledge base, registry entry), pointing the consultant at the engagement-root `README.md` — the wayfinding front door that already renders the scaffold state and stays current as the engagement progresses — and recommending `consult-scope` as the next step — the SMART key question and five scoping dimensions anchor the engagement before any action field is derived. When the user wants to continue immediately, dispatch `Skill("cogni-consult:consult-scope")` in the same session; otherwise stop here and report that the engagement is ready for scoping.
 
 > **Strategy Advisor voice** — point the consultant at the Strategy Advisor output style this plugin ships (answer-first, MECE options). Enable it from the `/config` output-style picker; it's opt-in and fixed at session start, so set it before scoping begins.
 


### PR DESCRIPTION
Closes #1010.

Phase 2 (integration) of the engagement-README-front-door epic: consumes the Phase-1 generator so the living front door exists from the moment an engagement is scaffolded, before scope is done.

## Summary
- `scripts/engagement-init.sh` now writes `<engagement-dir>/README.md` as its final step, calling `generate-engagement-readme.py` after `consult-project.json` is written. The initial README reflects the scaffold-only state via the generator's graceful-degradation branch.
- The generator's own JSON output is redirected off stdout so `engagement-init.sh` keeps its single-JSON-line output contract; the call is non-fatal (degrades to a stderr warning) so a README-generation failure never aborts scaffolding.
- `skills/consult-setup/SKILL.md` step 3 notes init now also writes the engagement-root README front door; step 6 points the consultant at that README as the front door alongside the `consult-scope` recommendation.
- `cogni-consult/CLAUDE.md` script tree + script table rows updated to match (developer-guide drift folded in by the refine pass).
- Bump cogni-consult 0.1.49 -> 0.1.50 in `plugin.json` and mirror it in `marketplace.json`.

## Scope decisions
- **In:** the three acceptance criteria — README exists + renders after init, idempotency preserved, SKILL.md documents the front door in steps 3 and 6 — plus the version bump and the hand-maintained developer-guide rows.
- **Idempotency (AC2)** is inherited from the existing `consult-project.json` short-circuit at the top of the script: a second run returns "already initialized" and exits before reaching the generator call, so scaffolding is never duplicated.
- **Generator unchanged:** its graceful-degradation branch already matches the scaffold-only shape and is covered by an existing test fixture — no edits and no new caller coordination needed.
- **Out:** the auto-generated README.md Components row resync (auto-generated surface, owned by cogni-docs:doc-generate) — tracked in the follow-up below. The auto-refresh-at-milestones wiring is a separate epic child, not this issue.

## Test plan (executed during resolution)
- [x] From a scratch dir, ran `bash .../engagement-init.sh test-eng "Test Engagement"`: stdout was exactly one success JSON line and `cogni-consult/test-eng/README.md` rendered the scaffold-only front door (scope: scoping, next action = consult-scope, no broken field links).
- [x] Re-ran the same command: returned `"engagement already initialized"` (success:false, exit 0), no duplicated scaffolding.
- [x] `bash cogni-consult/tests/test_generate_engagement_readme.sh` — all fixtures pass (generator untouched).
- [x] `consult-setup` SKILL.md steps 3 and 6 document the README front door.
- [x] `plugin.json` and the `cogni-consult` marketplace entry both read `0.1.50`.

## Follow-up issues
- #1014 — resync cogni-consult's auto-generated README sections via cogni-docs:doc-generate after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)