### PR TITLE
cogni-projects: scaffold plugin skeleton + projects-setup

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,8 +5,8 @@
     "email": "stephan@cogni-work.ai"
   },
   "metadata": {
-    "description": "Insight-wave is a 13-plugin ecosystem for Claude Code that turns consulting, research, portfolio, and communication workflows into AI-assisted, bilingual (EN/DE) pipelines — trend scouting, portfolio messaging, narrative transformation, visual deliverables, sales enablement, claim verification, knowledge management, wiki-first research, and end-to-end consulting orchestration.",
-    "version": "1.0.3"
+    "description": "Insight-wave is a 14-plugin ecosystem for Claude Code that turns consulting, research, portfolio, and communication workflows into AI-assisted, bilingual (EN/DE) pipelines — trend scouting, portfolio messaging, narrative transformation, visual deliverables, sales enablement, claim verification, knowledge management, wiki-first research, project-portfolio steering, and end-to-end consulting orchestration.",
+    "version": "1.0.4"
   },
   "plugins": [
     {
@@ -265,6 +265,24 @@
         "responsive",
         "multi-page",
         "agent"
+      ]
+    },
+    {
+      "name": "cogni-projects",
+      "source": "./cogni-projects",
+      "version": "0.0.1",
+      "maturity": "incubating",
+      "description": "Partner-facing project-portfolio steering for consulting firms — models consultants, projects, and staffing so partners can match people to work by availability, profile fit, and strategic impact. Scaffolds a self-contained portfolio directory that later skills (staffing match, backfilling, partner-meeting dashboard) write into.",
+      "keywords": [
+        "projects",
+        "portfolio",
+        "staffing",
+        "consulting",
+        "project-portfolio",
+        "resource-management",
+        "partner-steering",
+        "consultants",
+        "assignments"
       ]
     }
   ]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,12 +1,12 @@
 # insight-wave
 
-13-plugin monorepo for consulting, sales, and marketing on Claude Code. Apache-2.0. All plugins follow the Claude Code plugin standard.
+14-plugin monorepo for consulting, sales, and marketing on Claude Code. Apache-2.0. All plugins follow the Claude Code plugin standard.
 
 ## Repo Structure
 
 ```
 insight-wave/
-├── .claude-plugin/marketplace.json    Marketplace manifest (13 plugins)
+├── .claude-plugin/marketplace.json    Marketplace manifest (14 plugins)
 ├── cogni-{name}/                      Each plugin directory
 │   ├── .claude-plugin/plugin.json     Plugin manifest (name, version, description)
 │   ├── README.md                      Plugin documentation (IS/DOES/MEANS messaging)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # insight-wave
 
-Open-source plugins for consulting, sales, and marketing on [Claude Code](https://claude.ai/code). 13 Apache-2.0 plugins that automate the research-heavy, methodology-driven work behind B2B deliverables — trend scouting, portfolio positioning, sales pitches, content creation, visual production, website generation, knowledge management, and source verification.
+Open-source plugins for consulting, sales, and marketing on [Claude Code](https://claude.ai/code). 14 Apache-2.0 plugins that automate the research-heavy, methodology-driven work behind B2B deliverables — trend scouting, portfolio positioning, sales pitches, content creation, visual production, website generation, knowledge management, and source verification.
 
 Each plugin implements an established framework (Corporate Visions, Double Diamond, TIPS, IS/DOES/MEANS) rather than general-purpose text generation. Outputs include inline citations, structured data models, and quality gates. Every deliverable follows a reproducible methodology you can inspect and override.
 
@@ -241,7 +241,7 @@ Plugins follow the [Claude Code plugin standard](https://code.claude.com/docs/en
 | [cogni-help](cogni-help/README.md) | Platform | 7 | 1 | 12-course curriculum, plugin discovery, workflow templates, troubleshooting, and cheatsheets |
 | [cogni-workspace](cogni-workspace/README.md) | Platform | 9 | 0 | Shared foundation — env vars, MCP installation, theme management, plugin discovery, workspace health, Obsidian integration, bundled wiki |
 
-**99 skills, 76 agents** across the 13 active plugins.
+**99 skills, 76 agents** across the 14 active plugins.
 
 See [Cross-Plugin Data Flow](docs/er-diagram.md) for how data flows between plugins, or browse the [full documentation](docs/ecosystem-overview.md).
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Each plugin implements an established framework (Corporate Visions, Double Diamo
 
 ## What the plugins do
 
-13 plugins organized around nine capability areas. Each area handles a distinct part of the consulting-to-delivery workflow; plugins within an area share data formats and can be used independently or together.
+14 plugins organized around nine capability areas. Each area handles a distinct part of the consulting-to-delivery workflow; plugins within an area share data formats and can be used independently or together.
 
 ### Knowledge Management
 
@@ -189,7 +189,7 @@ The workplace combines Claude Code with [Obsidian](https://obsidian.md/) for per
 ```
 insight-wave/
 ├── .claude-plugin/
