### PR TITLE
cogni-projects: return the entity-script envelope on every path, resolve symlinks in the containment guard

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -270,7 +270,7 @@
     {
       "name": "cogni-projects",
       "source": "./cogni-projects",
-      "version": "0.0.4",
+      "version": "0.0.5",
       "maturity": "incubating",
       "description": "Partner-facing project-portfolio steering for consulting firms — models consultants, projects, and staffing so partners can match people to work by availability, profile fit, and strategic impact. Scaffolds a self-contained portfolio directory and authors the validated consultant, project, and assignment records that later skills (staffing match, backfilling, partner-meeting dashboard) read from.",
       "keywords": [

--- a/cogni-projects/.claude-plugin/plugin.json
+++ b/cogni-projects/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-projects",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Partner-facing project-portfolio steering for consulting firms — models consultants, projects, and staffing so partners can match people to work by availability, profile fit, and strategic impact. Scaffolds a self-contained portfolio directory and authors the validated consultant, project, and assignment records that later skills (staffing match, backfilling, partner-meeting dashboard) read from.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-projects/references/data-model.md
+++ b/cogni-projects/references/data-model.md
@@ -10,7 +10,7 @@ the later staffing-match / backfilling / dashboard skills.
 Partners author these records manually (no external system dependency in the
 MVP), so the schema is deliberately flat and human-writable.
 
-## Portfolio layout
+## Portfolio Layout
 
 A portfolio is one `cogni-projects/<portfolio-slug>/` directory rooted by a
 `projects-portfolio.json` manifest (scaffolded by `projects-setup`):
@@ -27,7 +27,7 @@ cogni-projects/<portfolio-slug>/
 Each entity lives in one markdown file under its type's subdirectory. The file's
 subdirectory determines its type, and the frontmatter `type` field must agree.
 
-## Frontmatter conventions
+## Frontmatter Conventions
 
 - Frontmatter is a leading `---` … `---` fence at the top of the file.
 - Values are **flat**: scalars, ISO dates (`YYYY-MM-DD`), integers, and simple
@@ -180,7 +180,7 @@ Valid `status` values:
 
 ---
 
-## Naming conventions
+## Naming Conventions
 
 | Entity | Slug shape | Example |
 |--------|-----------|---------|
@@ -191,7 +191,7 @@ Valid `status` values:
 The `--` double-hyphen separator in assignment slugs makes the join legible and
 keeps one assignment per consultant-project pair addressable by a stable slug.
 
-## Manifest registration
+## Manifest Registration
 
 When `projects-entities` authors an entity, `scripts/register-entity.py
 <portfolio-dir> <entity-file>` upserts a **summary ref** into the matching array
@@ -218,7 +218,7 @@ The entity markdown file is the source of truth for full field values; the
 manifest ref is the index the dashboard and staffing skills scan without opening
 every file.
 
-## Entity relationships
+## Entity Relationships
 
 ```mermaid
 erDiagram

--- a/cogni-projects/scripts/register-entity.py
+++ b/cogni-projects/scripts/register-entity.py
@@ -112,7 +112,10 @@ def main(argv):
     ref = {key: str(fm[key]) for key in REF_FIELDS[entity_type]}
     # The ref points at the entity file relative to the portfolio root, so the
     # dashboard and staffing skills can resolve it without knowing the cwd.
-    rel = os.path.relpath(os.path.abspath(entity_file), os.path.abspath(portfolio_dir))
+    # realpath, not abspath: abspath leaves symlinks unresolved, so an entity
+    # reached through a symlinked directory would clear the check below while
+    # still resolving outside the root.
+    rel = os.path.relpath(os.path.realpath(entity_file), os.path.realpath(portfolio_dir))
     # Refuse an entity that lives outside the target portfolio. Validation cannot
     # catch this — a foreign entity file is itself perfectly valid — but the ref
     # would escape the root, and consumers resolve `file` relative to it, so one
@@ -194,4 +197,11 @@ def main(argv):
 
 
 if __name__ == "__main__":
-    sys.exit(main(sys.argv[1:]))
+    # Same envelope contract as validate-entities.py: this script also writes,
+    # so a hand-edited manifest of the wrong shape must report as a failure the
+    # caller can read rather than a traceback mid-write.
+    try:
+        _code = main(sys.argv[1:])
+    except Exception as _exc:  # noqa: BLE001 — deliberate catch-all
+        _code = _fail("unexpected failure: %s: %s" % (type(_exc).__name__, _exc))
+    sys.exit(_code)

--- a/cogni-projects/scripts/validate-entities.py
+++ b/cogni-projects/scripts/validate-entities.py
@@ -233,6 +233,12 @@ def validate_file(filepath):
     except OSError as exc:
         err("<file>", "cannot read file: %s" % exc)
         return errors, warnings
+    except UnicodeDecodeError as exc:
+        # Entity records are UTF-8 by contract, but a record saved as latin-1
+        # (a DACH name is the usual way in) would otherwise raise past the
+        # envelope every other path returns.
+        err("<file>", "cannot decode file as UTF-8 — re-save it as UTF-8: %s" % exc)
+        return errors, warnings
 
     fm = parse_frontmatter(text)
     if fm is None:
@@ -361,7 +367,20 @@ def main(argv):
 
     errors, warnings = [], []
     for f in all_files:
-        e, w = validate_file(f)
+        # Report an unexpected failure as an ordinary per-field error rather
+        # than raising: one unreadable record must not abort the scan and hide
+        # every valid entity behind it, and callers gate registration on this
+        # envelope.
+        try:
+            e, w = validate_file(f)
+        except Exception as exc:  # noqa: BLE001 — the envelope is the contract
+            e, w = [{
+                "entity": "unknown",
+                "file": f,
+                "field": "<file>",
+                "message": "unexpected failure while validating: %s: %s"
+                           % (type(exc).__name__, exc),
+            }], []
         errors.extend(e)
         warnings.extend(w)
 
@@ -379,4 +398,16 @@ def main(argv):
 
 
 if __name__ == "__main__":
-    sys.exit(main(sys.argv[1:]))
+    # The envelope is the contract on every path, so nothing may escape as a
+    # traceback — not argument handling, not directory walking, not manifest
+    # I/O. Callers gate registration on parsing this, and a traceback on stderr
+    # reads to them as neither success nor a reportable failure.
+    try:
+        _code = main(sys.argv[1:])
+    except Exception as _exc:  # noqa: BLE001 — deliberate catch-all
+        print(json.dumps({
+            "success": False, "data": {"errors": [], "warnings": []},
+            "error": "unexpected failure: %s: %s" % (type(_exc).__name__, _exc),
+        }, ensure_ascii=False))
+        _code = 2
+    sys.exit(_code)

--- a/cogni-projects/skills/projects-entities/SKILL.md
+++ b/cogni-projects/skills/projects-entities/SKILL.md
@@ -20,7 +20,7 @@ partner-meeting dashboard all read from — every entity authored here is a row
 those later skills reason over.
 
 Entities are Obsidian-browsable markdown files with YAML frontmatter. The full
-field contract lives in [`references/data-model.md`](../../references/data-model.md);
+field contract lives in [`../../references/data-model.md`](../../references/data-model.md);
 read it before authoring so the frontmatter matches what `validate-entities.py`
 enforces.
 
@@ -54,8 +54,7 @@ initialized portfolio, it does not scaffold one.
 ### Step 2: Determine the entity type and gather fields
 
 Decide whether the user is authoring a **consultant**, **project**, or
-**assignment**, then gather the required fields for that type from
-[`../../references/data-model.md`](../../references/data-model.md) (ask only for
+**assignment**, then gather the required fields for that type (ask only for
 what is missing):
 
 Every entity, whatever its type, additionally requires `type` — which must match


### PR DESCRIPTION
Follow-up to the merged #1121. The review gate on that PR ran against its final head and surfaced findings after the merge had already been decided, so they land here instead. The substantive one is a live bug in `main`.

## Why this exists

Issue #1113 AC3 requires the entity scripts to return the `{success, data, error}` envelope on **every** path — "never a bare traceback or non-JSON stderr-only output". Three paths in `main` still break that contract. Each is reproduced below, and each is fixed here.

## Summary

- **Non-UTF-8 entity record crashed the validator** (`validate-entities.py`). `except OSError` does not catch `UnicodeDecodeError` (a `ValueError` subclass), so a record saved as latin-1 escaped the envelope and printed a bare traceback. A DACH name is the usual way in — the repo's CLAUDE.md mandates ä/ö/ü/ß support, so this is a realistic record, not a contrived fixture. Worse, in a whole-portfolio scan the first such record **aborted the run**, hiding every valid entity behind it.
- **Unreadable entity directory crashed the validator.** The directory walk sat outside any guard, so `chmod 000` on `consultants/` raised `PermissionError` past the envelope — the same class of filesystem failure the per-read catch addresses.
- **Corrupt manifest crashed the registrar** (`register-entity.py`). A `projects-portfolio.json` hand-edited to the wrong shape raised `AttributeError` mid-write, past the envelope, from the script that performs the writes.
- **Containment guard was symlink-blind.** The out-of-portfolio check resolved with `os.path.abspath`, which leaves symlinks unresolved, so an entity reached through a symlinked directory cleared the guard while still resolving outside the root — precisely the cross-portfolio ref-escape the guard exists to prevent. Now resolves with `realpath`.
- Cosmetic, from the same review: title-case the five remaining `data-model.md` H2s to match the sibling convention in cogni-portfolio / cogni-trends / cogni-consult, and drop a redundant data-model link from the skill's Step 2 lead sentence.
- Patch-bump `cogni-projects` 0.0.4 -> 0.0.5, mirrored in `marketplace.json`.

## Design note

The fix is deliberately at two levels rather than one. The narrow catch stays in `validate_file()` because `register-entity.py` calls it as a **library function**, bypassing `main()` — and because it yields an actionable message ("re-save it as UTF-8") that a generic top-level catch cannot. The top-level guard in each script's `__main__` dispatch is what actually makes "envelope on every path" true, covering argument handling, directory walking, and manifest I/O. The scan-loop guard is kept for a distinct reason a top-level guard cannot serve: it lets the scan **continue** past a bad record so one file no longer suppresses the rest.

## Verification

Every path re-checked on this branch; all return parseable JSON.

| Case | Before | After |
|---|---|---|
| valid entity | `{"success": true}` | `{"success": true}` rc=0 |
| latin-1 entity | **bare traceback** rc=1 | envelope, per-field `<file>` error rc=1 |
| portfolio scan (1 bad + 1 good) | **traceback, scan aborted** | envelope, `checked: 2` — good entity reported rc=1 |
| unreadable directory | **PermissionError traceback** | envelope rc=2 |
| corrupt manifest | **AttributeError traceback** | envelope rc=2 |
| symlink escape | silently **registered** | refused rc=2 |
| register valid / idempotent re-run | ok | `created` -> `updated`, array stays length 1 rc=0 |

- `python3 -m py_compile` passes on both scripts; stdlib-only preserved (no pyyaml or any pip import).
- `scripts/check-breadcrumbs.py` passes.
- Both manifests parse and mirror 0.0.5; maturity stays `incubating` for the 0.0.x band; the em dash remains genuine UTF-8 (no escapes).

## Scope

README regeneration remains deferred to the cogni-docs pipeline, as declared in #1121.

🤖 Generated with [Claude Code](https://claude.com/claude-code)