### PR TITLE
cogni-projects: a non-string role no longer fails the whole render

### DIFF
--- a/cogni-projects/scripts/render-dashboard.py
+++ b/cogni-projects/scripts/render-dashboard.py
@@ -240,29 +240,50 @@ def _is_closed(status):
     return str(status or "").strip().lower() == "closed"
 
 
-def _status_text(raw, label, warnings):
-    """Read an entity's `status` as text, warning when it was not text already.
+def _text_field(raw, field, label, warnings):
+    """Read a parsed entity field as text, warning when it was not text already.
 
     The frontmatter parser this script borrows from validate-entities.py coerces
     any all-digit scalar to an int before the schema enum is ever checked — and
-    the renderer never runs that validator. So a hand-edited `status: 2026`
-    arrives here as an int, and calling a str method on it straight raises
-    inside _compute, which no local handler catches: the module-level catch-all
-    then discards every warning collected so far and fails the whole render.
-    That inverts this script's contract, where one bad record costs a warning
-    and nothing else.
+    the renderer never runs that validator. So a hand-edited `status: 2026` or
+    `role: 2` arrives here as an int. Comparing or calling a str method on it
+    raises inside _compute, which no local handler catches: the module-level
+    catch-all then discards every warning collected so far and fails the whole
+    render. That inverts this script's contract, where one bad record costs a
+    warning and nothing else.
 
-    The guard keys on `raw is not None`, deliberately not on truthiness —
-    `status: 0` coerces to a falsy int, which a truthy check would silently
-    normalize to "unknown" with no warning at all.
+    `role` fails harder than `status`, because _compute sorts the covered-role
+    set and Python refuses to order a str against an int — one numeric role
+    beside any text role was enough.
+
+    Both sides of a comparison must come through here, not just the side that
+    raised. `open_roles` entries are coerced by the same parser, so normalizing
+    only the assignment role would trade the crash for something quieter and
+    worse: a numeric role that matches its numeric open_roles entry today would
+    stop matching, silently reporting a filled role as open.
+
+    The guard keys on `raw is not None`, deliberately not on truthiness — a
+    falsy `status: 0` or `role: 0` would otherwise normalize away with no
+    warning at all.
+
+    Normalizing every text field once, where the entities are parsed, would
+    close this class rather than its instances, and retire this helper with it.
+    That is tracked as its own change: it decides the string-typed field set for
+    every entity type, and staffing-score.py reads the same parser, where a
+    numeric role label scores every consultant at zero fit instead of raising.
     """
     if raw is None:
         return ""
     if not isinstance(raw, str):
         warnings.append(
-            "%s has a non-string status %r — coerced to text; fix the record" % (label, raw)
+            "%s has a non-string %s %r — coerced to text; fix the record" % (label, field, raw)
         )
     return str(raw).strip()
+
+
+def _status_text(raw, label, warnings):
+    """Read an entity's `status` as text. See _text_field for the why."""
+    return _text_field(raw, "status", label, warnings)
 
 
 def _open_role_demand(projects):
@@ -303,7 +324,10 @@ def _compute(entities, warnings):
         label = "project %s" % (proj.get("name") or slug or "(unnamed)")
         # An undeclared open_roles is not an empty one — see _normalize_open_roles.
         declared_roles = _normalize_open_roles(proj)
-        open_roles = declared_roles or []
+        # Coerced so both sides of the covered/open_roles comparison are text.
+        # Length is preserved, so roles_total and _project_health still see the
+        # declared count.
+        open_roles = [_text_field(r, "open_roles entry", label, warnings) for r in (declared_roles or [])]
         status = _status_text(proj.get("status"), label, warnings)
         if declared_roles is None and status != "closed":
             warnings.append("%s has no open_roles — staffing status unknown" % label)
@@ -316,7 +340,7 @@ def _compute(entities, warnings):
                 continue
             a_label = "assignment %s" % (a.get("_file") or a.get("slug") or "(unknown)")
             if _status_text(a.get("status"), a_label, warnings) in ACTIVE_ASSIGNMENT_STATES:
-                role = a.get("role")
+                role = _text_field(a.get("role"), "role", a_label, warnings)
                 if role:
                     covered.add(role)
         # An assignment role that matches no listed open role may be a label

--- a/cogni-projects/skills/projects-dashboard/SKILL.md
+++ b/cogni-projects/skills/projects-dashboard/SKILL.md
@@ -112,10 +112,10 @@ A failure here is cosmetic — the dashboard is already written to `data.path`.
   `.metadata/`. Re-running only rewrites `output/dashboard.html`.
 - **Partial snapshots are expected mid-authoring.** A project without a
   `strategic_impact`, a project that omits `open_roles`, an entity whose
