### PR TITLE
cogni-consult: user-facing seed templates in consult-resume

### DIFF
--- a/cogni-consult/skills/consult-resume/SKILL.md
+++ b/cogni-consult/skills/consult-resume/SKILL.md
@@ -45,7 +45,7 @@ setup owns scaffolding and the knowledge-base binding.
   against discovery and select it directly; confirm only when the match is
   ambiguous.
 - **Multiple, and the user named none** → you MUST output the full engagement
-  list (name, slug, `scope_state`, scope config `updated`) and STOP for the
+  list, rendered as the table below, and STOP for the
   user's explicit choice. Never silently select or infer an engagement in this
   case. The active git branch, working-tree / uncommitted changes, and recent
   commit history are **not** authorized selection signals — they must never
@@ -84,8 +84,7 @@ pre-list skip signal — the matcher above is unchanged and still selects on a
 name or slug the user types. The table carries no slug and no `Scope` column;
 instead, where `scope_state` (the scoping-phase status, not the engagement's
 scope) is not `complete`, append ` · noch nicht geschärft` inside the
-engagement's name cell. The parenthetical in the obligation above enumerates
-the data to load, not the columns to render.
+engagement's name cell.
 
 `Zuletzt bearbeitet` is the newest `transitions[].timestamp` in
 `<path>/.metadata/execution-log.json` (`<path>` from discovery), date part only.
@@ -131,19 +130,22 @@ Key question: <key_question>
 
 | Action Field | Status | Deliverables | Next Deliverable |
 |--------------|--------|--------------|------------------|
