### PR TITLE
cogni-consult: consult-resume lists and stops on ambiguous engagement selection

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -35,7 +35,7 @@
     {
       "name": "cogni-consult",
       "source": "./cogni-consult",
-      "version": "0.1.71",
+      "version": "0.1.72",
       "maturity": "preview",
       "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
       "keywords": [

--- a/cogni-consult/.claude-plugin/plugin.json
+++ b/cogni-consult/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-consult",
-  "version": "0.1.71",
+  "version": "0.1.72",
   "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-consult/skills/consult-resume/SKILL.md
+++ b/cogni-consult/skills/consult-resume/SKILL.md
@@ -39,10 +39,16 @@ setup owns scaffolding and the knowledge-base binding.
 ### 2. Select the Engagement
 
 - **One engagement** → select it silently.
-- **Multiple** → list them (name, slug, `scope_state`, scope config
-  `updated`) and ask
-  which to resume — unless the user already named one; then fuzzy-match on
-  name or slug and confirm only when the match is ambiguous.
+- **Multiple, and the user named one** → fuzzy-match the named name or slug
+  against discovery and select it directly; confirm only when the match is
+  ambiguous.
+- **Multiple, and the user named none** → you MUST output the full engagement
+  list (name, slug, `scope_state`, scope config `updated`) and STOP for the
+  user's explicit choice. Never silently select or infer an engagement in this
+  case. The active git branch, working-tree / uncommitted changes, and recent
+  commit history are **not** authorized selection signals — they must never
+  substitute for the user's choice or override the list-and-stop obligation.
+  Only a name or slug explicitly named in the user's message may skip the list.
 
 Conduct the conversation in the resolved **interaction language** (workspace
 default, overridden by the user's message language) — independent of the


### PR DESCRIPTION
Closes #1093.

## Summary
- Rewrite consult-resume Step 2 (`### 2. Select the Engagement`) so that when discovery returns more than one engagement AND the user's message names none, the skill MUST output the full engagement list (name, slug, `scope_state`, `updated`) and STOP for an explicit user choice — no silent selection.
- Add an explicit negative constraint: the active git branch, working-tree / uncommitted changes, and recent commit history are never authorized signals for engagement selection.
- Preserve the named-engagement fast path: an explicitly named name/slug fuzzy-matches directly and only asks to confirm when the match is ambiguous.
- Bump `cogni-consult` patch version 0.1.71 → 0.1.72 and mirror it in the marketplace manifest (repo convention for any skill change).

## Scope decisions
- In scope: prose hardening of the one section (SKILL.md §2) plus the mandated version bump. Satisfies all three acceptance criteria in a single section.
- Out of scope: no script change — grep confirmed discovery already returns every list field and no code path reads git context, so the bug is prose latitude, not logic. The interaction-language pointer and the single-engagement fast path are untouched.

## Test plan
- [ ] Revised §2: the multiple-and-unnamed case uses MUST/STOP imperative language and enumerates name, slug, `scope_state`, `updated` (AC-1).
- [ ] Section explicitly forbids using git branch / working-tree changes / commit history as a selection signal (AC-2).
- [ ] A named name/slug still routes directly via fuzzy-match, confirming only on ambiguity (AC-3).
- [ ] `cogni-consult/.claude-plugin/plugin.json` shows 0.1.72 and the marketplace.json cogni-consult entry mirrors it.