-  `status` is not text (an all-digit value such as `status: 2026` is read as a
-  number, then coerced back to text), or an entity file that cannot be read or
-  decoded is reported in the warnings list, not treated as an error. One bad
-  record never costs the rest of the portfolio.
+  `status` or role label is not text (an all-digit value such as `status: 2026`
+  or `role: 2` is read as a number, then coerced back to text), or an entity
+  file that cannot be read or decoded is reported in the warnings list, not
+  treated as an error. One bad record never costs the rest of the portfolio.
 - **Theming is optional.** The dashboard renders with a built-in palette;
   pass `--design-variables <path.json>` to override colors when a themed look is
   wanted.

--- a/cogni-projects/skills/projects-dashboard/SKILL.md
+++ b/cogni-projects/skills/projects-dashboard/SKILL.md
@@ -110,12 +110,16 @@ A failure here is cosmetic — the dashboard is already written to `data.path`.
 - **Read-only.** The renderer never writes `projects-portfolio.json` (only
   `projects-entities` does, via `register-entity.py`) and never touches
   `.metadata/`. Re-running only rewrites `output/dashboard.html`.
-- **Partial snapshots are expected mid-authoring.** A project without a
+- **Partial snapshots are expected mid-authoring.** Any of these is reported in
+  the warnings list, not treated as an error: a project without a
   `strategic_impact`, a project that omits `open_roles`, an entity whose
-  `status` or role label is not text (an all-digit value such as `status: 2026`
-  or `role: 2` is read as a number, then coerced back to text), or an entity
-  file that cannot be read or decoded is reported in the warnings list, not
-  treated as an error. One bad record never costs the rest of the portfolio.
+  `status`, role label, or `open_roles` entry is not text, or an entity file
+  that cannot be read or decoded. A non-text value — `status: 2026`, `role: 2`,
+  or `open_roles: [2]` — is read as a number, then coerced back to text. Both
+  sides of the role comparison are coerced, so a numeric role still matches its
+  numeric `open_roles` entry and still counts as filled: such a warning says to
+  fix the record, not that the coverage figure beside it is wrong. One bad
+  record never costs the rest of the portfolio.
 - **Theming is optional.** The dashboard renders with a built-in palette;
   pass `--design-variables <path.json>` to override colors when a themed look is
   wanted.

--- a/cogni-projects/tests/test-render-dashboard.sh
+++ b/cogni-projects/tests/test-render-dashboard.sh
@@ -518,9 +518,11 @@ assert_json "10c falsy int status still warns" \
 assert_json "10d project surfaced by name" \
   "any('non-string status' in w and 'Numeric Status' in w for w in d['data']['warnings'])"
 # The assignment is named by its relative path — _read_entities sets _file on
-# every kept entity, while slug is optional frontmatter.
-assert_json "10e assignment surfaced by file" \
-  "any('non-string status' in w and 'numeric-assignment.md' in w for w in d['data']['warnings'])"
+# every kept entity, while slug is optional frontmatter. Counted for the same
+# reason 11c/11d are: this read sits inside _compute's per-project slug filter,
+# and hoisting it out would warn once per project while `any(...)` stayed green.
+assert_json "10e assignment surfaced by file, exactly once" \
+  "sum('non-string status' in w and 'numeric-assignment.md' in w for w in d['data']['warnings']) == 1"
 assert_json "10f every project still counted"      "d['data']['projects'] == 3"
 assert_no_traceback "10g no traceback on stderr" "$STDERR10"
 # A needle without quote characters: warnings reach the HTML through _esc, which
@@ -543,6 +545,12 @@ assert_html "10h healthy project still rendered" \
 # something quieter: `symmetry`'s numeric role matches its numeric open_roles
 # entry today, and would stop matching, reporting a filled role as open. With
 # only one side coerced, 11f reads 1 instead of 0.
+#
+# The third project is clean throughout, and 11h/11l are its pair: they assert a
+# bad record costs neither the project count nor the render of an untouched
+# project — the same claim Fixture 10 makes with Sound Delivery at 10f/10h.
+# Both of this fixture's other projects are bad-record demonstrations, so
+# without it nothing here checks that resilience.
 # ---------------------------------------------------------------------------
 PF11="$TMPROOT/nonstring-role"
 seed_portfolio "$PF11"
