### PR TITLE
cogni-projects: portfolio-init emits the failure envelope, not a traceback

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -270,7 +270,7 @@
     {
       "name": "cogni-projects",
       "source": "./cogni-projects",
-      "version": "0.0.8",
+      "version": "0.0.9",
       "maturity": "incubating",
       "description": "Partner-facing project-portfolio steering for consulting firms — models consultants, projects, and staffing so partners can match people to work by availability, profile fit, and strategic impact. Scaffolds a self-contained portfolio directory, authors the validated consultant, project, and assignment records, ranks candidate consultants per open role, and renders a read-only partner-meeting dashboard over them, so the backfilling recommender builds on the same portfolio.",
       "keywords": [

--- a/cogni-projects/.claude-plugin/plugin.json
+++ b/cogni-projects/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-projects",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "Partner-facing project-portfolio steering for consulting firms — models consultants, projects, and staffing so partners can match people to work by availability, profile fit, and strategic impact. Scaffolds a self-contained portfolio directory, authors the validated consultant, project, and assignment records, ranks candidate consultants per open role, and renders a read-only partner-meeting dashboard over them, so the backfilling recommender builds on the same portfolio.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-projects/scripts/portfolio-init.sh
+++ b/cogni-projects/scripts/portfolio-init.sh
@@ -23,7 +23,7 @@ fi
 mkdir -p "$BASE_DIR"/{consultants,projects,assignments,.metadata}
 
 SLUG="$SLUG" NAME="$NAME" BASE_DIR="$BASE_DIR" python3 - <<'PY'
-import json, os, datetime, tempfile
+import json, os, datetime, sys, tempfile
 
 base = os.environ["BASE_DIR"]
 today = datetime.date.today().isoformat()
@@ -77,29 +77,38 @@ def _atomic_write_json(path, data, ensure_ascii):
 
 # Seed the metadata logs before the manifest so a completed init always carries
 # the audit trail the later staffing/backfilling skills append to.
-for log, payload in [
-    ("execution-log.json", {"transitions": []}),
-    ("staffing-log.json", {"matches": []}),
-    ("decision-log.json", {"decisions": []}),
-]:
-    _atomic_write_json(os.path.join(base, ".metadata", log), payload, ensure_ascii=True)
+# A write failure re-raises OSError out of _atomic_write_json (its temp cleanup
+# has already run). Catch the whole write path so any failure surfaces as the
+# {success, data, error} envelope on stdout with a non-zero exit — never a raw
+# traceback under `set -euo pipefail`. A missing projects-portfolio.json still
+# correctly marks the init as incomplete, since the manifest is written last.
+try:
+    for log, payload in [
+        ("execution-log.json", {"transitions": []}),
+        ("staffing-log.json", {"matches": []}),
+        ("decision-log.json", {"decisions": []}),
+    ]:
+        _atomic_write_json(os.path.join(base, ".metadata", log), payload, ensure_ascii=True)
 
-# Root manifest written LAST: its existence marks a completed init (see the
-# idempotency check above). Entity arrays start empty — later children
-# (data model + entity-authoring, staffing match engine) populate them.
-project = {
-    "slug": os.environ["SLUG"],
-    "name": os.environ["NAME"],
-    "language": "en",
-    "consultants": [],
-    "projects": [],
-    "assignments": [],
-    "workflow_state": {"portfolio": "initialized"},
-    "plugin_refs": {},
-    "created": today,
-    "updated": today,
-}
-_atomic_write_json(os.path.join(base, "projects-portfolio.json"), project, ensure_ascii=False)
+    # Root manifest written LAST: its existence marks a completed init (see the
+    # idempotency check above). Entity arrays start empty — later children
+    # (data model + entity-authoring, staffing match engine) populate them.
+    project = {
+        "slug": os.environ["SLUG"],
+        "name": os.environ["NAME"],
+        "language": "en",
+        "consultants": [],
+        "projects": [],
+        "assignments": [],
+        "workflow_state": {"portfolio": "initialized"},
+        "plugin_refs": {},
+        "created": today,
+        "updated": today,
+    }
+    _atomic_write_json(os.path.join(base, "projects-portfolio.json"), project, ensure_ascii=False)
 
-print(json.dumps({"success": True, "data": {"path": base, "slug": project["slug"]}, "error": ""}))
+    print(json.dumps({"success": True, "data": {"path": base, "slug": project["slug"]}, "error": ""}))
+except Exception as exc:
+    print(json.dumps({"success": False, "data": {"path": base}, "error": str(exc)}))
+    sys.exit(1)
 PY

--- a/cogni-projects/tests/test_portfolio_init.sh
+++ b/cogni-projects/tests/test_portfolio_init.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Test portfolio-init.sh — the portfolio skeleton + manifest initializer.
+#
+# Regression for the failure-envelope contract: a write failure at any
+# _atomic_write_json call site (the three .metadata seed logs or the manifest)
+# must surface the {success, data, error} envelope on stdout with a non-zero
+# exit — never a raw Python traceback under `set -euo pipefail`.
+#
+# Covers:
+#   AC-1: a write failure prints the {success:false, ...} envelope + exits non-zero.
+#   AC-2: temp cleanup + manifest-written-last ordering preserved — on that
+#         failure path projects-portfolio.json is absent (init correctly
+#         incomplete) and no .*.tmp debris is left behind.
+#   plus the happy path still emits {success:true} and writes the manifest.
+#
+# stdlib-only (bash + python3, no pytest/pip), matching the house convention.
+#
+# Usage: bash cogni-projects/tests/test_portfolio_init.sh
+# Exits non-zero on any assertion failure.
+
+set -u  # NOT -e: a failing assertion must not abort the per-fixture counter.
+
+TESTS_DIR="$(cd "$(dirname "$0")" && pwd)"
+PLUGIN_DIR="$(cd "$TESTS_DIR/.." && pwd)"
+SCRIPT="$PLUGIN_DIR/scripts/portfolio-init.sh"
+
+if [ ! -f "$SCRIPT" ]; then
+  echo "FAIL: portfolio-init.sh not found at $SCRIPT" >&2
+  exit 1
+fi
+
+TMPROOT="$(mktemp -d)"
+trap 'chmod -R u+rwx "$TMPROOT" 2>/dev/null; rm -rf "$TMPROOT"' EXIT
+
+failures=0
+pass() { printf 'OK   %s\n' "$1"; }
+fail() { printf 'FAIL %s: %s\n' "$1" "$2" >&2; failures=$((failures + 1)); }
+
+# assert_json <label> <python-bool-expr over `d`> — pipes the captured last
+# stdout line (the envelope) into python3 and checks the expression is truthy.
+assert_json() {
+  local label="$1" expr="$2"
+  if printf '%s' "$LAST_JSON" | python3 -c "import json,sys
+d = json.loads(sys.stdin.read())
+sys.exit(0 if ($expr) else 1)" 2>/dev/null; then
+    pass "$label"
+  else
+    fail "$label" "envelope assertion failed on: $LAST_JSON"
+  fi
+}
+
+# --- Fixture 1: happy path -------------------------------------------------
+# A clean run emits {success:true} and writes projects-portfolio.json last.
+WORK1="$TMPROOT/happy"
+mkdir -p "$WORK1"
+OUT1="$(cd "$WORK1" && bash "$SCRIPT" demo "Demo Portfolio" 2>/dev/null)"
+RC1=$?
+LAST_JSON="$(printf '%s\n' "$OUT1" | tail -n 1)"
+if [ "$RC1" -eq 0 ]; then pass "1a happy path exits zero"; else fail "1a happy path exits zero" "rc=$RC1"; fi
+assert_json "1b happy path envelope success:true" "d['success'] is True"
+if [ -f "$WORK1/cogni-projects/demo/projects-portfolio.json" ]; then
+  pass "1c manifest written"
+else
+  fail "1c manifest written" "projects-portfolio.json missing"
+fi
+
+# --- Fixture 2: write failure -> envelope, not traceback -------------------
+# Pre-create the base skeleton with a read-only .metadata dir. The script's
+# `mkdir -p` is a no-op on the existing dir, then _atomic_write_json's mkstemp
+# in .metadata raises PermissionError (an OSError) — the top-level guard must
+# turn that into the {success:false} envelope + a non-zero exit.
+if [ "$(id -u)" -eq 0 ]; then
+  printf 'SKIP 2 write-failure fixture (running as root — mode bits do not deny)\n'
+else
+  WORK2="$TMPROOT/failure"
+  mkdir -p "$WORK2/cogni-projects/demo/.metadata"
+  chmod 0555 "$WORK2/cogni-projects/demo/.metadata"
+  OUT2="$(cd "$WORK2" && bash "$SCRIPT" demo "Demo Portfolio" 2>/dev/null)"
+  RC2=$?
+  LAST_JSON="$(printf '%s\n' "$OUT2" | tail -n 1)"
+  if [ "$RC2" -ne 0 ]; then pass "2a write failure exits non-zero"; else fail "2a write failure exits non-zero" "rc=$RC2"; fi
+  assert_json "2b failure envelope parses"          "isinstance(d, dict)"
+  assert_json "2c failure envelope success:false"   "d['success'] is False"
+  assert_json "2d failure envelope carries error"   "isinstance(d.get('error'), str) and len(d['error']) > 0"
+  if [ ! -f "$WORK2/cogni-projects/demo/projects-portfolio.json" ]; then
+    pass "2e manifest absent on failure (init correctly incomplete)"
+  else
+    fail "2e manifest absent on failure" "projects-portfolio.json should not exist"
+  fi
+  # Restore write bit so the tmp .metadata can be inspected / cleaned, then
+  # assert no half-written temp debris was left behind by _atomic_write_json.
+  chmod 0755 "$WORK2/cogni-projects/demo/.metadata"
+  if [ -z "$(find "$WORK2/cogni-projects/demo/.metadata" -name '.*.tmp' 2>/dev/null)" ]; then
+    pass "2f no temp-file debris left behind"
+  else
+    fail "2f no temp-file debris left behind" "a .*.tmp file survived the failed write"
+  fi
+fi
+
+# --- Summary ---------------------------------------------------------------
+if [ "$failures" -eq 0 ]; then
+  echo "All portfolio-init tests passed."
+  exit 0
+else
+  echo "$failures assertion(s) failed." >&2
+  exit 1
+fi


### PR DESCRIPTION
Closes #1128.

## Summary
- `portfolio-init.sh` imported `json, os, datetime, tempfile` but not `sys`, and its heredoc had no top-level try/except — so an `OSError` re-raised by `_atomic_write_json` escaped as a raw Python traceback under `set -euo pipefail`, breaking the `{success, data, error}` envelope contract on exactly the failure path where a clean, parseable error matters most.
- Added `import sys` and wrapped the seed-log loop, the manifest write, and the success print in a single top-level `try/except Exception` that, on any write-path failure, prints `{"success": false, "data": {"path": base}, "error": "<message>"}` on stdout and `sys.exit(1)`. A broad `Exception` guard means any write failure yields the envelope, per the issue's intent.
- Preserved `_atomic_write_json`'s temp-file cleanup and the manifest-written-last ordering — the existence of `projects-portfolio.json` stays a reliable "fully initialized" marker (absent on the failure path).
- Added `tests/test_portfolio_init.sh`, a stdlib-only sibling suite that forces a write failure via a read-only `base/.metadata` directory and asserts the failure envelope + non-zero exit + no temp-file debris, alongside a happy-path assertion. (Lives in its own suite, matching `test-render-dashboard.sh` — the existing `test_register_entity.sh` loads a Python module and cannot drive a bash heredoc script; the issue explicitly permits a sibling suite.)
- Bumped cogni-projects `0.0.8` -> `0.0.9` in `plugin.json` and mirrored it in `marketplace.json`.

## Acceptance criteria
- [x] A write failure at any `_atomic_write_json` call site prints the `{success, data, error}` envelope on stdout and exits non-zero.
- [x] Temp-file cleanup and the manifest-written-last ordering preserved.
- [x] A regression assertion covering the failure envelope added (`tests/test_portfolio_init.sh`).

## Test plan
- [x] `bash cogni-projects/tests/test_portfolio_init.sh` passes (9/9 assertions: happy path + failure envelope + non-zero exit + no temp debris).
- [x] `bash cogni-projects/tests/test_register_entity.sh` still passes (no sibling regression).
- [x] `plugin.json` and `marketplace.json` both read `0.0.9`.