### PR TITLE
cogni-consult: cascade assumption edits to dependent deliverables (Phase 1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -35,7 +35,7 @@
     {
       "name": "cogni-consult",
       "source": "./cogni-consult",
-      "version": "0.1.65",
+      "version": "0.1.66",
       "maturity": "preview",
       "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
       "keywords": [

--- a/cogni-consult/.claude-plugin/plugin.json
+++ b/cogni-consult/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-consult",
-  "version": "0.1.65",
+  "version": "0.1.66",
   "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-consult/references/dependency-model.md
+++ b/cogni-consult/references/dependency-model.md
@@ -84,8 +84,9 @@ engagement's single-session write model (the same assumption every
 engagement are not serialized, and the last registry writer wins.
 
 `used_by[]` is what makes an assumption propagatable: once the registry knows
-every citer, a value correction can cascade staleness to exactly the files
-that rest on the old number.
+every citer, a value correction cascades staleness to exactly the files that
+rest on the old number. `cascade-stale --assumption <id>` implements this — see
+*Cascade semantics* below.
 
 ### `blocks[]` is derived, never stored
 
@@ -233,6 +234,34 @@ python3 scripts/deliverable-graph.py <engagement-dir> cascade-stale \
 - The write is **idempotent.** A deliverable already carrying `status:"stale"` is
   left untouched (its original `flagged_at` survives), so re-running `cascade-stale`
   produces no new write and no churn. Only not-yet-stale dependents are flagged.
+
+### Assumption cascade (`--assumption <id>`)
+
+The same subcommand cascades from an **assumption** instead of a deliverable
+coordinate, so editing an assumption value flags every deliverable that rests on
+the old number:
+
+```bash
+python3 scripts/deliverable-graph.py <engagement-dir> cascade-stale \
+    --assumption asm-tam --trigger assumption_update
+```
+
+- `coordinate` and `--assumption` are **mutually exclusive** — exactly one must be
+  given. The positional deliverable path is unchanged.
+- The assumption plays the role of the changed upstream node. Its **direct
+  dependents** are the deliverables that cite it, resolved at load time by mapping
+  each `used_by[].file` citer path through the same path→coordinate helper the
+  inferred-edge pass uses (`assumption_blocks`). Staleness then cascades onward
+  through the ordinary deliverable `blocks` graph, exactly as a deliverable edit
+  would — so both the direct citer **and** its transitive downstream are flagged.
+- Everything else is identical to the deliverable cascade: the same
+  read-modify-write, sibling preservation, idempotency, and flag-not-rewrite
+  contract (a single shared writer backs both paths). The `reason` names the
+  assumption id; the recommended `--trigger` value is `assumption_update`.
+- A missing or malformed `assumptions.json` never breaks the deliverable cascade
+  path — the registry is loaded fail-soft (empty edge maps on absence);
+  `resolve-assumptions.py` remains the loud validator for that file. Addressing an
+  `--assumption <id>` that is not in the registry is a clean error envelope.
 
 ## Topological refresh semantics
 

--- a/cogni-consult/scripts/deliverable-graph.py
+++ b/cogni-consult/scripts/deliverable-graph.py
@@ -9,7 +9,9 @@ Usage:
   python3 deliverable-graph.py <engagement-dir> refresh-order
   python3 deliverable-graph.py <engagement-dir> schedule
   python3 deliverable-graph.py <engagement-dir> cascade-stale <action_field>/<deliverable> \
-      --trigger deliverable_update|claims_correction [--include-inferred]
+      --trigger deliverable_update|claims_correction|assumption_update [--include-inferred]
+  python3 deliverable-graph.py <engagement-dir> cascade-stale --assumption <id> \
+      --trigger assumption_update
 
 Returns JSON on stdout: {"success": bool, "data": {...}, "error": "string"}
 
@@ -48,7 +50,7 @@ import os
 import sys
 from datetime import datetime, timezone
 
-VALID_TRIGGERS = ("deliverable_update", "claims_correction")
+VALID_TRIGGERS = ("deliverable_update", "claims_correction", "assumption_update")
 
 
 def node_key(action_field, deliverable):
@@ -316,6 +318,13 @@ def load_graph(engagement_dir):
     # Advisory only — never feeds cycle/dangling detection, never mutates state.
     inferred_edges, inferred_blocks = _infer_source_edges(nodes, depends_on)
 
+    # Fourth pass: load the assumption registry (tolerate absence/malformed) and
+    # invert each entry's used_by[] citer edges into an assumption -> deliverable
+    # adjacency — the assumption-edge analogue of the depends_on -> blocks
+    # inversion above. Absent registry ⇒ empty maps (the deliverable cascade path
+    # stays fully functional without an assumptions.json).
+    assumption_ids, assumption_blocks = _load_assumption_edges(engagement_dir, nodes)
+
     return {
         "nodes": nodes,
         "depends_on": depends_on,
@@ -323,7 +332,57 @@ def load_graph(engagement_dir):
         "dangling": dangling,
         "inferred_edges": inferred_edges,
         "inferred_blocks": inferred_blocks,
+        "assumptions": assumption_ids,
+        "assumption_blocks": assumption_blocks,
     }
+
+
+def _load_assumption_edges(engagement_dir, nodes):
+    """Return (assumption_ids, assumption_blocks) from the engagement-root registry.
+
+    assumption_ids is the set of every id declared in assumptions.json;
+    assumption_blocks maps each assumption id to the deliverable node keys that
+    cite it, resolved by running each used_by[].file citer path through the
+    existing _coord_from_path helper (the same path->coordinate mapping the
+    inferred-edge pass uses) and keeping only coordinates that are real nodes.
+
+    A missing registry (FileNotFoundError) or a hand-corrupted one
+    (JSONDecodeError/OSError) yields empty maps rather than raising: the cascade
+    deliverable path must stay functional without an assumptions.json, and
+    resolve-assumptions.py is the loud validator for that file.
+    """
+    path = os.path.join(engagement_dir, "assumptions.json")
+    try:
+        with open(path, encoding="utf-8") as f:
+            raw = json.load(f)
+    except FileNotFoundError:
+        return set(), {}
+    except (json.JSONDecodeError, OSError):
+        return set(), {}
+
+    assumption_ids = set()
+    assumption_blocks = {}
+    entries = raw.get("assumptions", []) if isinstance(raw, dict) else []
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        asm_id = entry.get("id")
+        if not asm_id:
+            continue
+        assumption_ids.add(asm_id)
+        citer_keys = []
+        for ref in entry.get("used_by") or []:
+            if not isinstance(ref, dict):
+                continue
+            coord = _coord_from_path(ref.get("file"))
+            if coord is None:
+                continue
+            ckey = node_key(*coord)
+            if ckey in nodes and ckey not in citer_keys:
+                citer_keys.append(ckey)
+        if citer_keys:
+            assumption_blocks[asm_id] = citer_keys
+    return assumption_ids, assumption_blocks
 
 
 def find_cycles(depends_on):
@@ -714,6 +773,57 @@ def cmd_cascade_stale(graph, key, trigger, include_inferred=False):
         blocks = _merge_adjacency(graph["blocks"], graph.get("inferred_blocks", {}))
     downstream = transitive(key, blocks)
     reason = f"upstream deliverable {key} changed (trigger: {trigger})"
+    return _flag_downstream_stale(
+        graph, downstream, reason, trigger, key, include_inferred
+    )
+
+
+def cmd_cascade_stale_assumption(graph, asm_id, trigger):
+    """Flag the deliverables that cite assumption `asm_id` — plus their transitive
+    downstream — as stale via the same idempotent flag-not-rewrite RMW.
+
+    The assumption-edge analogue of `cmd_cascade_stale`: the assumption plays the
+    role of the changed upstream node, its used_by[] citers are its direct
+    dependents (resolved into `assumption_blocks` at load time), and staleness
+    then cascades through the ordinary deliverable `blocks` graph exactly as a
+    deliverable edit would. Editing an assumption value therefore flags every
+    dependent stale (AC1) without ever rewriting an artifact (flag-not-rewrite),
+    and re-running is a no-op on already-stale entries (AC3).
+    """
+    if trigger not in VALID_TRIGGERS:
+        raise ValueError(
+            f"--trigger must be one of {VALID_TRIGGERS}, got: {trigger!r}"
+        )
+    if asm_id not in graph.get("assumptions", set()):
+        raise ValueError(
+            f"unknown assumption id: {asm_id!r} — no matching entry in the "
+            f"engagement-root assumptions.json registry"
+        )
+    blocks = graph["blocks"]
+    downstream = set()
+    for citer_key in graph.get("assumption_blocks", {}).get(asm_id, []):
+        downstream.add(citer_key)
+        downstream.update(transitive(citer_key, blocks))
+    reason = f"upstream assumption {asm_id} changed (trigger: {trigger})"
+    return _flag_downstream_stale(
+        graph, sorted(downstream), reason, trigger, asm_id, include_inferred=False
+    )
+
+
+def _flag_downstream_stale(graph, downstream, reason, trigger, trigger_id,
+                           include_inferred):
+    """Shared idempotent by_file RMW: flag every deliverable key in `downstream`
+    with lineage_status={status:"stale", reason, flagged_at, trigger}.
+
+    The single write path for both the deliverable (`cmd_cascade_stale`) and the
+    assumption (`cmd_cascade_stale_assumption`) cascades — it is generic over
+    "a set of downstream deliverable keys to flag", so neither caller duplicates
+    the read-modify-write, sibling-preservation, or idempotency logic. Preserves
+    every sibling field; a deliverable already carrying status:"stale" is left
+    untouched (its original flagged_at survives). `trigger_id` is the changed
+    upstream identity (a deliverable key or an assumption id) echoed as
+    data.trigger.
+    """
     flagged_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
     # Group target downstream keys by the field.json file that holds them, so each
@@ -754,7 +864,7 @@ def cmd_cascade_stale(graph, key, trigger, include_inferred=False):
     return {
         "success": True,
         "data": {
-            "trigger": key,
+            "trigger": trigger_id,
             "trigger_event": trigger,
             "downstream_count": len(downstream),
             "newly_flagged": sorted(newly_flagged),
@@ -785,7 +895,14 @@ def main():
     sub.add_parser("refresh-order")
     sub.add_parser("schedule")
     p_cascade = sub.add_parser("cascade-stale")
-    p_cascade.add_argument("coordinate")
+    p_cascade.add_argument("coordinate", nargs="?", default=None)
+    p_cascade.add_argument(
+        "--assumption",
+        metavar="ID",
+        default=None,
+        help="cascade from an assumptions.json id via its used_by[] edges "
+        "instead of an <action_field>/<deliverable> coordinate",
+    )
     p_cascade.add_argument(
         "--trigger", required=True, choices=list(VALID_TRIGGERS)
     )
@@ -815,10 +932,20 @@ def main():
         elif args.command == "schedule":
             result = cmd_schedule(graph)
         elif args.command == "cascade-stale":
-            af, d = parse_coordinate(args.coordinate)
-            result = cmd_cascade_stale(
-                graph, node_key(af, d), args.trigger, args.include_inferred
-            )
+            if (args.coordinate is None) == (args.assumption is None):
+                raise ValueError(
+                    "cascade-stale requires exactly one of "
+                    "<action_field>/<deliverable> or --assumption <id>"
+                )
+            if args.assumption is not None:
+                result = cmd_cascade_stale_assumption(
+                    graph, args.assumption, args.trigger
+                )
+            else:
+                af, d = parse_coordinate(args.coordinate)
+                result = cmd_cascade_stale(
+                    graph, node_key(af, d), args.trigger, args.include_inferred
+                )
         else:  # pragma: no cover — argparse already enforces the choice set
             raise ValueError(f"unknown command: {args.command}")
     except (ValueError, OSError, json.JSONDecodeError) as exc:

--- a/cogni-consult/tests/test_deliverable_graph.sh
+++ b/cogni-consult/tests/test_deliverable_graph.sh
@@ -28,6 +28,9 @@
 #  19  schedule-unscheduled  duration-less deliverable listed under unscheduled[], treated as zero, no crash (AC3)
 #  20  schedule-cycle        schedule over a cyclic graph short-circuits success:false
 #  21  schedule-invalid-duration  invalid/negative authored durations surface under unscheduled[] (treated as zero); authored duration:0 stays scheduled
+#  22  cascade-stale-assumption   editing an assumption flags every used_by[] dependent (citer + transitive downstream) stale via RMW, preserves siblings (AC1)
+#  23  cascade-stale-assumption-idempotent  a second assumption cascade produces no new writes (AC3)
+#  24  cascade-stale-no-registry  deliverable cascade works with no assumptions.json (graceful); --assumption without a registry errors cleanly; coordinate/--assumption are mutually exclusive
 #
 # Usage: bash cogni-consult/tests/test_deliverable_graph.sh
 # Exits non-zero on any assertion failure.
@@ -549,6 +552,57 @@ EOF
 OUT="$(run "$DSI" schedule)"
 assert_json "schedule-invalid-duration" "$OUT" \
   "d['success'] is True and d['data']['unscheduled'] == ['plan/neg', 'plan/txt'] and (lambda s: s['plan/zero']['unscheduled'] is False and s['plan/zero']['earliest_finish'] == 0 and s['plan/neg']['unscheduled'] is True and s['plan/neg']['earliest_finish'] == 0 and s['plan/txt']['unscheduled'] is True and s['plan/txt']['earliest_finish'] == 0)({e['key']: e for e in d['data']['schedule']})"
+
+# ---------------------------------------------------------------------------
+# 22  cascade-stale-assumption   editing an assumption flags every used_by[]
+#     dependent stale (the direct citer AND its transitive downstream) via the
+#     shared flag-not-rewrite RMW, preserving siblings (AC1).
+# ---------------------------------------------------------------------------
+DA="$TMPROOT/cascade-assumption"; seed_chain "$DA"
+cat > "$DA/assumptions.json" <<'EOF'
+{
+  "assumptions": [
+    {"id": "asm-tam", "name": "TAM", "value": "12B",
+     "used_by": [{"file": "action-fields/market-evidence/market-sizing.md", "resolved_at": "2026-06-20T00:00:00Z"}]}
+  ]
+}
+EOF
+OUT="$(run "$DA" cascade-stale --assumption asm-tam --trigger assumption_update)"
+assert_json "cascade-stale-assumption" "$OUT" \
+  "d['success'] is True and set(d['data']['newly_flagged']) == {'market-evidence/market-sizing', 'portfolio-fit/portfolio-screen', 'go-to-market/gtm-play'} and d['data']['already_stale'] == [] and d['data']['trigger'] == 'asm-tam' and d['data']['trigger_event'] == 'assumption_update'"
+
+# the citing deliverable itself is flagged (it is downstream of the assumption),
+# keeps its siblings, and the reason names the assumption id
+assert_json "cascade-stale-assumption-citer-flagged" \
+  "$(python3 -c "import json; print(json.dumps(json.load(open('$DA/action-fields/market-evidence/field.json'))['deliverables'][0]))")" \
+  "d['state'] == 'complete' and d['dt_stage'] == 'test' and d['lineage_status']['status'] == 'stale' and d['lineage_status']['trigger'] == 'assumption_update' and 'asm-tam' in d['lineage_status']['reason']"
+
+# ---------------------------------------------------------------------------
+# 23  cascade-stale-assumption-idempotent   a second assumption cascade produces
+#     no new writes — every dependent is already stale (AC3).
+# ---------------------------------------------------------------------------
+OUT="$(run "$DA" cascade-stale --assumption asm-tam --trigger assumption_update)"
+assert_json "cascade-stale-assumption-idempotent" "$OUT" \
+  "d['success'] is True and d['data']['newly_flagged'] == [] and set(d['data']['already_stale']) == {'market-evidence/market-sizing', 'portfolio-fit/portfolio-screen', 'go-to-market/gtm-play'}"
+
+# ---------------------------------------------------------------------------
+# 24  cascade-stale-no-registry   the deliverable cascade path stays fully
+#     functional when no assumptions.json exists (graceful absence); addressing
+#     an assumption without a registry is a clean error envelope; and requiring
+#     exactly one of coordinate / --assumption is enforced.
+# ---------------------------------------------------------------------------
+DN="$TMPROOT/cascade-no-registry"; seed_chain "$DN"   # no assumptions.json written
+OUT="$(run "$DN" cascade-stale market-evidence/market-sizing --trigger deliverable_update)"
+assert_json "cascade-stale-no-registry-deliverable" "$OUT" \
+  "d['success'] is True and set(d['data']['newly_flagged']) == {'portfolio-fit/portfolio-screen', 'go-to-market/gtm-play'}"
+
+OUT="$(run "$DN" cascade-stale --assumption asm-missing --trigger assumption_update)"
+assert_json "cascade-stale-no-registry-assumption-error" "$OUT" \
+  "d['success'] is False and 'unknown assumption id' in d['error']"
+
+OUT="$(run "$DN" cascade-stale market-evidence/market-sizing --assumption asm-tam --trigger deliverable_update)"
+assert_json "cascade-stale-mutually-exclusive" "$OUT" \
+  "d['success'] is False and 'exactly one of' in d['error']"
 
 # ---------------------------------------------------------------------------
 echo


### PR DESCRIPTION
Refs #982.

Extends `deliverable-graph.py cascade-stale` so editing an assumption flags every dependent deliverable stale via the assumption's `used_by[]` edges — mirroring the existing `depends_on[]` deliverable cascade and preserving the flag-not-rewrite contract.

## Summary
- `load_graph` now also loads engagement-root `assumptions.json` (fail-soft on absence/malformed) and inverts each entry's `used_by[]` citers into an assumption-id → deliverable-key adjacency (`assumption_blocks`) by running each `used_by[].file` through the existing `_coord_from_path` helper.
- Adds `assumption_update` to `VALID_TRIGGERS` (auto-propagates to the CLI `--trigger` choice set) and refreshes the module Usage docstring.
- Adds a `cascade-stale --assumption <id>` addressing path — mutually exclusive with the positional `<action_field>/<deliverable>` coordinate — that resolves the downstream set from the assumption adjacency then reuses a single shared idempotent `by_file` read-modify-write writer (`_flag_downstream_stale`). No duplication of the deliverable path's write logic; the positional path is unchanged.
- Documents the mechanism in `references/dependency-model.md`.
- Bumps `cogni-consult` 0.1.65 → 0.1.66 in `plugin.json` and mirrors it in the root `marketplace.json`.

## Scope decisions
- **In (AC1, AC3):** an assumption-value edit flags every `used_by[]` dependent stale — the direct citer **and** its transitive downstream — never rewriting artifacts (flag-not-rewrite preserved); the cascade is idempotent on re-run (already-stale entries are skipped).
- **Deferred (AC2):** the derived-value evaluator (B2-eval) — deterministic recompute of values derived from assumptions plus the thin wrapper over `cogni-portfolio/scripts/propagate-corrections.sh`. There is no `derived_from`/`formula` schema anywhere today, so AC2 is a wholly-new, independently-reviewable surface. **#982 is kept open (`Refs`, not `Closes`)** to track it.

## Test plan
- [x] `tests/test_deliverable_graph.sh` passes — 23 existing cases + new cases 22/23/24 (registered in the numbered Coverage header):
  - **22** assumption edit flags each `used_by[]` dependent (citer + transitive downstream) stale, preserving siblings, reason names the assumption id.
  - **23** re-running the same `--assumption` cascade yields zero newly-flagged (idempotent).
  - **24** missing `assumptions.json` still runs the deliverable path without error; `--assumption` without a registry errors cleanly; coordinate/`--assumption` mutual-exclusivity enforced.
- [x] Sibling `tests/test_resolve_assumptions.sh` still passes (no cross-break).
- [x] `plugin.json` and `marketplace.json` both read 0.1.66 for cogni-consult.

Phase-1 child of epic #984 (assumption SSOT), maintainer go/no-go cleared.