### PR TITLE
Relicense docs: AGPL-3.0 -> Apache-2.0 across READMEs, contributing, and wiki mirrors

### DIFF
--- a/CLA.md
+++ b/CLA.md
@@ -33,7 +33,7 @@ You hereby grant to the Project Owner a perpetual, worldwide, non-exclusive, no-
 
 ## 3. Dual-Licensing Acknowledgment
 
-You acknowledge and agree that the Project Owner may offer the Project, including your Contributions, under additional license terms beyond the GNU Affero General Public License v3.0 (AGPL-3.0), including commercial and proprietary licenses. This is a key reason for requiring this CLA.
+You acknowledge and agree that the Project Owner may offer the Project, including your Contributions, under additional license terms beyond the Apache License 2.0 (Apache-2.0), including commercial and proprietary licenses. This is a key reason for requiring this CLA.
 
 ## 4. Representations
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # insight-wave
 
-13-plugin monorepo for consulting, sales, and marketing on Claude Code. AGPL-3.0. All plugins follow the Claude Code plugin standard.
+13-plugin monorepo for consulting, sales, and marketing on Claude Code. Apache-2.0. All plugins follow the Claude Code plugin standard.
 
 ## Repo Structure
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ insight-wave has two types of contributions with different terms. Please read th
 
 ## Contributing to Core Plugins
 
-Core plugins are maintained by insight-wave and licensed under AGPL-3.0:
+Core plugins are maintained by insight-wave and licensed under Apache-2.0:
 
 - cogni-workspace
 - cogni-trends
@@ -85,7 +85,7 @@ Anyone can publish a plugin to the insight-wave marketplace. You retain full cop
 
 ### Requirements
 
-- License your plugin under AGPL-3.0 for the marketplace listing
+- License your plugin under Apache-2.0 for the marketplace listing
 - Include a README with installation and usage instructions
 - Follow semantic versioning
 - Meet the quality standards described in [MARKETPLACE_TERMS.md](MARKETPLACE_TERMS.md)
