### PR TITLE
cogni-claims: add `assumption` to EntityRef.type enum

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -52,7 +52,7 @@
     {
       "name": "cogni-claims",
       "source": "./cogni-claims",
-      "version": "0.10.4",
+      "version": "0.10.5",
       "maturity": "preview",
       "description": "Claim verification and management system. Verifies sourced claims against cited URLs, detects deviations, guides users through resolution, and provides interactive cobrowsing recovery for unreachable sources.",
       "keywords": [

--- a/cogni-claims/.claude-plugin/plugin.json
+++ b/cogni-claims/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-claims",
-  "version": "0.10.4",
+  "version": "0.10.5",
   "description": "Claim verification and management system. Verifies sourced claims against cited URLs, detects deviations, guides users through resolution, and provides interactive cobrowsing recovery for unreachable sources.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-claims/skills/claim-entity/references/schema.md
+++ b/cogni-claims/skills/claim-entity/references/schema.md
@@ -74,7 +74,7 @@ Optional provenance link from a claim back to the portfolio entity file and fiel
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `type` | enum | yes | Entity type: `market`, `customer`, `competitor`, `proposition` |
+| `type` | enum | yes | Entity type: `market`, `customer`, `competitor`, `proposition`, `assumption` |
 | `file` | string | yes | Relative path from project root to the entity JSON file (e.g., `markets/mid-market-saas-dach.json`) |
 | `field_path` | string | yes | Dot-notation path to the specific field. Supports array indices (`evidence[0].statement`) and name-based lookup (`named_customers[?name=="Siemens AG"].revenue.value`) for stable targeting when array order may change. |
 
@@ -86,6 +86,7 @@ Optional provenance link from a claim back to the portfolio entity file and fiel
 | customer | `named_customers[?name=="Siemens AG"].employees`, `named_customers[?name=="Siemens AG"].revenue.value` |
 | competitor | `competitors[?name=="Datadog"].positioning`, `competitors[?name=="Datadog"].strengths[0]` |
 | proposition | `evidence[0].statement`, `does_statement`, `means_statement` |
+| assumption | `assumptions[?id=="asm-tam-dach-2027"].value`, `assumptions[?id=="asm-tam-dach-2027"].status`, `assumptions[?id=="asm-tam-dach-2027"].rationale` |
 
 ### DeviationRecord
 


### PR DESCRIPTION
Refs #1032.

Extends the cogni-claims `EntityRef.type` enum with `assumption` so a cogni-consult `claim`-type assumption can carry a valid provenance link. This is the isolated, standalone-shippable half of #1032; the cross-plugin verify-wiring round-trip is deferred to #1053 (see below).

## Summary
- Add `assumption` to the `EntityRef.type` enum in `claim-entity` schema.md (field-table row + a Field Path Examples row using the shared-array `assumptions[?id=="…"].field` lookup shape).
- Bump cogni-claims plugin version 0.10.4 → 0.10.5 (base off origin/main) and mirror it in the root marketplace.json.

## Scope decisions
- **In:** the enum extension — documentation-only in cogni-claims (no code validates the enum; grep of `claims-store.sh` confirms), low-risk, independently reviewable, a discrete completed deliverable of #1032.
- **Deferred (still in epic #984 DoD):** the cogni-consult verify-wiring half — lifting `TYPE_STATUS_CAP["claim"]` from `reviewed` to `verified` (`resolve-assumptions.py`) and building the net-new submit/verify/propagate round-trip. Deferred because it carries two unresolved contract-level design forks (below), not by habit; those touch the cogni-claims schema contract and need a human decision before code can be written.

## Follow-up issues
- #1053 — cogni-consult: wire claim-type assumption verify round-trip (blocked on the two open questions below; in epic #984 close gate).

## Open questions
1. **entity_ref shape reconciliation:** cogni-consult citations use a flat-string `entity_ref` (`references/data-model.md`) while cogni-claims `EntityRef` is an object `{type,file,field_path}` (`schema.md`). Which shape wins, or how do they map? Schema-contract decision.
2. **`verified` evidence mechanism:** simply loosening the `claim` status cap reopens the hand-authoring hole the cap exists to close. What evidence gates `status=="verified"` — e.g. a required non-null `citation.claim_id` back-reference to a cogni-claims `ClaimRecord.id`, failing loud otherwise? Needs a human ruling before the wiring lands.

## Test plan
- [x] `grep -n assumption cogni-claims/skills/claim-entity/references/schema.md` shows `assumption` in the `type` enum row and a new Field Path Examples row.
- [x] cogni-claims `.claude-plugin/plugin.json` version bumped 0.10.4 → 0.10.5 and the root `.claude-plugin/marketplace.json` cogni-claims entry mirrors it; both parse as valid JSON.
- [x] No cogni-consult files changed in this PR (the wiring is deferred); `resolve-assumptions.py` and test #18 `verified-reserved` remain unchanged.