@@ -569,6 +577,18 @@ status: active
 open_roles: [2026]
 ---
 # Symmetry Check
+EOF
+write_entity "$PF11/projects/clean.md" <<'EOF'
+---
+type: project
+slug: clean
+name: Clean Delivery
+client: CleanCo
+strategic_impact: 4
+status: active
+open_roles: [architect]
+---
+# Clean Delivery
 EOF
 # Every assignment names a project that exists — _compute filters on the
 # project before it reads the role, so an orphan would never reach the
@@ -626,6 +646,22 @@ status: active
 ---
 # assignment
 EOF
+# Text role matching the declared open_roles entry, so `clean` contributes no
+# open role and 11f/11k stay at 0 — the clean project has to be genuinely
+# clean, or it would perturb the very counts the symmetry guard pins.
+write_entity "$PF11/assignments/clean-role.md" <<'EOF'
+---
+type: assignment
+slug: eli--clean
+consultant: eli
+project: clean
+role: architect
+start_date: 2026-02-01
+end_date: 2026-08-01
+status: active
+---
+# assignment
+EOF
 
 # Direct invoke for the same reason Fixture 10 does it — run() discards stderr
 # and 11i asserts a traceback never reached it.
@@ -635,10 +671,14 @@ HTML11="$PF11/output/dashboard.html"
 
 assert_json "11a non-string role still succeeds" "d['success'] is True"
 assert_json "11b marked partial"                 "d['data']['partial'] is True"
-assert_json "11c non-string role surfaced by file" \
-  "any('non-string role' in w and 'numeric-role.md' in w for w in d['data']['warnings'])"
-assert_json "11d falsy zero role still warns" \
-  "any('non-string role' in w and 'zero-role.md' in w for w in d['data']['warnings'])"
+# Counted, not merely present: the role read sits inside _compute's per-project
+# slug filter, so each offending assignment must warn exactly once. Moving that
+# read outside the filter would warn once per project iteration instead — a
+# regression `any(...)` cannot see, because the warning is still there.
+assert_json "11c non-string role surfaced by file, exactly once" \
+  "sum('non-string role' in w and 'numeric-role.md' in w for w in d['data']['warnings']) == 1"
+assert_json "11d falsy zero role still warns, exactly once" \
+  "sum('non-string role' in w and 'zero-role.md' in w for w in d['data']['warnings']) == 1"
 assert_json "11e non-string open_roles entry surfaced by project" \
   "any('non-string open_roles entry' in w and 'Symmetry Check' in w for w in d['data']['warnings'])"
 assert_json "11f numeric role still fills its numeric open_role" \
@@ -647,11 +687,12 @@ assert_json "11f numeric role still fills its numeric open_role" \
 # coerced '0' and '2' roles as matching no open_roles label.
 assert_json "11g symmetric match raises no mismatch warning" \
   "not any('matches no open_roles label' in w and 'Symmetry Check' in w for w in d['data']['warnings'])"
-assert_json "11h every project still counted"    "d['data']['projects'] == 2"
+assert_json "11h every project still counted"    "d['data']['projects'] == 3"
 assert_no_traceback "11i no traceback on stderr" "$STDERR11"
 assert_html "11j symmetry project still rendered" "Symmetry Check" "$HTML11"
 assert_html "11k open-roles tile agrees with the envelope" \
   '<div class="n">0</div><div class="l">Open roles</div>' "$HTML11"
+assert_html "11l clean sibling project still rendered" "Clean Delivery" "$HTML11"
 
 echo
 if [ "$failures" -eq 0 ]; then

--- a/cogni-projects/tests/test-render-dashboard.sh
+++ b/cogni-projects/tests/test-render-dashboard.sh
@@ -528,6 +528,131 @@ assert_no_traceback "10g no traceback on stderr" "$STDERR10"
 assert_html "10h healthy project still rendered" \
   "Sound Delivery" "$PF10/output/dashboard.html"
 
