### PR TITLE
cogni-consult: finalize per-number provenance marker wording + placement

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -35,7 +35,7 @@
     {
       "name": "cogni-consult",
       "source": "./cogni-consult",
-      "version": "0.1.66",
+      "version": "0.1.67",
       "maturity": "preview",
       "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
       "keywords": [

--- a/cogni-consult/.claude-plugin/plugin.json
+++ b/cogni-consult/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-consult",
-  "version": "0.1.66",
+  "version": "0.1.67",
   "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-consult/references/publish-routing.md
+++ b/cogni-consult/references/publish-routing.md
@@ -107,7 +107,10 @@ renderer) owns the slide-vs-notes and emphasis decisions. The five pieces:
 4. **`key_figures:`** — a brief-level list promoting the hero numbers out of
    prose (e.g. `~25 auditors`, `8–10 shortlist`, `240 min`, `≥80% return`,
    `~30 backlog`) so the renderer can build big-number moments rather than
-   burying them in body text. Default: none (numbers stay inline).
+   burying them in body text. A promoted figure that carries a provenance
+   marker keeps it (e.g. `€4.2bn (prov: claim/reviewed)`) — the marker travels
+   with the value into the stat block, never stripped. Default: none (numbers
+   stay inline).
 5. **Climax and TBD marks** — name the point slide for emphasis (e.g.
    `climax: slide 11` — the asks), and flag genuine placeholders
    (`tbd: ["CO-1…4 staffing", "confirm exact title"]`) so the renderer treats
@@ -144,8 +147,11 @@ otherwise avoids.
 Build a **consult-native infographic brief** directly from the deliverable
 rather than dispatching a local renderer: the Pyramid governing thought as the
 headline, the key quantified facts / hero numbers pulled from the deliverable's
-evidence, each MECE group as one infographic segment (a stat-or-insight block),
-and a single call-to-action takeaway — citations preserved in the brief. This is
+evidence (a hero number that carries a provenance marker keeps it — the
+`(prov: type/status)` parenthetical travels with the value into its stat block,
+never stripped), each MECE group as one infographic segment (a stat-or-insight
+block), and a single call-to-action takeaway — citations preserved in the brief.
+This is
 exactly what Claude Design's infographic generator consumes; Claude Design
 renders and themes it. Write it alongside the deliverable, e.g.
 `action-fields/<field-slug>/publish/<deliverable-slug>-infographic-brief.md`.
@@ -267,8 +273,13 @@ can never re-form a `{{asm:…}}` placeholder or trip the
 `unresolved_after_substitution` check on a re-resolve. Because every publish
 route delegates to this single resolution pass, the marker surfaces in all four
 formats (slides / web-poster / report / infographic) with no per-route change.
-The marker vocabulary is **provisional** pending a design rework of its wording
-and placement across the formats.
+The marker wording is **settled**: the raw `(prov: type/status)` parenthetical is
+the finalized form — compact, link-safe, brace-free, and format-agnostic, so it
+reads the same inline and when a number is promoted to a hero figure. When a
+route lifts a number out of prose into a standalone hero figure (the
+`key_figures:` list for slides / web-poster, or an infographic hero number), the
+marker **travels with the promoted value** — rendered immediately after it, never
+stripped — so a hero stat carries its provenance just as an inline number does.
 
 ### Verify path — reuse by contract, no new verifier
 

--- a/cogni-consult/scripts/resolve-assumptions.py
+++ b/cogni-consult/scripts/resolve-assumptions.py
@@ -75,8 +75,11 @@ def _render_value(entry):
     placeholder, and it is brace-free so it can never re-form a `{{asm:…}}`
     placeholder and re-trigger the post-substitution leftover check. Untyped
     (legacy) entries render bare, so pre-provenance registries are unaffected.
-    The marker vocabulary is provisional pending a design rework of its wording
-    and placement across the publish formats.
+    The marker wording is settled: the raw ``(prov: type/status)`` parenthetical
+    is the finalized form — compact, link-safe, brace-free, and format-agnostic,
+    so it renders identically inline and when a number is promoted to a hero
+    figure. A promoted hero number carries this marker with it rather than
+    dropping it, so provenance is never lost when a figure becomes a stat block.
     """
     value = str(entry["value"])
     ptype = entry.get("provenance_type")


### PR DESCRIPTION
Closes #1034.

## Summary
- Settle the per-number provenance marker: the raw `(prov: type/status)` parenthetical is confirmed as the finalized wording (compact, link-safe, brace-free, format-agnostic, already test-locked) — no render format-string change.
- Document the placement rule for the two standalone-hero-number surfaces: the marker travels WITH a promoted number (carried, not stripped) so provenance is never lost when a figure becomes a hero stat — the parenthetical sits immediately after the promoted value. Added to the `key_figures:` list (slides / web-poster) and the infographic hero-number route.
- Drop all "provisional" language in `resolve-assumptions.py` and `references/publish-routing.md` now that the vocabulary and placement are settled.
- Bump cogni-consult 0.1.66 -> 0.1.67 (plugin.json + marketplace.json).

## Scope decisions
- IN: marker wording finalization, placement rule for `key_figures:` and infographic hero numbers, removal of provisional flags, version bump.
- OUT (unchanged, deliberately): the PROVENANCE_TYPES / STATUS_LADDER / TYPE_STATUS_CAP enum contract and all validate_provenance / schema / on-disk registry surfaces — changing them would ripple into schema and stored registries and is not what the issue asks. Client-friendly copy rewording of the marker is a larger, subjective change and was not adopted; the raw enum token is the settled wording.
- No test edits: keeping the format string unchanged means tests 16/20/21 stay green and act as the finalized-wording guard.

## Test plan
- [x] `bash cogni-consult/tests/test_resolve_assumptions.sh` passes (14/14; provenance-marker render asserts the unchanged `(prov: type/status)` string).
- [x] `grep -ri provisional` on the two edited files returns nothing.
- [x] `references/publish-routing.md` `key_figures:` and infographic sections state the marker-carries-with-promoted-number placement rule.
- [x] `cogni-consult/.claude-plugin/plugin.json` and root `.claude-plugin/marketplace.json` both show `0.1.67`.
- [x] breadcrumb guard passes — no new `#NNN` refs in edited files.