### PR TITLE
cogni-consult: wire resolve-propagate + assumption staleness cascade

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -35,7 +35,7 @@
     {
       "name": "cogni-consult",
       "source": "./cogni-consult",
-      "version": "0.1.73",
+      "version": "0.1.74",
       "maturity": "preview",
       "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
       "keywords": [

--- a/cogni-consult/.claude-plugin/plugin.json
+++ b/cogni-consult/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-consult",
-  "version": "0.1.73",
+  "version": "0.1.74",
   "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-consult/references/publish-routing.md
+++ b/cogni-consult/references/publish-routing.md
@@ -303,9 +303,12 @@ source; cogni-consult builds **no** verifier of its own. **Propagate:**
 unless the referenced ClaimRecord is itself `verified`. At render time
 `resolve-assumptions.py` enforces the same evidence gate: a cited claim-type
 assumption at `verified` must carry a `citation.claim_id` that resolves to a
-verified ClaimRecord, else the resolve fails loud. Cascading deviated/resolved
-verdicts back onto records (the broader corrections wrapper) remains a separate
-follow-up surface.
+verified ClaimRecord, else the resolve fails loud. **Resolve-propagate:**
+cascading deviated/resolved verdicts back onto records is wired into the
+consult-design-thinking *Claims-correction cascade* step — `submit-assumption-claim.py
+resolve-propagate` writes the corrected value back and demotes `verified` →
+`reviewed`, then `deliverable-graph.py cascade-stale --assumption` fans the
+staleness to every deliverable citing that assumption.
 
 ### Link-render mode (`--mode link`, opt-in)
 

--- a/cogni-consult/skills/consult-design-thinking/SKILL.md
+++ b/cogni-consult/skills/consult-design-thinking/SKILL.md
@@ -509,22 +509,36 @@ which format fits; the design-thinking loop ends at `complete`.
   (`$CLAUDE_PLUGIN_ROOT/references/research-routing.md`), never raw web
   search; every evidence-backed claim in the artifact carries the
   `sources[]` lineage triple so corrections can cascade.
-- **Claims-correction cascade**: when the consultant surfaces a cogni-claims
-  correction that reaches a deliverable through its `sources[]` lineage (a
-  cited claim was deviated and resolved upstream), flag that deliverable's
-  downstream dependents stale so the corrected ground propagates:
+- **Claims-correction cascade**: when the consultant surfaces a resolved
+  cogni-claims correction, propagate the corrected ground — the script depends
+  on what the correction touched:
+
+  *A deliverable's cited source* (a claim in its `sources[]` lineage was
+  deviated then resolved upstream) — flag that deliverable's downstream
+  dependents stale, so its `lineage_status.trigger` reads `claims_correction`:
 
   ```bash
   python3 $CLAUDE_PLUGIN_ROOT/scripts/deliverable-graph.py <engagement-dir> \
       cascade-stale <field-slug>/<deliverable-slug> --trigger claims_correction
   ```
 
-  Run it on the deliverable whose artifact cites the corrected source; the
-  flagged dependents' `lineage_status.trigger` reads `claims_correction` so
-  the reason stays traceable. A `"success": false` (node not found, bad dir)
-  is non-blocking here too — surface the error and continue. There is no
-  automated cogni-claims callback into cogni-consult — this is a
-  consultant-initiated step when a correction is noticed.
+  *A claim-type assumption's value* (its ClaimRecord is `resolved` with
+  `resolution.action: corrected`) — write the corrected value back, then fan
+  staleness to every deliverable citing that assumption:
+
+  ```bash
+  python3 $CLAUDE_PLUGIN_ROOT/scripts/submit-assumption-claim.py <engagement-dir> \
+      resolve-propagate <asm-id> --corrected-value <value> [--claim-id <id>]
+  python3 $CLAUDE_PLUGIN_ROOT/scripts/deliverable-graph.py <engagement-dir> \
+      cascade-stale --assumption <asm-id> --trigger assumption_update
+  ```
+
+  `resolve-propagate` mutates the assumption of record (demotes `verified` →
+  `reviewed`) and is **fail-loud** (`"success": false` / exit 1) — surface
+  `data.failed_check` and STOP, don't cascade a value that never changed. Every
+  `cascade-stale` form is non-blocking (exit 0) — surface the error and
+  continue. cogni-claims has no push callback into cogni-consult, so this stays
+  a consultant-initiated step, run when a correction is noticed.
 - **Loop, not gate**: stages may re-enter earlier stages; `state` stays
   `in-progress` until the test stage passes. State transitions go in the
   execution log; per-stage `dt_stage` moves are logged separately to


### PR DESCRIPTION
Closes #1081.

Deferred from #1033 (PR #1084): the `resolve-propagate` leg shipped, but no skill step invoked it, no `cascade-stale --assumption` fired, and two narratives still described the cogni-claims callback as manual/absent. This wires the orchestration and refreshes the stale prose. Both callee legs already exist and are tested (`tests/test_resolve_assumptions.sh`); no code or test changes.

## Summary
- Rewrite the consult-design-thinking `Claims-correction cascade` bullet into a two-case sequence: **(A)** a deliverable's cited source changed → the existing coordinate-form `deliverable-graph.py cascade-stale <field>/<deliverable> --trigger claims_correction`; **(B)** a claim-type assumption's value was corrected → a new two-step: `submit-assumption-claim.py resolve-propagate <asm-id> --corrected-value <value> [--claim-id <id>]` (fail-loud — surface `data.failed_check` and STOP on exit 1), then on success `deliverable-graph.py cascade-stale --assumption <asm-id> --trigger assumption_update` (non-blocking — surface error, continue).
- Preserve the two distinct script contracts: `resolve-propagate` is fail-loud (mutates the assumption of record, must stop on failure); `cascade-stale` always exits 0 (surface-and-continue). The narrative keeps them non-interchangeable.
- Soften "There is no automated cogni-claims callback" to describe the now-wired but still consultant-initiated flow (cogni-claims has no push into cogni-consult).
- Refresh `publish-routing.md` to cross-reference the now-wired consult-design-thinking step instead of calling it a "separate follow-up surface".
- Bump cogni-consult 0.1.73 → 0.1.74 in plugin.json and mirror in marketplace.json.

## Scope
- Full scope of the #1033 deferral — orchestration wiring for both legs plus the two stale-narrative rewrites and the version bump. Nothing left as un-filed prose; no deferred follow-ups.
- Untouched: `dependency-model.md` already documents `cascade-stale --assumption` correctly; no script/agent/test changes (both legs already covered by `tests/test_resolve_assumptions.sh`, which passes).

## Test plan
- [x] `bash cogni-consult/tests/test_resolve_assumptions.sh` passes (incl. all resolve-propagate assertions) — no regression, no code changed.
- [x] SKILL.md two-step sequence present with correct flags and fail-loud/non-blocking distinction spelled out.
- [x] Deliverable-coordinate `--trigger claims_correction` case preserved as distinct.
- [x] publish-routing.md cross-references the wired step.
- [x] plugin.json + marketplace.json show 0.1.74 (single-line diffs, non-ASCII preserved).

## Review notes
- `consult-design-thinking/SKILL.md` is 546 lines, over the plugin's documented 500-line SKILL-body soft cap. This breach is **pre-existing** (532 lines before this change); the change added ~14 lines of genuine orchestration wiring. Extracting dense contracts into `references/orchestration/` was explicitly out of this issue's scope. Flagged by the skill-quality gate as `introduced_by_change: false` (annotation, not a re-plan trigger).