-| Marktevidenz | complete | 2/2 complete | — |
-| Portfolio-Fit | in-progress | 1/3 complete | Wettbewerbskarte (ideate · pyramid-principle) |
-| Markteintritt | pending | 0/2 started | Kanalstrategie (empathize · —) |
+| Market Evidence | complete | 2/2 complete | — |
+| Portfolio Fit | in-progress | 1/3 complete | Competitor map (ideate · pyramid-principle) |
+| Go-to-Market | pending | 0/2 started | Channel strategy (empathize · —) |
 ```
+
+That is a German session: the `zuletzt bearbeitet` label follows the
+interaction language, while the action-field and deliverable names are the
+stored titles — here English, because an engagement's stored titles keep their
+technical terms whatever the session language.
 
 Name action fields and deliverables by the `title` in their `field.json`,
 falling back to the slug only when no title is stored — slugs are storage keys,
-not display names. `zuletzt bearbeitet` resolves exactly as in step 2; compute
-it for the selected engagement here when step 2's branch did not already.
-Step 2's language rule covers this table too: render the header label and the
-column headers in the interaction language, and dates in the same day-first
-shape. Action-field and deliverable titles are rendered as stored — never
-translated.
+not display names. Titles are rendered as stored, never translated.
+`zuletzt bearbeitet` resolves exactly as in step 2; compute it for the selected
+engagement here when step 2's branch did not already. Step 2's language rule
+covers the header label and the date shape in this table too.
 
 `Deliverables` counts `complete` over total; `Next Deliverable` names the
 first non-complete deliverable with its `dt_stage` and stored

--- a/cogni-consult/skills/consult-resume/SKILL.md
+++ b/cogni-consult/skills/consult-resume/SKILL.md
@@ -96,10 +96,14 @@ Read the log once per discovered engagement here, after discovery and before
 the sort; the single-engagement and named-engagement branches skip that cost
 entirely.
 
-German sessions render the strings above and dates as `TT.MM.JJJJ`; an English
-session uses the natural-language English equivalents and the same day-first
-date shape. The columns, sort, cap, overflow line, and closing line are the
-same in either language.
+German sessions render the strings above and dates as `TT.MM.JJJJ`. An English
+session renders the same table, so it is seeded by example too rather than left
+to improvise: header `# | Engagement | Last worked on`, row suffix
+` · not yet scoped`, overflow line `N more — say “all” for the full list.`, and
+closing line `A number or a name is enough. Then I'll show you where it stands
+and one next step.` Dates keep the same day-first shape, so a date reads the
+same way in either session. The columns, sort, cap, and the list-and-stop
+obligation are identical in both languages.
 
 Conduct the conversation in the resolved **interaction language** (workspace
 default, overridden by the user's message language) — independent of the
@@ -140,9 +144,12 @@ interaction language, while the action-field and deliverable names are the
 stored titles — here English, because an engagement's stored titles keep their
 technical terms whatever the session language.
 
-Name action fields and deliverables by the `title` in their `field.json`,
-falling back to the slug only when no title is stored — slugs are storage keys,
-not display names. Titles are rendered as stored, never translated.
+Name action fields by the `title` read from
+`<engagement-path>/action-fields/<slug>/field.json` — step 3's rollup carries a
+field's `slug` but not its title — and deliverables by the `title` the rollup
+passes through with each deliverable. Fall back to the slug only when no title
+is stored; slugs are storage keys, not display names, and titles are rendered
+as stored, never translated.
 `zuletzt bearbeitet` resolves exactly as in step 2; compute it for the selected
 engagement here when step 2's branch did not already. Step 2's language rule
 covers the header label and the date shape in this table too.

--- a/cogni-consult/skills/consult-resume/SKILL.md
+++ b/cogni-consult/skills/consult-resume/SKILL.md
@@ -52,6 +52,56 @@ setup owns scaffolding and the knowledge-base binding.
   substitute for the user's choice or override the list-and-stop obligation.
   Only a name or slug explicitly named in the user's message may skip the list.
 
+Render that list as this table — never as raw field names:
+
+```
+# | Engagement                                                  | Zuletzt bearbeitet
+1 | Lean-Canvas-Schärfung cogni-work                            | 13.07.2026
+2 | Benchmark Skill- & Agent-Entwicklung · noch nicht geschärft | 11.07.2026
+3 | Marktzugang Mittelstand                                     | 02.07.2026
+4 | Serviceportfolio Nord                                       | 28.06.2026
+5 | Digitalisierung Werk 2 · noch nicht geschärft               | 21.06.2026
+
+Weitere 6 — sag „alle“ für die vollständige Liste.
+
+Nummer oder Name genügt. Danach zeige ich dir den Stand und einen nächsten Schritt.
+```
+
+Pad the name column to the widest rendered cell so the date column lines up —
+the suffixed rows usually set that width.
+
+Sort by last activity, newest first, breaking ties on engagement name ascending
+so the numbering is stable across a re-render. Number the rendered rows `1`,
+`2`, `3` — bare, never `#1`. Cap the table at five rows: with five or fewer
+engagements render every one and omit the overflow line entirely (never
+`Weitere 0`); above five, render the top five and set `N` to the remainder. On
+an „alle“ reply, re-render every engagement with continuous numbering and no
+overflow line — the closing line still applies, and the list-and-stop
+obligation above still holds.
+
+The number is a reply index into the list as most recently rendered, not a new
+pre-list skip signal — the matcher above is unchanged and still selects on a
+name or slug the user types. The table carries no slug and no `Scope` column;
+instead, where `scope_state` (the scoping-phase status, not the engagement's
+scope) is not `complete`, append ` · noch nicht geschärft` inside the
+engagement's name cell. The parenthetical in the obligation above enumerates
+the data to load, not the columns to render.
+
+`Zuletzt bearbeitet` is the newest `transitions[].timestamp` in
+`<path>/.metadata/execution-log.json` (`<path>` from discovery), date part only.
+Fall back to the engagement's root `updated` only when that log is absent,
+empty, or unreadable — per `references/data-model.md`, "Deliverable work never
+touches it", so root `updated` tracks scope edits rather than engagement
+freshness. When neither is available, sort the engagement last and render `—`.
+Read the log once per discovered engagement here, after discovery and before
+the sort; the single-engagement and named-engagement branches skip that cost
+entirely.
+
+German sessions render the strings above and dates as `TT.MM.JJJJ`; an English
+session uses the natural-language English equivalents and the same day-first
+date shape. The columns, sort, cap, overflow line, and closing line are the
+same in either language.
+
 Conduct the conversation in the resolved **interaction language** (workspace
 default, overridden by the user's message language) — independent of the
 engagement's `language` field, which is the deliverable axis. See
@@ -76,15 +126,24 @@ problem for the consultant to see, not to paper over).
 Lead with the key question, then one table row per action field:
 
 ```
-Engagement: <name> (<slug>) — scope config updated <date>
+Engagement: <name> — zuletzt bearbeitet <TT.MM.JJJJ>
 Key question: <key_question>
 
 | Action Field | Status | Deliverables | Next Deliverable |
 |--------------|--------|--------------|------------------|
-| market-evidence | complete | 2/2 complete | — |
-| portfolio-fit | in-progress | 1/3 complete | competitor-map (ideate · pyramid-principle) |
-| go-to-market | pending | 0/2 started | channel-strategy (empathize · —) |
+| Marktevidenz | complete | 2/2 complete | — |
+| Portfolio-Fit | in-progress | 1/3 complete | Wettbewerbskarte (ideate · pyramid-principle) |
+| Markteintritt | pending | 0/2 started | Kanalstrategie (empathize · —) |
 ```
+
+Name action fields and deliverables by the `title` in their `field.json`,
+falling back to the slug only when no title is stored — slugs are storage keys,
+not display names. `zuletzt bearbeitet` resolves exactly as in step 2; compute
+it for the selected engagement here when step 2's branch did not already.
+Step 2's language rule covers this table too: render the header label and the
+column headers in the interaction language, and dates in the same day-first
+shape. Action-field and deliverable titles are rendered as stored — never
+translated.
 
 `Deliverables` counts `complete` over total; `Next Deliverable` names the
 first non-complete deliverable with its `dt_stage` and stored

--- a/cogni-consult/skills/consult-resume/SKILL.md
+++ b/cogni-consult/skills/consult-resume/SKILL.md
@@ -267,7 +267,7 @@ Branch on the derived state, first match wins, and say *why*:
   for an `in-progress` or resumed deliverable, which the branches below own.)
 - **A deliverable is `in-progress`** → resume it where it stands; recommend
   `consult-design-thinking` naming the field, the deliverable, and its