-│   └── marketplace.json                    # Marketplace manifest (13 plugins)
+│   └── marketplace.json                    # Marketplace manifest (14 plugins)
 ├── docs/                                   # User documentation
 │   ├── getting-started.md                  # Forwarder → workflows/install-to-infographic.md
 │   ├── ecosystem-overview.md               # Plugin landscape and data flow

--- a/cogni-projects/.claude-plugin/plugin.json
+++ b/cogni-projects/.claude-plugin/plugin.json
@@ -1,0 +1,21 @@
+{
+  "name": "cogni-projects",
+  "version": "0.0.1",
+  "description": "Partner-facing project-portfolio steering for consulting firms — models consultants, projects, and staffing so partners can match people to work by availability, profile fit, and strategic impact. Scaffolds a self-contained portfolio directory that later skills (staffing match, backfilling, partner-meeting dashboard) write into.",
+  "author": {
+    "name": "Stephan de Haas",
+    "email": "stephan@cogni-work.ai"
+  },
+  "license": "Apache-2.0",
+  "keywords": [
+    "projects",
+    "portfolio",
+    "staffing",
+    "consulting",
+    "project-portfolio",
+    "resource-management",
+    "partner-steering",
+    "consultants",
+    "assignments"
+  ]
+}

--- a/cogni-projects/CLAUDE.md
+++ b/cogni-projects/CLAUDE.md
@@ -1,0 +1,59 @@
+# cogni-projects
+
+Partner-facing project-portfolio steering for consulting firms. Models
+consultants, projects, and staffing so partners can match people to work by
+availability, profile fit, and strategic impact. This is the foundation
+scaffold — the data model and staffing engine land in later roadmap children.
+
+## Plugin Architecture
+
+```
+cogni-projects/
+├── .claude-plugin/plugin.json        Plugin manifest (name, version, description)
+├── README.md                         Plugin documentation (IS/DOES/MEANS messaging)
+├── CLAUDE.md                         This developer guide
+├── skills/
+│   └── projects-setup/SKILL.md       Initialize a portfolio directory (entry point)
+├── scripts/
+│   └── portfolio-init.sh             Idempotent portfolio scaffolder (stdlib-only)
+└── references/                       Schemas + framework docs (populated by later children)
+```
+
+Planned (not yet scaffolded — see the roadmap epic):
+
+- `skills/` for the staffing match engine, backfilling recommender, and the
+  partner-meeting dashboard.
+- `references/data-model.md` defining the consultant / project / assignment
+  entity schemas that `projects-portfolio.json` and its entity dirs hold.
+
+## Data Model
+
+A portfolio is one `cogni-projects/<portfolio-slug>/` directory:
+
+- `projects-portfolio.json` — root manifest. Holds portfolio identity (`slug`,
+  `name`, `language`, `created`, `updated`) plus the `consultants[]`,
+  `projects[]`, and `assignments[]` entity lists (empty at scaffold time) and a
+  `workflow_state` object.
+- `consultants/`, `projects/`, `assignments/` — per-entity record directories.
+- `.metadata/` — append-only logs (`execution-log.json`, `staffing-log.json`,
+  `decision-log.json`) later skills write to.
+
+## Conventions
+
+- **Scripts return JSON** `{"success": bool, "data": {...}, "error": "string"}`
+  and are stdlib-only (bash + python3, no pip). See `scripts/portfolio-init.sh`.
+- **Idempotency keys on the manifest**, not the bare directory: an interrupted
+  scaffold (dirs created, manifest never written) is repairable by re-running,
+  and a completed re-run returns `{"success": false}` "already initialized" and
+  exits 0 without overwriting anything.
+- **Manifest written last** so its existence is a reliable "fully initialized"
+  marker.
+- **Domain-prefixed skill names** — generic names (`setup`, `dashboard`,
+  `resume`) must carry the `projects-` prefix per repo convention (enforced by
+  `cogni-workspace/scripts/check-skill-names.sh`).
+
+## Dependencies
+
+| Plugin | Required | Purpose |
+|--------|----------|---------|
+| _(none yet)_ | — | Cross-plugin bridges to cogni-consult and cogni-portfolio are planned as later roadmap children. |

