### PR TITLE
cogni-projects: exclude closed projects from open-role total

### DIFF
--- a/cogni-projects/scripts/render-dashboard.py
+++ b/cogni-projects/scripts/render-dashboard.py
@@ -222,6 +222,43 @@ def _project_health(filled, open_roles, status):
     return ("%d/%d roles open" % (total - filled, total), "warn")
 
 
+def _is_closed(status):
+    """Whether a project status means the work is over — delivered or lost.
+
+    Matches case-insensitively, the way staffing-score.py does, so the dashboard
+    and the staffing shortlist agree on which projects are still live.
+
+    Two older checks in this file — _project_health's `status == "closed"` and
+    the warning gate in _compute — compare the literal case-sensitively and are
+    deliberately left alone here, since switching them changes what a row
+    renders. That means a non-conforming `status: Closed` is read as closed by
+    this predicate but not by those two, so the tile and the row would disagree.
+    The schema only admits lowercase `closed`, so that split needs a record that
+    already failed validation; unify the three when one is willing to take the
+    rendering change.
+    """
+    return str(status or "").strip().lower() == "closed"
+
+
+def _open_role_demand(projects):
+    """Sum unfilled roles across the projects that still represent live demand.
+
+    A closed project is delivered or lost, so its declared roles are not work
+    anyone will staff — staffing-score.py drops the same set before scoring, and
+    the data model says as much. Counting them here made the headline number
+    disagree with the shortlist a partner acts on.
+
+    Only `closed` is excluded, never an `active` allowlist: `prospective` is a
+    valid status, and filtering to active alone would silently drop pipeline
+    demand — the same divergence in the other direction.
+    """
+    return sum(
+        p["roles_total"] - p["roles_filled"]
+        for p in projects
+        if not _is_closed(p["status"])
+    )
+
+
 def _compute(entities, warnings):
     """Derive per-project staffing + the portfolio value/utilization aggregates.
 
@@ -349,7 +386,7 @@ def _render_html(portfolio, projects, value_by_impact, util, warnings, theme):
         )
 
     avg = "—" if util["avg_allocation"] is None else "%d%%" % util["avg_allocation"]
-    total_open = sum(p["roles_total"] - p["roles_filled"] for p in projects)
+    total_open = _open_role_demand(projects)
 
     return """<!DOCTYPE html>
 <html lang="en"><head><meta charset="utf-8">
@@ -495,7 +532,7 @@ def main(argv):
             "consultants": util["consultants"],
             "avg_allocation": util["avg_allocation"],
             "fully_allocated": util["fully_allocated"],
-            "open_roles": sum(p["roles_total"] - p["roles_filled"] for p in projects),
+            "open_roles": _open_role_demand(projects),
             "warnings": warnings,
             "partial": bool(warnings),
         },

