### PR TITLE
cogni-consult: surface engagement scope in README front door (closes #1038)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -35,7 +35,7 @@
     {
       "name": "cogni-consult",
       "source": "./cogni-consult",
-      "version": "0.1.61",
+      "version": "0.1.62",
       "maturity": "preview",
       "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
       "keywords": [

--- a/cogni-consult/.claude-plugin/plugin.json
+++ b/cogni-consult/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-consult",
-  "version": "0.1.61",
+  "version": "0.1.62",
   "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-consult/scripts/generate-engagement-readme.py
+++ b/cogni-consult/scripts/generate-engagement-readme.py
@@ -277,6 +277,7 @@ def render_readme(engagement_dir, eng, summary, action):
     lines += ["", "## Status", ""]
     scope_label = "complete" if eng["scope_state"] == "complete" else "scoping"
     lines.append(f"- **Scope:** {scope_label}")
+    lines.append(f"- **Action fields:** {len(eng['action_fields'])} derived")
     lines.append(f"- **Overall completion:** {summary['completion_pct']}% "
                  f"({summary['deliverables_complete']}/{summary['deliverables_total']} deliverables)")
     if eng["action_fields"]:
@@ -291,7 +292,15 @@ def render_readme(engagement_dir, eng, summary, action):
     lines += ["", "## Next", "", action]
 
     # Wayfinding — every link resolves within the engagement dir by construction.
+    # Scope key-question leads: it is the engagement's primary framing artifact
+    # (SMART key question + scoping dimensions + derived action fields). Fail-soft
+    # via _link_if_exists so a scaffold-only engagement stays broken-link-free.
     way = []
+    scope_link = _link_if_exists(
+        engagement_dir, os.path.join("scope", "key-question.md"), "Scope: key question"
+    )
+    if scope_link:
+        way.append(f"- {scope_link}")
     for f in eng["action_fields"]:
         field_rel = os.path.join("action-fields", f["slug"])
         field_link = _link_if_exists(engagement_dir, field_rel, f["title"])

--- a/cogni-consult/tests/test_generate_engagement_readme.sh
+++ b/cogni-consult/tests/test_generate_engagement_readme.sh
@@ -117,7 +117,7 @@ print('PASS' if not missing else 'FAIL ' + ', '.join(missing))
 #   seed_scoped <dir> <deliverables-json>
 seed_scoped() {
   local dir="$1" delivs="$2"
-  mkdir -p "$dir/action-fields/market-evidence" "$dir/personas" "$dir/sources" "$dir/.metadata"
+  mkdir -p "$dir/action-fields/market-evidence" "$dir/personas" "$dir/sources" "$dir/.metadata" "$dir/scope"
   cat > "$dir/consult-project.json" <<'EOF'
 {
   "slug": "acme",
@@ -135,6 +135,8 @@ EOF
 }
 EOF
   echo '{"decisions": []}' > "$dir/.metadata/decision-log.json"
+  # Scope narrative — the primary framing artifact the front door links first.
+  echo "# Key question" > "$dir/scope/key-question.md"
 }
 
 # --- Fixture 1: fully-scoped engagement — four sections, resolving links, README-only write
@@ -158,6 +160,8 @@ assert_md_has "1f field done/total row" "$MD1" "| Market evidence | 1/2 |"
 assert_md_has "1g next section"         "$MD1" "## Next"
 assert_md_has "1h wayfinding section"   "$MD1" "## Wayfinding"
 assert_md_has "1i decision-log link"    "$MD1" "(.metadata/decision-log.json)"
+assert_md_has "1m scope key-question link" "$MD1" "(scope/key-question.md)"
+assert_md_has "1n action fields count"     "$MD1" "**Action fields:** 1 derived"
 assert_links_resolve "1j all links resolve" "$D1"
 # Deliverable without a .md artifact gets no link (would be broken).
 assert_md_lacks "1k no broken deliv link" "$MD1" "(action-fields/market-evidence/competitor-map.md)"
@@ -187,6 +191,8 @@ assert_json "2a2 rung is scope"         "$OUT2" "d['data']['next_action_rung'] =
 assert_md_has "2b status reads scoping" "$MD2" "**Scope:** scoping"
 assert_md_has "2c next recommends scope" "$MD2" "consult-scope"
 assert_md_lacks "2d no field links"     "$MD2" "(action-fields/"
+assert_md_lacks "2f no scope link"      "$MD2" "(scope/key-question.md)"
+assert_md_has "2g action fields zero"   "$MD2" "**Action fields:** 0 derived"
 assert_links_resolve "2e links resolve" "$D2"
 
 # --- Fixture 3: personas gate pending blocks deliverable work ------------------------


### PR DESCRIPTION
## What

Extends `cogni-consult/scripts/generate-engagement-readme.py` so the engagement README front door surfaces the engagement **scope**, not just a one-word scope state.

- **Wayfinding:** adds a `scope/key-question.md` link at the top of `## Wayfinding` via the existing `_link_if_exists` helper — the scope narrative (SMART key question + scoping dimensions + derived action fields) is the engagement's primary framing artifact, so it leads. Fail-soft: emitted only when the file exists, so a scaffold-only engagement stays broken-link-free.
- **Status:** adds an `Action fields: N derived` line, counting the already-loaded `action_fields[]`.
- Preserves the `GENERATED_MARKER` overwrite guard and the read-only-except-README contract (no behavior change).

## Why

Today the front door shows only a one-word `Scope: scoping|complete` line; the full scope narrative in `scope/key-question.md` was unlinked, so the front door under-reported the single most important framing artifact. A Wayfinding link keeps the README a wayfinder (not a copy) and preserves the single-source-of-truth read model — the rejected alternative was inlining the whole scope narrative.

## Test

`tests/test_generate_engagement_readme.sh`: `seed_scoped` now writes `scope/key-question.md`; fixture 1 asserts the scope link renders + `Action fields: 1 derived`; fixture 2 (scaffold, no scope dir) asserts no scope link + `Action fields: 0 derived`. Full suite green. Breadcrumb guard clean.

## Version

cogni-consult 0.1.61 → 0.1.62; mirrored in `.claude-plugin/marketplace.json`.

Child of epic #1042 (engagement README front door). Independent, no build-order dependency.

Closes #1038

🤖 Generated with [Claude Code](https://claude.com/claude-code)
