### PR TITLE
cogni-workspace: canonical agent-model-cost reference doc

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -118,7 +118,7 @@
     {
       "name": "cogni-workspace",
       "source": "./cogni-workspace",
-      "version": "0.6.36",
+      "version": "0.6.37",
       "maturity": "preview",
       "description": "Foundation-layer plugin for insight-wave marketplace plugins. Manages shared infrastructure (env vars, settings), MCP server installation and Desktop config patching, theme management, theme picker, plugin discovery, workspace health, an interactive workspace-configuration dashboard, Obsidian vault integration, and a bundled vendor-curated insight-wave reference wiki queryable via the ask skill.",
       "keywords": [

--- a/cogni-workspace/.claude-plugin/plugin.json
+++ b/cogni-workspace/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-workspace",
-  "version": "0.6.36",
+  "version": "0.6.37",
   "description": "Foundation-layer plugin for insight-wave marketplace plugins. Manages shared infrastructure (env vars, settings), MCP server installation and Desktop config patching, theme management, theme picker, plugin discovery, workspace health, an interactive workspace-configuration dashboard, Obsidian vault integration, and a bundled vendor-curated insight-wave reference wiki queryable via the ask skill.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-workspace/references/agent-model-cost.md
+++ b/cogni-workspace/references/agent-model-cost.md
@@ -1,0 +1,64 @@
+# Agent Model Cost Reference
+
+The single canonical source of truth for **which model tier each agent role uses** and **how to turn an agent's word counts into a USD `cost_estimate`**. Research agents emit `cost_estimate` in their output JSON; orchestrators accumulate these into a per-run total. Cite this file by its repo-relative path (`cogni-workspace/references/agent-model-cost.md`) rather than duplicating the coefficients inline, so a rate change lands in exactly one place.
+
+## Role → model strategy
+
+Mirrors the root `CLAUDE.md` § "Agent Model Strategy" (the authority). Keep the two in lockstep.
+
+| Role | Model | Rationale |
+|------|-------|-----------|
+| Orchestration | sonnet (skill context) | Phase dispatch, sub-question generation |
+| Research | sonnet | Web research, section researchers, deep researchers |
+| Heavy synthesis | opus | Demanding rewrites (cogni-copywriting), 60-candidate scoring (cogni-trends) |
+| Quality assessment | haiku | High-volume rubric evaluation (3-5 dimensions per entity) |
+| Content generation | sonnet | Narrative writers, report writers, content writers |
+
+**How to pick when building a new agent:** default to sonnet; promote to opus only if a sonnet test fails on quality (tone-critical rewrites, multi-axis scoring across many candidates); demote to haiku only when sonnet's output never differs meaningfully from haiku's at the agent's volume (high-volume rubric scoring).
+
+## Per-word → USD cost formula
+
+Research agents report input/output **word** counts; convert to tokens, then to USD.
+
+**1. Words → tokens**
+
+```
+tokens ≈ words × 0.75          # ≈ 1.33 words per token
+```
+
+**2. Tokens → USD**
+
+```
+USD = (input_tokens  / 1_000_000) × input_rate
+    + (output_tokens / 1_000_000) × output_rate
+```
+
+`input_rate` / `output_rate` are the per-million-token rates for the agent's model tier (below).
+
+## Per-model rates (USD per million tokens)
+
+| Model | Input $/MTok | Output $/MTok |
+|-------|-------------:|--------------:|
+| Sonnet (Claude Sonnet) | 3.00 | 15.00 |
+| Opus (Claude Opus 4.x) | 15.00 | 75.00 |
+| Haiku (Claude Haiku 4.5) | 1.00 | 5.00 |
+
+These are published **list prices**. Verify the current figures against <https://www.anthropic.com/pricing> before relying on them for billing — the coefficients here are for producing an *estimate*, not an invoice. Prompt caching and batch discounts are out of scope for the `cost_estimate` figure (it models the un-cached, non-batched cost).
+
+## Worked example
+
+A research agent (sonnet) consumes **2,000 input words** and emits **800 output words**:
+
+```
+input_tokens  = 2000 × 0.75 = 1500
+output_tokens =  800 × 0.75 =  600
+USD = (1500 / 1e6) × 3.00 + (600 / 1e6) × 15.00
+    = 0.0045 + 0.0090
+    = $0.0135
+```
+
+So the agent reports `cost_estimate ≈ $0.014`. An orchestrator running twenty such agents accumulates `≈ $0.27` for the research phase.
+
+## Consumers
+
+Any agent or skill that computes a `cost_estimate`, or that documents a role → model choice, should cite this file rather than restating the table or the coefficients. Inline duplications drift; a single canonical reference does not.

--- a/cogni-workspace/wiki/wiki/pages/concept-agent-model-strategy.md
+++ b/cogni-workspace/wiki/wiki/pages/concept-agent-model-strategy.md
@@ -32,6 +32,8 @@ Agents pick model tiers by role across insight-wave, with cost-per-task as the d
 
 Research agents report `cost_estimate` in their output JSON — input/output words plus an estimated USD figure. Orchestrating skills accumulate these so a complete pipeline run can quote a total cost back to the user.
 
+The canonical role→model strategy table and the per-word→USD cost formula (token conversion, per-model list rates, and a worked example) live in `cogni-workspace/references/agent-model-cost.md` — cite that reference rather than duplicating the coefficients.
+
 ## How to apply this when building a new agent
 
 Pick the cheapest model that passes a representative test of the agent's actual work. Default to sonnet; promote to opus only if a haiku/sonnet test fails on quality, demote to haiku only if sonnet's output never differs meaningfully from haiku's at the agent's volume.

--- a/wiki/wiki/pages/concept-agent-model-strategy.md
+++ b/wiki/wiki/pages/concept-agent-model-strategy.md
@@ -32,6 +32,8 @@ Agents pick model tiers by role across insight-wave, with cost-per-task as the d
 
 Research agents report `cost_estimate` in their output JSON — input/output words plus an estimated USD figure. Orchestrating skills accumulate these so a complete pipeline run can quote a total cost back to the user.
 
+The canonical role→model strategy table and the per-word→USD cost formula (token conversion, per-model list rates, and a worked example) live in `cogni-workspace/references/agent-model-cost.md` — cite that reference rather than duplicating the coefficients.
+
 ## How to apply this when building a new agent
 
 Pick the cheapest model that passes a representative test of the agent's actual work. Default to sonnet; promote to opus only if a haiku/sonnet test fails on quality, demote to haiku only if sonnet's output never differs meaningfully from haiku's at the agent's volume.


### PR DESCRIPTION
Closes #1088.

Phase 1 (foundation) of Epic #1091; unblocks #1089 and #1090.

## Summary
- Create `cogni-workspace/references/agent-model-cost.md` — the single source of truth for (1) the role→model strategy table (mirrored verbatim from root `CLAUDE.md` § Agent Model Strategy) and (2) the per-word→USD cost formula, per-model list rates, and a worked example.
- Cite the new doc from both byte-identical wiki copies (`cogni-workspace/wiki/wiki/pages/concept-agent-model-strategy.md` and the repo-root mirror `wiki/wiki/pages/concept-agent-model-strategy.md`), in the `## Cost telemetry` section.
- Bump `cogni-workspace` version 0.6.36 → 0.6.37 in both `.claude-plugin/plugin.json` and the marketplace.json entry (surgical string edits).

## Scope decisions
- Full scope: all three acceptance criteria ship in this one PR (low-complexity, one coherent change — not decomposed).
- Cost coefficients documented: token estimate `tokens ≈ words × 0.75`; `USD = (input_tokens/1e6)×input_rate + (output_tokens/1e6)×output_rate`; per-model list rates Sonnet $3.00/$15.00 (issue-specified), Opus $15.00/$75.00, Haiku $1.00/$5.00 — non-Sonnet rates labelled list prices verifiable at anthropic.com/pricing.
- Cite format: the two wiki copies are byte-identical and must stay so. A filesystem-relative link would resolve to different strings from each copy's location (one under `cogni-workspace/`, the mirror at repo root), breaking byte-identity — so both cite the doc by its stable repo-relative path `cogni-workspace/references/agent-model-cost.md`.
- Deferred: nothing. Phase-2 consumers (#1089, #1090) are separate issues, out of scope here.

## Test plan
- [x] `cogni-workspace/references/agent-model-cost.md` exists with a strategy-table section AND a formula/coefficients section (worked example + anthropic.com/pricing note).
- [x] Both wiki copies cite the new doc; `diff` reports no differences (still byte-identical).
- [x] `cogni-workspace/.claude-plugin/plugin.json` and the marketplace.json entry both read `0.6.37`.
- [x] `scripts/check-breadcrumbs.py` passes (0 violations); JSON manifests valid.