@@ -100,7 +100,7 @@ Anyone can publish a plugin to the insight-wave marketplace. You retain full cop
 ### Submission Process
 
 1. Ensure your plugin meets the [marketplace quality standards](MARKETPLACE_TERMS.md#5-quality-standards)
-2. Include an AGPL-3.0 LICENSE file in your repository
+2. Include an Apache-2.0 LICENSE file in your repository
 3. Submit your plugin for review via a marketplace listing PR
 4. Once approved, your plugin will be listed on the marketplace
 

--- a/MARKETPLACE_TERMS.md
+++ b/MARKETPLACE_TERMS.md
@@ -8,11 +8,11 @@ These terms govern the submission and listing of third-party plugins on the insi
 
 ## 2. License Requirement
 
-All plugins listed on the insight-wave marketplace must be licensed under the **GNU Affero General Public License v3.0 (AGPL-3.0)**. You must include a copy of the AGPL-3.0 license in your plugin repository.
+All plugins listed on the insight-wave marketplace must be licensed under the **Apache License 2.0 (Apache-2.0)**. You must include a copy of the Apache-2.0 license in your plugin repository.
 
 ## 3. Author's Dual-Licensing Rights
 
-You explicitly retain the right to offer your plugin under additional or alternative licenses, including commercial licenses. The AGPL-3.0 requirement applies only to the version listed on the insight-wave marketplace. You are free to sell commercial licenses of your plugin independently.
+You explicitly retain the right to offer your plugin under additional or alternative licenses, including commercial licenses. The Apache-2.0 requirement applies only to the version listed on the insight-wave marketplace. You are free to sell commercial licenses of your plugin independently.
 
 ## 4. No Exclusivity
 
@@ -58,7 +58,7 @@ insight-wave may update these terms from time to time. Plugin authors will be no
 
 | What you keep | What you agree to |
 |---|---|
-| Full copyright ownership | License under AGPL-3.0 for marketplace listing |
+| Full copyright ownership | License under Apache-2.0 for marketplace listing |
 | Right to dual-license / sell commercial licenses | Meet quality standards |
 | Freedom to distribute elsewhere | Accept potential delisting for violations |
 | Control over your own contribution terms | -- |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # insight-wave
 
-Open-source plugins for consulting, sales, and marketing on [Claude Code](https://claude.ai/code). 13 AGPL-3.0 plugins that automate the research-heavy, methodology-driven work behind B2B deliverables — trend scouting, portfolio positioning, sales pitches, content creation, visual production, website generation, knowledge management, and source verification.
+Open-source plugins for consulting, sales, and marketing on [Claude Code](https://claude.ai/code). 13 Apache-2.0 plugins that automate the research-heavy, methodology-driven work behind B2B deliverables — trend scouting, portfolio positioning, sales pitches, content creation, visual production, website generation, knowledge management, and source verification.
 
 Each plugin implements an established framework (Corporate Visions, Double Diamond, TIPS, IS/DOES/MEANS) rather than general-purpose text generation. Outputs include inline citations, structured data models, and quality gates. Every deliverable follows a reproducible methodology you can inspect and override.
 
@@ -214,7 +214,7 @@ insight-wave/
 ├── CLA.md                                  # Contributor License Agreement
 ├── CODE_OF_CONDUCT.md                      # Contributor Covenant v2.1
 ├── CONTRIBUTING.md                         # Contribution guide & CLA info
-├── LICENSE                                 # AGPL-3.0-only
+├── LICENSE                                 # Apache-2.0
 ├── MARKETPLACE_TERMS.md                    # Third-party plugin terms
 ├── SECURITY.md                             # Vulnerability disclosure policy
 ├── community-plugin-contributing-template.md
@@ -279,7 +279,7 @@ cogni-works offers plugin engineering for domain-specific workflows, managed dep
 
 ## License
 
-All plugins are licensed under AGPL-3.0-only. See [LICENSE](LICENSE) for details.
+All plugins are licensed under Apache-2.0. See [LICENSE](LICENSE) for details.
 
 ---
 

--- a/cogni-claims/README.md
+++ b/cogni-claims/README.md
@@ -150,7 +150,7 @@ cogni-claims/
 ├── README.md                     Plugin documentation
 ├── CLAUDE.md                     Developer guide
 ├── CONTRIBUTING.md               Contribution guidelines
-├── LICENSE                       AGPL-3.0
+├── LICENSE                       Apache-2.0
 ├── skills/                       2 verification skills
 │   ├── claims/                   Lifecycle orchestrator (submit → verify → resolve)
 │   └── claim-entity/             Cross-plugin data contract and schema definitions
@@ -182,7 +182,7 @@ Need a custom verification workflow, a new deviation type for your domain, or in
 
 ## License
 
-[AGPL-3.0](LICENSE) — see [CONTRIBUTING.md](CONTRIBUTING.md) for contribution terms.
+[Apache-2.0](LICENSE) — see [CONTRIBUTING.md](CONTRIBUTING.md) for contribution terms.
 
 ---
 

--- a/cogni-consult/README.md
+++ b/cogni-consult/README.md
@@ -225,7 +225,7 @@ Need a tailored deliverable type, a custom acting persona, or this orchestrator 
 
 ## License
 
-[AGPL-3.0](LICENSE) — see [CONTRIBUTING.md](CONTRIBUTING.md) for contribution terms.
+[Apache-2.0](LICENSE) — see [CONTRIBUTING.md](CONTRIBUTING.md) for contribution terms.
 
 ---
 

--- a/cogni-copywriting/README.md
+++ b/cogni-copywriting/README.md
@@ -197,7 +197,7 @@ Need a custom messaging framework, your house style baked into the polish rules,
 
 ## License
 
-[AGPL-3.0](LICENSE) — see [CONTRIBUTING.md](CONTRIBUTING.md) for contribution terms.
+[Apache-2.0](LICENSE) — see [CONTRIBUTING.md](CONTRIBUTING.md) for contribution terms.
 
 ---
 

--- a/cogni-help/README.md
+++ b/cogni-help/README.md
@@ -207,7 +207,7 @@ Need a bespoke training curriculum for your team, a new workflow tour, or a plug
 
 ## License
 
-[AGPL-3.0](LICENSE) — see [CONTRIBUTING.md](CONTRIBUTING.md) for contribution terms.
+[Apache-2.0](LICENSE) — see [CONTRIBUTING.md](CONTRIBUTING.md) for contribution terms.
 
 ---
 

--- a/cogni-knowledge/README.md
+++ b/cogni-knowledge/README.md
@@ -209,7 +209,7 @@ cogni-knowledge/
 ├── README.md                     Plugin documentation
 ├── CLAUDE.md                     Developer guide
 ├── CHANGELOG.md                  Version history
-├── LICENSE                       AGPL-3.0
+├── LICENSE                       Apache-2.0
 ├── _archive/                     Archived research+report chain (see _archive/README.md)
 ├── agents/                       16 forked + new pipeline agents
 ├── references/                   21 framework + design docs
@@ -240,7 +240,7 @@ Need a knowledge base tuned to your domain, custom ingest sources, or a pipeline
 
 ## License
 
-[AGPL-3.0](LICENSE) — see [CONTRIBUTING.md](../CONTRIBUTING.md) for contribution terms.
+[Apache-2.0](LICENSE) — see [CONTRIBUTING.md](../CONTRIBUTING.md) for contribution terms.
 
 ---
 

--- a/cogni-marketing/README.md
+++ b/cogni-marketing/README.md
@@ -200,7 +200,7 @@ Need custom content formats, a CRM integration, or a marketing engine tailored t
 
 ## License
 
-[AGPL-3.0](LICENSE) — see [CONTRIBUTING.md](CONTRIBUTING.md) for contribution terms.
+[Apache-2.0](LICENSE) — see [CONTRIBUTING.md](CONTRIBUTING.md) for contribution terms.
 
 ---
 

--- a/cogni-narrative/README.md
+++ b/cogni-narrative/README.md
@@ -188,7 +188,7 @@ Need a custom story arc framework, your house narrative style encoded as a gate,
 
 ## License
 
-[AGPL-3.0](LICENSE) — see [CONTRIBUTING.md](CONTRIBUTING.md) for contribution terms.
+[Apache-2.0](LICENSE) — see [CONTRIBUTING.md](CONTRIBUTING.md) for contribution terms.
 
 ---
 

--- a/cogni-portfolio/README.md
+++ b/cogni-portfolio/README.md
@@ -236,7 +236,7 @@ Need a custom taxonomy template, an industry-specific proposition framework, or 
 
 ## License
 
-[AGPL-3.0](LICENSE) — see [CONTRIBUTING.md](CONTRIBUTING.md) for contribution terms.
+[Apache-2.0](LICENSE) — see [CONTRIBUTING.md](CONTRIBUTING.md) for contribution terms.
 
 ---
 

--- a/cogni-sales/README.md
+++ b/cogni-sales/README.md
@@ -170,7 +170,7 @@ Need a custom sales methodology beyond Why Change, a CRM integration, or a new p
 
 ## License
 
-[AGPL-3.0](LICENSE) — see [CONTRIBUTING.md](CONTRIBUTING.md) for contribution terms.
+[Apache-2.0](LICENSE) — see [CONTRIBUTING.md](CONTRIBUTING.md) for contribution terms.
 
 ---
 

--- a/cogni-trends/README.md
+++ b/cogni-trends/README.md
@@ -270,7 +270,7 @@ Need a custom trend framework, additional market coverage with new regional auth
 
 ## License
 
-[AGPL-3.0](LICENSE) — see [CONTRIBUTING.md](CONTRIBUTING.md) for contribution terms.
+[Apache-2.0](LICENSE) — see [CONTRIBUTING.md](CONTRIBUTING.md) for contribution terms.
 
 ---
 

--- a/cogni-visual/README.md
+++ b/cogni-visual/README.md
@@ -203,7 +203,7 @@ Need bespoke visual templates, a branded rendering pipeline tuned to your house 
 
 ## License
 
-[AGPL-3.0](LICENSE) — see [CONTRIBUTING.md](CONTRIBUTING.md) for contribution terms.
+[Apache-2.0](LICENSE) — see [CONTRIBUTING.md](CONTRIBUTING.md) for contribution terms.
 
 ---
 

--- a/cogni-website/README.md
+++ b/cogni-website/README.md
@@ -225,7 +225,7 @@ Need a custom page type, a CMS integration, or a domain-specific website templat
 
 ## License
 
-[AGPL-3.0](LICENSE) — see [CONTRIBUTING.md](CONTRIBUTING.md) for contribution terms.
+[Apache-2.0](LICENSE) — see [CONTRIBUTING.md](CONTRIBUTING.md) for contribution terms.
 
 ---
 

--- a/cogni-workspace/README.md
+++ b/cogni-workspace/README.md
@@ -234,7 +234,7 @@ Need bespoke workspace configurations, custom theme infrastructure, or a new plu
 
 ## License
 
-[AGPL-3.0](LICENSE) — see [CONTRIBUTING.md](CONTRIBUTING.md) for contribution terms.
+[Apache-2.0](LICENSE) — see [CONTRIBUTING.md](CONTRIBUTING.md) for contribution terms.
 
 ---
 

--- a/cogni-workspace/wiki/wiki/index.md
+++ b/cogni-workspace/wiki/wiki/index.md
@@ -6,7 +6,7 @@ This is the content catalog for **insight-wave**. Every wiki page is listed here
 
 ### Ecosystem
 
-- [[ecosystem-overview]] — insight-wave is a 13-plugin monorepo for consulting, sales, and marketing on Claude Code, AGPL-3.
+- [[ecosystem-overview]] — insight-wave is a 13-plugin monorepo for consulting, sales, and marketing on Claude Code, Apache-2.0.
 
 ### Architecture
 

--- a/cogni-workspace/wiki/wiki/pages/arch-plugin-anatomy.md
+++ b/cogni-workspace/wiki/wiki/pages/arch-plugin-anatomy.md
@@ -25,7 +25,7 @@ How insight-wave plugins are structured on disk. Every plugin follows the same s
 ├── references/*.md               Plugin-wide framework references
 ├── templates/                    Pluggable templates (optional)
 ├── CLAUDE.md                     Developer reference
-├── CONTRIBUTING.md, LICENSE      AGPL-3.0-only
+├── CONTRIBUTING.md, LICENSE      Apache-2.0
 └── README.md                     User-facing introduction
 ```
 

--- a/cogni-workspace/wiki/wiki/pages/ecosystem-overview.md
+++ b/cogni-workspace/wiki/wiki/pages/ecosystem-overview.md
@@ -10,7 +10,7 @@ sources:
 status: stable
 ---
 
-insight-wave is a 13-plugin monorepo for consulting, sales, and marketing on Claude Code, AGPL-3.0, with all plugins following the standard Claude Code plugin shape.
+insight-wave is a 13-plugin monorepo for consulting, sales, and marketing on Claude Code, Apache-2.0, with all plugins following the standard Claude Code plugin shape.
 
 ## Repository shape
 

--- a/community-plugin-contributing-template.md
+++ b/community-plugin-contributing-template.md
@@ -6,13 +6,13 @@ Thank you for your interest in contributing to [Plugin Name]!
 
 ## License
 
-This plugin is licensed under the [GNU Affero General Public License v3.0](LICENSE).
+This plugin is licensed under the [Apache License 2.0](LICENSE).
 
 ## Contributor License Agreement
 
 <!-- OPTION A: Simple inbound=outbound (no dual-licensing by contributors) -->
 
-By submitting a pull request, you agree that your contributions are licensed under the same AGPL-3.0 license that covers this project.
+By submitting a pull request, you agree that your contributions are licensed under the same Apache-2.0 license that covers this project.
 
 <!-- OPTION B: CLA for dual-licensing (uncomment if you want dual-licensing rights)
 
@@ -26,7 +26,7 @@ You represent that you have the right to grant this license and that your contri
 is your original work.
 
 This allows [Your Name] to offer commercial licenses of this plugin alongside the
-AGPL-3.0 open-source version.
+Apache-2.0 open-source version.
 
 -->
 

--- a/docs/architecture/plugin-anatomy.md
+++ b/docs/architecture/plugin-anatomy.md
@@ -31,7 +31,7 @@ A fully featured plugin looks like this:
 │   └── {template-name}/        # Pluggable templates (e.g., industry taxonomies)
 ├── CLAUDE.md                    # Developer reference (architecture, conventions)
 ├── CONTRIBUTING.md              # Contribution terms
-├── LICENSE                      # AGPL-3.0-only
+├── LICENSE                      # Apache-2.0
 └── README.md                    # User-facing introduction
 ```
 
@@ -52,7 +52,7 @@ The plugin manifest identifies the plugin and its version. Claude Code uses this
     "name": "Stephan de Haas",
     "email": "stephan@cogni-work.ai"
   },
-  "license": "AGPL-3.0-only",
+  "license": "Apache-2.0",
   "keywords": [
     "claim-verification",
     "fact-checking",

--- a/docs/contributing/plugin-development.md
+++ b/docs/contributing/plugin-development.md
@@ -55,7 +55,7 @@ Create `my-plugin/.claude-plugin/plugin.json`:
     "name": "Your Name",
     "email": "you@example.com"
   },
-  "license": "AGPL-3.0-only",
+  "license": "Apache-2.0",
   "keywords": [
     "relevant-keyword",
     "domain-term"
@@ -269,7 +269,7 @@ Run scripts manually from the command line to verify behavior before hooking the
 
 Your plugin must satisfy the quality standards in [MARKETPLACE_TERMS.md](https://github.com/cogni-work/insight-wave/blob/main/MARKETPLACE_TERMS.md):
 
-- AGPL-3.0 `LICENSE` file present
+- Apache-2.0 `LICENSE` file present
 - `README.md` with installation and usage instructions
 - `plugin.json` with accurate description and version
 - At least one working skill with a tested trigger description
@@ -299,13 +299,13 @@ To list your plugin, submit a PR to the insight-wave repository that adds your p
 - [ ] All skills have been tested against their trigger descriptions
 - [ ] `CLAUDE.md` documents the architecture and conventions
 - [ ] `CONTRIBUTING.md` is present (use the template at `community-plugin-contributing-template.md`)
-- [ ] `LICENSE` file is present with AGPL-3.0 text
+- [ ] `LICENSE` file is present with Apache-2.0 text
 - [ ] Skill names pass the naming convention check
 - [ ] No external package dependencies in scripts
 
 ### Contribution Terms
 
-You retain full copyright and all rights to your plugin. You are free to dual-license it, sell commercial licenses, and distribute it elsewhere. The marketplace listing requires AGPL-3.0, not an assignment of rights.
+You retain full copyright and all rights to your plugin. You are free to dual-license it, sell commercial licenses, and distribute it elsewhere. The marketplace listing requires Apache-2.0, not an assignment of rights.
 
 For PRs to your own plugin from other contributors, set up your own contribution terms. See `community-plugin-contributing-template.md` for a starting template covering both simple inbound=outbound and CLA-based dual-licensing options.
 

--- a/docs/plugin-guide/cogni-claims.md
+++ b/docs/plugin-guide/cogni-claims.md
@@ -208,7 +208,7 @@ See [../workflows/new-engagement.md](../workflows/new-engagement.md) for the ful
 
 ## Extending This Plugin
 
-cogni-claims is open-source under AGPL-3.0. The most useful contribution areas are:
+cogni-claims is open-source under Apache-2.0. The most useful contribution areas are:
 
 - **New deviation types** — the current taxonomy covers misquotation, unsupported conclusion, selective omission, data staleness, and source contradiction. If you encounter a systematic error pattern not in this list, a new type is a good addition.
 - **Source fetching improvements** — JavaScript-heavy pages and login-gated sources are the hardest cases. Contributions that improve the claim-verifier agent's ability to handle these are high-value.

--- a/wiki/wiki/index.md
+++ b/wiki/wiki/index.md
@@ -6,7 +6,7 @@ This is the content catalog for **insight-wave**. Every wiki page is listed here
 
 ### Ecosystem
 
-- [[ecosystem-overview]] — insight-wave is a 13-plugin monorepo for consulting, sales, and marketing on Claude Code, AGPL-3.
+- [[ecosystem-overview]] — insight-wave is a 13-plugin monorepo for consulting, sales, and marketing on Claude Code, Apache-2.0.
 
 ### Architecture
 

--- a/wiki/wiki/pages/arch-plugin-anatomy.md
+++ b/wiki/wiki/pages/arch-plugin-anatomy.md
@@ -25,7 +25,7 @@ How insight-wave plugins are structured on disk. Every plugin follows the same s
 ├── references/*.md               Plugin-wide framework references
 ├── templates/                    Pluggable templates (optional)
 ├── CLAUDE.md                     Developer reference
-├── CONTRIBUTING.md, LICENSE      AGPL-3.0-only
+├── CONTRIBUTING.md, LICENSE      Apache-2.0
 └── README.md                     User-facing introduction
 ```
 

--- a/wiki/wiki/pages/ecosystem-overview.md
+++ b/wiki/wiki/pages/ecosystem-overview.md
@@ -10,7 +10,7 @@ sources:
 status: stable
 ---
 
-insight-wave is a 13-plugin monorepo for consulting, sales, and marketing on Claude Code, AGPL-3.0, with all plugins following the standard Claude Code plugin shape.
+insight-wave is a 13-plugin monorepo for consulting, sales, and marketing on Claude Code, Apache-2.0, with all plugins following the standard Claude Code plugin shape.
 
 ## Repository shape
 


### PR DESCRIPTION
Closes #1058.

Phase 3 (documentation) of relicense epic #1059, after the LICENSE swap (#1056, merged). Pure markdown string-replacement sweep of every self-referential insight-wave license statement from AGPL-3.0 to Apache-2.0. No plugin.json or version changes (owned by sibling manifest issue #1057).

## Summary
- Flipped all 14 README `## License` footers (root + 13 plugins): `[AGPL-3.0](LICENSE)` / `AGPL-3.0` / `AGPL-3.0-only` → `Apache-2.0`.
- Updated prose license statements in CLAUDE.md, CONTRIBUTING.md, CLA.md, MARKETPLACE_TERMS.md, community-plugin-contributing-template.md, and 3 `docs/` files (incl. full-name "GNU Affero General Public License v3.0" → "Apache License 2.0").
- Updated the 6 wiki-mirror pages under `wiki/wiki/` and `cogni-workspace/wiki/wiki/`.

## Scope decisions
- **Kept-with-rationale (AC3):** `cogni-portfolio/templates/b2b-opensource/search-patterns.md`, `.../template.md`, `cogni-portfolio/agents/proposition-review-assessor.md` — AGPL there is open-source-licensing example/domain content (license-term search patterns, license-model option lists, a differentiation scoring note), NOT insight-wave's own license.
- **Kept (out of scope):** `docs/relicensing/vendored-license-audit.md` — the Phase-1 audit record; its AGPL mentions describe the relicense process and point-in-time audit state (rewriting them would falsify the record).
- **OUT:** no plugin.json edits, no version bumps (sibling issue #1057 owns the manifest relicense; bumping here would collide).

## Verification
- 28 target files: 0 residual `AGPL`/`Affero` self-referential statements.
- Diff scope: 28 `.md` files only (42/42), no `plugin.json`/`marketplace.json`.
- The 3 kept portfolio files + the audit record are unchanged.