+# ---------------------------------------------------------------------------
+# Fixture 11 — a role label that is not text. The same parse-time int coercion
+# that hit `status` reaches `role`, and lands harder: _compute sorts the
+# covered-role set, and Python refuses to order a str against an int, so one
+# `role: 2` next to any text role raised and cost the whole render.
+#
+# 11c and 11d are the truthy/falsy pair, mirroring 10c/10d — a guard keyed on
+# truthiness rather than on None would let `role: 0` through unremarked.
+#
+# 11f, 11g and 11k are the symmetry guard, and they are the reason this fixture
+# carries a second project. `open_roles` entries are coerced by the same parser,
+# so stringifying only the assignment side would fix the crash and introduce
+# something quieter: `symmetry`'s numeric role matches its numeric open_roles
+# entry today, and would stop matching, reporting a filled role as open. With
+# only one side coerced, 11f reads 1 instead of 0.
+# ---------------------------------------------------------------------------
+PF11="$TMPROOT/nonstring-role"
+seed_portfolio "$PF11"
+write_entity "$PF11/projects/mixed.md" <<'EOF'
+---
+type: project
+slug: mixed
+name: Mixed Roles
+client: MixCo
+strategic_impact: 3
+status: active
+open_roles: [lead]
+---
+# Mixed Roles
+EOF
+write_entity "$PF11/projects/symmetry.md" <<'EOF'
+---
+type: project
+slug: symmetry
+name: Symmetry Check
+client: SymCo
+strategic_impact: 2
+status: active
+open_roles: [2026]
+---
+# Symmetry Check
+EOF
+# Every assignment names a project that exists — _compute filters on the
+# project before it reads the role, so an orphan would never reach the
+# coercion and the fixture would pass against the unfixed script. `active` is
+# in ACTIVE_ASSIGNMENT_STATES, so these genuinely reach the role read.
+write_entity "$PF11/assignments/numeric-role.md" <<'EOF'
+---
+type: assignment
+slug: ada--mixed
+consultant: ada
+project: mixed
+role: 2
+start_date: 2026-02-01
+end_date: 2026-08-01
+status: active
+---
+# assignment
+EOF
+write_entity "$PF11/assignments/text-role.md" <<'EOF'
+---
+type: assignment
+slug: bo--mixed
+consultant: bo
+project: mixed
+role: lead
+start_date: 2026-02-01
+end_date: 2026-08-01
+status: active
+---
+# assignment
+EOF
+write_entity "$PF11/assignments/zero-role.md" <<'EOF'
+---
+type: assignment
+slug: cy--mixed
+consultant: cy
+project: mixed
+role: 0
+start_date: 2026-02-01
+end_date: 2026-08-01
+status: active
+---
+# assignment
+EOF
+write_entity "$PF11/assignments/symmetry-role.md" <<'EOF'
+---
+type: assignment
+slug: di--symmetry
+consultant: di
+project: symmetry
+role: 2026
+start_date: 2026-02-01
+end_date: 2026-08-01
+status: active
+---
+# assignment
+EOF
+
+# Direct invoke for the same reason Fixture 10 does it — run() discards stderr
+# and 11i asserts a traceback never reached it.
+STDERR11="$TMPROOT/stderr11.txt"
+LAST_JSON="$(python3 "$SCRIPT" "$PF11" 2>"$STDERR11" | tail -n 1)"
+HTML11="$PF11/output/dashboard.html"
+
+assert_json "11a non-string role still succeeds" "d['success'] is True"
+assert_json "11b marked partial"                 "d['data']['partial'] is True"
+assert_json "11c non-string role surfaced by file" \
+  "any('non-string role' in w and 'numeric-role.md' in w for w in d['data']['warnings'])"
+assert_json "11d falsy zero role still warns" \
+  "any('non-string role' in w and 'zero-role.md' in w for w in d['data']['warnings'])"
+assert_json "11e non-string open_roles entry surfaced by project" \
+  "any('non-string open_roles entry' in w and 'Symmetry Check' in w for w in d['data']['warnings'])"
+assert_json "11f numeric role still fills its numeric open_role" \
+  "d['data']['open_roles'] == 0"
+# Scoped to Symmetry Check on purpose — Mixed Roles legitimately reports its
+# coerced '0' and '2' roles as matching no open_roles label.
+assert_json "11g symmetric match raises no mismatch warning" \
+  "not any('matches no open_roles label' in w and 'Symmetry Check' in w for w in d['data']['warnings'])"
+assert_json "11h every project still counted"    "d['data']['projects'] == 2"
+assert_no_traceback "11i no traceback on stderr" "$STDERR11"
+assert_html "11j symmetry project still rendered" "Symmetry Check" "$HTML11"
+assert_html "11k open-roles tile agrees with the envelope" \
+  '<div class="n">0</div><div class="l">Open roles</div>' "$HTML11"
+
 echo
 if [ "$failures" -eq 0 ]; then
   echo "All render-dashboard tests passed."


### PR DESCRIPTION
Closes #1162.

## Summary