-  `dt_stage` ("competitor-map is mid-ideate — pick the loop back up there").
+  `dt_stage` ("Competitor map is mid-ideate — pick the loop back up there").
 - **A deliverable is `complete` but its `persona_review` is `pending` or
   `in-progress`** → the acting-persona challenge hasn't closed; recommend
   `consult-personas` to run (or finish) the challenge pass.


### PR DESCRIPTION
Refs #1140.

## Summary

`consult-resume` specified its two user-facing tables by naming raw field identifiers, and the shipped sample rows were themselves slugs and engine values. On the default path (no output style active) the model reproduces exactly what the SKILL.md showed it — so `scope_state` surfaced as a Title-Cased `Scope` column and engine values passed straight through. This replaces both specs with rendered templates.

**Step 2 — engagement selection list.** Now `# | Engagement | Zuletzt bearbeitet`, sorted by last activity descending with a name-ascending tie-break so numbering is stable across a re-render, capped at five rows with an overflow line, and closed with a line stating what happens after the choice.

**Step 4 — dashboard header.** `Engagement: <name> (<slug>) — scope config updated <date>` becomes `Engagement: <name> — zuletzt bearbeitet <TT.MM.JJJJ>`, and the sample rows are de-slugged to `field.json` `title` values.

### Three drops, not renames

- **`Slug`** — the fuzzy matcher is untouched and still selects on a slug the user types, so the column costs a selection path nothing. The file says this explicitly, so the next reader does not restore it "to keep selection working."
- **`Scope`** — it carried `scope_state`, which is the *scoping-phase* status rather than the engagement's scope, and its value is identical in nearly every row. Demoted to a ` · noch nicht geschärft` row suffix when not `complete`.
- **`Route`** — deferred with the rest of the action-fields table (see below); untouched here.

### `Zuletzt bearbeitet` data source

The newest `transitions[].timestamp` in `<path>/.metadata/execution-log.json`, falling back to the root `updated` only when that log is absent, empty, or unreadable — `references/data-model.md` is explicit that "Deliverable work never touches it," so root `updated` tracks scope edits, not engagement freshness. When neither is available the engagement sorts last and renders `—`.

No pre-selection data source carried last activity before this change: `engagement-status.sh` never opens the execution log and runs only *after* selection, and `_discover_extractor.py` returns no last-activity field. The skill therefore reads the log once per discovered engagement, after discovery and before the sort — and the single-engagement and named-engagement branches skip that cost entirely. Moving the computation into the extractor is filed as #1158.

## The byte-for-byte constraint

Acceptance criterion 2 pins two sentences at `:47-52` as **correctness, not register** — the list-and-stop obligation and the git-signal prohibition. Both survive byte-for-byte, and `:44-45` (the matcher) shows no diff.

That sentence also contained the parenthetical `(name, slug, scope_state, scope config updated)` — the very raw-field enumeration criterion 1 targets. This PR originally kept it and neutralized it with a prose sentence ("it enumerates the data to load, not the columns to render"). **That reading was reversed on human adjudication**: a prose rule is exactly what the epic argues the model loses to whatever the template shows it, so the parenthetical is now replaced by `rendered as the table below` — permitted by criterion 2, which lets the *list-format wording* differ.