--- a/cogni-projects/skills/projects-dashboard/SKILL.md
+++ b/cogni-projects/skills/projects-dashboard/SKILL.md
@@ -33,6 +33,13 @@ records (their field contract lives in
   Two flags read alike but are not: `no open roles` means the project needs
   nobody right now, while `staffing unknown` means it never declared
   `open_roles`, so coverage cannot be read — never narrate it as covered.
+  The headline figure (`data.open_roles` and the `Open roles` tile) counts
+  unfilled roles on non-closed projects only — closed work is delivered or
+  lost, not live demand — so it matches the set `projects-staff` shortlists. A
+  `prospective` project still counts, so read it as live-and-pipeline demand,
+  not active-only. The closed project stays in the table with its `closed`
+  flag and still counts toward the `Projects` tile, so a shrinking open-role
+  total is not a missing project.
 - **Portfolio value**: projects grouped by `strategic_impact` (1–5), so the
   high-impact work is visible at a glance.
 - **Utilization**: the envelope carries an average-allocation figure and a

--- a/cogni-projects/tests/test-render-dashboard.sh
+++ b/cogni-projects/tests/test-render-dashboard.sh
@@ -391,6 +391,50 @@ assert_html_lacks "8e url() beacon theme value rejected" \
 assert_html "8f safe accent still applied alongside rejected url()" \
   "#00ff88" "$PF8/output/dashboard.html"
 
+# Fixture 9 — a closed project's declared roles are not open demand. The closed
+# project stays visible in the table with its flag (9g/9h); only the headline
+# figure drops it, so a shrinking total is not a vanished project. 9c and 9f are
+# a pair because the envelope and the HTML tile are separate call sites in the
+# renderer — fixing one alone would ship a dashboard that disagrees with itself,
+# so asserting only one of them would let that regression through.
+PF9="$TMPROOT/closed"
+seed_portfolio "$PF9"
+write_entity "$PF9/projects/live-crm.md" <<'EOF'
+---
+type: project
+slug: live-crm
+name: Live CRM Rollout
+client: Northwind
+strategic_impact: 4
+status: active
+open_roles: [crm-lead]
+---
+# Live CRM Rollout
+EOF
+write_entity "$PF9/projects/legacy-migration.md" <<'EOF'
+---
+type: project
+slug: legacy-migration
+name: Legacy Migration
+client: Northwind
+strategic_impact: 3
+status: closed
+open_roles: [migration-lead, data-engineer]
+---
+# Legacy Migration
+EOF
+run "$PF9"
+HTML9="$PF9/output/dashboard.html"
+assert_json "9a closed-portfolio render succeeds" "d['success'] is True"
+assert_json "9b closed project still counted as a project" "d['data']['projects'] == 2"
+assert_json "9c open roles exclude the closed project" "d['data']['open_roles'] == 1"
+assert_json "9d closed project emits no warning" "d['data']['warnings'] == []"
+assert_json "9e clean snapshot" "d['data']['partial'] is False"
+assert_html "9f tile agrees with the envelope" \
+  '<div class="n">1</div><div class="l">Open roles</div>' "$HTML9"
+assert_html "9g closed project still listed" "Legacy Migration" "$HTML9"
+assert_html "9h closed health flag still rendered" ">closed</span>" "$HTML9"
+
 echo
 if [ "$failures" -eq 0 ]; then
   echo "All render-dashboard tests passed."


### PR DESCRIPTION
Refs #1152.

## Summary
- `render-dashboard.py` counted unfilled roles on **every** project, including ones with `status: closed`, in both the JSON envelope (`data.open_roles`) and the "Open roles" HTML tile. A partner reading the dashboard saw hiring demand that `projects-staff` would never act on.
- Both summation sites now call one `_open_role_demand` helper, so they cannot drift apart again, and the closed check is named as `_is_closed` and matches case-insensitively the way `staffing-score.py` does.
- Closed projects still appear in the table with their `closed` flag and still count toward the `Projects` tile — only the demand figure drops them.
- Added regression Fixture 9 and a scope caveat in `projects-dashboard/SKILL.md`.

## Scope decisions
- **Route (a), not (b).** Acceptance criterion 1 allowed either excluding closed projects or labelling the divergence. Excluded, because every other closed-project signal in the plugin already points that way: `staffing-score.py` drops them before scoring, `references/data-model.md` says their roles are not open work to staff, and `_project_health` already renders them muted. Labelling would have entrenched a number no other surface agrees with. The SKILL.md caveat is added anyway, so the narrower figure is not mis-narrated.
- **Other aggregates untouched.** `value_by_impact` and the `Projects` tile still count all projects — lifetime-value and portfolio-size views, not demand figures, and outside the acceptance criteria.
- **No cross-script refactor.** A rejected alternative plan extracted a shared `is_closed_project()` into `validate-entities.py` for both this script and `staffing-score.py`. Not taken: `staffing-score.py` has no test suite, and no CI runs any of these tests, so the broader change's only guard would have been manual.

## Review notes
**A pre-existing case-sensitivity split, now visible.** `_project_health` and `_compute`'s warning gate both compare `status == "closed"` **case-sensitively**; the new `_is_closed` is case-**insensitive**, because that is what parity with `staffing-score.py` requires. So on a non-conforming `status: Closed`, the tile treats the project as closed while the row does not — the tile and row would disagree.

This is deliberate but worth a reviewer's eye. Making the new predicate case-sensitive instead would keep the file internally consistent but break the parity the issue asks for; unifying all three would change what a row renders, which is a behaviour change beyond this fix's scope. `Closed` is not a schema-valid status, so reaching the split requires a record that already fails validation. `_is_closed`'s docstring records the trade-off and names the unification as the eventual fix. Raised by the pre-commit quality pass, not by the original plan.

## Verification
- `bash cogni-projects/tests/test-render-dashboard.sh` — all fixtures pass, including new Fixture 9. There is no CI job for this suite (`lint.yml` has only the breadcrumb, external-dispatch, and version-bump gates), so this was run by hand.
- The regression test was confirmed to **fail against the unfixed renderer**: with `render-dashboard.py` restored from `origin/main`, assertions `9c` (envelope reports `open_roles: 3`) and `9f` (tile renders 3) both fail. A test that passed either way would prove nothing.
- `bash cogni-projects/tests/test_register_entity.sh` and `test_portfolio_init.sh` — both still pass.
- No `plugin.json` / `marketplace.json` version line is touched; the post-merge workflow owns the bump.

## Follow-up issues
- #1155 — cogni-projects: a non-string project status crashes the whole dashboard render instead of warning

#1155 is an **adjacent pre-existing defect** found while planning this fix, not deferred scope of #1152. Because the plan carries a non-empty `deferred[]`, this PR links with `Refs` rather than `Closes`, so merging will not auto-Refs #1152 — it can be closed by hand at merge, since its acceptance criteria are fully delivered here.