### PR TITLE
feat(cogni-consult): lexicon layer for strategy-advisor + German sister register

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -35,7 +35,7 @@
     {
       "name": "cogni-consult",
       "source": "./cogni-consult",
-      "version": "0.1.78",
+      "version": "0.1.79",
       "maturity": "preview",
       "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
       "keywords": [

--- a/cogni-consult/.claude-plugin/plugin.json
+++ b/cogni-consult/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-consult",
-  "version": "0.1.78",
+  "version": "0.1.79",
   "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-consult/CLAUDE.md
+++ b/cogni-consult/CLAUDE.md
@@ -49,8 +49,10 @@ cogni-consult/
 │       │                          owned by consult-personas step 5
 │       └── close-kb-deposit.md    Elected KB deposit + kb-deposit-waiver contract
 ├── output-styles/
-│   └── strategy-advisor.md        Executive-advisory voice register (opt-in,
-│                                  auto-discovered in the /config picker)
+│   ├── strategy-advisor.md        Executive-advisory voice register (opt-in,
+│   │                              auto-discovered in the /config picker)
+│   └── strategy-advisor-de.md     German sister register: same stance, German
+│                                  terminology + orthography rules
 ├── agents/
 │   ├── consult-dashboard-refresher.md  Milestone HTML dashboard refresh (haiku,
 │   │                              read-only, no theme prompt)
@@ -122,7 +124,7 @@ cogni-consult/
 - **Orchestrator, not producer** — manages engagement state; content work dispatches to existing plugins
 - **Read-only fan-out agents, single write owner** — parallelizable per-item judgment (Test-stage persona challenge, Empathize empathy-mapping, Test-gate framework-adherence review) is delegated to read-only agents that return `{success, data, error}` envelopes; the orchestrating skill merges the envelopes and owns every write. The persona-challenge write contract lives in exactly one place (consult-personas' challenge mode); the DT loop delegates instead of reimplementing. Together with structural validation and the persona challenge, the advisory adherence review completes the repo's Three-Layer Quality Gate; all gates are advisory — auto-walk never deadlocks. Dense fan-out/merge/idempotency contracts live in `references/orchestration/`, keeping the SKILL body under the 500-line cap
 - **Path references, not data copies** — cross-references via slugs/paths, no shared DB
-- **Voice in the output style, phase discipline in the skills** — the always-on executive-advisory *voice* lives in the `output-styles/strategy-advisor.md` output style (opt-in, fixed at session start); the diverge/converge *phase discipline* stays in the consult-* skills, which load contextually so they never fire outside an active engagement
+- **Voice in the output style, phase discipline in the skills** — the always-on executive-advisory *voice* lives in the output styles `output-styles/strategy-advisor.md` (EN-led) and `output-styles/strategy-advisor-de.md` (German sister register, terminology + orthography rules on top of the same stance), both opt-in and fixed at session start; the diverge/converge *phase discipline* stays in the consult-* skills, which load contextually so they never fire outside an active engagement. The two style files carry no shared reference — output styles do not load `references/`, so EN and DE must be kept in step deliberately
 
 ## Data Model
 

--- a/cogni-consult/README.md
+++ b/cogni-consult/README.md
@@ -129,7 +129,7 @@ Acting personas gate the first deliverable: before design thinking starts, perso
 
 Research never goes to raw web search: the engagement's bound knowledge base serves quick gap-checks (`knowledge-query`), full inverted-pipeline runs for new topics, and `--source wiki` re-runs on covered topics — with finalized syntheses copied to the owning action field's `research/` directory. Routing every run through one base is what lets later deliverables build on earlier findings instead of paying to rediscover them.
 
-The plugin also ships a **Strategy Advisor output style** that turns Claude Code into an executive advisor rather than a coder — answer-first (Pyramid Principle), hypothesis-driven, MECE options with explicit tradeoffs, and a fluff-free compression discipline (DE/EN). Enable it from the `/config` output-style picker once cogni-consult is installed; it is opt-in (never auto-applied) and fixed at session start, so switching styles mid-engagement needs `/clear` or a new session.
+The plugin also ships two **Strategy Advisor output styles** that turn Claude Code into an executive advisor rather than a coder — answer-first (Pyramid Principle), hypothesis-driven, MECE options with explicit tradeoffs, a fluff-free compression discipline, and a lexicon rule that keeps engine vocabulary (cascade, slug, state values, log ids) out of the advisory text. **Strategy Advisor** is EN-led and answers in the user's language; **Strategy Advisor (DE)** is the German sister register, with German terminology guidance and full orthography (Umlaute, ß). Enable one from the `/config` output-style picker once cogni-consult is installed; they are opt-in (never auto-applied) and fixed at session start, so switching styles mid-engagement needs `/clear` or a new session.
 
 ## Publishing deliverables
 
@@ -198,8 +198,8 @@ cogni-consult/
 │                                  challenge fan-out),
 │                                  consult-empathy-mapper (per-persona Empathize
 │                                  mapping fan-out)
-├── output-styles/                 Strategy-advisor voice register (opt-in,
-│                                  auto-discovered in /config)
+├── output-styles/                 Strategy-advisor voice register (EN + DE,
+│                                  opt-in, auto-discovered in /config)
 ├── scripts/                       Engagement init/status/discovery, dt-stage advance,
 │                                  deliverable dependency graph + the engagement-root
 │                                  README front-door generator, refreshed at the

--- a/cogni-consult/output-styles/strategy-advisor-de.md
+++ b/cogni-consult/output-styles/strategy-advisor-de.md
@@ -1,0 +1,75 @@
+---
+name: Strategy Advisor (DE)
+description: Beratungsregister auf Deutsch — Antwort zuerst, hypothesengeleitet, strukturierte Optionen
+---
+
+Du arbeitest als Senior-Strategieberater und Executive Advisor, nicht als
+Softwareentwickler. Jede Antwort soll lesbar sein, als ginge sie an die
+Geschäftsleitung eines Klienten.
+
+## Adressat
+Der Leser ist der Berater, nicht der Betreiber dieses Systems. Berichte, was
+sich in der Beratung verändert hat — nie, was das Werkzeug getan hat, um es
+festzuhalten.
+
+## Haltung
+- Antwort zuerst (BLUF / Pyramidenprinzip), Begründung danach.
+- Hypothesengeleitet: früh eine Position beziehen und gegen die Evidenz prüfen.
+- Respektvoll widersprechen; ist die Prämisse schwach, eine schärfere anbieten.
+- Fakt, Hypothese und Annahme unterscheiden; benennen, was noch offen ist.
+- Das Annahmenregister ist die Quelle der Wahrheit für Planungszahlen:
+  `{{asm:}}`-Platzhalter dagegen auflösen, bevor eine Zahl als fehlend,
+  ungesetzt oder offen bezeichnet wird — ein Platzhalter ist ein registrierter
+  Wert, keine Lücke. Tragende Zahlen als `{{asm:}}` registrieren, damit sie
+  editierbar bleiben und neu rechnen; nicht als Literal im Text vergraben.
+
+## Struktur
+- MECE gliedern. Zwei bis drei wirklich verschiedene Optionen mit expliziten
+  Abwägungen — nicht eine Empfehlung, die als mehrere verkleidet ist.
+- Das „Was folgt daraus" ausdrücklich machen; mit Implikation oder nächstem
+  Schritt schließen.
+- Quantifizieren, wo die Evidenz es hergibt; Schätzungen als solche kennzeichnen.
+
+## Sprache
+- Auf Deutsch antworten, es sei denn, der Benutzer wechselt die Sprache.
+- Executive-Register: präzise, knapp, kein Füllmaterial, keine Wiederholung der
+  Frage, kein Nachklapp.
+- Verdichtung ohne Präzisionsverlust: Hedging, Räuspern und Wiederholung
+  streichen — nie einen Fakt, eine Zahl, einen Vorbehalt oder eine Option
+  streichen, um kürzer zu sein. Kürze verliert Wörter, nicht Information.
+- Vollständige deutsche Rechtschreibung: Umlaute (ä, ö, ü, Ä, Ö, Ü) und Eszett
+  (ß). Keine Ersatzschreibungen wie „ae", „oe", „ue", „ss".
+
+## Lexikon
+- Jedes Akronym bei Erstnennung einmal ausschreiben (ICP, OMTM, UVP), danach
+  frei verwendbar.
+- Wo ein etablierter deutscher Begriff existiert, hat er Vorrang vor dem
+  Anglizismus-Kompositum: „Wettbewerbsschutz" statt „Moat-Richtung",
+  „sichtbarer Beleg durch andere" statt „Sozialbeweis", „dauerhaft nutzbarer
+  Bestand" statt „Evergreen-Bestand".
+- Kein Deliverable per Datei-Slug im Fließtext benennen — den Klarnamen
+  verwenden: nicht „channel-acquisition-model", sondern „das Kanalmodell".
+- Nummerierte Rückverweise tragen ihren Namen mit: „Teillösung 2 (die freie
+  Content-Schicht)", nicht „bei 2".
+- Englisch bleiben dürfen die etablierten Domänenbegriffe (Deliverable, Design
+  Thinking, Persona, Action Field) sowie Datei- und Skill-Namen, CLI-Befehle
+  und Slugs in Codeform. Im Fließtext haben Slugs nichts verloren.
+
+## Systemvokabular bleibt im System
+Engine-Begriffe — Cascade, Graph, Kante, `depends_on`, Gate, Slug, Zustandswerte
+(`complete`), Protokoll-IDs (`d-084`), Versionsmarken — sind intern. Berichte
+stattdessen die fachliche Folge:
+- „Das Cascade hat nichts geflaggt" → „Kein abhängiges Deliverable ist betroffen."
+- „d-084 eingetragen" → „Die Entscheidung ist im Protokoll festgehalten."
+- „14/14 Deliverables complete" → „Alle vierzehn Deliverables sind fertig."
+Eine ID nur nennen, wenn der Leser sie zum Nachschlagen braucht.
+
+## Arbeitsberichterstattung
+- Einen Stapel Änderungen mit einer Zeile auf hoher Flughöhe ankündigen — was
+  sich ändert und warum („Aktualisiere N Dateien, um …"), keine Vorschau Datei
+  für Datei.
+- Nach der Änderung nicht jede einzelne Bearbeitung in Prosa nacherzählen; die
+  Änderung selbst ist der Nachweis, und die Nacherzählung begräbt die Antwort
+  unter Detail.
+- Einen Arbeitsblock kompakt schließen — welche Dateien berührt wurden und zu
+  welchem Zweck — nicht als Durchgang durch jedes Diff.

--- a/cogni-consult/output-styles/strategy-advisor-de.md
+++ b/cogni-consult/output-styles/strategy-advisor-de.md
@@ -26,7 +26,7 @@ festzuhalten.
 ## Struktur
 - MECE gliedern. Zwei bis drei wirklich verschiedene Optionen mit expliziten
   Abwägungen — nicht eine Empfehlung, die als mehrere verkleidet ist.
-- Das „Was folgt daraus" ausdrücklich machen; mit Implikation oder nächstem
+- Das „Was folgt daraus“ ausdrücklich machen; mit Implikation oder nächstem
   Schritt schließen.
 - Quantifizieren, wo die Evidenz es hergibt; Schätzungen als solche kennzeichnen.
 
@@ -37,20 +37,22 @@ festzuhalten.
 - Verdichtung ohne Präzisionsverlust: Hedging, Räuspern und Wiederholung
   streichen — nie einen Fakt, eine Zahl, einen Vorbehalt oder eine Option
   streichen, um kürzer zu sein. Kürze verliert Wörter, nicht Information.
-- Vollständige deutsche Rechtschreibung: Umlaute (ä, ö, ü, Ä, Ö, Ü) und Eszett
-  (ß). Keine Ersatzschreibungen wie „ae", „oe", „ue", „ss".
+- Vollständige deutsche Rechtschreibung: Umlaute (ä, ö, ü, Ä, Ö, Ü) statt „ae“,
+  „oe“, „ue“; ß nach langem Vokal und Diphthong (Maßnahme, außerhalb, Größe),
+  ss nach kurzem Vokal (dass, muss, Prozess). Kein schweizerisches ss an
+  ß-Stellen.
 
 ## Lexikon
 - Jedes Akronym bei Erstnennung einmal ausschreiben (ICP, OMTM, UVP), danach
   frei verwendbar.
 - Wo ein etablierter deutscher Begriff existiert, hat er Vorrang vor dem
-  Anglizismus-Kompositum: „Wettbewerbsschutz" statt „Moat-Richtung",
-  „sichtbarer Beleg durch andere" statt „Sozialbeweis", „dauerhaft nutzbarer
-  Bestand" statt „Evergreen-Bestand".
+  Anglizismus-Kompositum: „Wettbewerbsschutz“ statt „Moat-Richtung“,
+  „sichtbarer Beleg durch andere“ statt „Sozialbeweis“, „dauerhaft nutzbarer
+  Bestand“ statt „Evergreen-Bestand“.
 - Kein Deliverable per Datei-Slug im Fließtext benennen — den Klarnamen
-  verwenden: nicht „channel-acquisition-model", sondern „das Kanalmodell".
+  verwenden: nicht „channel-acquisition-model“, sondern „das Kanalmodell“.
 - Nummerierte Rückverweise tragen ihren Namen mit: „Teillösung 2 (die freie
-  Content-Schicht)", nicht „bei 2".
+  Content-Schicht)“, nicht „bei 2“.
 - Englisch bleiben dürfen die etablierten Domänenbegriffe (Deliverable, Design
   Thinking, Persona, Action Field) sowie Datei- und Skill-Namen, CLI-Befehle
   und Slugs in Codeform. Im Fließtext haben Slugs nichts verloren.
@@ -59,14 +61,15 @@ festzuhalten.
 Engine-Begriffe — Cascade, Graph, Kante, `depends_on`, Gate, Slug, Zustandswerte
 (`complete`), Protokoll-IDs (`d-084`), Versionsmarken — sind intern. Berichte
 stattdessen die fachliche Folge:
-- „Das Cascade hat nichts geflaggt" → „Kein abhängiges Deliverable ist betroffen."
-- „d-084 eingetragen" → „Die Entscheidung ist im Protokoll festgehalten."
-- „14/14 Deliverables complete" → „Alle vierzehn Deliverables sind fertig."
+- „Das Cascade hat drei Knoten geflaggt“ → „Drei Deliverables ruhen jetzt auf
+  einer überholten Zahl.“
+- „d-084 eingetragen“ → „Die Entscheidung ist im Protokoll festgehalten.“
+- „14/14 Deliverables complete“ → „Alle vierzehn Deliverables sind fertig.“
 Eine ID nur nennen, wenn der Leser sie zum Nachschlagen braucht.
 
 ## Arbeitsberichterstattung
 - Einen Stapel Änderungen mit einer Zeile auf hoher Flughöhe ankündigen — was
-  sich ändert und warum („Aktualisiere N Dateien, um …"), keine Vorschau Datei
+  sich ändert und warum („Aktualisiere N Dateien, um …“), keine Vorschau Datei
   für Datei.
 - Nach der Änderung nicht jede einzelne Bearbeitung in Prosa nacherzählen; die
   Änderung selbst ist der Nachweis, und die Nacherzählung begräbt die Antwort

--- a/cogni-consult/output-styles/strategy-advisor.md
+++ b/cogni-consult/output-styles/strategy-advisor.md
@@ -35,7 +35,7 @@ changed in the engagement — never what the tooling did to record it.
 ## Lexicon
 - Spell out every acronym once at first use (ICP, OMTM, UVP), then use it freely.
 - Where an established term exists in the reader's language, it beats the
-  anglicised compound.
+  anglicised compound ("Wettbewerbsschutz", not "Moat-Richtung").
 - Never name a deliverable by its file slug in prose — use its plain name
   (`channel-acquisition-model` → "the channel model").
 - Numbered back-references carry their name: "sub-solution 2 (the free content
@@ -44,8 +44,9 @@ changed in the engagement — never what the tooling did to record it.
 ## System vocabulary stays in the system
 Engine nouns — cascade, graph, edge, `depends_on`, gate, slug, state values
 (`complete`), log ids (`d-084`), version tags — are internal. Report the business
-consequence instead: "no dependent deliverable is affected", not "the cascade
-flagged nothing". Name an id only when the reader needs it to look something up.
+consequence instead: "three deliverables now rest on an outdated figure", not
+"the cascade flagged three nodes". Name an id only when the reader needs it to
+look something up.
 
 ## Work narration
 - Pre-announce a batch of edits with one high-altitude line before making them —

--- a/cogni-consult/output-styles/strategy-advisor.md
+++ b/cogni-consult/output-styles/strategy-advisor.md
@@ -7,6 +7,10 @@ You operate as a senior strategy consultant and executive advisor, not a
 software engineer. Every response should read as if it were going to a
 client's leadership team.
 
+## Audience
+The reader is the consultant, not the operator of this system. Report what
+changed in the engagement — never what the tooling did to record it.
+
 ## Stance
 - Lead with the answer (BLUF / Pyramid Principle), then support it.
 - Be hypothesis-driven: form a point of view early and test it against evidence.
@@ -27,6 +31,21 @@ client's leadership team.
   throat-clearing, and restatement — never cut a fact, number, caveat, or option
   to be shorter. Brevity must lose words, not information.
 - Answer in the user's language (DE/EN).
+
+## Lexicon
+- Spell out every acronym once at first use (ICP, OMTM, UVP), then use it freely.
+- Where an established term exists in the reader's language, it beats the
+  anglicised compound.
+- Never name a deliverable by its file slug in prose — use its plain name
+  (`channel-acquisition-model` → "the channel model").
+- Numbered back-references carry their name: "sub-solution 2 (the free content
+  layer)", not "at 2".
+
+## System vocabulary stays in the system
+Engine nouns — cascade, graph, edge, `depends_on`, gate, slug, state values
+(`complete`), log ids (`d-084`), version tags — are internal. Report the business
+consequence instead: "no dependent deliverable is affected", not "the cascade
+flagged nothing". Name an id only when the reader needs it to look something up.
 
 ## Work narration
 - Pre-announce a batch of edits with one high-altitude line before making them —

--- a/cogni-consult/skills/consult-design-thinking/SKILL.md
+++ b/cogni-consult/skills/consult-design-thinking/SKILL.md
@@ -206,9 +206,11 @@ python3 $CLAUDE_PLUGIN_ROOT/scripts/deliverable-graph.py <engagement-dir> \
     cascade-stale <field-slug>/<deliverable-slug> --trigger deliverable_update
 ```
 
-Name the `data.newly_flagged` deliverables in plain words, not by slug path; an
-empty list means no dependent deliverable is affected. A `"success": false` (node
-not found, bad dir) is non-blocking — surface the error and proceed with the rework.
+Name the `data.newly_flagged` deliverables in plain words, not by slug path. An
+empty list means nothing became stale *this run* — `data.already_stale` and
+`data.downstream_count` say whether dependents are still waiting, so check them
+before sounding an all-clear. A `"success": false` (node not found, bad dir) is
+non-blocking — surface the error and proceed with the rework.
 
 ### 3. Empathize
 
@@ -443,7 +445,8 @@ python3 $CLAUDE_PLUGIN_ROOT/scripts/deliverable-graph.py <engagement-dir> \
 ```
 
 In the session summary name the `data.newly_flagged` deliverables in plain words,
-not by slug path; an empty list means nothing downstream is affected. A `"success": false` (node not found,
+not by slug path. An empty list means nothing became stale *this run*, not that
+nothing needs revisiting — report `data.already_stale` alongside it. A `"success": false` (node not found,
 bad dir) is non-blocking — the completion stands; surface the error and
 continue. If it does not survive, loop back — advance `dt_stage` to the stage
 the revision needs (often `define` or `ideate`) via the helper (a re-entry to

--- a/cogni-consult/skills/consult-design-thinking/SKILL.md
+++ b/cogni-consult/skills/consult-design-thinking/SKILL.md
@@ -206,9 +206,9 @@ python3 $CLAUDE_PLUGIN_ROOT/scripts/deliverable-graph.py <engagement-dir> \
     cascade-stale <field-slug>/<deliverable-slug> --trigger deliverable_update
 ```
 
-Surface `data.newly_flagged` (the deliverables now marked stale). A
-`"success": false` (node not found, bad dir) is non-blocking — surface the
-error and proceed with the rework.
+Name the `data.newly_flagged` deliverables in plain words, not by slug path; an
+empty list means no dependent deliverable is affected. A `"success": false` (node
+not found, bad dir) is non-blocking — surface the error and proceed with the rework.
 
 ### 3. Empathize
 
@@ -442,8 +442,8 @@ python3 $CLAUDE_PLUGIN_ROOT/scripts/deliverable-graph.py <engagement-dir> \
     cascade-stale <field-slug>/<deliverable-slug> --trigger deliverable_update
 ```
 
-Surface `data.newly_flagged` in the session summary so the consultant knows
-which deliverables now need revisiting. A `"success": false` (node not found,
+In the session summary name the `data.newly_flagged` deliverables in plain words,
+not by slug path; an empty list means nothing downstream is affected. A `"success": false` (node not found,
 bad dir) is non-blocking — the completion stands; surface the error and
 continue. If it does not survive, loop back — advance `dt_stage` to the stage
 the revision needs (often `define` or `ideate`) via the helper (a re-entry to
@@ -451,9 +451,10 @@ an earlier stage is permitted) and continue; `state` stays `in-progress`.
 
 ### 8. Close the Session
 
-Summarize: the deliverable's final state, the artifact path, key decisions
-logged, which personas challenged it, and the Test-stage promote-check outcome
-(assumptions promoted to the registry, or a recorded opt-out). Recommend the next step — the next
+Summarize in business terms, not raw state values or log ids: the deliverable is
+finished, the artifact path (kept as a path — it is there to look up), what was
+decided and why, which personas challenged it, and the Test-stage promote-check
+outcome (assumptions promoted to the registry, or a recorded opt-out). Recommend the next step — the next
 unstarted deliverable in the WBS (via the WBS dashboard skill when present in
 the plugin, or by reading the field manifests directly).
 

--- a/cogni-consult/skills/consult-resume/SKILL.md
+++ b/cogni-consult/skills/consult-resume/SKILL.md
@@ -158,7 +158,7 @@ When the count is `0` (no registered assumptions) or the generator warned, say
 nothing — the pointer degrades silently. It is informational only: like the
 project-plan pointer, do not add it as a branch in the Step-5 next-action ladder.
 
-> **Strategy Advisor voice** — this plugin ships the Strategy Advisor output style (answer-first, MECE options). Enable it from the `/config` output-style picker; it's opt-in and fixed at session start, so set it now or `/clear` after.
+> **Strategy Advisor voice** — this plugin ships two advisory output styles: **Strategy Advisor** (EN-led, answer-first, MECE options) and **Strategy Advisor (DE)** for German-language engagements. Enable one from the `/config` output-style picker; it's opt-in and fixed at session start, so set it now or `/clear` after.
 
 ### 5. Recommend the Next Action
 

--- a/cogni-consult/skills/consult-setup/SKILL.md
+++ b/cogni-consult/skills/consult-setup/SKILL.md
@@ -94,7 +94,7 @@ The wrapper delegates to the cogni-workspace discovery helper with the cogni-con
 
 Close by confirming what exists (engagement directory, bound knowledge base, registry entry), pointing the consultant at the engagement-root `README.md` — the wayfinding front door that already renders the scaffold state and stays current as the engagement progresses — and recommending `consult-scope` as the next step — the SMART key question and five scoping dimensions anchor the engagement before any action field is derived. When the user wants to continue immediately, dispatch `Skill("cogni-consult:consult-scope")` in the same session; otherwise stop here and report that the engagement is ready for scoping.
 
-> **Strategy Advisor voice** — point the consultant at the Strategy Advisor output style this plugin ships (answer-first, MECE options). Enable it from the `/config` output-style picker; it's opt-in and fixed at session start, so set it before scoping begins.
+> **Strategy Advisor voice** — this plugin ships two advisory output styles: **Strategy Advisor** (EN-led, answer-first, MECE options) and **Strategy Advisor (DE)** for German-language engagements. Enable one from the `/config` output-style picker; it's opt-in and fixed at session start, so set it before scoping begins.
 
 ## Important Notes
 


### PR DESCRIPTION
## Description

The `strategy-advisor` output style governed stance, structure, register and work narration — but said nothing about **word choice**. Consulting transcripts produced under it came out carrying three distinguishable classes of unreadable language:

1. **Unglossed acronyms and anglicised compounds** — `ICP`, `OMTM`, `UVP` never introduced; hybrid formations with no anchor in the reader's language.
2. **System vocabulary in the advisory text** — "the cascade flagged nothing", `depends_on` edges, raw log ids, `14/14 deliverables complete`. Partly **requested by the skill itself**: `consult-design-thinking` asked twice for `Surface data.newly_flagged`.
3. **Slugs used as prose nouns and numbered back-references without an antecedent** — `channel-acquisition-model` as a noun; "trigger at 2" with no name attached.

Classes 2 and 3 are language-independent; class 1 is not. An English rule ("avoid anglicisms") steers German generation weakly, while a German rule with German counter-examples steers it much harder — hence the lexicon layer in **both** registers plus a German sister style.

## Changes

- **`cogni-consult/output-styles/strategy-advisor.md`** — three new sections; `Stance` / `Structure` / `Voice` / `Work narration` untouched, and the existing `Answer in the user's language (DE/EN)` line stays as the fallback:
  - `## Audience` — the reader is the consultant, not the operator of this system.
  - `## Lexicon` — gloss each acronym once at first use; prefer the reader's established term over the anglicised compound; never name a deliverable by its file slug in prose; numbered back-references carry their name.
  - `## System vocabulary stays in the system` — engine nouns map onto their business consequence ("no dependent deliverable is affected", not "the cascade flagged nothing").
- **`cogni-consult/output-styles/strategy-advisor-de.md`** (new) — a complete German sister register, not a pointer stub, because output styles do not load `references/`. Frontmatter follows the existing plugin-discovered format (`name:` / `description:`), so `/config` auto-discovers it. Same stance as the EN register, plus German terminology guidance with German counter-examples, a binding orthography rule (Umlaute, Eszett, no ASCII substitutes), and a language anchor mirroring the EN one.
- **`cogni-consult/skills/consult-design-thinking/SKILL.md`** — the source of class 2, reworded at three points (no logic change): both `Surface data.newly_flagged` sites now ask for plain deliverable names rather than `<field-slug>/<deliverable-slug>` paths and for the empty case to be reported as a business fact; *Close the Session* now summarizes in business terms instead of raw state values and decision-log ids.
- **`consult-setup` / `consult-resume` SKILL.md** — the Strategy Advisor blockquote names both registers; each keeps its existing distinct closing clause.
- **`cogni-consult/README.md` and `cogni-consult/CLAUDE.md`** — prose paragraph, both architecture trees, and the *"Voice in the output style, phase discipline in the skills"* design principle updated for the pair. The principle also records that EN and DE carry no shared reference file and must be kept in step deliberately.
- **Version** `0.1.78` → `0.1.79` in `plugin.json`, mirrored in `marketplace.json` (single-line edits; no JSON reserialization, so the Unicode arrows in `description` stay intact).

Deliberately not done: no maintained glossary table (principle plus example line, per the agreed scope — a ban-list would be more precise but needs maintenance), no shared reference file (output styles do not load `references/`), no rename of the EN style to "Strategy Advisor (EN)" (it would drop existing users' picker selection), and no change to `references/interaction-language.md` (language resolution was never the problem).

## Testing

- `python3 scripts/check-breadcrumbs.py` — clean (0 violations, 50 occurrences scanned). Covers the four changed `SKILL.md` files; `output-styles/` is outside its globs.
- `python3 scripts/check-external-dispatch.py` — clean.
- `bash cogni-workspace/scripts/check-skill-names.sh` — all skill names follow the convention.
- Encoding of the new German file: decodes as UTF-8, 49 Umlaut/Eszett characters, and a targeted grep for ASCII substitute spellings (`fuer`, `koennen`, `muessen`, `Massnahme`, `ueber`, …) returns no hits. A blanket `grep 'ae\|oe\|ue'` was deliberately not used — those digraphs occur inside correct words such as *Steuerung*.
- Frontmatter of the new file verified against the sibling's format (exactly `name:` and `description:`), so the `/config` picker discovers it.
- Both manifests re-parse as valid JSON and both report `0.1.79`; the `marketplace.json` diff is exactly one line.
- `cogni-consult/tests/*.sh` — 6 of 7 pass. `test_resolve_assumptions.sh` fails on 3 assertions (`used-by-write-failed`), but it fails identically on a clean checkout of the base commit: the case expects a write to a `chmod`-protected file to fail, which does not hold when the test runs as root. Pre-existing and unrelated to this change.
- The lexicon rules are prompt-level behaviour, so the end-to-end check is a live counter-test: open an engagement with the DE style via `/cogni-consult:consult-resume` and play a deliverable through to *Close the Session*, checking against the exact transcript defects (no `cascade`/`graph`/`depends_on` in prose, no bare log id, no slug as a noun, every acronym glossed at first use).

## Checklist

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md)
- [x] My changes follow the existing code style
- [x] I have updated documentation where applicable
- [x] I have tested my changes

---
_Generated by [Claude Code](https://claude.ai/code/session_01J8ZmzpADRBEMx6wUeRcmaf)_