The result is easier to audit than the original: **the whole Step 2 region has exactly one changed line.** `:44-46` and `:49-53` show zero diff, so every protected sentence is byte-identical by inspection.

## Scope — this PR is partial

Ships acceptance criteria 1–6 and the criterion-8 acceptance bar, all scoped to `consult-resume`. **Criterion 7** — the `consult-action-fields` WBS table — is deferred to #1157, which is in epic #1147's close gate. Hence `Refs #1140`, not `Closes`: the issue stays open until #1157 lands.

Seed templates 1 and 2 shipped together because they live in one file and share one data-source decision; splitting them would have left the skill self-contradictory, with the list saying "zuletzt bearbeitet" while the header four sections later still said "scope config updated".

**Deliberately untouched:** the `Action Field` → `Handlungsfeld` allowlist entry in `output-styles/strategy-advisor-de.md` (epic sibling #1144 owns narrowing it); the missing `interaction-language.md` pointer in `consult-action-fields` (sibling #1141's Step 0 gate owns that wiring); `generate-engagement-readme.py`'s separate 3-column rollup table, where a careless `State` rename would corrupt it. No `plugin.json` / `marketplace.json` version — the post-merge workflow owns the bump.

## Review notes

- **Pre-existing, not introduced by this change.** The `skill-quality-reviewer` flagged ~40 lines in §5 (four conditional "further offers" that fire only on a specific request or rare deliverable state) as always-loaded body that progressive disclosure would push to `references/`. Tagged `introduced_by_change: false` and annotated rather than fixed — coupling an unrelated refactor to a focused change is the wrong trade. Body is 331 lines against a 500 cap, so this is headroom management, not a violation.
- **Human adjudication (see the pinned comment).** The gatekeeper held this PR at contract-forming on an `insufficient_coverage` escalation — an issue-quality finding about #1140's acceptance bar, raised before the diff was read; all five points it named were already covered. Two exemplar defects found on the human read were fixed in a follow-up commit: the surviving raw-field parenthetical, and a Step 4 sample that translated stored titles next to a rule forbidding translation.
- The German strings are green-field: the plugin ships no `section-headers-de.md` and had no `TT.MM.JJJJ` precedent, so `Zuletzt bearbeitet`, ` · noch nicht geschärft`, and the two new sentences establish the convention rather than conform to one. They use proper umlauts and typographic `„…"` quotes per the repo's per-language encoding rule (the issue body's straight closing quote is a transcription artifact).

## Test plan

- [x] `git diff origin/main` changes exactly one line in the Step 2 region (the list-format wording) — `:44-46` and `:49-53` show zero diff, so the matcher and both protected sentences are byte-identical
- [x] No `Slug` / `Scope` / `scope_state` column header anywhere; `name, slug`, `scope config updated` and `(<slug>)` absent from the file
- [x] The Step 4 exemplar carries the titles `references/data-model.md` actually stores (`Market Evidence`, not a translation), so it demonstrates de-slugging without teaching translation
- [x] The shipped exemplar obeys its own cap — 5 rows plus `Weitere 6` (11 total), name column padded uniformly to 59 chars so the date column lines up
- [x] Encoding: proper umlauts and `„…“` throughout; no ASCII substitutes
- [x] All 7 `cogni-consult/tests/*.sh` pass
- [x] `scripts/check-breadcrumbs.py` clean (0 files affected), `scripts/check-version-bump.py` `[ok]` (1 plugin touched, 0 violations), `cogni-workspace/scripts/check-skill-names.sh` OK
- [x] Skill frontmatter untouched; no `plugin.json` / `marketplace.json` in the diff
- [ ] **Manual acceptance bar (criterion 8, needs a human):** run `/cogni-consult:consult-resume` in a German workspace with **no output style active** against the registered engagements — expect ≤5 rows, columns `# | Engagement | Zuletzt bearbeitet`, no slug column, no `Scope` column, and a closing line stating what happens after the choice

## Follow-up issues

- #1157 — collapse the `consult-action-fields` WBS dashboard to five user-facing columns (acceptance criterion 7; in epic #1147's close gate)
- #1158 — precompute engagement `last_activity` in `_discover_extractor.py` instead of the per-engagement read loop (optional; not in the epic DoD)

Plan record: https://github.com/cogni-work/insight-wave/issues/1140#issuecomment-5090140190