A hand-edited `role: 2` cost the entire dashboard. The frontmatter parser this renderer borrows from `validate-entities.py` int-coerces any all-digit scalar before the schema enum is ever checked, and the renderer never runs that validator — so `_compute`'s `sorted(covered)` was asked to order an `int` against a `str`, raised, and the module-level catch-all discarded every warning collected so far. This is the same contract inversion already fixed for `status`, reached through `role` instead.

- Generalize the existing read-site guard into `_text_field(raw, field, label, warnings)` and route the assignment `role` through it. `None` returns `""` silently; any other non-string warns and coerces. Like the original it keys on `raw is not None`, not truthiness, so a falsy `role: 0` is surfaced rather than dropped without a word.
- **Normalize `open_roles` entries the same way.** This is the load-bearing half. They pass through the same int coercion, and the fill checks are membership tests that never raise — they just answer wrongly. A one-sided fix would have converted a today-correct `2026 in [2026]` match into `"2026" in [2026]`, silently reporting a filled role as open on a partner-facing staffing number.
- Regression coverage as Fixture 11, following the Fixture 10 pattern.
- One clause in the skill's Notes bullet so the warn-and-degrade contract documents a non-text role label alongside a non-text status.

## Why both sides, not just the one that crashed

This is the finding that shaped the change. An exploration pass patched a throwaway copy to stringify `role` alone and ran the symmetric fixture:

```
"open_roles": 1,
"warnings": [
  "assignment assignments/symmetry-role.md has a non-string role 2026 — coerced to text; fix the record",
  "project Symmetry Check: assignment role '2026' matches no open_roles label — possible label mismatch"
]
```

`roles_filled` flipped from 1 to 0 and a spurious label-mismatch warning appeared. That trades a loud crash for a quiet wrong number, which is worse. Fixture 11 carries a second project specifically to pin it: assertions 11f/11g/11k fail if either side is left uncoerced.

## Scope

Takes the issue's **option 1** (read-site defense), symmetrically. `_coerce` in `validate-entities.py` is untouched, per the issue's explicit constraint — its int coercion is wanted for numeric fields and the parser is shared.

**Option 2 (normalize every text field at the `_read_entities` parse boundary) stays filed as its own change**, as the issue itself scoped it: it decides the string-typed field set for every entity type. The helper's docstring carries that signpost, and now also names `staffing-score.py` — it reads the same parser and, on a numeric role label, scores every consultant at zero profile fit and echoes the raw int into the shortlist rather than raising. Whoever picks that change up needs to know there is a second consumer.

A quality pass folded `_status_text` into a delegate of the new helper. It turned out to be the same function with the field name hard-coded, so keeping both would have meant two copies of one body and one operator-facing warning template. Warning strings are byte-identical; fixtures 10c/10d/10e pass unchanged.

## Accepted behaviour change

A numeric `open_roles` entry now emits a warning, so an all-numeric portfolio that rendered clean before becomes `partial: true`. Kept rather than coerced silently — it mirrors the existing "fix the record" contract, and only fires on records already off-schema, where a numeric role label is pathological rather than idiomatic.

## Verification

- `bash cogni-projects/tests/test-render-dashboard.sh` — green, 59 assertions (48 existing + 11 new).
- `test_register_entity.sh` and `test_portfolio_init.sh` — green.
- **Mutation-tested, both directions.** Reverting both call sites fails 10 of Fixture 11's assertions with the reported `TypeError`. Reverting *only* the `open_roles` normalization fails 4 — including 11f reading `open_roles: 1` instead of `0` — so the symmetry guard genuinely bites and is not decoration.
- The issue's exact repro (`open_roles: [lead]`, assignments `role: 2` and `role: lead`) now returns `success: true`, `partial: true`, names the offending record in `warnings[]`, and writes `dashboard.html`.
- Breadcrumb guard: 0 violations. Version-bump gate: 0 plugins touched. Skill-name check: OK.
- Performance measured on a 300-project x 6000-assignment portfolio: +1.0 ms (+1.1%). The pre-existing project filter fires before the coercion, so nothing is added to the quadratic path — 8,400 helper calls against 1.8M inner-loop iterations.

## Reviewer notes

- No version bump in this branch; the post-merge workflow owns it.
- `sorted(covered)` is deliberately left without `key=str`. The coercion at the read sites is the contract; a local sort key would let a future gap degrade to a silently wrong count instead of a visible failure.
- Enumerated every other parsed-entity value in this file that is compared, sorted, or joined — `type` (dict-key membership, already degrades), `assignment.project` vs `project.slug` (both coerced identically, symmetric), the display fields (all through `_esc`), and the numeric fields. No third exposed read site in this file.