### PR TITLE
cogni-consult: surface assumption registry in engagement README

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -35,7 +35,7 @@
     {
       "name": "cogni-consult",
       "source": "./cogni-consult",
-      "version": "0.1.63",
+      "version": "0.1.64",
       "maturity": "preview",
       "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
       "keywords": [

--- a/cogni-consult/.claude-plugin/plugin.json
+++ b/cogni-consult/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-consult",
-  "version": "0.1.63",
+  "version": "0.1.64",
   "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-consult/scripts/generate-engagement-readme.py
+++ b/cogni-consult/scripts/generate-engagement-readme.py
@@ -6,15 +6,17 @@ Reads the same read model as engagement-status.sh and
 skills/consult-dashboard/scripts/generate-dashboard.py — consult-project.json
 plus each action-fields/<slug>/field.json, with deliverable state as the
 single source of truth and field/engagement rollups derived at read time —
-and writes <engagement-dir>/README.md with five sections:
+and writes <engagement-dir>/README.md with six sections:
 
   1. H1 engagement name + SMART key question
   2. Status snapshot — scope state, per-field done/total, overall completion %
   3. Knowledge base — the bound cogni-knowledge base + synthesis-file count,
      mirroring the dashboard kb_line derivation so the two surfaces agree
-  4. The single next recommended deliverable (next-action derivation with the
+  4. Assumptions — the quantified planning registry (assumptions.json) with each
+     entry's value, provenance type, and position on the verification ladder
+  5. The single next recommended deliverable (next-action derivation with the
      personas_gate step spliced in after staleness, before in-progress work)
-  5. A wayfinding link block with relative Obsidian links (only to targets
+  6. A wayfinding link block with relative Obsidian links (only to targets
      that exist, so a scaffold-only engagement emits no broken links)
 
 Read-only over all engagement state except the README.md it writes.
@@ -110,6 +112,7 @@ def load_engagement(engagement_dir):
         "scope_state": (project.get("workflow_state") or {}).get("scope", "pending"),
         "knowledge_base": (project.get("plugin_refs") or {}).get("knowledge_base"),
         "research_total": research_total,
+        "assumptions": load_assumptions(engagement_dir),
         "action_fields": fields,
         "warnings": warnings,
     }
@@ -156,6 +159,22 @@ def load_personas_gate(engagement_dir):
     except OSError:
         pass
     return "pending"
+
+
+def load_assumptions(engagement_dir):
+    """Read the engagement-root assumptions.json registry fail-soft, mirroring
+    load_personas_gate: a missing / empty / unreadable / malformed registry
+    degrades to an empty list, never an error. Returns the list of assumption
+    records (each carrying at least name/value, optionally provenance_type and
+    status on the verification ladder)."""
+    path = os.path.join(engagement_dir, "assumptions.json")
+    try:
+        with open(path) as f:
+            data = json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return []
+    entries = data.get("assumptions") if isinstance(data, dict) else None
+    return entries if isinstance(entries, list) else []
 
 
 # ---------------------------------------------------------------------------
@@ -316,6 +335,27 @@ def render_readme(engagement_dir, eng, summary, action):
         kb_line = "No knowledge base bound yet."
     lines += ["", "## Knowledge base", "", kb_line]
 
+    # Assumptions — the engagement's quantified planning numbers and, critically,
+    # where each sits on the verification ladder (stated → reviewed → verified).
+    # Always rendered (mirroring Knowledge base) so an absent/empty registry
+    # degrades to a neutral line rather than dropping the section. Type/Status are
+    # optional per record → a neutral "—" placeholder, never a traceback.
+    assumptions = eng["assumptions"]
+    lines += ["", "## Assumptions", ""]
+    if assumptions:
+        n = len(assumptions)
+        plural = "assumption" if n == 1 else "assumptions"
+        lines.append(f"{n} {plural} registered.")
+        lines += ["", "| Name | Value | Type | Status |", "|---|---|---|---|"]
+        for a in assumptions:
+            lines.append(
+                f"| {_md_cell(a.get('name'))} | {_md_cell(a.get('value'))} | "
+                f"{_md_cell(a.get('provenance_type') or '—')} | "
+                f"{_md_cell(a.get('status') or '—')} |"
+            )
+    else:
+        lines.append("No assumptions registered yet.")
+
     lines += ["", "## Next", "", action]
 
     # Wayfinding — every link resolves within the engagement dir by construction.
@@ -356,6 +396,7 @@ def render_readme(engagement_dir, eng, summary, action):
         (os.path.join("scope", "research"), "Scope research"),
         ("personas", "Personas"),
         ("sources", "Sources"),
+        ("assumptions.json", "Assumptions registry"),
         (os.path.join(".metadata", "decision-log.json"), "Decision log"),
     ):
         link = _link_if_exists(engagement_dir, rel, label)

--- a/cogni-consult/tests/test_generate_engagement_readme.sh
+++ b/cogni-consult/tests/test_generate_engagement_readme.sh
@@ -147,6 +147,14 @@ seed_scoped "$D1" '[
 ]'
 echo '{"source": "scope-seeded", "name": "CFO"}' > "$D1/personas/cfo.json"
 echo "# Market sizing" > "$D1/action-fields/market-evidence/market-sizing.md"
+# Assumption registry with one entry — exercises the populated Assumptions table
+# and the resolving wayfinding link. Written before the BEFORE1 snapshot so the
+# "writes only README.md" check (1l) still sees README.md as the only new file.
+cat > "$D1/assumptions.json" <<'EOF'
+{"assumptions": [
+  {"id": "asm-tam", "name": "DACH TAM", "value": "€1.2B", "provenance_type": "claim", "status": "reviewed"}
+]}
+EOF
 BEFORE1="$(cd "$D1" && find . -type f | sort)"
 OUT1="$(run "$D1")"
 AFTER1="$(cd "$D1" && find . -type f | sort)"
@@ -168,6 +176,12 @@ assert_md_lacks "1k no broken deliv link" "$MD1" "(action-fields/market-evidence
 # Knowledge base section renders; an unbound engagement shows the neutral line.
 assert_md_has "1o kb section"           "$MD1" "## Knowledge base"
 assert_md_has "1p kb neutral line"      "$MD1" "No knowledge base bound yet."
+# Assumptions section renders the registry: count line, table row (value + type +
+# verification status), and a resolving wayfinding link.
+assert_md_has "1q assumptions section"  "$MD1" "## Assumptions"
+assert_md_has "1r assumptions count"    "$MD1" "1 assumption registered."
+assert_md_has "1s assumptions row"      "$MD1" "| DACH TAM | €1.2B | claim | reviewed |"
+assert_md_has "1t assumptions wayfinding link" "$MD1" "(assumptions.json)"
 # The run wrote README.md and nothing else (AC3).
 DIFF1="$(comm -13 <(printf '%s\n' "$BEFORE1") <(printf '%s\n' "$AFTER1"))"
 if [ "$DIFF1" = "./README.md" ]; then
@@ -196,6 +210,9 @@ assert_md_has "2c next recommends scope" "$MD2" "consult-scope"
 assert_md_lacks "2d no field links"     "$MD2" "(action-fields/"
 assert_md_lacks "2f no scope link"      "$MD2" "(scope/key-question.md)"
 assert_md_has "2g action fields zero"   "$MD2" "**Action fields:** 0 derived"
+# Assumptions section renders even with no registry file — neutral line, no crash.
+assert_md_has "2h assumptions section"  "$MD2" "## Assumptions"
+assert_md_has "2i assumptions neutral"  "$MD2" "No assumptions registered yet."
 assert_links_resolve "2e links resolve" "$D2"
 
 # --- Fixture 3: personas gate pending blocks deliverable work ------------------------


### PR DESCRIPTION
Closes #1040.

## Summary
- Add a fail-soft `load_assumptions(engagement_dir)` helper to `generate-engagement-readme.py` (mirrors `load_personas_gate`) — opens `<root>/assumptions.json`, catches `(FileNotFoundError, json.JSONDecodeError, OSError)` → `[]`, guards non-list, returns `data.get("assumptions") or []`. Exposed as `assumptions` on the `load_engagement` return dict.
- Render an `## Assumptions` section (always rendered, mirroring `## Knowledge base`) after Knowledge base and before Next: when non-empty, a count line + markdown table `| Name | Value | Type | Status |` (one row per record, each cell via `_md_cell`, absent `provenance_type`/`status` → `—`); when empty/absent, the neutral line `No assumptions registered yet.`
- Add an `assumptions.json` Wayfinding link via `_link_if_exists(engagement_dir, "assumptions.json", "Assumptions registry")`, guarded so scaffold-only engagements stay broken-link-free.
- Extend `tests/test_generate_engagement_readme.sh`: fixture 1 gets an `assumptions.json` with one entry asserting the heading, the table row, and a resolving wayfinding link; fixture 2 (scaffold) asserts the heading + neutral line.
- Preserve the `GENERATED_MARKER` overwrite guard and read-only-except-README contract (untouched).
- Bump `cogni-consult/.claude-plugin/plugin.json` and the root `marketplace.json` cogni-consult entry 0.1.63 → 0.1.64.

## Scope decisions
- Full scope in one PR, mirroring the shape of the sibling scope (#1038) and bound-KB (#1039) README-front-door additions already on main. The section is always-rendered (like Knowledge base) so an absent registry degrades to a neutral line rather than omitting the section. No SKILL.md or agent files touched — script + test change only.
- Nothing deferred: the issue is a single additive, fail-soft change, independent of the other epic children.

## Test plan
- [x] `bash cogni-consult/tests/test_generate_engagement_readme.sh` passes (fixture 1 asserts `## Assumptions`, the row `| DACH TAM | €1.2B | claim | reviewed |`, and the resolving `(assumptions.json)` link; fixture 2 asserts the heading + `No assumptions registered yet.`).
- [x] Generator against a registry with an untyped record → renders `—` for Type/Status, no traceback.
- [x] Scaffold-only engagement (absent registry) → neutral line, no broken Wayfinding link.
- [x] Hand-authored README (no `GENERATED_MARKER`) still refused (overwrite guard intact — regression test 7a).
- [x] `plugin.json` and marketplace.json cogni-consult entry both show 0.1.64.

Plan record: https://github.com/cogni-work/insight-wave/issues/1040#issuecomment-4932574654