### PR TITLE
cogni-consult: assumption single-source registry + {{asm:id}} resolver

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -35,7 +35,7 @@
     {
       "name": "cogni-consult",
       "source": "./cogni-consult",
-      "version": "0.1.52",
+      "version": "0.1.53",
       "maturity": "preview",
       "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
       "keywords": [

--- a/cogni-consult/.claude-plugin/plugin.json
+++ b/cogni-consult/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-consult",
-  "version": "0.1.52",
+  "version": "0.1.53",
   "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-consult/CLAUDE.md
+++ b/cogni-consult/CLAUDE.md
@@ -68,6 +68,9 @@ cogni-consult/
 │   │                              next action, relative Obsidian links)
 │   ├── deliverable-graph.py       Deliverable dependency-graph engine: validate /
 │   │                              trace / impact / refresh-order / cascade-stale
+│   ├── resolve-assumptions.py     Render-time {{asm:id}} resolver against the
+│   │                              engagement-root assumptions.json registry
+│   │                              (fail-loud on unknown ids)
 │   ├── discover-projects.sh       Thin wrapper over the cogni-workspace discovery helper
 │   └── _discover_extractor.py     Per-engagement field extractor for the wrapper
 └── skills/
@@ -109,6 +112,7 @@ cogni-consult/
 
 Each engagement lives in `cogni-consult/{slug}/` with:
 - `consult-project.json` — engagement config, key question, action-field list, scope state, plugin refs
+- `assumptions.json` — single source of truth for assumption values; deliverables and briefs cite them as `{{asm:id}}` placeholders resolved at publish time by `resolve-assumptions.py`
 - `scope/` — key question + 5 scoping dimensions + derived action-field list
 - `action-fields/{field-slug}/` — one directory per WBS field: `field.json` (single source of truth for the field's deliverable states) + deliverable markdown artifacts
 - `personas/` — acting stakeholder personas (JSON)
@@ -125,6 +129,7 @@ Full schemas: `references/data-model.md`.
 | `engagement-status.sh` | Read consult-project.json + derive field/deliverable rollups from `field.json` files, plus the `personas_gate` rollup (satisfied when a `personas/*.json` has `source: scope-seeded` or the extensionless `personas/.gate-waiver` marker is present, else pending) → JSON |
 | `generate-engagement-readme.py` | Write the Obsidian-browsable `README.md` front door at the engagement root from the same read model (key question, status snapshot, single next recommended deliverable incl. the `personas_gate` rung, wayfinding links that only target existing files); read-only except the `README.md` it writes. Invoked at scaffold time by `engagement-init.sh` and, unconditionally and non-fatally, at the dashboard milestones — `consult-design-thinking` (session close), `consult-action-fields` (WBS change), `consult-resume` (re-entry) — the markdown parallel to `consult-dashboard-refresher`'s theme-gated HTML refresh |
 | `deliverable-graph.py` | Deliverable dependency-graph engine over all `field.json` files: `validate` (cycles + dangling refs), `trace` (upstream lineage), `impact` (downstream blast radius), `refresh-order` (topological layering of stale deliverables), `cascade-stale` (flag downstream `lineage_status` via idempotent RMW). Full model: `references/dependency-model.md` |
+| `resolve-assumptions.py` | Render-time resolver replacing `{{asm:<slug>}}` placeholders with values from the engagement-root `assumptions.json` registry (single source of truth for assumption values). Fail-loud on unresolvable placeholders; wired into `consult-publish` as the mandatory post-build/pre-lineage pass (contract: `references/publish-routing.md`) |
 | `discover-projects.sh` | Thin wrapper delegating to `cogni-workspace/scripts/discover-plugin-projects.sh` (registry: `$HOME/.claude/cogni-consult-projects.json`) |
 | `_discover_extractor.py` | Per-engagement JSON field extractor consumed by the discovery wrapper (reads the flat consult-project.json schema) |
 

--- a/cogni-consult/README.md
+++ b/cogni-consult/README.md
@@ -156,6 +156,7 @@ Publishing is **consultant-elected and never automatic** — it does not fire at
 | `engagement-status.sh` | Script | Derive field/deliverable rollups from `field.json` files → JSON |
 | `dt-stage-advance.sh` | Script | Guarded, logged design-thinking stage advance for one deliverable — validates the transition (single-step forward, same-stage re-set, or earlier-stage re-entry) before writing it |
 | `deliverable-graph.py` | Script | Deliverable dependency-graph engine over all `field.json` files: validate / trace / impact / refresh-order / cascade-stale |
+| `resolve-assumptions.py` | Script | Render-time resolver replacing `{{asm:id}}` placeholders with values from the engagement-root `assumptions.json` registry — fail-loud on unresolvable placeholders, wired into `consult-publish` |
 | `discover-projects.sh` | Script | Engagement discovery (delegates to the cogni-workspace helper) |
 | `consult-dashboard/scripts/generate-dashboard.py` | Script | Render the engagement HTML dashboard from `consult-project.json` + `field.json` files (read-only) |
 

--- a/cogni-consult/references/data-model.md
+++ b/cogni-consult/references/data-model.md
@@ -10,6 +10,8 @@ from the legacy phase-folder model.
 ```
 cogni-consult/{engagement-slug}/
 ├── consult-project.json                   # Engagement config + scope state + plugin refs
+├── assumptions.json                       # Single source of truth for assumption values
+│                                          #   ({{asm:id}} placeholders resolve against it)
 ├── .metadata/
 │   ├── execution-log.json                 # Workflow-state transitions and timestamps
 │   ├── method-log.json                    # Methods proposed and selected per deliverable
@@ -111,6 +113,54 @@ list, and cross-plugin project references — not per-deliverable state.
 | `plugin_refs` | No | Slugs/relative paths to projects created by other plugins. `plugin_refs.knowledge_base` binds one cogni-knowledge base per engagement — research compounds there across all deliverables |
 | `created` | Yes | ISO date of engagement creation |
 | `updated` | Yes | ISO date of last modification **of this root file** (scope edits, action-field list changes, plugin-ref binding). Deliverable work never touches it — engagement freshness derives from `.metadata/execution-log.json` timestamps |
+
+### assumptions.json (Assumption Registry)
+
+One per engagement, at the engagement root. The single source of truth for
+**assumption values** — the quantified planning numbers (market sizes, rates,
+headcounts, price points) an engagement otherwise repeats as dozens of separate
+literals. An assumption's `value` lives in **exactly one place**: this registry.
+Deliverables and briefs never inline the number; they cite it with a
+`{{asm:<suffix>}}` placeholder (e.g. `{{asm:tam-dach-2027}}` for the entry
+`asm-tam-dach-2027`), resolved at render time by
+`scripts/resolve-assumptions.py` — so one registry edit updates every rendered
+occurrence of a registered number, mirroring the `field.json` state-ownership
+discipline. (The convention applies to numbers a consultant registers; wiring
+the authoring stages to prompt for registration is a later roadmap step.)
+
+```json
+{
+  "assumptions": [
+    {
+      "id": "asm-tam-dach-2027",
+      "name": "DACH mid-market cloud TAM 2027",
+      "value": "€4.2bn",
+      "rationale": "Destatis base + 11% CAGR, mid-market segment share per Bitkom",
+      "citation": {
+        "source_url": "https://www.destatis.de/...",
+        "entity_ref": "cogni-consult/dach-cloud-expansion/assumptions/asm-tam-dach-2027",
+        "propagated_at": "2026-07-08T09:00:00Z"
+      },
+      "created": "2026-07-08",
+      "updated": "2026-07-08"
+    }
+  ]
+}
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `id` | Yes | `asm-` + kebab-case slug, unique within the registry. Cited in text as `{{asm:<slug>}}` (the placeholder carries the id without its `asm-` prefix). Ids are engagement-local today but kept globally unique in shape (typed prefix + slug) so a later cross-engagement lift needs no renumbering |
+| `name` | Yes | Human-readable label for the assumption |
+| `value` | Yes | The rendered value, verbatim (string, unit included — e.g. `"€4.2bn"`). What the resolver substitutes for every placeholder occurrence |
+| `rationale` | No | How the value was derived — the audit trail in prose |
+| `citation` | No | Source-lineage triple (`source_url`, `entity_ref`, `propagated_at`) per the monorepo convention, so cogni-claims corrections can cascade to the assumption |
+| `created` / `updated` | Yes | ISO dates of entry creation / last value edit |
+
+Resolution is **fail-loud** — the full failure contract is canonical in
+`references/publish-routing.md` (Assumption Resolution), not restated here. The
+registry is scaffolded empty (`{"assumptions": []}`) by `engagement-init.sh`;
+the render wire-in point is `consult-publish`.
 
 ### action-fields/{field-slug}/field.json (WBS Field)
 

--- a/cogni-consult/references/data-model.md
+++ b/cogni-consult/references/data-model.md
@@ -152,7 +152,7 @@ the authoring stages to prompt for registration is a later roadmap step.)
 |-------|----------|-------------|
 | `id` | Yes | `asm-` + kebab-case slug, unique within the registry. Cited in text as `{{asm:<slug>}}` (the placeholder carries the id without its `asm-` prefix). Ids are engagement-local today but kept globally unique in shape (typed prefix + slug) so a later cross-engagement lift needs no renumbering |
 | `name` | Yes | Human-readable label for the assumption |
-| `value` | Yes | The rendered value, verbatim (string, unit included — e.g. `"€4.2bn"`). What the resolver substitutes for every placeholder occurrence |
+| `value` | Yes | The rendered value, verbatim (string, unit included — e.g. `"€4.2bn"`); never `null` — the resolver rejects a null/absent value rather than rendering `None`. What the resolver substitutes for every placeholder occurrence |
 | `rationale` | No | How the value was derived — the audit trail in prose |
 | `citation` | No | Source-lineage triple (`source_url`, `entity_ref`, `propagated_at`) per the monorepo convention, so cogni-claims corrections can cascade to the assumption |
 | `created` / `updated` | Yes | ISO dates of entry creation / last value edit |

--- a/cogni-consult/references/publish-routing.md
+++ b/cogni-consult/references/publish-routing.md
@@ -174,15 +174,25 @@ Scope guidance: `--scope=tone` for a light pass that preserves structure;
 Pyramid / BLUF restructuring before a client-facing presentation. `TARGET_LANG`
 translates when the brief's language differs from the deliverable's.
 
+One hard rule regardless of scope: the polish must preserve `{{asm:id}}`
+placeholder tokens **verbatim**. Assumption resolution runs after any polish
+(it is the last transformation before lineage recording), and a reworded token
+no longer matches the resolver's strict form — the resolver's
+malformed-placeholder check catches near-misses that still contain `asm`, but
+a fully prose-ified token is unrecoverable, so instruct the copywriter to
+treat `{{...}}` tokens as frozen.
+
 ## Assumption Resolution (mandatory, fail-loud)
 
 Every route's built brief runs through the assumption resolver **after the
-brief file is written and before the publish lineage is recorded** — one
-generic pass covers all four formats, since every route terminates in a brief
-file. The resolver replaces each `{{asm:<slug>}}` placeholder with the `value`
-of the `asm-<slug>` entry in the engagement-root `assumptions.json` registry
-(the single source of truth for assumption values — schema:
-`references/data-model.md`, Assumption Registry).
+brief file is written (and after any optional voice polish) and before the
+publish lineage is recorded** — one generic pass covers all four formats,
+since every route terminates in a brief file. The resolver replaces each
+`{{asm:<slug>}}` placeholder with the `value` of the `asm-<slug>` entry in the
+engagement-root `assumptions.json` registry (the single source of truth for
+assumption values — schema: `references/data-model.md`, Assumption Registry).
+The write is atomic (temp file + rename), so a failed run never truncates the
+built brief.
 
 ```bash
 python3 "$CLAUDE_PLUGIN_ROOT/scripts/resolve-assumptions.py" \
@@ -197,9 +207,23 @@ polish's graceful degradation:
   `data.failed_check: "unknown_assumption_id"`, `data.ids[]` listing **every**
   unresolved id (not just the first). The publish run stops; nothing is
   recorded in `field.json`.
-- **Duplicate registry id** or **missing/unreadable registry while
-  placeholders exist** → `success: false`, exit 1, with the matching
-  `failed_check` discriminator. Same stop.
+- **Malformed placeholder** — a `{{...asm...}}` token that does not match the
+  strict `{{asm:<kebab-slug>}}` form (uppercase, underscores, stray spaces) →
+  `success: false`, exit 1, `failed_check: "malformed_placeholder"`,
+  `data.tokens[]` listing every offender. Typos fail loud instead of shipping
+  verbatim.
+- **Placeholder remaining after substitution** — a registry value that itself
+  embeds (or re-forms) a placeholder → `success: false`, exit 1,
+  `failed_check: "unresolved_after_substitution"`; nothing is written.
+- **Defective registry entry** — missing/malformed `id`
+  (`invalid_assumption_id`), missing or `null` `value`
+  (`missing_assumption_value`), or **duplicate id**
+  (`duplicate_assumption_id`) → `success: false`, exit 1, listing every
+  offender. Same stop.
+- **Missing/unreadable registry while placeholders exist** →
+  `success: false`, exit 1 (`registry_missing` / `registry_unreadable`).
+  Re-running `engagement-init.sh` backfills an empty registry on engagements
+  that predate it.
 - **No placeholders in the brief** → `success: true` no-op
   (`placeholders_found: 0`); registry absence is then not an error, so
   engagements predating the registry publish unchanged.

--- a/cogni-consult/references/publish-routing.md
+++ b/cogni-consult/references/publish-routing.md
@@ -174,6 +174,40 @@ Scope guidance: `--scope=tone` for a light pass that preserves structure;
 Pyramid / BLUF restructuring before a client-facing presentation. `TARGET_LANG`
 translates when the brief's language differs from the deliverable's.
 
+## Assumption Resolution (mandatory, fail-loud)
+
+Every route's built brief runs through the assumption resolver **after the
+brief file is written and before the publish lineage is recorded** — one
+generic pass covers all four formats, since every route terminates in a brief
+file. The resolver replaces each `{{asm:<slug>}}` placeholder with the `value`
+of the `asm-<slug>` entry in the engagement-root `assumptions.json` registry
+(the single source of truth for assumption values — schema:
+`references/data-model.md`, Assumption Registry).
+
+```bash
+python3 "$CLAUDE_PLUGIN_ROOT/scripts/resolve-assumptions.py" \
+  <engagement-dir> resolve <brief-path> --in-place
+```
+
+The invocation emits a single `{"success": bool, "data": {...}, "error": str}`
+envelope. Failure contract — deliberately the inverse of the optional voice
+polish's graceful degradation:
+
+- **Unknown placeholder id** → `success: false`, exit 1,
+  `data.failed_check: "unknown_assumption_id"`, `data.ids[]` listing **every**
+  unresolved id (not just the first). The publish run stops; nothing is
+  recorded in `field.json`.
+- **Duplicate registry id** or **missing/unreadable registry while
+  placeholders exist** → `success: false`, exit 1, with the matching
+  `failed_check` discriminator. Same stop.
+- **No placeholders in the brief** → `success: true` no-op
+  (`placeholders_found: 0`); registry absence is then not an error, so
+  engagements predating the registry publish unchanged.
+
+A placeholder is never silently left in the handoff and never silently
+dropped — an unresolvable assumption is a data error the consultant fixes in
+`assumptions.json` (or in the placeholder), not a rendering detail.
+
 ## Handoff Contract
 
 Every route terminates in a **brief file** built natively inside this skill —

--- a/cogni-consult/scripts/engagement-init.sh
+++ b/cogni-consult/scripts/engagement-init.sh
@@ -83,6 +83,13 @@ with open(os.path.join(base, "sources", "README.md"), "w") as f:
         "  when the material is deliverable-local and should not enter the shared base.\n"
     )
 
+# Assumption registry: single source of truth for {{asm:id}} values (see
+# references/data-model.md). Seeded empty, before the manifest, so a completed
+# init always carries the registry the render resolver reads.
+with open(os.path.join(base, "assumptions.json"), "w") as f:
+    json.dump({"assumptions": []}, f, indent=2)
+    f.write("\n")
+
 # Manifest written last: its existence marks a completed init (see the
 # idempotency check above).
 with open(os.path.join(base, "consult-project.json"), "w") as f:

--- a/cogni-consult/scripts/engagement-init.sh
+++ b/cogni-consult/scripts/engagement-init.sh
@@ -14,6 +14,12 @@ BASE_DIR="cogni-consult/${SLUG}"
 # Idempotency keys on the manifest, not the bare directory, so an interrupted
 # run (skeleton created, manifest never written) is repairable by re-running.
 if [ -f "$BASE_DIR/consult-project.json" ]; then
+  # Backfill: engagements initialized before the assumption registry existed
+  # gain an empty assumptions.json on re-run, keeping the repairable-by-re-run
+  # contract true for the registry too (the resolver hard-fails without it).
+  if [ ! -f "$BASE_DIR/assumptions.json" ]; then
+    printf '{\n  "assumptions": []\n}\n' > "$BASE_DIR/assumptions.json"
+  fi
   BASE_DIR="$BASE_DIR" python3 -c 'import json, os; print(json.dumps({"success": False, "data": {"path": os.environ["BASE_DIR"]}, "error": "engagement already initialized (consult-project.json exists)"}))'
   exit 0
 fi

--- a/cogni-consult/scripts/resolve-assumptions.py
+++ b/cogni-consult/scripts/resolve-assumptions.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Render-time resolver for {{asm:id}} assumption placeholders.
+
+Usage:
+  python3 resolve-assumptions.py <engagement-dir> resolve <file> [--in-place]
+
+Reads the engagement's assumptions.json registry (the single source of truth
+for assumption values — see references/data-model.md) and replaces every
+`{{asm:<suffix>}}` placeholder in the target file with the `value` of the
+registry entry whose id is `asm-<suffix>`. Without --in-place the resolved
+text is returned in the envelope (a dry-run); with it, the file is rewritten.
+Read-only toward the registry and toward field.json.
+
+Fail-loud contract: an unknown placeholder id, a duplicate registry id, or a
+missing registry when placeholders exist all return success:false with a
+data.failed_check discriminator and exit 1 — a placeholder is never silently
+left in, and never silently dropped. All offending ids are listed at once so
+a consultant can fix every typo in one pass.
+
+Output: single-line JSON envelope {"success": bool, "data": {...}, "error": str}.
+Stdlib-only.
+"""
+
+import argparse
+import json
+import os
+import re
+import sys
+
+PLACEHOLDER_RE = re.compile(r"\{\{asm:([a-z0-9][a-z0-9-]*)\}\}")
+ID_PREFIX = "asm-"
+
+
+def _emit(success, data, error):
+    print(json.dumps({"success": success, "data": data, "error": error}))
+    sys.exit(0 if success else 1)
+
+
+def load_registry(engagement_dir):
+    """Return {id: entry} from assumptions.json, failing loudly on any defect."""
+    path = os.path.join(engagement_dir, "assumptions.json")
+    if not os.path.isfile(path):
+        _emit(False, {"failed_check": "registry_missing", "path": path},
+              "assumptions.json not found at engagement root — placeholders exist "
+              "but there is no registry to resolve them against")
+    try:
+        with open(path) as f:
+            raw = json.load(f)
+    except (json.JSONDecodeError, OSError) as exc:
+        _emit(False, {"failed_check": "registry_unreadable", "path": path},
+              "assumptions.json could not be read/parsed: %s" % exc)
+    registry = {}
+    duplicates = []
+    for entry in raw.get("assumptions", []):
+        asm_id = entry.get("id", "")
+        if asm_id in registry:
+            duplicates.append(asm_id)
+        registry[asm_id] = entry
+    if duplicates:
+        _emit(False, {"failed_check": "duplicate_assumption_id", "ids": sorted(set(duplicates))},
+              "duplicate assumption id(s) in registry — the single-source contract "
+              "requires exactly one entry per id")
+    return registry
+
+
+def cmd_resolve(args):
+    try:
+        with open(args.file) as f:
+            text = f.read()
+    except OSError as exc:
+        _emit(False, {"failed_check": "file_unreadable", "path": args.file},
+              "target file could not be read: %s" % exc)
+
+    suffixes = PLACEHOLDER_RE.findall(text)
+    if not suffixes:
+        # Nothing to resolve — a registry-less or placeholder-free brief passes.
+        _emit(True, {"file": args.file, "placeholders_found": 0, "output": None}, "")
+
+    unique_ids = sorted({ID_PREFIX + s for s in suffixes})
+    registry = load_registry(args.engagement_dir)
+    missing = [i for i in unique_ids if i not in registry]
+    if missing:
+        _emit(False, {"failed_check": "unknown_assumption_id", "ids": missing},
+              "unknown assumption id(s): %s — define them in assumptions.json "
+              "or fix the placeholder(s)" % ", ".join(missing))
+
+    resolved = PLACEHOLDER_RE.sub(
+        lambda m: str(registry[ID_PREFIX + m.group(1)]["value"]), text)
+
+    data = {
+        "file": args.file,
+        "placeholders_found": len(suffixes),
+        "unique_ids": unique_ids,
+        "output": args.file if args.in_place else None,
+    }
+    if args.in_place:
+        with open(args.file, "w") as f:
+            f.write(resolved)
+    else:
+        data["resolved_text"] = resolved
+    _emit(True, data, "")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Resolve {{asm:id}} placeholders against the engagement's assumptions.json")
+    parser.add_argument("engagement_dir", help="engagement root (directory holding consult-project.json)")
+    sub = parser.add_subparsers(dest="action", required=True)
+
+    p_resolve = sub.add_parser("resolve", help="resolve placeholders in a file")
+    p_resolve.add_argument("file", help="file containing {{asm:id}} placeholders")
+    p_resolve.add_argument("--in-place", action="store_true",
+                           help="write resolved text back to the file (omit for a dry-run envelope)")
+    p_resolve.set_defaults(func=cmd_resolve)
+
+    args = parser.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/cogni-consult/scripts/resolve-assumptions.py
+++ b/cogni-consult/scripts/resolve-assumptions.py
@@ -8,14 +8,17 @@ Reads the engagement's assumptions.json registry (the single source of truth
 for assumption values — see references/data-model.md) and replaces every
 `{{asm:<suffix>}}` placeholder in the target file with the `value` of the
 registry entry whose id is `asm-<suffix>`. Without --in-place the resolved
-text is returned in the envelope (a dry-run); with it, the file is rewritten.
-Read-only toward the registry and toward field.json.
+text is returned in the envelope (a dry-run); with it, the file is rewritten
+atomically (temp file + rename). Read-only toward the registry and field.json.
 
-Fail-loud contract: an unknown placeholder id, a duplicate registry id, or a
-missing registry when placeholders exist all return success:false with a
-data.failed_check discriminator and exit 1 — a placeholder is never silently
-left in, and never silently dropped. All offending ids are listed at once so
-a consultant can fix every typo in one pass.
+Fail-loud contract: an unknown placeholder id, a malformed placeholder (an
+{{...asm...}} token that does not match the strict form), a placeholder still
+present after substitution (e.g. a registry value that itself embeds one), a
+defective registry entry (missing/invalid id, missing/null value, duplicate
+id), or a missing registry when placeholders exist all return success:false
+with a data.failed_check discriminator and exit 1 — a placeholder is never
+silently left in, and never silently dropped. All offenders are listed at
+once so a consultant can fix every defect in one pass.
 
 Output: single-line JSON envelope {"success": bool, "data": {...}, "error": str}.
 Stdlib-only.
@@ -26,8 +29,13 @@ import json
 import os
 import re
 import sys
+import tempfile
 
 PLACEHOLDER_RE = re.compile(r"\{\{asm:([a-z0-9][a-z0-9-]*)\}\}")
+# Anything brace-wrapped that mentions "asm" but is not a strict match — a
+# typo'd id (uppercase, underscore, spaces) must fail loud, never ship.
+LOOSE_ASM_RE = re.compile(r"\{\{[^{}]*asm[^{}]*\}\}", re.IGNORECASE)
+ID_RE = re.compile(r"^asm-[a-z0-9][a-z0-9-]*$")
 ID_PREFIX = "asm-"
 
 
@@ -42,20 +50,35 @@ def load_registry(engagement_dir):
     if not os.path.isfile(path):
         _emit(False, {"failed_check": "registry_missing", "path": path},
               "assumptions.json not found at engagement root — placeholders exist "
-              "but there is no registry to resolve them against")
+              "but there is no registry to resolve them against (re-run "
+              "engagement-init.sh to backfill an empty registry)")
     try:
         with open(path) as f:
             raw = json.load(f)
     except (json.JSONDecodeError, OSError) as exc:
         _emit(False, {"failed_check": "registry_unreadable", "path": path},
               "assumptions.json could not be read/parsed: %s" % exc)
+
     registry = {}
-    duplicates = []
+    bad_ids, missing_values, duplicates = [], [], []
     for entry in raw.get("assumptions", []):
-        asm_id = entry.get("id", "")
+        asm_id = entry.get("id")
+        if not isinstance(asm_id, str) or not ID_RE.match(asm_id):
+            bad_ids.append(repr(asm_id))
+            continue
         if asm_id in registry:
             duplicates.append(asm_id)
+        if entry.get("value") is None:
+            missing_values.append(asm_id)
         registry[asm_id] = entry
+    if bad_ids:
+        _emit(False, {"failed_check": "invalid_assumption_id", "ids": sorted(set(bad_ids))},
+              "registry entries with missing or malformed id (expected asm- + "
+              "kebab-case slug): %s" % ", ".join(sorted(set(bad_ids))))
+    if missing_values:
+        _emit(False, {"failed_check": "missing_assumption_value", "ids": sorted(set(missing_values))},
+              "registry entries missing a value (or value is null): %s"
+              % ", ".join(sorted(set(missing_values))))
     if duplicates:
         _emit(False, {"failed_check": "duplicate_assumption_id", "ids": sorted(set(duplicates))},
               "duplicate assumption id(s) in registry — the single-source contract "
@@ -71,12 +94,18 @@ def cmd_resolve(args):
         _emit(False, {"failed_check": "file_unreadable", "path": args.file},
               "target file could not be read: %s" % exc)
 
-    suffixes = PLACEHOLDER_RE.findall(text)
-    if not suffixes:
+    strict_tokens = set(PLACEHOLDER_RE.findall(text))
+    malformed = sorted(t for t in set(LOOSE_ASM_RE.findall(text))
+                       if not PLACEHOLDER_RE.fullmatch(t))
+    if malformed:
+        _emit(False, {"failed_check": "malformed_placeholder", "tokens": malformed},
+              "placeholder-like token(s) that do not match {{asm:<kebab-slug>}}: "
+              "%s — fix the placeholder(s); nothing was resolved" % ", ".join(malformed))
+    if not strict_tokens:
         # Nothing to resolve — a registry-less or placeholder-free brief passes.
         _emit(True, {"file": args.file, "placeholders_found": 0, "output": None}, "")
 
-    unique_ids = sorted({ID_PREFIX + s for s in suffixes})
+    unique_ids = sorted(ID_PREFIX + s for s in strict_tokens)
     registry = load_registry(args.engagement_dir)
     missing = [i for i in unique_ids if i not in registry]
     if missing:
@@ -84,18 +113,40 @@ def cmd_resolve(args):
               "unknown assumption id(s): %s — define them in assumptions.json "
               "or fix the placeholder(s)" % ", ".join(missing))
 
-    resolved = PLACEHOLDER_RE.sub(
+    resolved, count = PLACEHOLDER_RE.subn(
         lambda m: str(registry[ID_PREFIX + m.group(1)]["value"]), text)
+
+    # A registry value may itself contain (or re-form) a placeholder; shipping
+    # it verbatim would break the never-silently-left-in contract.
+    leftovers = sorted(set(LOOSE_ASM_RE.findall(resolved)))
+    if leftovers:
+        _emit(False, {"failed_check": "unresolved_after_substitution", "tokens": leftovers},
+              "placeholder-like token(s) remain after substitution (a registry "
+              "value embeds one?): %s — nothing was written" % ", ".join(leftovers))
 
     data = {
         "file": args.file,
-        "placeholders_found": len(suffixes),
+        "placeholders_found": count,
         "unique_ids": unique_ids,
         "output": args.file if args.in_place else None,
     }
     if args.in_place:
-        with open(args.file, "w") as f:
-            f.write(resolved)
+        # Atomic replace: never truncate the only copy of the built brief.
+        tmp_path = None
+        try:
+            fd, tmp_path = tempfile.mkstemp(
+                dir=os.path.dirname(os.path.abspath(args.file)), suffix=".tmp")
+            with os.fdopen(fd, "w") as f:
+                f.write(resolved)
+            os.replace(tmp_path, args.file)
+        except OSError as exc:
+            if tmp_path is not None:
+                try:
+                    os.unlink(tmp_path)
+                except OSError:
+                    pass
+            _emit(False, {"failed_check": "write_failed", "path": args.file},
+                  "resolved text could not be written (original file untouched): %s" % exc)
     else:
         data["resolved_text"] = resolved
     _emit(True, data, "")

--- a/cogni-consult/skills/consult-publish/SKILL.md
+++ b/cogni-consult/skills/consult-publish/SKILL.md
@@ -134,6 +134,24 @@ brief-only contract otherwise avoids) — they are no longer the standard path.
 When `cogni-copywriting` is absent, the optional polish step is skipped. Either
 way the run still produces a valid brief.
 
+### 4.5 Resolve assumption placeholders (mandatory)
+
+After the brief is written and before its lineage is recorded, resolve every
+`{{asm:id}}` placeholder against the engagement's `assumptions.json` registry
+(the single source of truth for assumption values — schema in
+`$CLAUDE_PLUGIN_ROOT/references/data-model.md`). Unlike the step-3 polish,
+this pass is **mandatory and fail-loud**, not optional and graceful-degrading:
+a placeholder that cannot be resolved must stop the publish, never ship as a
+literal `{{asm:...}}` in a client-facing brief and never be silently dropped.
+
+Run the resolver on the built brief in place; the exact invocation and failure
+contract are canonical in `$CLAUDE_PLUGIN_ROOT/references/publish-routing.md`
+(Assumption Resolution section) — read it rather than restating it here. On
+`success: false`, stop the publish, tell the consultant which assumption ids
+are unknown (the envelope lists all of them), and do **not** proceed to step 5
+— the deliverable's registry (or the placeholder) needs fixing first. A brief
+with no placeholders passes trivially.
+
 ### 5. Record the publish lineage in field.json
 
 Store the brief as a **path reference plus lineage** on the deliverable entry —
@@ -194,6 +212,10 @@ If multiple formats were produced in this session, list each brief path.
   local-render fallback only. When `cogni-copywriting` is absent the optional
   polish step is skipped. Either way the run still produces a valid brief — a
   missing downstream plugin degrades the output, it never fails the run.
+- **Assumption resolution is fail-loud, not graceful-degrading.** The step-4.5
+  `{{asm:id}}` pass is the one mandatory gate between building a brief and
+  handing it off — a missing polish degrades style, but an unresolved
+  assumption ships a wrong or placeholder number to a client.
 - **Framework-shaped, not arc-shaped.** All four routes build the brief directly
   from the deliverable's framework (Pyramid/MECE/SCQA). None arc-ifies and none
   dispatches the arc-optimized cogni-visual story skills on the standard path —

--- a/cogni-consult/skills/consult-publish/SKILL.md
+++ b/cogni-consult/skills/consult-publish/SKILL.md
@@ -83,7 +83,10 @@ standard path.
 
 The dispatch invocation and the `--scope` options (`tone` / `compress` / `full`)
 are the canonical ones in `$CLAUDE_PLUGIN_ROOT/references/publish-routing.md` —
-see its "Optional Voice Polish" section rather than restating them here.
+see its "Optional Voice Polish" section rather than restating them here. One
+hard rule regardless of scope: the polish must preserve `{{asm:id}}` placeholder
+tokens **verbatim** — a reworded token no longer matches the step-4.5 resolver
+and would slip past the fail-loud gate.
 
 ### 4. Build the brief by route
 
@@ -136,8 +139,9 @@ way the run still produces a valid brief.
 
 ### 4.5 Resolve assumption placeholders (mandatory)
 
-After the brief is written and before its lineage is recorded, resolve every
-`{{asm:id}}` placeholder against the engagement's `assumptions.json` registry
+After the brief is written — and after any optional step-3 polish, so
+resolution is unambiguously the last transformation before step 5 — resolve
+every `{{asm:id}}` placeholder against the engagement's `assumptions.json` registry
 (the single source of truth for assumption values — schema in
 `$CLAUDE_PLUGIN_ROOT/references/data-model.md`). Unlike the step-3 polish,
 this pass is **mandatory and fail-loud**, not optional and graceful-degrading:
@@ -149,8 +153,8 @@ contract are canonical in `$CLAUDE_PLUGIN_ROOT/references/publish-routing.md`
 (Assumption Resolution section) — read it rather than restating it here. On
 `success: false`, stop the publish, tell the consultant which assumption ids
 are unknown (the envelope lists all of them), and do **not** proceed to step 5
-— the deliverable's registry (or the placeholder) needs fixing first. A brief
-with no placeholders passes trivially.
+— the engagement's registry (or the deliverable's placeholder) needs fixing
+first. A brief with no placeholders passes trivially.
 
 ### 5. Record the publish lineage in field.json
 

--- a/cogni-consult/tests/test_resolve_assumptions.sh
+++ b/cogni-consult/tests/test_resolve_assumptions.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# Regression test for cogni-consult/scripts/resolve-assumptions.py — the
+# fail-loud {{asm:id}} render resolver.
+#
+# Fixtures are heredoc'd inline — no committed JSON blobs to maintain. Each
+# fixture builds a minimal engagement dir + target file under a temp root,
+# runs the resolver, and asserts on the JSON envelope plus the on-disk state.
+#
+# Coverage:
+#   1  resolve-in-place    two occurrences of one id both replaced (AC1)
+#   2  dry-run             no --in-place -> resolved_text in envelope, file untouched
+#   3  unknown-id          all missing ids listed, exit 1, file untouched (AC2)
+#   4  malformed           uppercase/underscore {{asm:...}} variants fail loud
+#   5  nested-value        registry value embedding a placeholder fails post-substitution
+#   6  missing-value       entry without value / value null -> missing_assumption_value
+#   7  bad-id              id-less or malformed-id entry -> invalid_assumption_id
+#   8  duplicate-id        two entries sharing an id -> duplicate_assumption_id
+#   9  registry-missing    placeholders without assumptions.json -> registry_missing
+#  10  no-placeholders     placeholder-free file passes even without a registry
+#
+# Usage: bash cogni-consult/tests/test_resolve_assumptions.sh
+# Exits non-zero on any assertion failure.
+
+# `set -u` only — `set -e` would abort on the first failing assertion and defeat
+# the per-fixture failure counter below.
+set -u
+
+TESTS_DIR="$(cd "$(dirname "$0")" && pwd)"
+PLUGIN_DIR="$(cd "$TESTS_DIR/.." && pwd)"
+SCRIPT="$PLUGIN_DIR/scripts/resolve-assumptions.py"
+
+if [ ! -f "$SCRIPT" ]; then
+  echo "FAIL: resolve-assumptions.py not found at $SCRIPT" >&2
+  exit 1
+fi
+
+TMPROOT="$(mktemp -d)"
+trap 'rm -rf "$TMPROOT"' EXIT
+
+failures=0
+pass() { printf 'OK   %s\n' "$1"; }
+fail() { printf 'FAIL %s: %s\n' "$1" "$2" >&2; failures=$((failures + 1)); }
+
+# Assert the envelope's success flag and (on failure envelopes) failed_check.
+# Args: <name> <expected-success> <expected-failed_check-or-empty> <envelope>
+assert_envelope() {
+  local name="$1" want_success="$2" want_check="$3" envelope="$4"
+  echo "$envelope" | ENV_SUCCESS="$want_success" ENV_CHECK="$want_check" python3 -c '
+import json, os, sys
+d = json.load(sys.stdin)
+ok = str(d["success"]).lower() == os.environ["ENV_SUCCESS"]
+check = os.environ["ENV_CHECK"]
+if check:
+    ok = ok and d["data"].get("failed_check") == check
+sys.exit(0 if ok else 1)
+' && pass "$name" || fail "$name" "envelope mismatch: $envelope"
+}
+
+ENG="$TMPROOT/eng"
+mkdir -p "$ENG"
+cat > "$ENG/assumptions.json" <<'EOF'
+{"assumptions": [{"id": "asm-tam-dach-2027", "name": "TAM", "value": "4.2bn EUR",
+                  "created": "2026-07-08", "updated": "2026-07-08"}]}
+EOF
+
+# 1 resolve-in-place
+F="$TMPROOT/brief.md"
+printf 'TAM {{asm:tam-dach-2027}} again {{asm:tam-dach-2027}}.\n' > "$F"
+OUT=$(python3 "$SCRIPT" "$ENG" resolve "$F" --in-place)
+assert_envelope "resolve-in-place envelope" true "" "$OUT"
+grep -q 'TAM 4.2bn EUR again 4.2bn EUR.' "$F" \
+  && pass "resolve-in-place file" || fail "resolve-in-place file" "$(cat "$F")"
+
+# 2 dry-run
+F="$TMPROOT/dry.md"
+printf 'dry {{asm:tam-dach-2027}}\n' > "$F"
+OUT=$(python3 "$SCRIPT" "$ENG" resolve "$F")
+echo "$OUT" | python3 -c 'import json,sys; d=json.load(sys.stdin); sys.exit(0 if "4.2bn EUR" in d["data"]["resolved_text"] else 1)' \
+  && pass "dry-run resolved_text" || fail "dry-run resolved_text" "$OUT"
+grep -q '{{asm:tam-dach-2027}}' "$F" \
+  && pass "dry-run file untouched" || fail "dry-run file untouched" "$(cat "$F")"
+
+# 3 unknown-id: all listed, file untouched
+F="$TMPROOT/unknown.md"
+printf '{{asm:tam-dach-2027}} {{asm:nope-1}} {{asm:nope-2}}\n' > "$F"
+OUT=$(python3 "$SCRIPT" "$ENG" resolve "$F" --in-place)
+RC=$?
+[ "$RC" -ne 0 ] && pass "unknown-id exit" || fail "unknown-id exit" "exit $RC"
+assert_envelope "unknown-id envelope" false "unknown_assumption_id" "$OUT"
+echo "$OUT" | python3 -c 'import json,sys; d=json.load(sys.stdin); sys.exit(0 if d["data"]["ids"] == ["asm-nope-1","asm-nope-2"] else 1)' \
+  && pass "unknown-id lists all" || fail "unknown-id lists all" "$OUT"
+grep -q '{{asm:tam-dach-2027}}' "$F" \
+  && pass "unknown-id file untouched" || fail "unknown-id file untouched" "$(cat "$F")"
+
+# 4 malformed placeholders fail loud
+F="$TMPROOT/malformed.md"
+printf 'bad {{asm:TAM-Dach-2027}} and {{asm:tam_dach}} and {{ asm:tam }}\n' > "$F"
+OUT=$(python3 "$SCRIPT" "$ENG" resolve "$F" --in-place)
+assert_envelope "malformed envelope" false "malformed_placeholder" "$OUT"
+
+# 5 nested placeholder in a registry value
+NEST="$TMPROOT/nest"; mkdir -p "$NEST"
+cat > "$NEST/assumptions.json" <<'EOF'
+{"assumptions": [{"id": "asm-outer", "name": "n", "value": "x ({{asm:inner}})"},
+                 {"id": "asm-inner", "name": "n", "value": "y"}]}
+EOF
+F="$TMPROOT/nested.md"
+printf '{{asm:outer}}\n' > "$F"
+OUT=$(python3 "$SCRIPT" "$NEST" resolve "$F" --in-place)
+assert_envelope "nested-value envelope" false "unresolved_after_substitution" "$OUT"
+grep -q '{{asm:outer}}' "$F" \
+  && pass "nested-value file untouched" || fail "nested-value file untouched" "$(cat "$F")"
+
+# 6 missing / null value
+BADVAL="$TMPROOT/badval"; mkdir -p "$BADVAL"
+cat > "$BADVAL/assumptions.json" <<'EOF'
+{"assumptions": [{"id": "asm-no-value", "name": "n"},
+                 {"id": "asm-null-value", "name": "n", "value": null}]}
+EOF
+F="$TMPROOT/badval.md"
+printf '{{asm:no-value}}\n' > "$F"
+OUT=$(python3 "$SCRIPT" "$BADVAL" resolve "$F" --in-place)
+assert_envelope "missing-value envelope" false "missing_assumption_value" "$OUT"
+
+# 7 id-less / malformed-id entries
+BADID="$TMPROOT/badid"; mkdir -p "$BADID"
+cat > "$BADID/assumptions.json" <<'EOF'
+{"assumptions": [{"name": "no id at all", "value": "1"},
+                 {"id": "not-asm-prefixed", "value": "2"}]}
+EOF
+F="$TMPROOT/badid.md"
+printf '{{asm:anything}}\n' > "$F"
+OUT=$(python3 "$SCRIPT" "$BADID" resolve "$F" --in-place)
+assert_envelope "bad-id envelope" false "invalid_assumption_id" "$OUT"
+
+# 8 duplicate id
+DUP="$TMPROOT/dup"; mkdir -p "$DUP"
+cat > "$DUP/assumptions.json" <<'EOF'
+{"assumptions": [{"id": "asm-a", "name": "n", "value": "1"},
+                 {"id": "asm-a", "name": "n", "value": "2"}]}
+EOF
+F="$TMPROOT/dup.md"
+printf '{{asm:a}}\n' > "$F"
+OUT=$(python3 "$SCRIPT" "$DUP" resolve "$F" --in-place)
+assert_envelope "duplicate-id envelope" false "duplicate_assumption_id" "$OUT"
+
+# 9 registry missing while placeholders exist
+NOREG="$TMPROOT/noreg"; mkdir -p "$NOREG"
+F="$TMPROOT/noreg.md"
+printf '{{asm:tam-dach-2027}}\n' > "$F"
+OUT=$(python3 "$SCRIPT" "$NOREG" resolve "$F" --in-place)
+assert_envelope "registry-missing envelope" false "registry_missing" "$OUT"
+
+# 10 placeholder-free file passes even without a registry
+F="$TMPROOT/plain.md"
+printf 'no placeholders here\n' > "$F"
+OUT=$(python3 "$SCRIPT" "$NOREG" resolve "$F" --in-place)
+assert_envelope "no-placeholders envelope" true "" "$OUT"
+
+if [ "$failures" -gt 0 ]; then
+  echo "$failures assertion(s) failed" >&2
+  exit 1
+fi
+echo "All resolve-assumptions assertions passed"


### PR DESCRIPTION
Closes #978.

Phase 1 (foundation) of the cogni-consult assumption single-source-of-truth roadmap: define an assumption value once, cite it everywhere via `{{asm:id}}`, resolve at publish time.

## Summary
- Add an `asm-*` assumption entity schema (id + value + citation) and a per-engagement `assumptions.json` registry section to `references/data-model.md`, mirroring the existing `field.json` single-source-of-truth pattern.
- Add `scripts/resolve-assumptions.py` — a stdlib-only, read-only render resolver that replaces `{{asm:id}}` placeholders with registry values, emits the `{success,data,error}` envelope, and fails loudly (listing every unknown id, `failed_check: "unknown_assumption_id"`) rather than silently.
- Scaffold an empty `assumptions.json` in `scripts/engagement-init.sh` (before `consult-project.json`, the completed-init marker).
- Wire the resolver into `skills/consult-publish/SKILL.md` as mandatory step 4.5 (post-build, pre-lineage); the canonical invocation + fail-loud contract live in `references/publish-routing.md` (new Assumption Resolution section).
- Register the new script + registry in the plugin developer guide `CLAUDE.md` and the README components table.
- Bump `cogni-consult` 0.1.52 → 0.1.53 in `plugin.json`, mirrored in root `marketplace.json`.

## Scope decisions
- **In:** registry schema doc + `assumptions.json` scaffold + resolver script + publish wire-in + developer-guide/README registration + version bump — the full stated scope of this child.
- **Assumption schema lives in `data-model.md`, not a new `assumption-model.md`:** data-model.md already centralizes every entity schema; a separate file would fragment the entity catalog.
- **Resolver runs at publish only:** the AC scopes resolution to publish briefs; all four publish routes build natively in one step-4 pass, so a single resolver call covers every format.
- **Out (already tracked as sibling epic children, not re-filed here):** edge-emission, provenance typing, cascade, and prose-regen (Phase 2/3/4).

## Plan record
https://github.com/cogni-work/insight-wave/issues/978#issuecomment-4919129847

## Test plan (executed)
- [x] `python3 cogni-consult/scripts/resolve-assumptions.py --help` runs; script is stdlib-only (argparse/json/os/re/sys).
- [x] With a fixture `assumptions.json` defining `asm-tam-dach-2027`, resolving brief text containing two `{{asm:tam-dach-2027}}` occurrences replaces both with the same value (AC1).
- [x] Resolving text with unknown ids returns `success:false`, exit 1, `failed_check: "unknown_assumption_id"` listing every missing id; the file is left untouched (AC2).
- [x] All outputs are valid `{success,data,error}` JSON envelopes (AC3); duplicate registry ids and missing/unreadable registry also fail loudly; a placeholder-free brief passes as a no-op even without a registry (pre-registry engagements publish unchanged).
- [x] `engagement-init.sh` scaffolds `assumptions.json` (empty) before `consult-project.json`; re-run is idempotent.
- [x] `check-breadcrumbs.py` and `check-skill-names.sh` pass; `bash -n` clean.
- [x] `plugin.json` and `marketplace.json` both show cogni-consult 0.1.53.