--- a/cogni-projects/README.md
+++ b/cogni-projects/README.md
@@ -1,0 +1,99 @@
+# cogni-projects
+
+> **Incubating** (v0.0.x) — skills, data formats, and workflows may change at any time.
+
+Partner project-portfolio steering for consulting firms on Claude Code. cogni-projects gives partners one place to model consultants, projects, and staffing — so they can match the right people to the right work by availability, profile fit, and strategic impact. This foundation release scaffolds the plugin and its portfolio entry point; the staffing engine and dashboards arrive in later releases.
+
+## Why this exists
+
+Consulting partners steer a portfolio of projects and people with spreadsheets and memory. Who is rolling off next month? Who fits this mandate? Which assignment moves the firm's strategy forward? Those questions have no shared home, so staffing decisions are ad hoc and hard to defend.
+
+| Problem | Consequence |
+|---------|-------------|
+| No shared model of consultants, projects, and assignments | Staffing lives in scattered spreadsheets and partners' heads |
+| Availability and fit are judged by recall | The best match is missed; benched people are overlooked |
+| Strategic impact is not weighed against availability | Staffing optimizes utilization, not firm strategy |
+
+## What it is
+
+cogni-projects is a Claude Code plugin that holds a **self-contained project portfolio**: a directory of consultants, projects, and assignments rooted by a single manifest. It is the 14th plugin in the insight-wave ecosystem and the home for partner-facing portfolio steering.
+
+At this foundation stage it provides the plugin skeleton and the `projects-setup` skill that scaffolds a portfolio directory. Staffing, backfilling, and partner-meeting views build on top of it.
+
+## What it does
+
+- **projects-setup** — initialize a new portfolio directory (`cogni-projects/<portfolio-slug>/`) with a root manifest and metadata logs. Idempotent: re-running never overwrites an existing portfolio.
+
+_More skills (staffing match engine, backfilling recommender, partner-meeting dashboard) land in later roadmap releases._
+
+## What it means for you
+
+You get one durable, browsable home for your project portfolio — the foundation every later staffing and steering capability writes into. Start a portfolio today; the engine that matches people to work plugs into the same directory as it ships.
+
+## Installation
+
+Install the insight-wave marketplace, then enable `cogni-projects` from the plugin list. The plugin follows the standard Claude Code plugin layout and requires no external dependencies.
+
+## Quick start
+
+```
+/cogni-projects:projects-setup
+```
+
+Answer the two prompts (portfolio name and slug) and cogni-projects scaffolds the portfolio directory.
+
+## Try it
+
+Initialize a demo portfolio:
+
+```
+/cogni-projects:projects-setup
+```
+
+Name it "Demo Advisory", accept the derived slug `demo-advisory`, and confirm. You will get a `cogni-projects/demo-advisory/` directory with a `projects-portfolio.json` manifest and a `.metadata/` log directory. Run it again — it reports the portfolio is already initialized and changes nothing.
+
+## Data model
+
+A portfolio is one directory:
+
+```
+cogni-projects/<portfolio-slug>/
+├── projects-portfolio.json    Root manifest (identity + consultants/projects/assignments lists)
+├── consultants/               Consultant entity records
+├── projects/                  Project entity records
+├── assignments/               Assignment records
+└── .metadata/                 Append-only logs (execution, staffing, decisions)
+```
+
+The manifest holds portfolio identity (`slug`, `name`, `language`, timestamps) plus the `consultants[]`, `projects[]`, and `assignments[]` lists that later skills populate.
+
+## How it works
+
+`projects-setup` gathers the portfolio name and slug, confirms the target directory, then runs `scripts/portfolio-init.sh` — a stdlib-only scaffolder that creates the directory skeleton and writes the `projects-portfolio.json` manifest last, so the manifest's existence marks a completed init. Re-running is safe: the script detects the manifest and returns a clean "already initialized" no-op without overwriting anything.
+
+## Components
+
+| Type | Name | Purpose |
+|------|------|---------|
+| Skill | `projects-setup` | Initialize a portfolio directory |
+| Script | `portfolio-init.sh` | Idempotent portfolio scaffolder |
+
+## Architecture
+
+cogni-projects is standalone at this stage. Its portfolio directory is designed as the shared substrate for later skills (staffing match, backfilling, dashboard) and for planned cross-plugin bridges to cogni-consult and cogni-portfolio.
+
+## Dependencies
+
+None. Later roadmap children introduce optional bridges to other insight-wave plugins.
+
+## Custom development
+
+The plugin follows the insight-wave conventions documented in `CLAUDE.md`: scripts return `{"success", "data", "error"}` JSON and are stdlib-only; skill names carry the `projects-` domain prefix; the portfolio manifest is the source of truth. Extend it by adding skills under `skills/` and scripts under `scripts/`.
+
+## License
+
+[Apache-2.0](../LICENSE) — see [CONTRIBUTING.md](../CONTRIBUTING.md) for contribution terms.
+
+---
+
+Built by [cogni-work](https://cogni-work.ai) — open-source tools for consulting intelligence.

--- a/cogni-projects/scripts/portfolio-init.sh
+++ b/cogni-projects/scripts/portfolio-init.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Create the cogni-projects portfolio directory skeleton + projects-portfolio.json.
+# Idempotent: re-run is safe; projects-portfolio.json existence is the completion marker.
+# Usage: bash portfolio-init.sh <portfolio-slug> <portfolio-name>
+# Output: JSON {"success": bool, "data": {...}, "error": "string"}
+
+set -euo pipefail
+
+SLUG="${1:?Usage: bash portfolio-init.sh <portfolio-slug> <portfolio-name>}"
+NAME="${2:?Usage: bash portfolio-init.sh <portfolio-slug> <portfolio-name>}"
+
+BASE_DIR="cogni-projects/${SLUG}"
+
+# Idempotency keys on the manifest, not the bare directory, so an interrupted
+# run (skeleton created, manifest never written) is repairable by re-running.
+# A re-run returns {"success": false, ... "already initialized"} and exits 0 —
+# a clean "nothing to do" signal, never an error state — and overwrites nothing.
+if [ -f "$BASE_DIR/projects-portfolio.json" ]; then
+  BASE_DIR="$BASE_DIR" python3 -c 'import json, os; print(json.dumps({"success": False, "data": {"path": os.environ["BASE_DIR"]}, "error": "portfolio already initialized (projects-portfolio.json exists)"}))'
+  exit 0
+fi
+
+mkdir -p "$BASE_DIR"/{consultants,projects,assignments,.metadata}
+
+SLUG="$SLUG" NAME="$NAME" BASE_DIR="$BASE_DIR" python3 - <<'PY'
+import json, os, datetime
+
+base = os.environ["BASE_DIR"]
+today = datetime.date.today().isoformat()
+
+# Seed the metadata logs before the manifest so a completed init always carries
+# the audit trail the later staffing/backfilling skills append to.
+for log, payload in [
+    ("execution-log.json", {"transitions": []}),
+    ("staffing-log.json", {"matches": []}),
+    ("decision-log.json", {"decisions": []}),
+]:
+    with open(os.path.join(base, ".metadata", log), "w") as f:
+        json.dump(payload, f, indent=2)
+        f.write("\n")
+
+# Root manifest written LAST: its existence marks a completed init (see the
+# idempotency check above). Entity arrays start empty — later children
+# (data model + entity-authoring, staffing match engine) populate them.
+project = {
+    "slug": os.environ["SLUG"],
+    "name": os.environ["NAME"],
+    "language": "en",
+    "consultants": [],
+    "projects": [],
+    "assignments": [],
+    "workflow_state": {"portfolio": "initialized"},
+    "plugin_refs": {},
+    "created": today,
+    "updated": today,
+}
+with open(os.path.join(base, "projects-portfolio.json"), "w") as f:
+    json.dump(project, f, indent=2, ensure_ascii=False)
+    f.write("\n")
+
+print(json.dumps({"success": True, "data": {"path": base, "slug": project["slug"]}, "error": ""}))
+PY

--- a/cogni-projects/skills/projects-setup/SKILL.md
+++ b/cogni-projects/skills/projects-setup/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: projects-setup
+description: |
+  This skill should be used when the user wants to start a new project-portfolio
+  for partner project-portfolio steering — cogni-projects models consultants,
+  projects, and staffing, so new portfolio work starts here. Trigger on: "set up
+  a projects portfolio", "start a project portfolio", "new cogni-projects
+  portfolio", "initialize project-portfolio steering", "create a staffing
+  portfolio", or any request to begin structured consultant/project/staffing
+  work — even if the user does not say "setup" explicitly.
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep
+---
+
+# Projects Setup
+
+Initialize a new cogni-projects portfolio: a self-contained directory holding
+consultants, projects, and assignments that later skills (staffing match,
+backfilling recommender, partner-meeting dashboard) read and write. This skill
+is the foundation entry point — run it once per portfolio before any staffing
+logic exists.
+
+## Core concept
+
+A **portfolio** is one `cogni-projects/<portfolio-slug>/` directory rooted by a
+`projects-portfolio.json` manifest. The manifest is the source of truth for the
+portfolio's identity and holds the (initially empty) `consultants[]`,
+`projects[]`, and `assignments[]` entity lists that downstream skills populate.
+A `.metadata/` directory carries the append-only logs those skills write to.
+
+Setup is **idempotent**: re-running against an already-initialized portfolio
+returns `{"success": false, ...}` with an "already initialized" message and
+never overwrites existing data.
+
+## Workflow
+
+### Step 1: Gather portfolio identity
+
+Determine two values from the user's request (ask only for what is missing):
+
+- **Portfolio name** — the human-readable label (e.g. "Nordic Advisory 2026").
+- **Portfolio slug** — a kebab-case identifier derived from the name (e.g.
+  `nordic-advisory-2026`). Derive it automatically from the name unless the user
+  supplies one.
+
+### Step 2: Confirm before writing
+
+Echo the resolved slug and name back to the user and confirm the target
+directory `cogni-projects/<slug>/` before running the init script.
+
+### Step 3: Scaffold the portfolio directory
+
+Run the init script (resolved against `CLAUDE_PLUGIN_ROOT`, with a plugin-cache
+fallback so it works whether the plugin is loaded locally or from cache):
+
+```bash
+bash "${CLAUDE_PLUGIN_ROOT:-$(ls -td "$HOME"/.claude/plugins/cache/*/cogni-projects/*/ 2>/dev/null | head -1)}/scripts/portfolio-init.sh" "<portfolio-slug>" "<portfolio-name>"
+```
+
+The script returns a single JSON line `{"success": bool, "data": {...},
+"error": "string"}`:
+
+- `success: true` — the portfolio was scaffolded. `data.path` is the new
+  directory; `data.slug` echoes the slug.
+- `success: false` with an "already initialized" error — the portfolio already
+  exists; nothing was changed. This is a clean no-op, not a failure.
+
+### Step 4: Summarize and point to next steps
+
+Report the created directory and outline what comes next: define the data model
+and author entities, then run the staffing match engine. Keep the summary short.
+
+## Output
+
+```
+cogni-projects/<portfolio-slug>/
+├── projects-portfolio.json    Root manifest (identity + consultants/projects/assignments)
+├── consultants/               Consultant entity records (populated later)
+├── projects/                  Project entity records (populated later)
+├── assignments/               Assignment records (populated later)
+└── .metadata/                 Append-only logs (execution, staffing, decisions)
+```


### PR DESCRIPTION
Closes #1112.

Phase 1 (foundation) of the cogni-projects roadmap (epic #1119) — the plugin skeleton and `projects-setup` entry point every later child (#1113, #1114) writes into.

## Summary
- Scaffold `cogni-projects/.claude-plugin/plugin.json` (name `cogni-projects`, version `0.0.1` → Incubating; mirrors the cogni-website manifest shape, no `maturity` field — maturity is version-derived).
- 16-section IS/DOES/MEANS `README.md` with the Incubating maturity callout after the H1 (license section links the repo-root `../LICENSE` / `../CONTRIBUTING.md` — no dangling per-plugin link), and a `CLAUDE.md` developer guide.
- Register cogni-projects in `.claude-plugin/marketplace.json`: new entry (`source ./cogni-projects`, `maturity: incubating`), `metadata.description` 13→14 ("14-plugin ecosystem"), `metadata.version` 1.0.3→1.0.4.
- Count self-consistency: bumped the stale "13-plugin"/"13 plugins" counts in the repo-root `CLAUDE.md` and `README.md` to 14.
- Domain-prefixed `projects-setup` skill running `scripts/portfolio-init.sh` to scaffold `cogni-projects/<portfolio-slug>/` with a root `projects-portfolio.json` manifest and a `.metadata/` dir.
- `portfolio-init.sh` follows the canonical `engagement-init.sh` contract: stdlib-only, `{success,data,error}` JSON envelope, idempotency keyed on the manifest, manifest written last.

## Scope decisions
- **In:** exactly the affected components satisfying all three ACs, plus the count self-consistency edits the refine pass surfaced.
- **Out (already filed as separate children):** the data model + entity-authoring skill (#1113) and the staffing match engine (#1114) — genuinely separable, so this scaffold closes fully on merge.
- **Not added (minimal framing):** per-plugin `LICENSE` / `CONTRIBUTING.md` — the repo-root Apache-2.0 LICENSE covers the monorepo; the README links it relatively to avoid a dangle.

## Test plan (verified locally)
- [x] `plugin.json` parses; `version` == `0.0.1`, no `maturity` field.
- [x] `marketplace.json` parses; `cogni-projects` entry with `maturity: incubating`; `metadata.description` says "14-plugin ecosystem"; `metadata.version` 1.0.4; 14 entries.
- [x] Repo-root `CLAUDE.md` / `README.md` show no residual "13-plugin"/"13 plugins" count.
- [x] `portfolio-init.sh <slug> <name>` → `{"success":true}`, creates `projects-portfolio.json` + `.metadata/`.
- [x] Re-run → `{"success":false}` "already initialized", exit 0, manifest checksum unchanged (no overwrite).
- [ ] `check-skill-names.sh` — passes for `projects-setup` (domain-prefixed); could not execute locally under macOS bash 3.2 (`declare -A`), runs clean under CI bash 4+.

Plan record: https://github.com/cogni-work/insight-wave/issues/1112#issuecomment-4999194621