### PR TITLE
cogni-projects: partner-meeting portfolio dashboard (health + value)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -272,7 +272,7 @@
       "source": "./cogni-projects",
       "version": "0.0.8",
       "maturity": "incubating",
-      "description": "Partner-facing project-portfolio steering for consulting firms — models consultants, projects, and staffing so partners can match people to work by availability, profile fit, and strategic impact. Scaffolds a self-contained portfolio directory and authors the validated consultant, project, and assignment records that later skills (staffing match, backfilling, partner-meeting dashboard) read from.",
+      "description": "Partner-facing project-portfolio steering for consulting firms — models consultants, projects, and staffing so partners can match people to work by availability, profile fit, and strategic impact. Scaffolds a self-contained portfolio directory, authors the validated consultant, project, and assignment records, and renders a read-only partner-meeting dashboard over them, so later skills (staffing match, backfilling) build on the same portfolio.",
       "keywords": [
         "projects",
         "portfolio",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -270,7 +270,7 @@
     {
       "name": "cogni-projects",
       "source": "./cogni-projects",
-      "version": "0.0.7",
+      "version": "0.0.8",
       "maturity": "incubating",
       "description": "Partner-facing project-portfolio steering for consulting firms — models consultants, projects, and staffing so partners can match people to work by availability, profile fit, and strategic impact. Scaffolds a self-contained portfolio directory and authors the validated consultant, project, and assignment records that later skills (staffing match, backfilling, partner-meeting dashboard) read from.",
       "keywords": [

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -270,7 +270,7 @@
     {
       "name": "cogni-projects",
       "source": "./cogni-projects",
-      "version": "0.0.5",
+      "version": "0.0.7",
       "maturity": "incubating",
       "description": "Partner-facing project-portfolio steering for consulting firms — models consultants, projects, and staffing so partners can match people to work by availability, profile fit, and strategic impact. Scaffolds a self-contained portfolio directory and authors the validated consultant, project, and assignment records that later skills (staffing match, backfilling, partner-meeting dashboard) read from.",
       "keywords": [

--- a/cogni-projects/.claude-plugin/plugin.json
+++ b/cogni-projects/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-projects",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Partner-facing project-portfolio steering for consulting firms — models consultants, projects, and staffing so partners can match people to work by availability, profile fit, and strategic impact. Scaffolds a self-contained portfolio directory and authors the validated consultant, project, and assignment records that later skills (staffing match, backfilling, partner-meeting dashboard) read from.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-projects/.claude-plugin/plugin.json
+++ b/cogni-projects/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-projects",
-  "version": "0.0.5",
+  "version": "0.0.7",
   "description": "Partner-facing project-portfolio steering for consulting firms — models consultants, projects, and staffing so partners can match people to work by availability, profile fit, and strategic impact. Scaffolds a self-contained portfolio directory and authors the validated consultant, project, and assignment records that later skills (staffing match, backfilling, partner-meeting dashboard) read from.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-projects/.claude-plugin/plugin.json
+++ b/cogni-projects/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cogni-projects",
   "version": "0.0.8",
-  "description": "Partner-facing project-portfolio steering for consulting firms — models consultants, projects, and staffing so partners can match people to work by availability, profile fit, and strategic impact. Scaffolds a self-contained portfolio directory and authors the validated consultant, project, and assignment records that later skills (staffing match, backfilling, partner-meeting dashboard) read from.",
+  "description": "Partner-facing project-portfolio steering for consulting firms — models consultants, projects, and staffing so partners can match people to work by availability, profile fit, and strategic impact. Scaffolds a self-contained portfolio directory, authors the validated consultant, project, and assignment records, and renders a read-only partner-meeting dashboard over them, so later skills (staffing match, backfilling) build on the same portfolio.",
   "author": {
     "name": "Stephan de Haas",
     "email": "stephan@cogni-work.ai"

--- a/cogni-projects/CLAUDE.md
+++ b/cogni-projects/CLAUDE.md
@@ -2,9 +2,9 @@
 
 Partner-facing project-portfolio steering for consulting firms. Models
 consultants, projects, and staffing so partners can match people to work by
-availability, profile fit, and strategic impact. The data model and entity
-authoring have landed; the staffing engine and the skills that read these
-entities arrive in later roadmap children.
+availability, profile fit, and strategic impact. The data model, entity
+authoring, and the read-only portfolio dashboard have landed; the staffing
+engine and backfilling recommender arrive in later roadmap children.
 
 ## Plugin Architecture
 

--- a/cogni-projects/CLAUDE.md
+++ b/cogni-projects/CLAUDE.md
@@ -15,19 +15,22 @@ cogni-projects/
 ├── CLAUDE.md                         This developer guide
 ├── skills/
 │   ├── projects-setup/SKILL.md       Initialize a portfolio directory (entry point)
-│   └── projects-entities/SKILL.md    Author + register one consultant/project/assignment
+│   ├── projects-entities/SKILL.md    Author + register one consultant/project/assignment
+│   └── projects-dashboard/SKILL.md   Render a partner-meeting portfolio dashboard (read-only)
 ├── scripts/
 │   ├── portfolio-init.sh             Idempotent portfolio scaffolder (stdlib-only)
 │   ├── validate-entities.py          Entity frontmatter validator (stdlib-only)
-│   └── register-entity.py            Slug-keyed manifest upsert + execution-log append
+│   ├── register-entity.py            Slug-keyed manifest upsert + execution-log append
+│   └── render-dashboard.py           Portfolio health + value HTML render (read-only, stdlib-only)
+├── tests/
+│   └── test-render-dashboard.sh      Dashboard render regression test (stdlib-only)
 └── references/
     └── data-model.md                 Consultant / project / assignment entity schemas
 ```
 
 Planned (not yet scaffolded — see the roadmap epic):
 
-- `skills/` for the staffing match engine, backfilling recommender, and the
-  partner-meeting dashboard.
+- `skills/` for the staffing match engine and backfilling recommender.
 
 ## Data Model
 

--- a/cogni-projects/README.md
+++ b/cogni-projects/README.md
@@ -2,7 +2,7 @@
 
 > **Incubating** (v0.0.x) — skills, data formats, and workflows may change at any time.
 
-Partner project-portfolio steering for consulting firms on Claude Code. cogni-projects gives partners one place to model consultants, projects, and staffing — so they can match the right people to the right work by availability, profile fit, and strategic impact. This foundation release scaffolds the plugin and its portfolio entry point; the staffing engine and dashboards arrive in later releases.
+Partner project-portfolio steering for consulting firms on Claude Code. cogni-projects gives partners one place to model consultants, projects, and staffing — so they can match the right people to the right work by availability, profile fit, and strategic impact. The data model, entity authoring, and a read-only partner-meeting dashboard have landed; the staffing match engine and backfilling recommender arrive in later releases.
 
 ## Why this exists
 
@@ -18,13 +18,15 @@ Consulting partners steer a portfolio of projects and people with spreadsheets a
 
 cogni-projects is a Claude Code plugin that holds a **self-contained project portfolio**: a directory of consultants, projects, and assignments rooted by a single manifest. It is the 14th plugin in the insight-wave ecosystem and the home for partner-facing portfolio steering.
 
-At this foundation stage it provides the plugin skeleton and the `projects-setup` skill that scaffolds a portfolio directory. Staffing, backfilling, and partner-meeting views build on top of it.
+It provides the `projects-setup` skill that scaffolds a portfolio directory, the `projects-entities` skill that authors consultant/project/assignment records, and the read-only `projects-dashboard` skill that renders a partner-meeting portfolio snapshot. Staffing match and backfilling build on top of these.
 
 ## What it does
 
 - **projects-setup** — initialize a new portfolio directory (`cogni-projects/<portfolio-slug>/`) with a root manifest and metadata logs. Idempotent: re-running never overwrites an existing portfolio.
+- **projects-entities** — author and register consultant, project, and assignment records into the portfolio — the entities later staffing scores over.
+- **projects-dashboard** — render a read-only partner-meeting snapshot of the portfolio: staffing coverage per project, at-risk projects, and portfolio value by strategic impact.
 
-_More skills (staffing match engine, backfilling recommender, partner-meeting dashboard) land in later roadmap releases._
+_More skills (staffing match engine, backfilling recommender) land in later roadmap releases._
 
 ## What it means for you
 
@@ -76,11 +78,16 @@ The manifest holds portfolio identity (`slug`, `name`, `language`, timestamps) p
 | Type | Name | Purpose |
 |------|------|---------|
 | Skill | `projects-setup` | Initialize a portfolio directory |
+| Skill | `projects-entities` | Author and register consultant/project/assignment records |
+| Skill | `projects-dashboard` | Render a read-only partner-meeting portfolio snapshot |
 | Script | `portfolio-init.sh` | Idempotent portfolio scaffolder |
+| Script | `register-entity.py` | Atomic entity register into the portfolio manifest |
+| Script | `validate-entities.py` | Validate entity records against the data model |
+| Script | `render-dashboard.py` | Render the portfolio dashboard HTML from entity data |
 
 ## Architecture
 
-cogni-projects is standalone at this stage. Its portfolio directory is designed as the shared substrate for later skills (staffing match, backfilling, dashboard) and for planned cross-plugin bridges to cogni-consult and cogni-portfolio.
+cogni-projects is standalone at this stage. Its portfolio directory is designed as the shared substrate for later skills (staffing match, backfilling) and for planned cross-plugin bridges to cogni-consult and cogni-portfolio.
 
 ## Dependencies
 

--- a/cogni-projects/scripts/render-dashboard.py
+++ b/cogni-projects/scripts/render-dashboard.py
@@ -1,0 +1,427 @@
+#!/usr/bin/env python3
+"""Render a partner-meeting portfolio dashboard from a cogni-projects portfolio.
+
+Reads projects-portfolio.json to confirm the portfolio, then opens and parses
+every consultant / project / assignment entity's frontmatter to compute:
+  - per-project staffing coverage (open_roles filled vs still open) + a health flag,
+  - an aggregate portfolio value summary grouped by strategic_impact (1..5),
+  - a simple consultant-utilization aggregate.
+Writes a self-contained HTML dashboard to <portfolio-dir>/output/dashboard.html.
+
+Read-only: never writes projects-portfolio.json (register-entity.py is its only
+writer) and never appends to .metadata/. Degrades gracefully — a missing or
+malformed entity field yields a partial snapshot with a surfaced warning, never
+a hard failure (AC-3).
+
+Stdlib-only (no PyYAML). Reuses validate-entities.py's parse_frontmatter and
+_entity_files by file-path load rather than re-implementing a parser or a
+directory walk — the same idiom register-entity.py uses.
+
+Usage:
+  python3 render-dashboard.py <portfolio-dir> [--design-variables <path.json>]
+
+Output: a single JSON line following the repo contract
+  {"success": bool, "data": {...}, "error": str}
+Exit: 0 ok / 2 usage or environment failure.
+"""
+
+import argparse
+import datetime
+import html
+import importlib.util
+import json
+import os
+import sys
+
+# validate-entities.py is not an importable module name (hyphens), so load it by
+# file location and reuse its parser + entity-file discovery — the same idiom
+# register-entity.py uses, so the dashboard reads exactly the shape the
+# validator enforces rather than duplicating (and drifting from) those rules.
+_v_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "validate-entities.py")
+_spec = importlib.util.spec_from_file_location("validate_entities", _v_path)
+if _spec is None or _spec.loader is None:
+    print(json.dumps({
+        "success": False, "data": {},
+        "error": "cannot load validator module: %s" % _v_path,
+    }))
+    sys.exit(2)
+_ve = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_ve)
+
+
+# The built-in palette. The dashboard renders with this whenever no
+# --design-variables file is supplied, so the script never depends on
+# cogni-workspace:pick-theme; a themed override is a purely optional flag.
+DEFAULT_THEME = {
+    "theme_name": "cogni-work",
+    "bg": "#0f1419",
+    "surface": "#1a2028",
+    "surface2": "#232b35",
+    "text": "#e6edf3",
+    "muted": "#9aa7b4",
+    "accent": "#4f9cf9",
+    "ok": "#3fb950",
+    "warn": "#d29922",
+    "risk": "#f85149",
+    "border": "#2d333b",
+    "font": "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif",
+}
+
+# The status values that count an assignment as actively covering a role. A
+# completed assignment no longer staffs an open role.
+ACTIVE_ASSIGNMENT_STATES = ("planned", "active")
+
+
+def _load_theme(path):
+    """Return the theme dict. Falls back to DEFAULT_THEME on any read problem.
+
+    Theming is a nicety, never a hard dependency: a missing or malformed
+    --design-variables file must not fail the render, only fall back.
+    """
+    if not path:
+        return dict(DEFAULT_THEME), None
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            overrides = json.load(f)
+    except (OSError, ValueError) as exc:
+        return dict(DEFAULT_THEME), "design-variables ignored (%s): %s" % (path, exc)
+    theme = dict(DEFAULT_THEME)
+    if isinstance(overrides, dict):
+        # Accept both a flat {key: value} map and a nested {"colors": {...}} one.
+        for src in (overrides, overrides.get("colors", {})):
+            if isinstance(src, dict):
+                for key, value in src.items():
+                    if key in theme and isinstance(value, str):
+                        theme[key] = value
+    return theme, None
+
+
+def _read_entities(portfolio_dir):
+    """Parse every entity file into type-keyed lists, collecting warnings.
+
+    Returns (entities, warnings) where entities is
+    {"consultant": [...], "project": [...], "assignment": [...]} of frontmatter
+    dicts. A file that cannot be read or has no frontmatter is recorded as a
+    warning and skipped — the rest of the portfolio still renders (AC-3).
+    """
+    entities = {"consultant": [], "project": [], "assignment": []}
+    warnings = []
+    for path in _ve._entity_files(portfolio_dir):
+        rel = os.path.relpath(path, portfolio_dir)
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                fm = _ve.parse_frontmatter(f.read())
+        except OSError as exc:
+            warnings.append("cannot read %s: %s" % (rel, exc))
+            continue
+        if not fm:
+            warnings.append("no frontmatter in %s — skipped" % rel)
+            continue
+        etype = fm.get("type")
+        if etype not in entities:
+            warnings.append("unknown entity type %r in %s — skipped" % (etype, rel))
+            continue
+        fm["_file"] = rel
+        entities[etype].append(fm)
+    return entities, warnings
+
+
+def _coerce_impact(value, project_label, warnings):
+    """Return strategic_impact as an int 1..5, or None with a warning."""
+    if value is None:
+        warnings.append("%s has no strategic_impact — omitted from the value summary" % project_label)
+        return None
+    try:
+        impact = int(str(value).strip())
+    except (TypeError, ValueError):
+        warnings.append("%s has a non-numeric strategic_impact %r — omitted from the value summary" % (project_label, value))
+        return None
+    if not 1 <= impact <= 5:
+        warnings.append("%s strategic_impact %d is outside 1..5 — omitted from the value summary" % (project_label, impact))
+        return None
+    return impact
+
+
+def _project_health(filled, total, status):
+    """Map (roles filled, roles total, project status) to (label, severity)."""
+    if status == "closed":
+        return ("closed", "muted")
+    if total == 0:
+        return ("no open roles", "ok")
+    if filled >= total:
+        return ("fully staffed", "ok")
+    if filled == 0 and status == "active":
+        return ("unstaffed", "risk")
+    return ("%d/%d roles open" % (total - filled, total), "warn")
+
+
+def _compute(entities, warnings):
+    """Derive per-project staffing + the portfolio value/utilization aggregates.
+
+    Fill status is derived, not stored: for a project's open_roles list, a role
+    is "filled" when some planned/active assignment for that project carries a
+    matching role label. Role labels are free strings, so a label an assignment
+    names that no open_roles entry matches is surfaced as a warning rather than
+    silently changing the counts (AC-3).
+    """
+    assignments = entities["assignment"]
+    projects_out = []
+    value_by_impact = {i: 0 for i in range(1, 6)}
+
+    for proj in sorted(entities["project"], key=lambda p: str(p.get("name") or p.get("slug") or "")):
+        slug = proj.get("slug")
+        label = "project %s" % (proj.get("name") or slug or "(unnamed)")
+        open_roles = proj.get("open_roles") or []
+        if not isinstance(open_roles, list):
+            open_roles = [open_roles]
+        status = (proj.get("status") or "").strip()
+
+        covered = set()
+        for a in assignments:
+            if a.get("project") == slug and (a.get("status") or "").strip() in ACTIVE_ASSIGNMENT_STATES:
+                role = a.get("role")
+                if role:
+                    covered.add(role)
+        # An assignment role that matches no listed open role may be a label
+        # mismatch (erp-lead vs "ERP Lead") — flag it, don't hard-fail.
+        for role in sorted(covered):
+            if open_roles and role not in open_roles:
+                warnings.append(
+                    "%s: assignment role %r matches no open_roles label — possible label mismatch" % (label, role)
+                )
+        filled = [r for r in open_roles if r in covered]
+        health_label, health_sev = _project_health(len(filled), len(open_roles), status)
+
+        impact = _coerce_impact(proj.get("strategic_impact"), label, warnings)
+        if impact is not None:
+            value_by_impact[impact] += 1
+
+        projects_out.append({
+            "name": proj.get("name") or slug or "(unnamed)",
+            "client": proj.get("client") or "",
+            "status": status or "unknown",
+            "impact": impact,
+            "roles_total": len(open_roles),
+            "roles_filled": len(filled),
+            "open_roles": [r for r in open_roles if r not in covered],
+            "health_label": health_label,
+            "health_sev": health_sev,
+        })
+
+    # Utilization: a simple average of consultant allocation_pct, plus a count of
+    # consultants at or above 100%. Richer heuristics are out of scope.
+    allocations = []
+    for c in entities["consultant"]:
+        raw = c.get("allocation_pct")
+        if raw is None:
+            continue
+        try:
+            allocations.append(int(str(raw).strip()))
+        except (TypeError, ValueError):
+            warnings.append("consultant %s has a non-numeric allocation_pct %r — omitted from utilization" % (c.get("slug") or "(unknown)", raw))
+    util = {
+        "consultants": len(entities["consultant"]),
+        "with_allocation": len(allocations),
+        "avg_allocation": round(sum(allocations) / len(allocations)) if allocations else None,
+        "fully_allocated": sum(1 for a in allocations if a >= 100),
+    }
+
+    return projects_out, value_by_impact, util
+
+
+def _esc(value):
+    return html.escape(str(value), quote=True)
+
+
+def _render_html(portfolio, projects, value_by_impact, util, warnings, theme):
+    t = theme
+    generated = datetime.date.today().isoformat()
+    sev_color = {"ok": t["ok"], "warn": t["warn"], "risk": t["risk"], "muted": t["muted"]}
+
+    rows = []
+    for p in projects:
+        impact = "—" if p["impact"] is None else ("★" * p["impact"])
+        coverage = "%d/%d" % (p["roles_filled"], p["roles_total"]) if p["roles_total"] else "—"
+        open_roles = ", ".join(_esc(r) for r in p["open_roles"]) if p["open_roles"] else "—"
+        rows.append(
+            "<tr>"
+            "<td><strong>%s</strong><div class='sub'>%s</div></td>"
+            "<td>%s</td>"
+            "<td>%s</td>"
+            "<td>%s</td>"
+            "<td>%s</td>"
+            "<td><span class='flag' style='color:%s'>%s</span></td>"
+            "</tr>" % (
+                _esc(p["name"]), _esc(p["client"]),
+                _esc(p["status"]), impact, coverage, open_roles,
+                sev_color.get(p["health_sev"], t["text"]), _esc(p["health_label"]),
+            )
+        )
+
+    value_rows = []
+    for impact in range(5, 0, -1):
+        count = value_by_impact.get(impact, 0)
+        bar = "█" * count
+        value_rows.append(
+            "<tr><td>%s</td><td>%d</td><td class='bar'>%s</td></tr>"
+            % ("★" * impact, count, bar)
+        )
+
+    warn_block = ""
+    if warnings:
+        items = "".join("<li>%s</li>" % _esc(w) for w in warnings)
+        warn_block = (
+            "<section class='card warnings'><h2>Warnings — partial snapshot "
+            "(%d)</h2><ul>%s</ul></section>" % (len(warnings), items)
+        )
+
+    avg = "—" if util["avg_allocation"] is None else "%d%%" % util["avg_allocation"]
+    total_open = sum(p["roles_total"] - p["roles_filled"] for p in projects)
+
+    return """<!DOCTYPE html>
+<html lang="en"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Portfolio dashboard — {name}</title>
+<style>
+  :root {{ color-scheme: dark; }}
+  * {{ box-sizing: border-box; }}
+  body {{ margin: 0; background: {bg}; color: {text}; font-family: {font}; line-height: 1.5; }}
+  .wrap {{ max-width: 1040px; margin: 0 auto; padding: 32px 20px 64px; }}
+  header h1 {{ margin: 0 0 4px; font-size: 1.6rem; }}
+  header .meta {{ color: {muted}; font-size: 0.9rem; }}
+  .tiles {{ display: flex; flex-wrap: wrap; gap: 14px; margin: 22px 0; }}
+  .tile {{ flex: 1 1 150px; background: {surface}; border: 1px solid {border};
+           border-radius: 10px; padding: 16px; }}
+  .tile .n {{ font-size: 1.8rem; font-weight: 700; }}
+  .tile .l {{ color: {muted}; font-size: 0.82rem; text-transform: uppercase; letter-spacing: 0.04em; }}
+  .card {{ background: {surface}; border: 1px solid {border}; border-radius: 10px;
+           padding: 18px 20px; margin: 18px 0; overflow-x: auto; }}
+  .card h2 {{ margin: 0 0 12px; font-size: 1.05rem; }}
+  table {{ width: 100%; border-collapse: collapse; font-size: 0.92rem; }}
+  th, td {{ text-align: left; padding: 9px 10px; border-bottom: 1px solid {border}; vertical-align: top; }}
+  th {{ color: {muted}; font-weight: 600; font-size: 0.78rem; text-transform: uppercase; letter-spacing: 0.03em; }}
+  td .sub {{ color: {muted}; font-size: 0.8rem; }}
+  .flag {{ font-weight: 600; }}
+  .bar {{ color: {accent}; letter-spacing: 1px; }}
+  .warnings {{ border-color: {warn}; }}
+  .warnings h2 {{ color: {warn}; }}
+  .warnings li {{ color: {muted}; font-size: 0.88rem; }}
+  footer {{ color: {muted}; font-size: 0.8rem; margin-top: 26px; }}
+</style></head>
+<body><div class="wrap">
+<header>
+  <h1>{name}</h1>
+  <div class="meta">Partner-meeting portfolio dashboard · generated {generated}</div>
+</header>
+<div class="tiles">
+  <div class="tile"><div class="n">{n_projects}</div><div class="l">Projects</div></div>
+  <div class="tile"><div class="n">{n_consultants}</div><div class="l">Consultants</div></div>
+  <div class="tile"><div class="n">{open_roles}</div><div class="l">Open roles</div></div>
+  <div class="tile"><div class="n">{avg}</div><div class="l">Avg allocation</div></div>
+</div>
+<section class="card">
+  <h2>Projects — staffing &amp; health</h2>
+  <table>
+    <thead><tr><th>Project</th><th>Status</th><th>Impact</th><th>Roles filled</th><th>Still open</th><th>Health</th></tr></thead>
+    <tbody>{rows}</tbody>
+  </table>
+</section>
+<section class="card">
+  <h2>Portfolio value — projects by strategic impact</h2>
+  <table>
+    <thead><tr><th>Impact</th><th>Projects</th><th></th></tr></thead>
+    <tbody>{value_rows}</tbody>
+  </table>
+</section>
+{warn_block}
+<footer>cogni-projects · read-only render · {generated}</footer>
+</div></body></html>
+""".format(
+        name=_esc(portfolio.get("name") or portfolio.get("slug") or "Portfolio"),
+        generated=generated,
+        bg=t["bg"], surface=t["surface"], surface2=t["surface2"], text=t["text"],
+        muted=t["muted"], accent=t["accent"], border=t["border"],
+        ok=t["ok"], warn=t["warn"], risk=t["risk"], font=t["font"],
+        n_projects=len(projects),
+        n_consultants=util["consultants"],
+        open_roles=total_open,
+        avg=avg,
+        rows="".join(rows) or "<tr><td colspan='6'>No projects yet.</td></tr>",
+        value_rows="".join(value_rows),
+        warn_block=warn_block,
+    )
+
+
+def _fail(message, code=2):
+    print(json.dumps({"success": False, "data": {}, "error": message}, ensure_ascii=False))
+    return code
+
+
+def main(argv):
+    ap = argparse.ArgumentParser(
+        description="Render a cogni-projects partner-meeting portfolio dashboard.",
+    )
+    ap.add_argument("portfolio_dir")
+    ap.add_argument("--design-variables", dest="design_variables", default=None)
+    args = ap.parse_args(argv)
+
+    portfolio_dir = os.path.abspath(args.portfolio_dir)
+    if not os.path.isdir(portfolio_dir):
+        return _fail("portfolio directory not found: %s" % portfolio_dir)
+
+    manifest_path = os.path.join(portfolio_dir, "projects-portfolio.json")
+    if not os.path.isfile(manifest_path):
+        return _fail(
+            "portfolio manifest not found: %s (run /cogni-projects:projects-setup first)"
+            % manifest_path
+        )
+
+    warnings = []
+    try:
+        with open(manifest_path, "r", encoding="utf-8") as f:
+            portfolio = json.load(f)
+    except (OSError, ValueError) as exc:
+        return _fail("cannot read portfolio manifest: %s" % exc)
+
+    theme, theme_warning = _load_theme(args.design_variables)
+    if theme_warning:
+        warnings.append(theme_warning)
+
+    entities, read_warnings = _read_entities(portfolio_dir)
+    warnings.extend(read_warnings)
+    projects, value_by_impact, util = _compute(entities, warnings)
+
+    out_dir = os.path.join(portfolio_dir, "output")
+    try:
+        os.makedirs(out_dir, exist_ok=True)
+        out_path = os.path.join(out_dir, "dashboard.html")
+        with open(out_path, "w", encoding="utf-8") as f:
+            f.write(_render_html(portfolio, projects, value_by_impact, util, warnings, theme))
+    except OSError as exc:
+        return _fail("cannot write dashboard: %s" % exc)
+
+    print(json.dumps({
+        "success": True,
+        "data": {
+            "path": out_path,
+            "portfolio": portfolio.get("slug") or "",
+            "projects": len(projects),
+            "consultants": util["consultants"],
+            "open_roles": sum(p["roles_total"] - p["roles_filled"] for p in projects),
+            "warnings": warnings,
+            "partial": bool(warnings),
+        },
+        "error": "",
+    }, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    # Same envelope contract as the sibling scripts: a hand-edited manifest or
+    # entity of the wrong shape must report as a readable failure, never a
+    # traceback that breaks the {success,data,error} contract mid-render.
+    try:
+        _code = main(sys.argv[1:])
+    except Exception as _exc:  # noqa: BLE001 — deliberate catch-all
+        _code = _fail("unexpected failure: %s: %s" % (type(_exc).__name__, _exc))
+    sys.exit(_code)

--- a/cogni-projects/scripts/render-dashboard.py
+++ b/cogni-projects/scripts/render-dashboard.py
@@ -11,7 +11,8 @@ Writes a self-contained HTML dashboard to <portfolio-dir>/output/dashboard.html.
 Read-only: never writes projects-portfolio.json (register-entity.py is its only
 writer) and never appends to .metadata/. Degrades gracefully — a missing or
 malformed entity field yields a partial snapshot with a surfaced warning, never
-a hard failure (AC-3).
+a hard failure, because a partial snapshot is more useful than no snapshot to a
+partner reviewing a portfolio that is still being authored.
 
 Stdlib-only (no PyYAML). Reuses validate-entities.py's parse_frontmatter and
 _entity_files by file-path load rather than re-implementing a parser or a
@@ -71,6 +72,26 @@ DEFAULT_THEME = {
 # completed assignment no longer staffs an open role.
 ACTIVE_ASSIGNMENT_STATES = ("planned", "active")
 
+# Theme values are interpolated into the <style> block rather than into escaped
+# text nodes, so a value carrying CSS-structural or markup characters could
+# close the stylesheet and inject arbitrary markup into the self-contained HTML.
+# The file is operator-supplied rather than portfolio-derived, so a conservative
+# denylist of CSS-structural characters is the proportionate guard: reject and
+# fall back rather than attempt to sanitize.
+# Single quotes stay legal: a font stack ("'Segoe UI', Roboto") needs them and
+# they cannot terminate a <style> block on their own.
+_THEME_VALUE_FORBIDDEN = set("<>{};@\\")
+_THEME_VALUE_MAX_LEN = 120
+
+
+def _valid_theme_value(value):
+    """Return True when a theme override is safe to interpolate into <style>."""
+    return (
+        isinstance(value, str)
+        and 0 < len(value) <= _THEME_VALUE_MAX_LEN
+        and not (_THEME_VALUE_FORBIDDEN & set(value))
+    )
+
 
 def _load_theme(path):
     """Return the theme dict. Falls back to DEFAULT_THEME on any read problem.
@@ -86,13 +107,20 @@ def _load_theme(path):
     except (OSError, ValueError) as exc:
         return dict(DEFAULT_THEME), "design-variables ignored (%s): %s" % (path, exc)
     theme = dict(DEFAULT_THEME)
+    rejected = set()
     if isinstance(overrides, dict):
         # Accept both a flat {key: value} map and a nested {"colors": {...}} one.
         for src in (overrides, overrides.get("colors", {})):
             if isinstance(src, dict):
                 for key, value in src.items():
-                    if key in theme and isinstance(value, str):
+                    if key not in theme:
+                        continue
+                    if _valid_theme_value(value):
                         theme[key] = value
+                    else:
+                        rejected.add(key)
+    if rejected:
+        return theme, "design-variables: ignored unsafe value(s) for %s — using the built-in palette for those keys" % ", ".join(sorted(rejected))
     return theme, None
 
 
@@ -101,8 +129,10 @@ def _read_entities(portfolio_dir):
 
     Returns (entities, warnings) where entities is
     {"consultant": [...], "project": [...], "assignment": [...]} of frontmatter
-    dicts. A file that cannot be read or has no frontmatter is recorded as a
-    warning and skipped — the rest of the portfolio still renders (AC-3).
+    dicts. A file that cannot be read, cannot be decoded, or has no frontmatter
+    is recorded as a warning and skipped — the rest of the portfolio still
+    renders, because one unreadable record must never cost the partner the whole
+    snapshot.
     """
     entities = {"consultant": [], "project": [], "assignment": []}
     warnings = []
@@ -111,7 +141,12 @@ def _read_entities(portfolio_dir):
         try:
             with open(path, "r", encoding="utf-8") as f:
                 fm = _ve.parse_frontmatter(f.read())
-        except OSError as exc:
+        # UnicodeDecodeError is a ValueError, not an OSError, so it escaped the
+        # original guard: one non-UTF-8 entity file must degrade to a single
+        # warning, not abort the whole render. Named explicitly rather than
+        # widening to ValueError, so a future parser fault still surfaces
+        # instead of being silently reported as an unreadable file.
+        except (OSError, UnicodeDecodeError) as exc:
             warnings.append("cannot read %s: %s" % (rel, exc))
             continue
         if not fm:
@@ -142,10 +177,37 @@ def _coerce_impact(value, project_label, warnings):
     return impact
 
 
-def _project_health(filled, total, status):
-    """Map (roles filled, roles total, project status) to (label, severity)."""
+def _normalize_open_roles(proj):
+    """Return the project's open_roles as a list, or None when undeclared.
+
+    None is the only representation of "fill status unknown", so every way of
+    failing to declare roles — key absent, `open_roles:` with no value, an
+    explicit null — collapses to the same state. Declaring an empty list stays
+    distinct: that is a project asserting it needs nobody, which is a real
+    answer rather than a missing one.
+    """
+    if "open_roles" not in proj:
+        return None
+    raw = proj["open_roles"]
+    if raw is None or (isinstance(raw, str) and not raw.strip()):
+        return None
+    if not isinstance(raw, list):
+        return [raw]
+    return raw
+
+
+def _project_health(filled, open_roles, status):
+    """Map (roles filled, declared open_roles, project status) to (label, severity).
+
+    open_roles is None when the project never declared any. Rendering that with
+    the same green as a fully staffed project would show an unstaffed project as
+    healthy on a partner's decision surface, so it gets its own warn state.
+    """
     if status == "closed":
         return ("closed", "muted")
+    if open_roles is None:
+        return ("staffing unknown", "warn")
+    total = len(open_roles)
     if total == 0:
         return ("no open roles", "ok")
     if filled >= total:
@@ -162,7 +224,8 @@ def _compute(entities, warnings):
     is "filled" when some planned/active assignment for that project carries a
     matching role label. Role labels are free strings, so a label an assignment
     names that no open_roles entry matches is surfaced as a warning rather than
-    silently changing the counts (AC-3).
+    silently changing the counts — a visible mismatch is safer than a confident
+    wrong number.
     """
     assignments = entities["assignment"]
     projects_out = []
@@ -171,10 +234,12 @@ def _compute(entities, warnings):
     for proj in sorted(entities["project"], key=lambda p: str(p.get("name") or p.get("slug") or "")):
         slug = proj.get("slug")
         label = "project %s" % (proj.get("name") or slug or "(unnamed)")
-        open_roles = proj.get("open_roles") or []
-        if not isinstance(open_roles, list):
-            open_roles = [open_roles]
+        # An undeclared open_roles is not an empty one — see _normalize_open_roles.
+        declared_roles = _normalize_open_roles(proj)
+        open_roles = declared_roles or []
         status = (proj.get("status") or "").strip()
+        if declared_roles is None and status != "closed":
+            warnings.append("%s has no open_roles — staffing status unknown" % label)
 
         covered = set()
         for a in assignments:
@@ -190,7 +255,7 @@ def _compute(entities, warnings):
                     "%s: assignment role %r matches no open_roles label — possible label mismatch" % (label, role)
                 )
         filled = [r for r in open_roles if r in covered]
-        health_label, health_sev = _project_health(len(filled), len(open_roles), status)
+        health_label, health_sev = _project_health(len(filled), declared_roles, status)
 
         impact = _coerce_impact(proj.get("strategic_impact"), label, warnings)
         if impact is not None:
@@ -209,7 +274,10 @@ def _compute(entities, warnings):
         })
 
     # Utilization: a simple average of consultant allocation_pct, plus a count of
-    # consultants at or above 100%. Richer heuristics are out of scope.
+    # consultants at or above 100%. Consultants with no allocation_pct are
+    # excluded from the average rather than counted as zero, so a thinly authored
+    # portfolio is not made to look under-allocated. Richer heuristics are out of
+    # scope.
     allocations = []
     for c in entities["consultant"]:
         raw = c.get("allocation_pct")
@@ -363,7 +431,20 @@ def main(argv):
     )
     ap.add_argument("portfolio_dir")
     ap.add_argument("--design-variables", dest="design_variables", default=None)
-    args = ap.parse_args(argv)
+    # argparse raises SystemExit on a usage error, and SystemExit is a
+    # BaseException — the top-level `except Exception` would not catch it, so a
+    # caller parsing stdout would get nothing at all. Convert it to the envelope
+    # every path in this repo is contracted to print.
+    try:
+        args = ap.parse_args(argv)
+    except SystemExit as exc:
+        # --help exits 0 having already printed help; that is a success path and
+        # must not be dressed up as a failure envelope.
+        if exc.code == 0:
+            return 0
+        # Derived from the parser rather than restated, so adding an argument
+        # cannot leave this message describing an older signature.
+        return _fail(ap.format_usage().strip())
 
     portfolio_dir = os.path.abspath(args.portfolio_dir)
     if not os.path.isdir(portfolio_dir):
@@ -407,6 +488,8 @@ def main(argv):
             "portfolio": portfolio.get("slug") or "",
             "projects": len(projects),
             "consultants": util["consultants"],
+            "avg_allocation": util["avg_allocation"],
+            "fully_allocated": util["fully_allocated"],
             "open_roles": sum(p["roles_total"] - p["roles_filled"] for p in projects),
             "warnings": warnings,
             "partial": bool(warnings),

--- a/cogni-projects/scripts/render-dashboard.py
+++ b/cogni-projects/scripts/render-dashboard.py
@@ -57,7 +57,6 @@ DEFAULT_THEME = {
     "theme_name": "cogni-work",
     "bg": "#0f1419",
     "surface": "#1a2028",
-    "surface2": "#232b35",
     "text": "#e6edf3",
     "muted": "#9aa7b4",
     "accent": "#4f9cf9",
@@ -75,12 +74,18 @@ ACTIVE_ASSIGNMENT_STATES = ("planned", "active")
 # Theme values are interpolated into the <style> block rather than into escaped
 # text nodes, so a value carrying CSS-structural or markup characters could
 # close the stylesheet and inject arbitrary markup into the self-contained HTML.
+# Parentheses are denied for a distinct reason: a value like
+# `url(https://evil.example/track.png)` is CSS-valid and would interpolate
+# verbatim into `background: url(...)`, turning a self-contained partner-meeting
+# artifact into one that fetches an external resource (a phone-home beacon) the
+# moment it is opened. Rejecting `(` / `)` blocks the url()/@import fetch surface
+# alongside the markup-injection one.
 # The file is operator-supplied rather than portfolio-derived, so a conservative
 # denylist of CSS-structural characters is the proportionate guard: reject and
 # fall back rather than attempt to sanitize.
 # Single quotes stay legal: a font stack ("'Segoe UI', Roboto") needs them and
 # they cannot terminate a <style> block on their own.
-_THEME_VALUE_FORBIDDEN = set("<>{};@\\")
+_THEME_VALUE_FORBIDDEN = set("<>{}();@\\")
 _THEME_VALUE_MAX_LEN = 120
 
 
@@ -407,7 +412,7 @@ def _render_html(portfolio, projects, value_by_impact, util, warnings, theme):
 """.format(
         name=_esc(portfolio.get("name") or portfolio.get("slug") or "Portfolio"),
         generated=generated,
-        bg=t["bg"], surface=t["surface"], surface2=t["surface2"], text=t["text"],
+        bg=t["bg"], surface=t["surface"], text=t["text"],
         muted=t["muted"], accent=t["accent"], border=t["border"],
         ok=t["ok"], warn=t["warn"], risk=t["risk"], font=t["font"],
         n_projects=len(projects),

--- a/cogni-projects/skills/projects-dashboard/SKILL.md
+++ b/cogni-projects/skills/projects-dashboard/SKILL.md
@@ -45,11 +45,13 @@ records:
   high-impact work is visible at a glance.
 - **Utilization**: `data.avg_allocation`, the average of consultant
   `allocation_pct`, plus `data.fully_allocated`, the count of consultants at or
-  above 100%. Consultants with no `allocation_pct`, or a non-numeric one (each
-  surfaced as a warning), are **excluded** from the average rather than counted
-  as zero, so a thinly authored portfolio is not made to look under-allocated.
-  When no consultant has a usable `allocation_pct`, `data.avg_allocation` is
-  `null` — report it as unknown, not `0%`.
+  above 100%. Consultants with no `allocation_pct` are silently **excluded** from
+  the average (it is an optional field, so its absence is not flagged); a
+  consultant whose `allocation_pct` is present but non-numeric is excluded **and**
+  surfaced as a warning. Excluding rather than counting as zero keeps a thinly
+  authored portfolio from being made to look under-allocated. When no consultant
+  has a usable `allocation_pct`, `data.avg_allocation` is `null` — report it as
+  unknown, not `0%`.
 
 Role labels are free strings, so when a project lists `open_roles`, a label an
 assignment names that no entry matches is surfaced as a warning rather than

--- a/cogni-projects/skills/projects-dashboard/SKILL.md
+++ b/cogni-projects/skills/projects-dashboard/SKILL.md
@@ -28,11 +28,26 @@ records:
 
 - **Staffing coverage** per project: a project lists the roles it still needs in
   `open_roles`; a role counts as *filled* when a planned or active assignment
-  for that project names a matching role. The dashboard shows filled-vs-open and
-  a health flag (fully staffed / partially staffed / unstaffed / closed).
+  for that project names a matching role. The dashboard shows filled-vs-open
+  plus a health flag derived deterministically from (roles filled, roles listed,
+  project status):
+
+  | Flag | Condition |
+  |------|-----------|
+  | `closed` | `status` is `closed` |
+  | `staffing unknown` | the project declares no `open_roles` at all (key absent, or present with no value) — fill status cannot be derived |
+  | `no open roles` | `open_roles` is present but empty |
+  | `fully staffed` | every listed role is covered |
+  | `unstaffed` | an **active** project has zero roles covered |
+  | `<n>/<m> roles open` | otherwise |
+
 - **Portfolio value**: projects grouped by `strategic_impact` (1–5), so the
   high-impact work is visible at a glance.
-- **Utilization**: a simple average of consultant `allocation_pct`.
+- **Utilization**: `data.avg_allocation`, the average of consultant
+  `allocation_pct`, plus `data.fully_allocated`, the count of consultants at or
+  above 100%. Consultants with no `allocation_pct` are **excluded** from the
+  average rather than counted as zero, so a thinly authored portfolio is not
+  made to look under-allocated.
 
 Role labels are free strings, so a label an assignment names that no `open_roles`
 entry matches is surfaced as a warning rather than silently mis-counted. Any
@@ -57,17 +72,32 @@ python3 "${CLAUDE_PLUGIN_ROOT:-$(ls -td "$HOME"/.claude/plugins/cache/*/cogni-pr
 
 The script writes a self-contained `output/dashboard.html` inside the portfolio
 directory and prints a `{"success", "data", "error"}` envelope whose `data.path`
-is the written file. When `data.partial` is `true`, `data.warnings` lists what
-was missing or mismatched — relay those to the user so they know the snapshot is
-incomplete and which records to fix.
+is the written file.
+
+**When `success` is `true`:** if `data.partial` is `true`, `data.warnings` lists
+what was missing or mismatched — relay those so the user knows the snapshot is
+incomplete and which records to fix. Note that `partial` is set by *any*
+warning, including a non-substantive one such as an unreadable
+`--design-variables` file, so check what the warnings actually say before
+describing the portfolio data itself as incomplete.
+
+**When `success` is `false`:** the render did not run at all — read `error`. This
+is the environment-level failure branch (missing portfolio directory, missing
+`projects-portfolio.json`, unwritable `output/`), distinct from the per-entity
+degradation above. A missing `projects-portfolio.json` means the directory is
+not an initialized portfolio: point the user at `projects-setup` rather than
+retrying the render.
 
 ### Step 3: Open it
 
-Open the generated dashboard in a browser:
+Report `data.path` as the deliverable, then offer to open it as a convenience:
 
 ```bash
-open "<portfolio-dir>/output/dashboard.html"
+open "<data.path>"      # macOS
+xdg-open "<data.path>"  # Linux
 ```
+
+A failure here is cosmetic — the dashboard is already written to `data.path`.
 
 ## Notes
 
@@ -75,8 +105,10 @@ open "<portfolio-dir>/output/dashboard.html"
   `projects-entities` does, via `register-entity.py`) and never touches
   `.metadata/`. Re-running only rewrites `output/dashboard.html`.
 - **Partial snapshots are expected mid-authoring.** A project without a
-  `strategic_impact`, or an assignment whose `role` does not match any
-  `open_roles` label, is reported in the warnings list, not treated as an error.
+  `strategic_impact`, a project that omits `open_roles`, an assignment whose
+  `role` does not match any `open_roles` label, or an entity file that cannot be
+  read or decoded is reported in the warnings list, not treated as an error. One
+  bad record never costs the rest of the portfolio.
 - **Theming is optional.** The dashboard renders with a built-in palette;
   pass `--design-variables <path.json>` to override colors when a themed look is
   wanted.

--- a/cogni-projects/skills/projects-dashboard/SKILL.md
+++ b/cogni-projects/skills/projects-dashboard/SKILL.md
@@ -39,18 +39,22 @@ records:
   | `no open roles` | `open_roles` is present but empty |
   | `fully staffed` | every listed role is covered |
   | `unstaffed` | an **active** project has zero roles covered |
-  | `<n>/<m> roles open` | otherwise |
+  | `<open>/<total> roles open` | otherwise — the leading number is the count of roles **still open** (not filled), the trailing number the total |
 
 - **Portfolio value**: projects grouped by `strategic_impact` (1–5), so the
   high-impact work is visible at a glance.
 - **Utilization**: `data.avg_allocation`, the average of consultant
   `allocation_pct`, plus `data.fully_allocated`, the count of consultants at or
-  above 100%. Consultants with no `allocation_pct` are **excluded** from the
-  average rather than counted as zero, so a thinly authored portfolio is not
-  made to look under-allocated.
+  above 100%. Consultants with no `allocation_pct`, or a non-numeric one (each
+  surfaced as a warning), are **excluded** from the average rather than counted
+  as zero, so a thinly authored portfolio is not made to look under-allocated.
+  When no consultant has a usable `allocation_pct`, `data.avg_allocation` is
+  `null` — report it as unknown, not `0%`.
 
-Role labels are free strings, so a label an assignment names that no `open_roles`
-entry matches is surfaced as a warning rather than silently mis-counted. Any
+Role labels are free strings, so when a project lists `open_roles`, a label an
+assignment names that no entry matches is surfaced as a warning rather than
+silently mis-counted (a project with absent or empty `open_roles` yields no such
+warning). Any
 missing or malformed field produces a **partial snapshot with a warning**, never
 a hard failure — a portfolio mid-authoring still renders.
 
@@ -67,7 +71,7 @@ portfolio exists, use it; otherwise list the candidates and ask which one.
 Run the renderer against the portfolio directory:
 
 ```bash
-python3 "${CLAUDE_PLUGIN_ROOT:-$(ls -td "$HOME"/.claude/plugins/cache/*/cogni-projects/*/ 2>/dev/null | head -1)}/scripts/render-dashboard.py" <portfolio-dir>
+python3 "${CLAUDE_PLUGIN_ROOT:-$(ls -td "$HOME"/.claude/plugins/cache/*/cogni-projects/*/ 2>/dev/null | head -1)}/scripts/render-dashboard.py" "<portfolio-dir>"
 ```
 
 The script writes a self-contained `output/dashboard.html` inside the portfolio

--- a/cogni-projects/skills/projects-dashboard/SKILL.md
+++ b/cogni-projects/skills/projects-dashboard/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: projects-dashboard
+description: |
+  This skill should be used when a partner or consultant wants a readable
+  snapshot of a cogni-projects portfolio for a partner meeting — staffing
+  coverage per project, at-risk projects, and portfolio value by strategic
+  impact — rather than reading raw entity files. Trigger on: "projects
+  dashboard", "portfolio dashboard", "partner-meeting dashboard", "show me the
+  project portfolio", "portfolio health", "staffing coverage", "which projects
+  are at risk", or any request to review the project portfolio at a glance —
+  even if the user does not say "dashboard" explicitly.
+allowed-tools: Read, Bash, Glob, Grep
+---
+
+# Projects Dashboard
+
+Render a partner-meeting snapshot of a cogni-projects portfolio: every project
+with its staffing coverage and a health flag, plus an aggregate view of
+portfolio value by strategic impact. The dashboard is a **read-only** view over
+the consultant, project, and assignment records that `projects-setup` and
+`projects-entities` produce — it never changes portfolio state.
+
+## Core concept
+
+The dashboard reads a **portfolio** — one `cogni-projects/<portfolio-slug>/`
+directory rooted by `projects-portfolio.json` — and derives, from the entity
+records:
+
+- **Staffing coverage** per project: a project lists the roles it still needs in
+  `open_roles`; a role counts as *filled* when a planned or active assignment
+  for that project names a matching role. The dashboard shows filled-vs-open and
+  a health flag (fully staffed / partially staffed / unstaffed / closed).
+- **Portfolio value**: projects grouped by `strategic_impact` (1–5), so the
+  high-impact work is visible at a glance.
+- **Utilization**: a simple average of consultant `allocation_pct`.
+
+Role labels are free strings, so a label an assignment names that no `open_roles`
+entry matches is surfaced as a warning rather than silently mis-counted. Any
+missing or malformed field produces a **partial snapshot with a warning**, never
+a hard failure — a portfolio mid-authoring still renders.
+
+## Workflow
+
+### Step 1: Find the portfolio
+
+Locate the target `cogni-projects/<portfolio-slug>/` directory (the one holding
+`projects-portfolio.json`). If the user named a portfolio, use it; if only one
+portfolio exists, use it; otherwise list the candidates and ask which one.
+
+### Step 2: Render the dashboard
+
+Run the renderer against the portfolio directory:
+
+```bash
+python3 "${CLAUDE_PLUGIN_ROOT:-$(ls -td "$HOME"/.claude/plugins/cache/*/cogni-projects/*/ 2>/dev/null | head -1)}/scripts/render-dashboard.py" <portfolio-dir>
+```
+
+The script writes a self-contained `output/dashboard.html` inside the portfolio
+directory and prints a `{"success", "data", "error"}` envelope whose `data.path`
+is the written file. When `data.partial` is `true`, `data.warnings` lists what
+was missing or mismatched — relay those to the user so they know the snapshot is
+incomplete and which records to fix.
+
+### Step 3: Open it
+
+Open the generated dashboard in a browser:
+
+```bash
+open "<portfolio-dir>/output/dashboard.html"
+```
+
+## Notes
+
+- **Read-only.** The renderer never writes `projects-portfolio.json` (only
+  `projects-entities` does, via `register-entity.py`) and never touches
+  `.metadata/`. Re-running only rewrites `output/dashboard.html`.
+- **Partial snapshots are expected mid-authoring.** A project without a
+  `strategic_impact`, or an assignment whose `role` does not match any
+  `open_roles` label, is reported in the warnings list, not treated as an error.
+- **Theming is optional.** The dashboard renders with a built-in palette;
+  pass `--design-variables <path.json>` to override colors when a themed look is
+  wanted.

--- a/cogni-projects/tests/test-render-dashboard.sh
+++ b/cogni-projects/tests/test-render-dashboard.sh
@@ -1,0 +1,247 @@
+#!/usr/bin/env bash
+# Test render-dashboard.py — the partner-meeting portfolio dashboard renderer.
+#
+# Covers the three acceptance criteria:
+#   AC-1: every project is listed with fill status + a health flag,
+#   AC-2: an aggregate portfolio value/impact summary is shown,
+#   AC-3: a missing field / role-label mismatch degrades to a partial snapshot
+#         (success stays true, a warning surfaces) rather than hard-failing.
+#
+# stdlib-only (bash + python3, no pytest/pip), matching the house convention.
+#
+# Usage: bash cogni-projects/tests/test-render-dashboard.sh
+# Exits non-zero on any assertion failure.
+
+set -u  # NOT -e: a failing assertion must not abort the per-fixture counter.
+
+TESTS_DIR="$(cd "$(dirname "$0")" && pwd)"
+PLUGIN_DIR="$(cd "$TESTS_DIR/.." && pwd)"
+SCRIPT="$PLUGIN_DIR/scripts/render-dashboard.py"
+
+if [ ! -f "$SCRIPT" ]; then
+  echo "FAIL: render-dashboard.py not found at $SCRIPT" >&2
+  exit 1
+fi
+
+TMPROOT="$(mktemp -d)"
+trap 'rm -rf "$TMPROOT"' EXIT
+
+failures=0
+pass() { printf 'OK   %s\n' "$1"; }
+fail() { printf 'FAIL %s: %s\n' "$1" "$2" >&2; failures=$((failures + 1)); }
+
+# assert_json <label> <python-bool-expr over `d`> — pipes the last stdout line
+# (the envelope) into python3 and checks the expression is truthy.
+assert_json() {
+  local label="$1" expr="$2"
+  if printf '%s' "$LAST_JSON" | python3 -c "import json,sys
+d = json.loads(sys.stdin.read())
+sys.exit(0 if ($expr) else 1)" 2>/dev/null; then
+    pass "$label"
+  else
+    fail "$label" "expr false: $expr | json=$LAST_JSON"
+  fi
+}
+
+assert_html() {
+  local label="$1" needle="$2" file="$3"
+  if grep -qF "$needle" "$file"; then
+    pass "$label"
+  else
+    fail "$label" "HTML missing needle: $needle"
+  fi
+}
+
+seed_portfolio() {
+  # $1 = portfolio dir. Seeds a manifest + entity subdirs.
+  local pf="$1"
+  mkdir -p "$pf"/{consultants,projects,assignments,.metadata}
+  cat > "$pf/projects-portfolio.json" <<'EOF'
+{"slug":"test","name":"Test Portfolio","language":"en","consultants":[],"projects":[],"assignments":[],"created":"2026-01-01","updated":"2026-01-01"}
+EOF
+}
+
+write_entity() { # $1 = path, $2 = frontmatter body (heredoc'd by caller)
+  cat > "$1"
+}
+
+# run <portfolio-dir> — invoke the renderer, capture last stdout line into LAST_JSON.
+run() {
+  LAST_JSON="$(python3 "$SCRIPT" "$1" 2>/dev/null | tail -n 1)"
+}
+
+# ---------------------------------------------------------------------------
+# Fixture 1 — happy path: two projects, one partly staffed, one unstaffed.
+# AC-1 (fill + health) and AC-2 (value aggregate).
+# ---------------------------------------------------------------------------
+PF1="$TMPROOT/happy"
+seed_portfolio "$PF1"
+write_entity "$PF1/projects/nordic-erp.md" <<'EOF'
+---
+type: project
+slug: nordic-erp
+name: Nordic Retail ERP
+client: Nordic Retail
+strategic_impact: 5
+status: active
+open_roles: [erp-lead, integration-architect, change-lead]
+---
+# Nordic Retail ERP
+EOF
+write_entity "$PF1/projects/small-audit.md" <<'EOF'
+---
+type: project
+slug: small-audit
+name: Compliance Audit
+client: FinCo
+strategic_impact: 2
+status: active
+open_roles: [auditor]
+---
+# Compliance Audit
+EOF
+write_entity "$PF1/consultants/mara.md" <<'EOF'
+---
+type: consultant
+slug: mara
+name: Mara Lindqvist
+seniority: principal
+skills: [erp, integration]
+allocation_pct: 80
+---
+# Mara
+EOF
+write_entity "$PF1/assignments/mara--nordic-erp.md" <<'EOF'
+---
+type: assignment
+slug: mara--nordic-erp
+consultant: mara
+project: nordic-erp
+role: erp-lead
+start_date: 2026-02-01
+end_date: 2026-08-01
+status: active
+---
+# assignment
+EOF
+
+run "$PF1"
+HTML1="$PF1/output/dashboard.html"
+assert_json "1a envelope success"        "d['success'] is True"
+assert_json "1b two projects counted"    "d['data']['projects'] == 2"
+assert_json "1c not partial (clean)"     "d['data']['partial'] is False"
+assert_json "1d no warnings"             "d['data']['warnings'] == []"
+assert_json "1e open roles = 3"          "d['data']['open_roles'] == 3"
+assert_html "1f AC-1 lists project"      "Nordic Retail ERP" "$HTML1"
+assert_html "1g AC-1 lists other project" "Compliance Audit" "$HTML1"
+assert_html "1h AC-1 fill status shown"  "1/3" "$HTML1"
+assert_html "1i AC-1 health flag shown"  "unstaffed" "$HTML1"
+assert_html "1j AC-2 value section"      "strategic impact" "$HTML1"
+
+# ---------------------------------------------------------------------------
+# Fixture 2 — idempotent re-render: running twice rewrites the same file and
+# stays successful (no accumulation, no state mutation).
+# ---------------------------------------------------------------------------
+run "$PF1"
+assert_json "2a re-render success"       "d['success'] is True"
+assert_json "2b re-render still 2 projects" "d['data']['projects'] == 2"
+# The manifest must not have been touched by the read-only render.
+if grep -qF '"consultants":[]' "$PF1/projects-portfolio.json"; then
+  pass "2c manifest untouched (read-only)"
+else
+  fail "2c manifest untouched (read-only)" "manifest changed"
+fi
+
+# ---------------------------------------------------------------------------
+# Fixture 3 — AC-3 graceful degradation: a project missing strategic_impact and
+# an assignment whose role does not match any open_roles label. The render must
+# still succeed with a partial snapshot and surfaced warnings.
+# ---------------------------------------------------------------------------
+PF3="$TMPROOT/partial"
+seed_portfolio "$PF3"
+write_entity "$PF3/projects/broken.md" <<'EOF'
+---
+type: project
+slug: broken
+name: Broken Project
+client: X
+status: active
+open_roles: [ERP Lead]
+---
+# broken (no strategic_impact; open_roles label differs in case)
+EOF
+write_entity "$PF3/consultants/ana.md" <<'EOF'
+---
+type: consultant
+slug: ana
+name: Ana Ström
+seniority: senior
+skills: [erp]
+---
+# Ana
+EOF
+write_entity "$PF3/assignments/ana--broken.md" <<'EOF'
+---
+type: assignment
+slug: ana--broken
+consultant: ana
+project: broken
+role: erp-lead
+start_date: 2026-02-01
+end_date: 2026-08-01
+status: active
+---
+# assignment (role erp-lead != open_roles "ERP Lead")
+EOF
+
+run "$PF3"
+assert_json "3a AC-3 still succeeds"     "d['success'] is True"
+assert_json "3b AC-3 marked partial"     "d['data']['partial'] is True"
+assert_json "3c AC-3 has warnings"       "len(d['data']['warnings']) >= 2"
+assert_json "3d AC-3 warns on missing impact" \
+  "any('strategic_impact' in w for w in d['data']['warnings'])"
+assert_json "3e AC-3 warns on label mismatch" \
+  "any('label mismatch' in w for w in d['data']['warnings'])"
+assert_html "3f AC-3 warnings rendered"  "partial snapshot" "$PF3/output/dashboard.html"
+
+# ---------------------------------------------------------------------------
+# Fixture 4 — missing manifest is a clean failure envelope, not a traceback.
+# ---------------------------------------------------------------------------
+PF4="$TMPROOT/no-manifest"
+mkdir -p "$PF4"
+run "$PF4"
+assert_json "4a missing manifest fails cleanly" "d['success'] is False"
+assert_json "4b failure names the manifest"     "'manifest' in d['error']"
+
+# ---------------------------------------------------------------------------
+# Fixture 5 — HTML-injection guard: an entity value with markup is escaped.
+# ---------------------------------------------------------------------------
+PF5="$TMPROOT/xss"
+seed_portfolio "$PF5"
+write_entity "$PF5/projects/evil.md" <<'EOF'
+---
+type: project
+slug: evil
+name: "<script>alert(1)</script>"
+client: X
+strategic_impact: 3
+status: active
+open_roles: [lead]
+---
+# evil
+EOF
+run "$PF5"
+assert_json "5a injection render succeeds" "d['success'] is True"
+if grep -qF '<script>alert(1)</script>' "$PF5/output/dashboard.html"; then
+  fail "5b entity markup escaped" "raw <script> present in output"
+else
+  pass "5b entity markup escaped"
+fi
+
+echo
+if [ "$failures" -eq 0 ]; then
+  echo "All render-dashboard tests passed."
+  exit 0
+fi
+echo "$failures assertion(s) failed." >&2
+exit 1

--- a/cogni-projects/tests/test-render-dashboard.sh
+++ b/cogni-projects/tests/test-render-dashboard.sh
@@ -48,7 +48,18 @@ assert_html() {
   if grep -qF "$needle" "$file"; then
     pass "$label"
   else
-    fail "$label" "HTML missing needle: $needle"
+    fail "$label" "HTML missing needle: $needle ($file)"
+  fi
+}
+
+# The negative counterpart — used by every "this must not have been injected"
+# check, which would otherwise be hand-rolled per fixture.
+assert_html_lacks() {
+  local label="$1" needle="$2" file="$3"
+  if grep -qF "$needle" "$file"; then
+    fail "$label" "HTML unexpectedly contains: $needle ($file)"
+  else
+    pass "$label"
   fi
 }
 
@@ -65,9 +76,10 @@ write_entity() { # $1 = path, $2 = frontmatter body (heredoc'd by caller)
   cat > "$1"
 }
 
-# run <portfolio-dir> — invoke the renderer, capture last stdout line into LAST_JSON.
+# run [args...] — invoke the renderer with any arguments (including none) and
+# capture the last stdout line, which is the envelope, into LAST_JSON.
 run() {
-  LAST_JSON="$(python3 "$SCRIPT" "$1" 2>/dev/null | tail -n 1)"
+  LAST_JSON="$(python3 "$SCRIPT" "$@" 2>/dev/null | tail -n 1)"
 }
 
 # ---------------------------------------------------------------------------
@@ -232,11 +244,139 @@ open_roles: [lead]
 EOF
 run "$PF5"
 assert_json "5a injection render succeeds" "d['success'] is True"
-if grep -qF '<script>alert(1)</script>' "$PF5/output/dashboard.html"; then
-  fail "5b entity markup escaped" "raw <script> present in output"
+assert_html_lacks "5b entity markup escaped" \
+  '<script>alert(1)</script>' "$PF5/output/dashboard.html"
+
+# ---------------------------------------------------------------------------
+# Fixture 6 — genuinely malformed entities, not merely incomplete ones: a
+# type-invalid strategic_impact, a project omitting open_roles entirely, and a
+# non-UTF-8 entity file. Each must degrade to a warning while the valid project
+# still renders. Fixture 3 covers only well-formed-but-incomplete data, which is
+# why a decode failure could abort the whole render without tripping the suite.
+# ---------------------------------------------------------------------------
+PF6="$TMPROOT/malformed"
+seed_portfolio "$PF6"
+write_entity "$PF6/projects/good.md" <<'EOF'
+---
+type: project
+slug: good
+name: Valid Project
+client: GoodCo
+strategic_impact: 4
+status: active
+open_roles: [lead]
+---
+# good
+EOF
+write_entity "$PF6/projects/typed-wrong.md" <<'EOF'
+---
+type: project
+slug: typed-wrong
+name: Type Invalid
+client: X
+strategic_impact: high
+status: active
+open_roles: [lead]
+---
+# strategic_impact is a word, not 1..5
+EOF
+write_entity "$PF6/projects/no-roles.md" <<'EOF'
+---
+type: project
+slug: no-roles
+name: Roles Omitted
+client: Y
+strategic_impact: 4
+status: active
+---
+# open_roles key absent entirely — staffing status is unknown, not zero
+EOF
+# The same unknown state reached by a different authoring shape: the key is
+# present but carries no value. This must not read as "declares no roles".
+write_entity "$PF6/projects/bare-roles.md" <<'EOF'
+---
+type: project
+slug: bare-roles
+name: Roles Blank
+client: Y2
+strategic_impact: 3
+status: active
+open_roles:
+---
+# open_roles present but empty — still unknown, not an assertion of zero
+EOF
+# A genuinely non-UTF-8 file: a latin-1 encoded byte that is invalid UTF-8.
+# Written via python3 because bash printf parses a leading '---' as options.
+python3 -c "
+import sys
+open(sys.argv[1], 'wb').write(
+    '---\ntype: project\nslug: latin1\nname: Caf\xe9 Rollout\nstatus: active\n---\n'.encode('latin-1')
+)" "$PF6/projects/latin1.md"
+
+STDERR6="$TMPROOT/stderr6.txt"
+LAST_JSON="$(python3 "$SCRIPT" "$PF6" 2>"$STDERR6" | tail -n 1)"
+
+assert_json "6a malformed set still succeeds"  "d['success'] is True"
+assert_json "6b marked partial"                "d['data']['partial'] is True"
+# The undecodable file is skipped; the four parseable projects still render.
+assert_json "6c valid projects still counted"  "d['data']['projects'] == 4"
+assert_json "6d warns on non-numeric impact" \
+  "any('strategic_impact' in w for w in d['data']['warnings'])"
+# Both the absent key and the bare-scalar shape must reach the unknown state.
+assert_json "6e warns on unknown staffing (both shapes)" \
+  "sum('staffing status unknown' in w for w in d['data']['warnings']) == 2"
+assert_json "6f warns on undecodable file" \
+  "any('cannot read' in w and 'latin1' in w for w in d['data']['warnings'])"
+if grep -qF 'Traceback' "$STDERR6"; then
+  fail "6g no traceback on stderr" "traceback present: $(head -3 "$STDERR6")"
 else
-  pass "5b entity markup escaped"
+  pass "6g no traceback on stderr"
 fi
+assert_html "6h unknown staffing flagged in HTML" \
+  "staffing unknown" "$PF6/output/dashboard.html"
+
+# A project omitting open_roles must NOT render with the same ok severity as a
+# project that explicitly declares none — that collapse is what made an
+# unstaffed project look healthy.
+assert_html_lacks "6i absent roles not shown as 'no open roles'" \
+  'no open roles' "$PF6/output/dashboard.html"
+
+# ---------------------------------------------------------------------------
+# Fixture 7 — the {success,data,error} envelope is printed on every path,
+# including an argparse usage error (SystemExit is a BaseException and would
+# otherwise escape the top-level handler, leaving stdout empty).
+# ---------------------------------------------------------------------------
+run
+assert_json "7a no-args still prints envelope" "d['success'] is False"
+assert_json "7b no-args error names usage"     "'usage' in d['error']"
+assert_json "7c usage names the real argument" "'portfolio_dir' in d['error']"
+
+# ---------------------------------------------------------------------------
+# Fixture 8 — a design-variables value that would break out of the <style>
+# block is rejected in favour of the built-in palette rather than interpolated.
+# ---------------------------------------------------------------------------
+PF8="$TMPROOT/theme"
+seed_portfolio "$PF8"
+write_entity "$PF8/projects/plain.md" <<'EOF'
+---
+type: project
+slug: plain
+name: Plain Project
+client: Z
+strategic_impact: 3
+status: active
+open_roles: [lead]
+---
+# plain
+EOF
+cat > "$TMPROOT/evil-theme.json" <<'EOF'
+{"bg": "#000</style><script>alert(1)</script>", "accent": "#ff0000"}
+EOF
+run "$PF8" --design-variables "$TMPROOT/evil-theme.json"
+assert_json "8a themed render succeeds" "d['success'] is True"
+assert_html_lacks "8b unsafe theme value rejected" \
+  '<script>alert(1)</script>' "$PF8/output/dashboard.html"
+assert_html "8c safe theme value still applied" "#ff0000" "$PF8/output/dashboard.html"
 
 echo
 if [ "$failures" -eq 0 ]; then

--- a/cogni-projects/tests/test-render-dashboard.sh
+++ b/cogni-projects/tests/test-render-dashboard.sh
@@ -378,6 +378,19 @@ assert_html_lacks "8b unsafe theme value rejected" \
   '<script>alert(1)</script>' "$PF8/output/dashboard.html"
 assert_html "8c safe theme value still applied" "#ff0000" "$PF8/output/dashboard.html"
 
+# A url() value is CSS-valid but would make the self-contained HTML fetch an
+# external resource (phone-home beacon) on open. Parentheses are denied, so it
+# is rejected in favour of the built-in palette rather than interpolated.
+cat > "$TMPROOT/beacon-theme.json" <<'EOF'
+{"bg": "url(https://evil.example/track.png)", "accent": "#00ff88"}
+EOF
+run "$PF8" --design-variables "$TMPROOT/beacon-theme.json"
+assert_json "8d beacon render succeeds" "d['success'] is True"
+assert_html_lacks "8e url() beacon theme value rejected" \
+  'evil.example' "$PF8/output/dashboard.html"
+assert_html "8f safe accent still applied alongside rejected url()" \
+  "#00ff88" "$PF8/output/dashboard.html"
+
 echo
 if [ "$failures" -eq 0 ]; then
   echo "All render-dashboard tests passed."


### PR DESCRIPTION
Closes #1116.

## Summary
- Add a domain-prefixed **`projects-dashboard`** skill that renders a partner-meeting snapshot of a cogni-projects portfolio (find portfolio → run renderer → open the HTML).
- Add stdlib-only **`scripts/render-dashboard.py`** (read-only): enumerates entities via `projects-portfolio.json`, then opens and parses every `projects/`, `consultants/`, `assignments/` markdown frontmatter — reusing `validate-entities.py`'s `parse_frontmatter` and `_entity_files` via the importlib file-path idiom `register-entity.py` already uses, so the dashboard reads exactly the shape the validator enforces instead of re-implementing a parser. Derives per-project staffing coverage (`open_roles` filled vs open) with a health flag, aggregates portfolio value by `strategic_impact` (1–5), and writes a self-contained, `html.escape()`d `output/dashboard.html`. Prints the `{success,data,error}` envelope with `data.path`; a top-level `__main__` try/except keeps a malformed entity from escaping as a traceback.
- **Graceful degradation (AC-3):** a missing field or a role-label mismatch (`erp-lead` vs `ERP Lead`) yields a partial snapshot with a surfaced warning and `success: true` — never a hard failure.
- Add **`tests/test-render-dashboard.sh`** (38 assertions): AC-1 (every project listed with fill status + health flag), AC-2 (value aggregate present), AC-3 (partial snapshot + warnings on a missing field / label mismatch), plus a manifest-missing clean-failure case, a read-only/idempotent re-render check, and an HTML-injection escaping check.
- Update `CLAUDE.md` (dashboard moved from "Planned" to present; skill/script/tests added to the architecture tree) and bump `cogni-projects` 0.0.5 → **0.0.8**.

## Acceptance criteria
- [x] **AC-1** — the dashboard lists every project with fill status and a health flag.
- [x] **AC-2** — an aggregate portfolio value/impact summary (projects grouped by `strategic_impact`) is shown.
- [x] **AC-3** — generation degrades gracefully to a partial snapshot when entities miss fields, never hard-failing.

## Scope decisions
- **HTML-only output** (the issue allows "markdown and/or HTML"), matching the house dashboards. Markdown dual-output, live cogni-portfolio value enrichment, and richer utilization heuristics are deliberately **out of scope** — separate concerns, not partial slices, so this issue closes complete.
- **Read-only by contract:** the renderer never writes `projects-portfolio.json` (`register-entity.py` is its sole writer) and never appends to `.metadata/`.
- **Copied the envelope-conformant `consult-dashboard` pattern**, not `cogni-portfolio/portfolio-dashboard`, which does not follow the `{success,data,error}` contract.
- **Theming is optional:** a `DEFAULT_THEME` is embedded so the MVP needs no `pick-theme` step; `--design-variables <path.json>` is an optional override.

## ⚠️ Version-line conflict expected with #1126
This PR bumps `cogni-projects` to **0.0.8** to sequence past the already-open sibling PR #1126 (which bumps 0.0.5 → 0.0.6). The `version` lines in `cogni-projects/.claude-plugin/plugin.json` and the cogni-projects entry of `.claude-plugin/marketplace.json` will **textually conflict** at merge time — whichever PR merges second should keep this PR's 0.0.8 on top of #1126's 0.0.6.

## Test plan
- [x] `bash cogni-projects/tests/test-render-dashboard.sh` → all 38 assertions pass.
- [x] `python3 cogni-projects/scripts/render-dashboard.py <portfolio-dir>` against a seeded portfolio → valid `{success:true}` envelope with `data.path` at `<portfolio-dir>/output/dashboard.html`; the HTML lists each project with roles-filled-vs-open, a health flag, and the strategic-impact value table.
- [x] AC-3 fixture: a project missing `strategic_impact` plus a role-label mismatch → `success:true`, `data.partial:true`, warnings surfaced in the envelope and rendered on the page.
- [x] `scripts/check-breadcrumbs.py` passes (exit 0); no breadcrumbs in the new skill/script.
- [ ] `cogni-workspace/scripts/check-skill-names.sh` — could not run locally (the script uses `declare -A`, which needs bash ≥ 4; the local shell is macOS bash 3.2). The name `projects-dashboard` clears the guard's exact-match check on the bare word `dashboard`, matching the existing `portfolio-dashboard` / `consult-dashboard` precedent; CI runs it on Linux.

## Note
The test simulates failure paths in-process (missing manifest, malformed fields, injection) rather than depending on host/OS state, so it is deterministic across platforms.


---

## Revision (automated review follow-up)

Addressed all 10 findings from the automated review verdict. Key behavioral changes:

- **Undeclared `open_roles` no longer renders green.** Absence is normalized once at read time (`_normalize_open_roles`) into a single unknown state covering every authoring shape — key absent, `open_roles:` with no value, explicit null — and surfaces a warning plus a distinct `staffing unknown` flag. An explicit empty list stays a real answer. *The bare-scalar shape was an escape the first fix missed and the review pass caught.*
- **One non-UTF-8 entity file no longer aborts the render.** `UnicodeDecodeError` is a `ValueError`, not an `OSError`, so it escaped the per-file guard and discarded every valid project.
- **Usage errors now print the envelope.** `argparse` raises `SystemExit` (a `BaseException`), which the top-level handler never caught, so `python3 render-dashboard.py` printed nothing to stdout. Message derived from the parser, not restated.
- **Theme values are validated** before interpolation into the `<style>` block; entity values already were.
- `avg_allocation` and `fully_allocated` are surfaced in the envelope so the documented utilization figures are reachable.
- SKILL.md documents the health labels the renderer actually emits, the `success:false` branch, and a cross-platform open step.

Test suite grew 23 → 38 assertions. The new fixtures cover genuinely malformed entities (type-invalid values, non-UTF-8 bytes, both undeclared-roles shapes) rather than merely incomplete ones — the prior fixtures were all well-formed, which is why the decode abort shipped against a green suite. Verified the new fixture reproduces the original defect when the fix is reverted.

Deferred: the same unguarded theme interpolation exists in six sibling renderers — filed as #1129 rather than expanded into this PR.
