### PR TITLE
cogni-workspace: font-aware theme-value guard profile

### DIFF
--- a/cogni-workspace/scripts/sanitize-theme.py
+++ b/cogni-workspace/scripts/sanitize-theme.py
@@ -12,7 +12,10 @@ lives in one place instead of being copy-pasted per renderer.
 Two consumption surfaces:
 
   * **In-plugin import** (the fast path used by renderers): load this file by
-    path and call :func:`is_safe_value` / :func:`sanitize_values`. Renderers in
+    path and call :func:`sanitize_section`, which resolves each section's profile
+    and shape from :data:`SECTION_PROFILES` so no renderer restates that policy.
+    (:func:`is_safe_value` / :func:`sanitize_values` remain the lower-level
+    surface for a caller that already knows the profile it wants.) Renderers in
     *other* plugins cannot rely on a normal ``import`` (separate plugin cache
     dirs), so the natural consumers are cogni-workspace's own renderers; the
     cross-plugin sharing mechanism is a separate, deferred decision.
@@ -31,17 +34,28 @@ Profiles
 
 ``font-aware``
     Denylist ``<>{};@\\`` (``strict``'s set minus the two paren characters), max
-    length 300. For the values ``strict`` cannot express: font stacks, shadows,
-    ``radius``, and ``google_fonts_import``. Permits ``rgba(...)`` / ``url(...)``
-    by allowing parens, and — through a *second, anchored acceptance path* — one
-    ``@import url(<https-url>);`` statement or one bare ``https://…`` URL. That
-    shape gate is the only way ``@`` and ``;`` can appear, which is what keeps
-    the relaxation from turning every declaration slot into an injection point:
-    a bare ``;`` would let ``red; background-image: url(https://evil/beacon.png)``
-    ride along inside ``:root``, and an ungated ``@`` would let the
-    top-level ``google_fonts_import`` slot carry any number of at-rules.
+    length 300, **no shape gate**. For the declaration *values* ``strict`` cannot
+    express: font stacks, shadows and ``radius``. Permits ``rgba(...)`` /
+    ``url(...)`` by allowing parens, while ``;`` and ``@`` stay forbidden.
 
-    Rejected under ``font-aware``: ``</style>`` / ``<script>`` and any markup
+``import-aware``
+    ``font-aware``'s denylist and bound, plus a *second, anchored acceptance
+    path*: one ``@import url(<https-url>);`` statement or one bare ``https://…``
+    URL. Applied to ``google_fonts_import`` alone.
+
+    The split between these two profiles is load-bearing, and collapsing them is
+    the bug this table shape exists to prevent. The shape gate's URL alternative
+    must tolerate ``@`` and ``;`` *inside* the URL — the shipped default needs
+    both for ``wght@400;500`` — so a value accepted by the gate can carry those
+    characters. That is safe **only** where the value is emitted as a complete
+    at-rule statement of its own, which is true of ``google_fonts_import`` and of
+    nothing else. Wired to a section interpolated as a raw declaration value
+    inside ``:root`` — as ``fonts`` / ``shadows`` / ``radius`` are — the same gate
+    re-admits exactly the declaration chaining the denylist exists to block:
+    ``https://a.example/x;background:red;position:fixed`` is a "bare URL" by
+    shape and a two-declaration injection by effect.
+
+    Rejected under both profiles: ``</style>`` / ``<script>`` and any markup
     breakout, rule-block injection (``{``/``}``), ``;`` declaration injection,
     ``data:`` / ``http:`` / protocol-relative schemes, chained imports
     (``@import a;@import b;``), media-qualified imports
@@ -76,29 +90,74 @@ import sys
 # This gate is consulted **only when the denylist path already failed**, i.e. for
 # values carrying ``@`` or ``;``. A value with none of the forbidden characters
 # is accepted without ever being shape-checked — deliberately, since it provably
-# cannot break out, and demanding this shape of every value would reject the
-# ``rgba(...)`` shadows and font stacks the profile exists to allow.
+# cannot break out.
+#
+# It belongs to ``import-aware`` alone. Because the URL alternative must allow
+# ``@`` and ``;`` inside the URL (the shipped default needs ``wght@400;500``),
+# wiring it to a profile covering raw declaration values would let
+# ``https://a.example/x;background:red`` through as a "bare URL" — see the
+# module docstring.
 #
 # ``_URL`` is named once because both alternatives must stay identical: excluding
 # whitespace, quotes, parens, angle brackets, braces and backslash is what makes
-# a shape-accepted value provably free of every breakout character. It still
-# allows ``@`` and ``;`` *inside* the URL — the shipped default needs both for
-# ``wght@400;500``.
+# a shape-accepted value provably free of every breakout character, and is also
+# what makes the captured URL safe to re-wrap in ``url('…')`` below.
 _URL = r"https://[^\s'\"()<>{}\\]+"
+# The named groups exist so :func:`normalize_font_import` can recover the URL
+# from either alternative. Group 1 stays the optional quote (the ``\1``
+# backreference pairs the closing quote with the opening one), so the named
+# groups are added *after* it.
 _FONT_IMPORT_RE = re.compile(
-    r"^(?:@import\s+url\(\s*(['\"]?)" + _URL + r"\1\s*\)\s*;?|" + _URL + r")\Z"
+    r"^(?:@import\s+url\(\s*(['\"]?)(?P<stmt>" + _URL + r")\1\s*\)\s*;?"
+    r"|(?P<bare>" + _URL + r"))\Z"
 )
 
-# profile name -> (forbidden character set, max length, optional shape regex).
-# The regex is the profile's *second* acceptance path; carrying it in the record
-# keeps this table the complete statement of policy, so a future profile is a new
-# row rather than a new branch inside is_safe_value.
+def normalize_font_import(value):
+    """Canonicalize an accepted import value into ``@import url('<url>');``.
+
+    Returns the canonical statement, or ``None`` when ``value`` is not a
+    well-formed import — the caller treats that as "no usable override" and
+    keeps its default.
+
+    Normalizing is a correctness requirement, not tidiness. The value is emitted
+    verbatim at the top of the ``<style>`` block, immediately before ``:root {``,
+    and two shapes the gate accepts are not self-terminating there: a **bare
+    URL** (no ``@import``, no ``;``) and an ``@import`` whose optional trailing
+    ``;`` is absent. In both cases CSS error recovery consumes the following
+    block, so the whole ``:root`` rule is swallowed and every theme variable is
+    silently lost. Re-emitting one canonical, terminated statement makes both
+    inputs safe by construction.
+
+    Re-wrapping is provably well-formed because ``_URL`` excludes quotes,
+    parens and whitespace, so the captured URL can never close the ``url('…')``
+    it is placed inside.
+    """
+    match = _FONT_IMPORT_RE.match(value) if isinstance(value, str) else None
+    if match is None:
+        return None
+    return "@import url('%s');" % (match.group("stmt") or match.group("bare"))
+
+
+# profile name -> (forbidden character set, max length, optional shape regex,
+# optional normalizer). The regex is the profile's *second* acceptance path and
+# the normalizer canonicalizes what that path accepts; carrying both in the
+# record keeps this table the complete statement of policy, so a future profile
+# is a new row rather than a new branch inside is_safe_value or sanitize_section.
+# A gate-carrying profile whose normalizer were wired up by name somewhere else
+# would fail silently — see normalize_font_import for what that costs.
 _PROFILES = {
-    "strict": (set("<>{}();@\\"), 120, None),
-    "font-aware": (set("<>{};@\\"), 300, _FONT_IMPORT_RE),
+    "strict": (set("<>{}();@\\"), 120, None, None),
+    "font-aware": (set("<>{};@\\"), 300, None, None),
+    "import-aware": (set("<>{};@\\"), 300, _FONT_IMPORT_RE, normalize_font_import),
 }
 DEFAULT_PROFILE = "strict"
 FONT_AWARE_PROFILE = "font-aware"
+IMPORT_AWARE_PROFILE = "import-aware"
+
+
+def _profile(name):
+    """Resolve a profile name to its record, failing closed onto ``strict``."""
+    return _PROFILES[name if name in _PROFILES else DEFAULT_PROFILE]
 
 # Which profile each design-variables section is vetted under, and whether it is
 # a ``{key: value}`` map or a single string value. This is a fact about the
@@ -110,7 +169,7 @@ SECTION_PROFILES = {
     "status": ("dict", DEFAULT_PROFILE),
     "fonts": ("dict", FONT_AWARE_PROFILE),
     "shadows": ("dict", FONT_AWARE_PROFILE),
-    "google_fonts_import": ("scalar", FONT_AWARE_PROFILE),
+    "google_fonts_import": ("scalar", IMPORT_AWARE_PROFILE),
     "radius": ("scalar", FONT_AWARE_PROFILE),
 }
 
@@ -130,8 +189,7 @@ def is_safe_value(value, profile=DEFAULT_PROFILE):
     unknown profile name falls back to ``strict``, i.e. fails closed onto the
     tightest policy.
     """
-    name = profile if profile in _PROFILES else DEFAULT_PROFILE
-    forbidden, max_len, shape = _PROFILES[name]
+    forbidden, max_len, shape, _ = _profile(profile)
     if not isinstance(value, str) or not (0 < len(value) <= max_len):
         return False
     if not (forbidden & set(value)):
@@ -175,6 +233,12 @@ def sanitize_section(section, value, defaults, profile=None):
     ``google_fonts_import`` legitimately means "no import" — so it yields
     ``defaults`` with nothing rejected rather than being reported as unsafe.
 
+    A scalar is additionally passed through its profile's normalizer, when that
+    profile declares one, so the value a renderer interpolates is canonical — for
+    ``import-aware`` that means an always-terminated ``@import`` statement. A
+    value that passes the denylist but the normalizer cannot canonicalize has no
+    valid rendering in that slot, so it is rejected rather than emitted raw.
+
     ``profile`` overrides the section's default profile; leave it ``None`` to
     apply the policy the renderers actually use.
     """
@@ -185,7 +249,10 @@ def sanitize_section(section, value, defaults, profile=None):
     if value in (None, ""):
         return defaults, []
     if is_safe_value(value, applied):
-        return value, []
+        normalizer = _profile(applied)[3]
+        clean = normalizer(value) if normalizer is not None else value
+        if clean is not None:
+            return clean, []
     return defaults, [section]
 
 
@@ -205,7 +272,7 @@ def _cli(argv):
     if not args:
         return {"success": False, "data": None,
                 "error": "usage: sanitize-theme.py <design-variables.json> "
-                         "[--profile=strict|font-aware]"}
+                         "[--profile=strict|font-aware|import-aware]"}
     if forced_profile is not None and forced_profile not in _PROFILES:
         return {"success": False, "data": None,
                 "error": "unknown profile %r (available: %s)"
@@ -237,9 +304,13 @@ def _cli(argv):
         if bad:
             rejected[section] = bad
     return {"success": True,
-            # ``profile`` is what was *forced*; null means each section was
-            # vetted under its own default, which ``section_profiles`` spells out.
-            "data": {"profile": forced_profile,
+            # ``profile`` stays a string on every invocation — it names the
+            # profile in force across the walk, falling back to the default when
+            # none was forced. Reporting the *forced* value here (and so ``null``
+            # by default) would be a type change on a field callers already read
+            # as always-a-string; the per-section detail this profile model adds
+            # is carried additively by ``section_profiles`` instead.
+            "data": {"profile": forced_profile or DEFAULT_PROFILE,
                      "section_profiles": section_profiles,
                      "checked": checked,
                      "rejected": rejected},

--- a/cogni-workspace/scripts/sanitize-theme.py
+++ b/cogni-workspace/scripts/sanitize-theme.py
@@ -23,43 +23,120 @@ Two consumption surfaces:
 
 Profiles
 --------
-``strict`` (the only profile shipped today, and the default)
+``strict`` (the default)
     Denylist ``<>{}();@\\``, max length 120. Rejects stylesheet/markup breakout
     **and** the ``url()`` / ``@import`` external-fetch surface (a self-contained
     artifact that phones home on open). Correct for ``colors`` / ``status`` /
-    border tokens, which never legitimately need those characters. It is
-    deliberately **not** applied to font or shadow values that legitimately
-    carry ``rgba(...)`` or ``@import url(...)`` — a ``font-aware`` profile that
-    permits those while still blocking breakout is future work.
+    border tokens, which never legitimately need those characters.
 
-Single quotes stay legal under ``strict``: a font stack (``'Segoe UI', Roboto``)
-needs them and they cannot terminate a ``<style>`` block on their own.
+``font-aware``
+    Denylist ``<>{};@\\`` (``strict``'s set minus the two paren characters), max
+    length 300. For the values ``strict`` cannot express: font stacks, shadows,
+    ``radius``, and ``google_fonts_import``. Permits ``rgba(...)`` / ``url(...)``
+    by allowing parens, and — through a *second, anchored acceptance path* — one
+    ``@import url(<https-url>);`` statement or one bare ``https://…`` URL. That
+    shape gate is the only way ``@`` and ``;`` can appear, which is what keeps
+    the relaxation from turning every declaration slot into an injection point:
+    a bare ``;`` would let ``red; background-image: url(https://evil/beacon.png)``
+    ride along inside ``:root``, and an ungated ``@`` would let the
+    top-level ``google_fonts_import`` slot carry any number of at-rules.
+
+    Rejected under ``font-aware``: ``</style>`` / ``<script>`` and any markup
+    breakout, rule-block injection (``{``/``}``), ``;`` declaration injection,
+    ``data:`` / ``http:`` / protocol-relative schemes, chained imports
+    (``@import a;@import b;``), media-qualified imports
+    (``@import url(...) screen;``), and anything with trailing content.
+
+    **Accepted residual, by policy:** a well-formed *https* ``@import`` from an
+    arbitrary host passes — there is deliberately no host allowlist, so
+    self-hosted, Bunny, and Adobe font hosts keep working. External imports are
+    kept rather than inlined; narrowing that is a maintainer policy decision,
+    not a property of this guard.
+
+Single quotes stay legal under both profiles: a font stack
+(``'Segoe UI', Roboto``) needs them and they cannot terminate a ``<style>``
+block on their own.
 """
 
 import json
+import re
 import sys
 
-# profile name -> (forbidden character set, max length)
+# One ``@import url(<https-url>);`` statement, or one bare ``https://…`` URL —
+# the two shapes renderers actually accept (``cogni-visual/enrich-report``
+# normalizes the latter into the former).
+#
+# Anchored ``^…\Z`` with **no trailing ``\s*``**. Both details are load-bearing:
+# ``$`` alone matches *before* a trailing newline, and a trailing ``\s*``
+# re-admits that newline even under ``\Z``. With the anchor tight, a shape-gated
+# value carrying anything after the statement — ``@import url('https://h/x.css');
+# body{color:red}``, a second chained ``@import``, or bare trailing whitespace —
+# fails closed onto the built-in default rather than being normalized away.
+#
+# This gate is consulted **only when the denylist path already failed**, i.e. for
+# values carrying ``@`` or ``;``. A value with none of the forbidden characters
+# is accepted without ever being shape-checked — deliberately, since it provably
+# cannot break out, and demanding this shape of every value would reject the
+# ``rgba(...)`` shadows and font stacks the profile exists to allow.
+#
+# ``_URL`` is named once because both alternatives must stay identical: excluding
+# whitespace, quotes, parens, angle brackets, braces and backslash is what makes
+# a shape-accepted value provably free of every breakout character. It still
+# allows ``@`` and ``;`` *inside* the URL — the shipped default needs both for
+# ``wght@400;500``.
+_URL = r"https://[^\s'\"()<>{}\\]+"
+_FONT_IMPORT_RE = re.compile(
+    r"^(?:@import\s+url\(\s*(['\"]?)" + _URL + r"\1\s*\)\s*;?|" + _URL + r")\Z"
+)
+
+# profile name -> (forbidden character set, max length, optional shape regex).
+# The regex is the profile's *second* acceptance path; carrying it in the record
+# keeps this table the complete statement of policy, so a future profile is a new
+# row rather than a new branch inside is_safe_value.
 _PROFILES = {
-    "strict": (set("<>{}();@\\"), 120),
+    "strict": (set("<>{}();@\\"), 120, None),
+    "font-aware": (set("<>{};@\\"), 300, _FONT_IMPORT_RE),
 }
 DEFAULT_PROFILE = "strict"
+FONT_AWARE_PROFILE = "font-aware"
+
+# Which profile each design-variables section is vetted under, and whether it is
+# a ``{key: value}`` map or a single string value. This is a fact about the
+# shared design-variables schema rather than about any one renderer — every
+# consumer reads the same section names in the same shapes — so it lives here
+# instead of being restated per renderer. Consume it via :func:`sanitize_section`.
+SECTION_PROFILES = {
+    "colors": ("dict", DEFAULT_PROFILE),
+    "status": ("dict", DEFAULT_PROFILE),
+    "fonts": ("dict", FONT_AWARE_PROFILE),
+    "shadows": ("dict", FONT_AWARE_PROFILE),
+    "google_fonts_import": ("scalar", FONT_AWARE_PROFILE),
+    "radius": ("scalar", FONT_AWARE_PROFILE),
+}
 
 
 def is_safe_value(value, profile=DEFAULT_PROFILE):
     """Return True when ``value`` is safe to interpolate into a ``<style>`` block.
 
-    A value is safe when it is a non-empty string within the profile's length
-    bound and carries none of the profile's forbidden characters. Non-strings
-    (numbers, dicts, None) are unsafe — theme values reach the stylesheet as raw
-    text, so only vetted strings may pass.
+    A value passes on either of two paths, and the profile's length bound
+    applies to both. The **denylist path** (the only one ``strict`` has) accepts
+    a non-empty string carrying none of the profile's forbidden characters. The
+    **shape path** accepts a value matching the profile's own regex, when it
+    declares one — see the module docstring for why that escape hatch is narrow
+    rather than a wider denylist.
+
+    Non-strings (numbers, dicts, None) are unsafe on both paths — theme values
+    reach the stylesheet as raw text, so only vetted strings may pass. An
+    unknown profile name falls back to ``strict``, i.e. fails closed onto the
+    tightest policy.
     """
-    forbidden, max_len = _PROFILES.get(profile, _PROFILES[DEFAULT_PROFILE])
-    return (
-        isinstance(value, str)
-        and 0 < len(value) <= max_len
-        and not (forbidden & set(value))
-    )
+    name = profile if profile in _PROFILES else DEFAULT_PROFILE
+    forbidden, max_len, shape = _PROFILES[name]
+    if not isinstance(value, str) or not (0 < len(value) <= max_len):
+        return False
+    if not (forbidden & set(value)):
+        return True
+    return shape is not None and bool(shape.match(value))
 
 
 def sanitize_values(values, defaults, profile=DEFAULT_PROFILE):
@@ -84,19 +161,55 @@ def sanitize_values(values, defaults, profile=DEFAULT_PROFILE):
     return clean, sorted(rejected)
 
 
+def sanitize_section(section, value, defaults, profile=None):
+    """Vet one design-variables section under the profile its consumers apply.
+
+    The single entry point a renderer should use: it resolves the section's
+    shape and profile from :data:`SECTION_PROFILES`, so no caller has to restate
+    which sections are dict-shaped or which profile each one takes. Returns
+    ``(clean, rejected)`` — ``clean`` being the vetted value (or ``defaults``
+    when the override is rejected) and ``rejected`` a list of dropped keys, or
+    ``[section]`` for a rejected scalar.
+
+    An absent or empty scalar is **not** an override — an empty
+    ``google_fonts_import`` legitimately means "no import" — so it yields
+    ``defaults`` with nothing rejected rather than being reported as unsafe.
+
+    ``profile`` overrides the section's default profile; leave it ``None`` to
+    apply the policy the renderers actually use.
+    """
+    shape, section_profile = SECTION_PROFILES[section]
+    applied = profile or section_profile
+    if shape == "dict":
+        return sanitize_values(value, defaults, applied)
+    if value in (None, ""):
+        return defaults, []
+    if is_safe_value(value, applied):
+        return value, []
+    return defaults, [section]
+
+
 def _cli(argv):
-    """Report which color/status override values a design-variables file would lose."""
+    """Report which design-variable override values a file would lose.
+
+    Walks every section in :data:`SECTION_PROFILES`, vetting each under the
+    profile that section's renderer applies. An explicit ``--profile=`` forces
+    one profile across all sections instead — useful for asking "what would
+    `strict` reject here?" of a file the renderer treats more leniently.
+    """
     args = [a for a in argv if not a.startswith("--")]
-    profile = DEFAULT_PROFILE
+    forced_profile = None
     for a in argv:
         if a.startswith("--profile="):
-            profile = a.split("=", 1)[1]
+            forced_profile = a.split("=", 1)[1]
     if not args:
         return {"success": False, "data": None,
-                "error": "usage: sanitize-theme.py <design-variables.json> [--profile=strict]"}
-    if profile not in _PROFILES:
+                "error": "usage: sanitize-theme.py <design-variables.json> "
+                         "[--profile=strict|font-aware]"}
+    if forced_profile is not None and forced_profile not in _PROFILES:
         return {"success": False, "data": None,
-                "error": "unknown profile %r (available: %s)" % (profile, ", ".join(sorted(_PROFILES)))}
+                "error": "unknown profile %r (available: %s)"
+                         % (forced_profile, ", ".join(sorted(_PROFILES)))}
     try:
         with open(args[0], "r", encoding="utf-8") as f:
             overrides = json.load(f)
@@ -106,18 +219,30 @@ def _cli(argv):
         return {"success": False, "data": None, "error": "design-variables must be a JSON object"}
 
     rejected = {}
+    section_profiles = {}
     checked = 0
-    for section in ("colors", "status"):
+    for section, (shape, section_profile) in SECTION_PROFILES.items():
+        section_profiles[section] = forced_profile or section_profile
         src = overrides.get(section)
-        if isinstance(src, dict):
-            for key, value in src.items():
-                checked += 1
-                if not is_safe_value(value, profile):
-                    rejected.setdefault(section, []).append(key)
-    for section in rejected:
-        rejected[section] = sorted(rejected[section])
+        # Report against the file's own keys, so `defaults` is `src` itself —
+        # the same walk `sanitize_section` gives a renderer, minus the fallback
+        # values a report has no use for.
+        if shape == "dict" and isinstance(src, dict):
+            checked += len(src)
+        elif shape == "scalar" and src not in (None, ""):
+            checked += 1
+        else:
+            continue
+        _, bad = sanitize_section(section, src, src, forced_profile)
+        if bad:
+            rejected[section] = bad
     return {"success": True,
-            "data": {"profile": profile, "checked": checked, "rejected": rejected},
+            # ``profile`` is what was *forced*; null means each section was
+            # vetted under its own default, which ``section_profiles`` spells out.
+            "data": {"profile": forced_profile,
+                     "section_profiles": section_profiles,
+                     "checked": checked,
+                     "rejected": rejected},
             "error": None}
 
 

--- a/cogni-workspace/scripts/sanitize-theme.py
+++ b/cogni-workspace/scripts/sanitize-theme.py
@@ -56,10 +56,21 @@ Profiles
     shape and a two-declaration injection by effect.
 
     Rejected under both profiles: ``</style>`` / ``<script>`` and any markup
-    breakout, rule-block injection (``{``/``}``), ``;`` declaration injection,
-    ``data:`` / ``http:`` / protocol-relative schemes, chained imports
+    breakout, rule-block injection (``{``/``}``), and ``;`` declaration
+    injection. Rejected under ``import-aware`` specifically: ``data:`` /
+    ``http:`` / protocol-relative schemes, chained imports
     (``@import a;@import b;``), media-qualified imports
-    (``@import url(...) screen;``), and anything with trailing content.
+    (``@import url(...) screen;``), and anything with trailing content —
+    all of these are properties of the *shape gate*, which ``font-aware``
+    deliberately does not carry.
+
+    **Consequence for ``font-aware``:** with no shape gate it permits an
+    arbitrary ``url(...)``, including non-https schemes, because the denylist
+    alone cannot distinguish them. That is safe only in a slot whose consuming
+    CSS property cannot fetch — ``font-family``, ``box-shadow`` and
+    ``border-radius``, which is exactly what the profile covers. A renderer must
+    **not** route a fetchable property (``background``, ``src``, ``mask``, …)
+    through ``font-aware``; such a slot needs ``strict``, or a new row here.
 
     **Accepted residual, by policy:** a well-formed *https* ``@import`` from an
     arbitrary host passes — there is deliberately no host allowlist, so
@@ -188,6 +199,14 @@ def is_safe_value(value, profile=DEFAULT_PROFILE):
     reach the stylesheet as raw text, so only vetted strings may pass. An
     unknown profile name falls back to ``strict``, i.e. fails closed onto the
     tightest policy.
+
+    **For a profile declaring a normalizer, acceptance here is necessary but not
+    sufficient.** The denylist path accepts values the shape gate never sees, so
+    an ``import-aware`` value can pass this check and still be unemittable —
+    ``'Roboto'`` is accepted, yet emitting it where an ``@import`` belongs
+    reintroduces the ``:root``-swallowing failure :func:`normalize_font_import`
+    exists to prevent. Callers must go through :func:`sanitize_section` (or
+    apply the profile's normalizer themselves) before emitting such a value.
     """
     forbidden, max_len, shape, _ = _profile(profile)
     if not isinstance(value, str) or not (0 < len(value) <= max_len):
@@ -240,11 +259,19 @@ def sanitize_section(section, value, defaults, profile=None):
     valid rendering in that slot, so it is rejected rather than emitted raw.
 
     ``profile`` overrides the section's default profile; leave it ``None`` to
-    apply the policy the renderers actually use.
+    apply the policy the renderers actually use. The override is **ignored for a
+    dict-shaped section when it names a normalizer-carrying profile**: the
+    per-key path cannot normalize, so honouring it would accept a gate-shaped
+    value and emit it raw into a declaration slot — reinstating the very
+    injection the profile split closes. An unknown section falls back to the
+    tightest policy rather than raising, matching :func:`_profile`, so a renderer
+    using a section outside the table degrades instead of killing the render.
     """
-    shape, section_profile = SECTION_PROFILES[section]
+    shape, section_profile = SECTION_PROFILES.get(section, ("dict", DEFAULT_PROFILE))
     applied = profile or section_profile
     if shape == "dict":
+        if _profile(applied)[3] is not None:
+            applied = section_profile
         return sanitize_values(value, defaults, applied)
     if value in (None, ""):
         return defaults, []

--- a/cogni-workspace/skills/workspace-dashboard/scripts/generate-dashboard.py
+++ b/cogni-workspace/skills/workspace-dashboard/scripts/generate-dashboard.py
@@ -165,41 +165,54 @@ def parse_theme_md(theme_path):
 def merge_tokens(design_variables, parsed_theme):
     """Pick the strongest available token source. Order: design-vars > theme.md > default.
 
-    Returns ``(theme, warnings)``. When design-variables supply ``colors`` /
-    ``status`` overrides, each value is vetted by the shared theme-value guard
-    (``cogni-workspace/scripts/sanitize-theme.py``) before it can reach the
-    ``<style>`` block: a value carrying stylesheet or markup breakout characters
-    is dropped and the built-in palette value is kept for that key, with the
-    rejection surfaced as a warning. Font, shadow, and ``@import`` values are
-    left untouched — they legitimately carry ``rgba(...)`` / ``url(...)`` and are
-    handled under a separate, deferred font-aware policy. If the guard fails to
-    load, override values pass through unguarded (theming is never a hard
-    dependency).
+    Returns ``(theme, warnings)``. Every design-variables override is vetted by
+    the shared theme-value guard (``cogni-workspace/scripts/sanitize-theme.py``)
+    before it can reach the ``<style>`` block: a rejected value is dropped, the
+    built-in value is kept for that key, and the rejection is surfaced as a
+    warning. Two profiles, because the values differ in kind — ``colors`` /
+    ``status`` are hex tokens vetted under ``strict``, while ``fonts`` /
+    ``shadows`` / ``radius`` / ``google_fonts_import`` are vetted under
+    ``font-aware``, which permits the ``rgba(...)`` / ``url(...)`` /
+    ``@import url(...)`` forms they legitimately carry while still rejecting
+    breakout and declaration injection.
+
+    Routing ``fonts`` through the guard also backfills any key the override
+    omits, which matters beyond safety: ``render_css`` indexes
+    ``theme['fonts']['headers'|'body'|'mono']`` directly, so a design-variables
+    file supplying only ``fonts.body`` used to crash the render with a
+    ``KeyError``.
+
+    Which profile covers which section is the guard's policy, not this
+    renderer's — ``sanitize_section`` resolves it — so the five sibling
+    renderers inherit the same mapping when they are wired to the guard rather
+    than each restating it. If the guard fails to load, every override passes
+    through unguarded; theming is never a hard dependency.
     """
     warnings = []
     if design_variables:
+        defaults = {
+            "colors": DEFAULT_THEME["colors"],
+            "status": DEFAULT_THEME["status"],
+            "fonts": DEFAULT_THEME["fonts"],
+            "shadows": DEFAULT_THEME["shadows"],
+            "google_fonts_import": "",
+            "radius": DEFAULT_THEME["radius"],
+        }
         if _THEME_GUARD is not None:
-            colors, rejected_colors = _THEME_GUARD.sanitize_values(
-                design_variables.get("colors", {}), DEFAULT_THEME["colors"])
-            status, rejected_status = _THEME_GUARD.sanitize_values(
-                design_variables.get("status", {}), DEFAULT_THEME["status"])
-            rejected = rejected_colors + rejected_status
+            vetted, rejected = {}, []
+            for section, default in defaults.items():
+                vetted[section], bad = _THEME_GUARD.sanitize_section(
+                    section, design_variables.get(section), default)
+                rejected += bad
             if rejected:
                 warnings.append(
                     "design-variables: ignored unsafe value(s) for %s — using the "
                     "built-in palette for those keys" % ", ".join(rejected))
         else:
-            colors = design_variables.get("colors", DEFAULT_THEME["colors"])
-            status = design_variables.get("status", DEFAULT_THEME["status"])
-        return {
-            "name": design_variables.get("theme_name", "custom"),
-            "colors": colors,
-            "status": status,
-            "fonts": design_variables.get("fonts", DEFAULT_THEME["fonts"]),
-            "google_fonts_import": design_variables.get("google_fonts_import", ""),
-            "radius": design_variables.get("radius", DEFAULT_THEME["radius"]),
-            "shadows": design_variables.get("shadows", DEFAULT_THEME["shadows"]),
-        }, warnings
+            vetted = {s: design_variables.get(s, d) for s, d in defaults.items()}
+        theme = dict(vetted)
+        theme["name"] = design_variables.get("theme_name", "custom")
+        return theme, warnings
     if parsed_theme:
         return parsed_theme, warnings
     return json.loads(json.dumps(DEFAULT_THEME)), warnings

--- a/cogni-workspace/skills/workspace-dashboard/scripts/generate-dashboard.py
+++ b/cogni-workspace/skills/workspace-dashboard/scripts/generate-dashboard.py
@@ -162,6 +162,22 @@ def parse_theme_md(theme_path):
     return theme
 
 
+def _merge_section(override, default):
+    """Merge one unvetted design-variables section onto its built-in default.
+
+    The degraded path's counterpart to the guard's own merge. Backfilling is not
+    cosmetic: ``render_css`` indexes ``theme['fonts']['headers'|'body'|'mono']``
+    and the shadow keys directly, so a partial override reaching it short a key
+    raises ``KeyError`` and kills the render — turning "the guard is missing"
+    into a hard failure, which is exactly what the no-hard-dependency contract
+    promises never happens. An absent or empty override is no override.
+    """
+    if isinstance(default, dict):
+        return {k: override.get(k, v) for k, v in default.items()} \
+            if isinstance(override, dict) else default
+    return override or default
+
+
 def merge_tokens(design_variables, parsed_theme):
     """Pick the strongest available token source. Order: design-vars > theme.md > default.
 
@@ -169,12 +185,12 @@ def merge_tokens(design_variables, parsed_theme):
     the shared theme-value guard (``cogni-workspace/scripts/sanitize-theme.py``)
     before it can reach the ``<style>`` block: a rejected value is dropped, the
     built-in value is kept for that key, and the rejection is surfaced as a
-    warning. Two profiles, because the values differ in kind — ``colors`` /
-    ``status`` are hex tokens vetted under ``strict``, while ``fonts`` /
-    ``shadows`` / ``radius`` / ``google_fonts_import`` are vetted under
-    ``font-aware``, which permits the ``rgba(...)`` / ``url(...)`` /
-    ``@import url(...)`` forms they legitimately carry while still rejecting
-    breakout and declaration injection.
+    warning. Three profiles, because the values differ in kind — ``colors`` /
+    ``status`` are hex tokens vetted under ``strict``; ``fonts`` / ``shadows`` /
+    ``radius`` are declaration values vetted under ``font-aware``, which permits
+    the ``rgba(...)`` / ``url(...)`` forms they legitimately carry; and
+    ``google_fonts_import``, the one slot emitted as a complete at-rule, is
+    vetted under ``import-aware``, the only profile that admits ``@`` and ``;``.
 
     Routing ``fonts`` through the guard also backfills any key the override
     omits, which matters beyond safety: ``render_css`` indexes
@@ -185,8 +201,17 @@ def merge_tokens(design_variables, parsed_theme):
     Which profile covers which section is the guard's policy, not this
     renderer's — ``sanitize_section`` resolves it — so the five sibling
     renderers inherit the same mapping when they are wired to the guard rather
-    than each restating it. If the guard fails to load, every override passes
-    through unguarded; theming is never a hard dependency.
+    than each restating it.
+
+    Theming is never a hard dependency, and that holds against a *stale* guard as
+    well as an absent one. The guard is loaded by path from its home plugin, so
+    an installed copy can predate ``sanitize_section`` while importing cleanly —
+    a call is then an ``AttributeError`` at render time, which the import-time
+    ``try`` cannot catch. Each surface is therefore feature-detected: the current
+    ``sanitize_section`` when present, else the older ``sanitize_values`` for the
+    hex-token sections, else unguarded pass-through. The detection is
+    ``hasattr``-based rather than a blanket ``try/except`` so a real failure
+    inside a present guard still surfaces instead of silently degrading.
     """
     warnings = []
     if design_variables:
@@ -198,18 +223,28 @@ def merge_tokens(design_variables, parsed_theme):
             "google_fonts_import": "",
             "radius": DEFAULT_THEME["radius"],
         }
-        if _THEME_GUARD is not None:
-            vetted, rejected = {}, []
-            for section, default in defaults.items():
-                vetted[section], bad = _THEME_GUARD.sanitize_section(
-                    section, design_variables.get(section), default)
-                rejected += bad
-            if rejected:
-                warnings.append(
-                    "design-variables: ignored unsafe value(s) for %s — using the "
-                    "built-in palette for those keys" % ", ".join(rejected))
-        else:
-            vetted = {s: design_variables.get(s, d) for s, d in defaults.items()}
+        # Resolve each surface once. ``getattr`` on ``None`` yields ``None``, so
+        # this covers "guard absent" and "guard too old" in one lookup.
+        guard_section = getattr(_THEME_GUARD, "sanitize_section", None)
+        guard_values = getattr(_THEME_GUARD, "sanitize_values", None)
+        vetted, rejected = {}, []
+        for section, default in defaults.items():
+            override = design_variables.get(section)
+            if guard_section is not None:
+                vetted[section], bad = guard_section(section, override, default)
+            elif guard_values is not None and section in ("colors", "status"):
+                # Older guard: vet what that surface can vet. Naming the two
+                # hex-token sections here does restate a slice of the guard's
+                # policy, but only for the degraded path — the current path above
+                # still asks the guard, which stays the single source of truth.
+                vetted[section], bad = guard_values(override, default)
+            else:
+                vetted[section], bad = _merge_section(override, default), []
+            rejected += bad
+        if rejected:
+            warnings.append(
+                "design-variables: ignored unsafe value(s) for %s — using the "
+                "built-in palette for those keys" % ", ".join(rejected))
         theme = dict(vetted)
         theme["name"] = design_variables.get("theme_name", "custom")
         return theme, warnings

--- a/cogni-workspace/tests/test-sanitize-theme.sh
+++ b/cogni-workspace/tests/test-sanitize-theme.sh
@@ -22,13 +22,19 @@ failures=0
 pass() { echo "OK   $1"; }
 fail() { echo "FAIL $1"; failures=$((failures + 1)); }
 
-# assert_py "<label>" "<python expr, True to pass>" — GUARD path is on sys.path.
+# assert_py "<label>" "<python expr, True to pass>" — the guard is bound as `g`
+# and the renderer as `r`, so an assertion can check the guard against the real
+# shipped DEFAULT_THEME instead of a synthetic stand-in. Both are import-safe
+# (the renderer guards its entry point behind __main__).
 assert_py() {
   local label="$1" expr="$2"
-  if python3 - "$GUARD" <<PY
+  if python3 - "$GUARD" "$RENDERER" <<PY
 import importlib.util, sys
-spec = importlib.util.spec_from_file_location("g", sys.argv[1])
-g = importlib.util.module_from_spec(spec); spec.loader.exec_module(g)
+def _load(name, path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    m = importlib.util.module_from_spec(spec); spec.loader.exec_module(m); return m
+g = _load("g", sys.argv[1])
+r = _load("r", sys.argv[2])
 sys.exit(0 if ($expr) else 1)
 PY
   then pass "$label"; else fail "$label"; fi
@@ -69,10 +75,10 @@ assert_py "1h unknown profile falls back to strict" 'g.is_safe_value("#000000</s
 
 echo "=== font-aware profile ==="
 # The exact DEFAULT_THEME value this plugin's own renderer ships (184 chars) —
-# over strict's 120 cap, which is why font-aware could not reuse the bound.
+# over strict's 120 cap, which is why import-aware could not reuse the bound.
 DEF_IMPORT="@import url('https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&family=Outfit:wght@300;400;500;600;700&display=swap');"
 assert_py "1i shipped default @import accepted" \
-  "g.is_safe_value('''$DEF_IMPORT''', 'font-aware') is True"
+  "g.is_safe_value('''$DEF_IMPORT''', 'import-aware') is True"
 assert_py "1j rgba shadow accepted" \
   'g.is_safe_value("0 1px 3px rgba(0,0,0,0.04), 0 1px 2px rgba(0,0,0,0.06)", "font-aware") is True'
 assert_py "1k font stack accepted" \
@@ -80,35 +86,66 @@ assert_py "1k font stack accepted" \
 # Forward-compat with cogni-visual/enrich-report, which normalizes a bare URL
 # into an @import — the profile must not be hostile to the pre-normalized shape.
 assert_py "1l bare https URL accepted" \
-  'g.is_safe_value("https://fonts.googleapis.com/css2?family=Outfit:wght@400;500&display=swap", "font-aware") is True'
+  'g.is_safe_value("https://fonts.googleapis.com/css2?family=Outfit:wght@400;500&display=swap", "import-aware") is True'
 assert_py "1m radius accepted" 'g.is_safe_value("12px", "font-aware") is True'
+
+# The defect this profile split exists to close. The shape gate has to tolerate
+# '@' and ';' inside a URL (wght@400;500), so wiring it to a profile covering raw
+# declaration values re-admits declaration chaining under the guise of a bare URL.
+# font-aware must therefore carry NO shape gate at all.
+INJ_URL="https://a.example/x;background:red;position:fixed"
+assert_py "1ma bare-URL declaration chaining rejected under font-aware" \
+  "g.is_safe_value('$INJ_URL', 'font-aware') is False"
+assert_py "1mb shape gate absent from font-aware (shipped @import rejected)" \
+  "g.is_safe_value('''$DEF_IMPORT''', 'font-aware') is False"
+# A URL needing the gate (it carries '@' and ';') has no acceptance path left in
+# font-aware. A plain URL with none of the forbidden characters still passes the
+# denylist there, which is harmless — it cannot break out of the declaration.
+assert_py "1mc gate-dependent URL rejected under font-aware" \
+  'g.is_safe_value("https://fonts.googleapis.com/css2?family=Outfit:wght@400;500", "font-aware") is False'
+# ...and the payload must not sneak through the section policy either.
+assert_py "1md fonts section rejects the injection payload" \
+  "g.sanitize_section('fonts', {'body':'$INJ_URL'}, {'body':'Roboto'}) == ({'body':'Roboto'}, ['body'])"
+assert_py "1me shadows section rejects the injection payload" \
+  "g.sanitize_section('shadows', {'sm':'$INJ_URL'}, {'sm':'0 1px 3px rgba(0,0,0,0.04)'}) == ({'sm':'0 1px 3px rgba(0,0,0,0.04)'}, ['sm'])"
+assert_py "1mf radius section rejects the injection payload" \
+  "g.sanitize_section('radius', '$INJ_URL', '12px') == ('12px', ['radius'])"
 assert_py "1n style breakout still rejected" \
   'g.is_safe_value("</style><script>alert(1)</script>", "font-aware") is False'
 assert_py "1o declaration injection rejected" \
   'g.is_safe_value("red; background-image: url(https://evil.example/b.png)", "font-aware") is False'
 assert_py "1p rule-block injection rejected" \
   'g.is_safe_value("red} body{background:red", "font-aware") is False'
+# The shape-gate rejections now belong to import-aware, the only profile that
+# carries the gate. Every one must still fail closed after the move — a gate that
+# relocated but stopped rejecting would be strictly worse than the original bug.
 assert_py "1q data: scheme rejected" \
-  "g.is_safe_value(\"@import url('data:text/css,body{color:red}');\", 'font-aware') is False"
+  "g.is_safe_value(\"@import url('data:text/css,body{color:red}');\", 'import-aware') is False"
 assert_py "1r http: scheme rejected" \
-  "g.is_safe_value(\"@import url('http://a.example/x.css');\", 'font-aware') is False"
+  "g.is_safe_value(\"@import url('http://a.example/x.css');\", 'import-aware') is False"
 assert_py "1s protocol-relative rejected" \
-  "g.is_safe_value(\"@import url('//a.example/x.css');\", 'font-aware') is False"
+  "g.is_safe_value(\"@import url('//a.example/x.css');\", 'import-aware') is False"
 assert_py "1t chained @import rejected" \
-  "g.is_safe_value(\"@import url('https://a.example/x.css');@import url('https://b.example/y.css');\", 'font-aware') is False"
+  "g.is_safe_value(\"@import url('https://a.example/x.css');@import url('https://b.example/y.css');\", 'import-aware') is False"
 assert_py "1u media-qualified @import rejected" \
-  "g.is_safe_value(\"@import url('https://a.example/x.css') screen;\", 'font-aware') is False"
+  "g.is_safe_value(\"@import url('https://a.example/x.css') screen;\", 'import-aware') is False"
 # The shape gate is anchored ^...\Z with no trailing \s* — anything after the
 # statement fails closed. Both details are load-bearing: \Z alone still accepts a
 # trailing newline if a \s* precedes it, and plain $ accepts one outright.
 assert_py "1v @import with trailing declaration rejected" \
-  "g.is_safe_value(\"@import url('https://a.example/x.css'); body{color:red}\", 'font-aware') is False"
+  "g.is_safe_value(\"@import url('https://a.example/x.css'); body{color:red}\", 'import-aware') is False"
 assert_py "1w @import with trailing newline rejected" \
-  "g.is_safe_value(\"@import url('https://a.example/x.css');\n\", 'font-aware') is False"
+  "g.is_safe_value(\"@import url('https://a.example/x.css');\n\", 'import-aware') is False"
 assert_py "1x @import with trailing space rejected" \
-  "g.is_safe_value(\"@import url('https://a.example/x.css'); \", 'font-aware') is False"
+  "g.is_safe_value(\"@import url('https://a.example/x.css'); \", 'import-aware') is False"
 assert_py "1y over-length rejected" \
-  'g.is_safe_value("https://a.example/" + "a"*300, "font-aware") is False'
+  'g.is_safe_value("https://a.example/" + "a"*300, "import-aware") is False'
+# The breakout family must stay rejected under import-aware too — the gate adds
+# an acceptance path, it must not subtract any denylist coverage.
+assert_py "1ya style breakout rejected under import-aware" \
+  'g.is_safe_value("</style><script>alert(1)</script>", "import-aware") is False'
+assert_py "1yb rule-block injection rejected under import-aware" \
+  'g.is_safe_value("red} body{background:red", "import-aware") is False'
 # Regression: the relaxations must not leak into strict, still the default
 # profile for colors/status.
 assert_py "1z strict still rejects rgba" 'g.is_safe_value("rgba(0,0,0,0.1)") is False'
@@ -140,8 +177,10 @@ assert_py "2h colors section resolves to strict" \
   'g.sanitize_section("colors", {"background":"rgba(0,0,0,0.1)"}, {"background":"#FAFAF8"}) == ({"background":"#FAFAF8"}, ["background"])'
 assert_py "2i fonts section resolves to font-aware" \
   'g.sanitize_section("fonts", {"body":"0 1px rgba(0,0,0,0.1)"}, {"body":"Roboto"})[0]["body"] == "0 1px rgba(0,0,0,0.1)"'
+# The \$ here used to be escaped, so both sides compared the *literal* string
+# "\$DEF_IMPORT" and the assertion held without ever exercising an import value.
 assert_py "2j scalar import accepted" \
-  "g.sanitize_section('google_fonts_import', '''\$DEF_IMPORT''', '') == ('''\$DEF_IMPORT''', [])"
+  "g.sanitize_section('google_fonts_import', '''$DEF_IMPORT''', '') == ('''$DEF_IMPORT''', [])"
 assert_py "2k scalar breakout falls back to default" \
   'g.sanitize_section("google_fonts_import", "</style><script>x</script>", "") == ("", ["google_fonts_import"])'
 # Empty means "no override", not "unsafe" — the renderer and the CLI report must
@@ -152,6 +191,34 @@ assert_py "2m absent scalar is not an override" \
   'g.sanitize_section("radius", None, "12px") == ("12px", [])'
 assert_py "2n explicit profile overrides section default" \
   "g.sanitize_section('fonts', {'body':'rgba(0,0,0,0.1)'}, {'body':'Roboto'}, 'strict') == ({'body':'Roboto'}, ['body'])"
+
+# google_fonts_import is emitted immediately before ':root {', so a value that is
+# not a self-terminating at-rule lets CSS error recovery swallow the whole :root
+# block — every theme variable silently lost. Both non-terminating shapes the
+# gate accepts are normalized to one canonical statement.
+assert_py "2o bare URL normalized into a terminated @import" \
+  "g.sanitize_section('google_fonts_import', 'https://fonts.googleapis.com/css2?family=Outfit', '') == (\"@import url('https://fonts.googleapis.com/css2?family=Outfit');\", [])"
+assert_py "2p semicolon-less @import normalized" \
+  "g.sanitize_section('google_fonts_import', \"@import url('https://a.example/x.css')\", '') == (\"@import url('https://a.example/x.css');\", [])"
+# (2j above already pins the canonical import round-tripping byte-identically.)
+# Passes the denylist but is no kind of import — no valid rendering in that slot.
+assert_py "2r non-import scalar falls back to default" \
+  "g.sanitize_section('google_fonts_import', 'Roboto', '') == ('', ['google_fonts_import'])"
+assert_py "2s normalize_font_import returns None on a non-import" \
+  'g.normalize_font_import("Roboto") is None'
+
+echo "=== shipped defaults must survive their own profiles ==="
+# Arity first, so the all()-loops below cannot pass vacuously on an empty dict.
+assert_py "5a DEFAULT_THEME ships 4 shadows and 3 font stacks" \
+  "len(r.DEFAULT_THEME['shadows']) == 4 and len(r.DEFAULT_THEME['fonts']) == 3"
+assert_py "5b every shipped shadow passes font-aware" \
+  "all(g.is_safe_value(v, 'font-aware') for v in r.DEFAULT_THEME['shadows'].values())"
+assert_py "5c every shipped font stack passes font-aware (incl. the 91-char one)" \
+  "all(g.is_safe_value(v, 'font-aware') for v in r.DEFAULT_THEME['fonts'].values())"
+assert_py "5d shipped google_fonts_import passes import-aware" \
+  "g.is_safe_value(r.DEFAULT_THEME['google_fonts_import'], 'import-aware')"
+assert_py "5e shipped radius passes font-aware" \
+  "g.is_safe_value(r.DEFAULT_THEME['radius'], 'font-aware')"
 
 echo "=== CLI envelope ==="
 cat > "$TMPROOT/dv-evil.json" <<'EOF'
@@ -177,7 +244,17 @@ assert_json "3d CLI reports rejected scalar section" "$TMPROOT/cli-font-evil.jso
 assert_json "3e CLI accepts legitimate shadow + radius" "$TMPROOT/cli-font-evil.json" \
   '"shadows" not in d["data"]["rejected"] and "radius" not in d["data"]["rejected"]'
 assert_json "3f CLI reports per-section profiles" "$TMPROOT/cli-font-evil.json" \
-  'd["data"]["section_profiles"]["colors"]=="strict" and d["data"]["section_profiles"]["fonts"]=="font-aware"' 
+  'd["data"]["section_profiles"]["colors"]=="strict" and d["data"]["section_profiles"]["fonts"]=="font-aware"'
+assert_json "3fa CLI reports import-aware for the import slot" "$TMPROOT/cli-font-evil.json" \
+  'd["data"]["section_profiles"]["google_fonts_import"]=="import-aware"'
+# Envelope back-compat: `profile` has always been a string. Reporting only what
+# was *forced* would make it null by default — a type change on a field callers
+# already read. The per-section detail rides on `section_profiles` instead.
+assert_json "3fb CLI profile stays a string by default" "$TMPROOT/cli-font-evil.json" \
+  'd["data"]["profile"]=="strict"'
+python3 "$GUARD" "$TMPROOT/dv-font-evil.json" --profile=font-aware > "$TMPROOT/cli-forced.json"
+assert_json "3fc forced profile reported and applied to every section" "$TMPROOT/cli-forced.json" \
+  'd["data"]["profile"]=="font-aware" and set(d["data"]["section_profiles"].values())=={"font-aware"}'
 # An absent/empty scalar is not an override: never counted, never rejected.
 cat > "$TMPROOT/dv-empty-import.json" <<'EOF'
 {"colors": {"background": "#123456"}, "google_fonts_import": ""}
@@ -218,6 +295,34 @@ assert_has "4k legitimate rgba shadow preserved" 'rgba(0,0,0,0.04)' "$WS/out.htm
 # An empty google_fonts_import means "no import" — a valid theme, so no warning.
 run_render "$TMPROOT/dv-empty-import.json"
 assert_json "4l empty import produces no warning" /tmp/render-out.json 'not d.get("theme_warnings")'
+# ...and "no import" must mean no import, not a silent fall back to DEFAULT_THEME's
+# hard-coded Google Fonts URL. Without this the absence is indistinguishable in
+# the output from the default having been applied.
+assert_lacks "4l2 no google-fonts fallback on empty import" 'fonts.googleapis.com' "$WS/out.html"
+
+# End-to-end proof for the profile split: a bare URL carrying chained declarations
+# must never reach :root, while the rest of the theme still applies.
+cat > "$TMPROOT/dv-font-url-injection.json" <<'EOF'
+{"colors": {"background": "#123456"},
+ "fonts": {"body": "https://a.example/x;background:red;position:fixed"}}
+EOF
+run_render "$TMPROOT/dv-font-url-injection.json"
+assert_json "4p url-injection render succeeds" /tmp/render-out.json 'd.get("status")=="ok"'
+assert_json "4q url-injection surfaced as warning" /tmp/render-out.json 'd.get("theme_warnings")'
+assert_lacks "4r injected declaration not in output" 'a.example' "$WS/out.html"
+assert_has   "4s theming otherwise intact" '#123456' "$WS/out.html"
+
+# A bare-URL import is normalized to a terminated @import, so the following
+# :root block survives instead of being swallowed by CSS error recovery.
+cat > "$TMPROOT/dv-bare-import.json" <<'EOF'
+{"colors": {"background": "#123456"},
+ "google_fonts_import": "https://fonts.googleapis.com/css2?family=Outfit&display=swap"}
+EOF
+run_render "$TMPROOT/dv-bare-import.json"
+assert_json "4t bare-import render succeeds" /tmp/render-out.json 'd.get("status")=="ok"'
+assert_has "4u bare URL normalized into a terminated @import" \
+  "@import url('https://fonts.googleapis.com/css2?family=Outfit&display=swap');" "$WS/out.html"
+assert_has "4v :root not swallowed — theme variable still applied" '#123456' "$WS/out.html"
 
 # Partial fonts override used to KeyError in render_css (it indexes headers/body/mono).
 cat > "$TMPROOT/dv-partial-fonts.json" <<'EOF'
@@ -227,6 +332,62 @@ run_render "$TMPROOT/dv-partial-fonts.json"
 assert_json "4m partial fonts override renders" /tmp/render-out.json 'd.get("status")=="ok"'
 assert_has "4n header font backfilled from defaults" "'Bricolage Grotesque'" "$WS/out.html"
 assert_has "4o overridden body font still applied" "'Inter', sans-serif" "$WS/out.html"
+
+echo "=== renderer degrades against a stale or absent guard ==="
+# The guard is loaded by path from its home plugin, so an installed copy can
+# predate `sanitize_section` yet import cleanly — the call is then an
+# AttributeError at render time, which the import-time try/except cannot catch.
+# That is strictly worse than no guard at all, so both degraded shapes are tested.
+LEGACY="$TMPROOT/legacy"
+mkdir -p "$LEGACY/scripts" "$LEGACY/skills/workspace-dashboard/scripts"
+cp "$RENDERER" "$LEGACY/skills/workspace-dashboard/scripts/generate-dashboard.py"
+# The renderer resolves ../../../scripts/sanitize-theme.py from its own __file__,
+# so this stub is what the copied renderer loads. It exposes only the pre-PR
+# surface: is_safe_value + sanitize_values, and no sanitize_section.
+cat > "$LEGACY/scripts/sanitize-theme.py" <<'EOF'
+"""Stand-in for a guard copy predating sanitize_section (base-commit surface)."""
+_FORBIDDEN = set("<>{}();@\\")
+
+
+def is_safe_value(value, profile="strict"):
+    return isinstance(value, str) and 0 < len(value) <= 120 and not (_FORBIDDEN & set(value))
+
+
+def sanitize_values(values, defaults, profile="strict"):
+    clean, rejected = dict(defaults), []
+    if isinstance(values, dict):
+        for key in defaults:
+            if key not in values:
+                continue
+            if is_safe_value(values[key], profile):
+                clean[key] = values[key]
+            else:
+                rejected.append(key)
+    return clean, sorted(rejected)
+EOF
+LEGACY_RENDERER="$LEGACY/skills/workspace-dashboard/scripts/generate-dashboard.py"
+LWS="$TMPROOT/lws"; mkdir -p "$LWS"
+run_legacy() { python3 "$LEGACY_RENDERER" "$LWS" --design-variables "$1" --output "$LWS/out.html" >/tmp/legacy-out.json 2>/tmp/legacy-err.txt; }
+
+run_legacy "$TMPROOT/dv-evil.json"
+assert_json "6a stale guard still renders (no AttributeError)" /tmp/legacy-out.json 'd.get("status")=="ok"'
+assert_lacks "6b stale guard still blocks the colour breakout" '</style><script>' "$LWS/out.html"
+assert_has   "6c stale guard falls back to the built-in palette" '#FAFAF8' "$LWS/out.html"
+# render_css indexes fonts[headers|body|mono] directly, so the degraded path must
+# still backfill or the render dies with a KeyError instead of an AttributeError.
+run_legacy "$TMPROOT/dv-partial-fonts.json"
+assert_json "6d stale guard handles a partial fonts override" /tmp/legacy-out.json 'd.get("status")=="ok"'
+assert_has   "6e stale guard backfills the omitted header font" "'Bricolage Grotesque'" "$LWS/out.html"
+
+# And with no guard at all — the unguarded pass-through branch. It must still
+# backfill: render_css indexes the fonts keys directly, so passing a partial
+# override straight through raised KeyError and made theming a hard dependency
+# in precisely the case the fallback exists to survive.
+rm -f "$LEGACY/scripts/sanitize-theme.py"
+run_legacy "$TMPROOT/dv-partial-fonts.json"
+assert_json "6f absent guard still renders" /tmp/legacy-out.json 'd.get("status")=="ok"'
+assert_has   "6g absent guard backfills the omitted header font" "'Bricolage Grotesque'" "$LWS/out.html"
+assert_has   "6h absent guard still applies the override" "'Inter', sans-serif" "$LWS/out.html"
 
 echo
 if [ "$failures" -eq 0 ]; then

--- a/cogni-workspace/tests/test-sanitize-theme.sh
+++ b/cogni-workspace/tests/test-sanitize-theme.sh
@@ -71,7 +71,11 @@ assert_py "1d empty rejected"           'g.is_safe_value("") is False'
 assert_py "1e non-string rejected"      'g.is_safe_value(123) is False'
 assert_py "1f overlong rejected"        'g.is_safe_value("#" + "a"*200) is False'
 assert_py "1g font stack single-quotes ok" "g.is_safe_value(\"'Segoe UI', Roboto\") is True"
-assert_py "1h unknown profile falls back to strict" 'g.is_safe_value("#000000</style>", "nope") is False'
+# Discriminating probe: rgba(...) is rejected by strict but accepted by the two
+# relaxed profiles, so this pins "falls back to *strict*". A markup-breakout
+# probe would not — every profile's denylist rejects that, so it would still
+# pass if the fallback were changed to font-aware.
+assert_py "1h unknown profile falls back to strict" 'g.is_safe_value("rgba(0,0,0,0.1)", "nope") is False'
 
 echo "=== font-aware profile ==="
 # The exact DEFAULT_THEME value this plugin's own renderer ships (184 chars) —
@@ -207,6 +211,43 @@ assert_py "2r non-import scalar falls back to default" \
 assert_py "2s normalize_font_import returns None on a non-import" \
   'g.normalize_font_import("Roboto") is None'
 
+# _URL's character class is the load-bearing safety property of the normalizer:
+# it is what makes re-wrapping the captured URL in url('...') provably
+# well-formed. Nothing else pins it — widening it to https://[^\s]+ leaves every
+# other assertion in this file green while making the guard inject a live rule
+# (the URL closes its own wrapper, terminates the at-rule, and opens a block).
+# One assertion per excluded character class, so a partial widening is caught too.
+assert_py "2t quote in URL rejected (would close the url('...') wrapper)" \
+  "g.is_safe_value(\"https://a.example/x');}body{background:red\", 'import-aware') is False"
+assert_py "2u normalize refuses a quote-bearing URL" \
+  "g.normalize_font_import(\"https://a.example/x')\") is None"
+assert_py "2w backslash in URL rejected" \
+  "g.is_safe_value('https://a.example/x\\\\y', 'import-aware') is False"
+assert_py "2x angle bracket in URL rejected" \
+  "g.is_safe_value('https://a.example/x<style>', 'import-aware') is False"
+assert_py "2y brace in URL rejected" \
+  "g.is_safe_value('https://a.example/x{y}', 'import-aware') is False"
+# Parens and whitespace are NOT in the denylist (font-aware needs parens for
+# rgba(...)), so these pass is_safe_value and are stopped at the emission
+# boundary instead — the acceptance-is-not-sufficiency property. Asserting them
+# on is_safe_value would be asserting the wrong thing; assert where it bites.
+assert_py "2v paren in URL never emitted" \
+  "g.normalize_font_import('https://a.example/x)') is None"
+assert_py "2z whitespace in URL never emitted" \
+  "g.normalize_font_import('https://a.example/x y') is None"
+assert_py "2v2 paren-bearing import falls back to default" \
+  "g.sanitize_section('google_fonts_import', 'https://a.example/x)', '') == ('', ['google_fonts_import'])"
+# The same payload must not survive the section policy either.
+assert_py "2za wrapper-closing payload falls back to default" \
+  "g.sanitize_section('google_fonts_import', \"https://a.example/x');}body{background:red\", '') == ('', ['google_fonts_import'])"
+# An import-aware profile forced onto a dict section must not smuggle the gate
+# back into a declaration slot — the per-key path cannot normalize.
+assert_py "2zb import-aware forced on a dict section does not accept a gate-shaped value" \
+  "g.sanitize_section('fonts', {'body':'$INJ_URL'}, {'body':'Roboto'}, 'import-aware') == ({'body':'Roboto'}, ['body'])"
+# Unknown sections fail closed rather than raising, matching _profile.
+assert_py "2zc unknown section falls back to strict instead of raising" \
+  "g.sanitize_section('gradients', {'a':'rgba(0,0,0,0.1)'}, {'a':'none'}) == ({'a':'none'}, ['a'])"
+
 echo "=== shipped defaults must survive their own profiles ==="
 # Arity first, so the all()-loops below cannot pass vacuously on an empty dict.
 assert_py "5a DEFAULT_THEME ships 4 shadows and 3 font stacks" \
@@ -241,8 +282,11 @@ assert_json "3c CLI reports rejected font key" "$TMPROOT/cli-font-evil.json" \
   'd["data"]["rejected"].get("fonts")==["body"]'
 assert_json "3d CLI reports rejected scalar section" "$TMPROOT/cli-font-evil.json" \
   'd["data"]["rejected"].get("google_fonts_import")==["google_fonts_import"]'
+# Paired with the checked count so this cannot hold vacuously: a pure negative
+# ("not in rejected") would still pass if the CLI stopped walking those sections
+# altogether. The fixture supplies 4 override values across 4 sections.
 assert_json "3e CLI accepts legitimate shadow + radius" "$TMPROOT/cli-font-evil.json" \
-  '"shadows" not in d["data"]["rejected"] and "radius" not in d["data"]["rejected"]'
+  '"shadows" not in d["data"]["rejected"] and "radius" not in d["data"]["rejected"] and d["data"]["checked"]==4'
 assert_json "3f CLI reports per-section profiles" "$TMPROOT/cli-font-evil.json" \
   'd["data"]["section_profiles"]["colors"]=="strict" and d["data"]["section_profiles"]["fonts"]=="font-aware"'
 assert_json "3fa CLI reports import-aware for the import slot" "$TMPROOT/cli-font-evil.json" \

--- a/cogni-workspace/tests/test-sanitize-theme.sh
+++ b/cogni-workspace/tests/test-sanitize-theme.sh
@@ -34,6 +34,20 @@ PY
   then pass "$label"; else fail "$label"; fi
 }
 
+# assert_json "<label>" "<json-file>" "<python expr over `d`, True to pass>" —
+# `d` is the parsed document. Keeps the label in one place; open-coding the
+# python3 -c ... && pass "L" || fail "L" form repeats it and lets a typo report
+# the wrong test name.
+assert_json() {
+  local label="$1" file="$2" expr="$3"
+  if python3 - "$file" <<PY
+import json, sys
+d = json.load(open(sys.argv[1]))
+sys.exit(0 if ($expr) else 1)
+PY
+  then pass "$label"; else fail "$label"; fi
+}
+
 # assert_lacks "<label>" "<needle>" "<file>"
 assert_lacks() {
   if [ -f "$3" ] && ! grep -qF "$2" "$3"; then pass "$1"; else fail "$1 (found '$2' or missing file)"; fi
@@ -53,6 +67,54 @@ assert_py "1f overlong rejected"        'g.is_safe_value("#" + "a"*200) is False
 assert_py "1g font stack single-quotes ok" "g.is_safe_value(\"'Segoe UI', Roboto\") is True"
 assert_py "1h unknown profile falls back to strict" 'g.is_safe_value("#000000</style>", "nope") is False'
 
+echo "=== font-aware profile ==="
+# The exact DEFAULT_THEME value this plugin's own renderer ships (184 chars) —
+# over strict's 120 cap, which is why font-aware could not reuse the bound.
+DEF_IMPORT="@import url('https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&family=Outfit:wght@300;400;500;600;700&display=swap');"
+assert_py "1i shipped default @import accepted" \
+  "g.is_safe_value('''$DEF_IMPORT''', 'font-aware') is True"
+assert_py "1j rgba shadow accepted" \
+  'g.is_safe_value("0 1px 3px rgba(0,0,0,0.04), 0 1px 2px rgba(0,0,0,0.06)", "font-aware") is True'
+assert_py "1k font stack accepted" \
+  "g.is_safe_value(\"'Segoe UI', Roboto\", 'font-aware') is True"
+# Forward-compat with cogni-visual/enrich-report, which normalizes a bare URL
+# into an @import — the profile must not be hostile to the pre-normalized shape.
+assert_py "1l bare https URL accepted" \
+  'g.is_safe_value("https://fonts.googleapis.com/css2?family=Outfit:wght@400;500&display=swap", "font-aware") is True'
+assert_py "1m radius accepted" 'g.is_safe_value("12px", "font-aware") is True'
+assert_py "1n style breakout still rejected" \
+  'g.is_safe_value("</style><script>alert(1)</script>", "font-aware") is False'
+assert_py "1o declaration injection rejected" \
+  'g.is_safe_value("red; background-image: url(https://evil.example/b.png)", "font-aware") is False'
+assert_py "1p rule-block injection rejected" \
+  'g.is_safe_value("red} body{background:red", "font-aware") is False'
+assert_py "1q data: scheme rejected" \
+  "g.is_safe_value(\"@import url('data:text/css,body{color:red}');\", 'font-aware') is False"
+assert_py "1r http: scheme rejected" \
+  "g.is_safe_value(\"@import url('http://a.example/x.css');\", 'font-aware') is False"
+assert_py "1s protocol-relative rejected" \
+  "g.is_safe_value(\"@import url('//a.example/x.css');\", 'font-aware') is False"
+assert_py "1t chained @import rejected" \
+  "g.is_safe_value(\"@import url('https://a.example/x.css');@import url('https://b.example/y.css');\", 'font-aware') is False"
+assert_py "1u media-qualified @import rejected" \
+  "g.is_safe_value(\"@import url('https://a.example/x.css') screen;\", 'font-aware') is False"
+# The shape gate is anchored ^...\Z with no trailing \s* — anything after the
+# statement fails closed. Both details are load-bearing: \Z alone still accepts a
+# trailing newline if a \s* precedes it, and plain $ accepts one outright.
+assert_py "1v @import with trailing declaration rejected" \
+  "g.is_safe_value(\"@import url('https://a.example/x.css'); body{color:red}\", 'font-aware') is False"
+assert_py "1w @import with trailing newline rejected" \
+  "g.is_safe_value(\"@import url('https://a.example/x.css');\n\", 'font-aware') is False"
+assert_py "1x @import with trailing space rejected" \
+  "g.is_safe_value(\"@import url('https://a.example/x.css'); \", 'font-aware') is False"
+assert_py "1y over-length rejected" \
+  'g.is_safe_value("https://a.example/" + "a"*300, "font-aware") is False'
+# Regression: the relaxations must not leak into strict, still the default
+# profile for colors/status.
+assert_py "1z strict still rejects rgba" 'g.is_safe_value("rgba(0,0,0,0.1)") is False'
+assert_py "1za strict still rejects the shipped default @import" \
+  "g.is_safe_value('''$DEF_IMPORT''') is False"
+
 echo "=== sanitize_values fallback ==="
 assert_py "2a rejected key keeps default" \
   'g.sanitize_values({"background":"#000000</style>"}, {"background":"#FAFAF8"})[0]["background"] == "#FAFAF8"'
@@ -62,15 +124,67 @@ assert_py "2c rejected key reported" \
   'g.sanitize_values({"background":"#000000</style>"}, {"background":"#FAFAF8"})[1] == ["background"]'
 assert_py "2d absent-in-defaults key ignored" \
   'g.sanitize_values({"rogue":"x"}, {"background":"#FAFAF8"})[0] == {"background":"#FAFAF8"}'
+assert_py "2e font-aware profile keeps default for rejected shadow" \
+  'g.sanitize_values({"sm":"red; background:url(https://evil.example/b.png)"}, {"sm":"0 1px 3px rgba(0,0,0,0.04)"}, "font-aware")[0]["sm"] == "0 1px 3px rgba(0,0,0,0.04)"'
+assert_py "2f font-aware profile applies legitimate rgba shadow" \
+  'g.sanitize_values({"sm":"0 2px 6px rgba(0,0,0,0.08)"}, {"sm":"0 1px 3px rgba(0,0,0,0.04)"}, "font-aware")[0]["sm"] == "0 2px 6px rgba(0,0,0,0.08)"'
+# render_css indexes theme['fonts'][...] directly, so a partial override must
+# come back with every key backfilled or the render raises KeyError.
+assert_py "2g partial fonts override backfills missing keys" \
+  'sorted(g.sanitize_values({"body":"Inter"}, {"headers":"Outfit","body":"Roboto","mono":"JetBrains Mono"}, "font-aware")[0]) == ["body","headers","mono"]'
+
+echo "=== sanitize_section (section -> profile policy) ==="
+# The policy lives in the guard, not in each renderer: a caller names the section
+# and gets the right profile and shape without restating either.
+assert_py "2h colors section resolves to strict" \
+  'g.sanitize_section("colors", {"background":"rgba(0,0,0,0.1)"}, {"background":"#FAFAF8"}) == ({"background":"#FAFAF8"}, ["background"])'
+assert_py "2i fonts section resolves to font-aware" \
+  'g.sanitize_section("fonts", {"body":"0 1px rgba(0,0,0,0.1)"}, {"body":"Roboto"})[0]["body"] == "0 1px rgba(0,0,0,0.1)"'
+assert_py "2j scalar import accepted" \
+  "g.sanitize_section('google_fonts_import', '''\$DEF_IMPORT''', '') == ('''\$DEF_IMPORT''', [])"
+assert_py "2k scalar breakout falls back to default" \
+  'g.sanitize_section("google_fonts_import", "</style><script>x</script>", "") == ("", ["google_fonts_import"])'
+# Empty means "no override", not "unsafe" — the renderer and the CLI report must
+# agree on this, or a valid theme warns in one path and reads clean in the other.
+assert_py "2l empty scalar is not an override" \
+  'g.sanitize_section("radius", "", "12px") == ("12px", [])'
+assert_py "2m absent scalar is not an override" \
+  'g.sanitize_section("radius", None, "12px") == ("12px", [])'
+assert_py "2n explicit profile overrides section default" \
+  "g.sanitize_section('fonts', {'body':'rgba(0,0,0,0.1)'}, {'body':'Roboto'}, 'strict') == ({'body':'Roboto'}, ['body'])"
 
 echo "=== CLI envelope ==="
 cat > "$TMPROOT/dv-evil.json" <<'EOF'
 {"colors": {"background": "#000000</style><script>alert(1)</script>", "primary": "#111111"}, "status": {"danger": "#f00"}}
 EOF
-CLI_OUT="$(python3 "$GUARD" "$TMPROOT/dv-evil.json")"
-echo "$CLI_OUT" | python3 -c 'import json,sys; d=json.load(sys.stdin); sys.exit(0 if d["success"] and d["data"]["rejected"].get("colors")==["background"] else 1)' \
-  && pass "3a CLI reports rejected color key" || fail "3a CLI reports rejected color key"
+python3 "$GUARD" "$TMPROOT/dv-evil.json" > "$TMPROOT/cli-evil.json"
+assert_json "3a CLI reports rejected color key" "$TMPROOT/cli-evil.json" \
+  'd["success"] and d["data"]["rejected"].get("colors")==["background"]' 
 python3 "$GUARD" >/dev/null 2>&1 && fail "3b CLI no-arg errors" || pass "3b CLI no-arg errors"
+
+# The CLI walks font/shadow/@import/radius too, each under its renderer's profile.
+cat > "$TMPROOT/dv-font-evil.json" <<'EOF'
+{"fonts": {"body": "X; background-image: url(https://evil.example/b.png)"},
+ "shadows": {"sm": "0 1px 3px rgba(0,0,0,0.04)"},
+ "google_fonts_import": "</style><script>alert(1)</script>",
+ "radius": "12px"}
+EOF
+python3 "$GUARD" "$TMPROOT/dv-font-evil.json" > "$TMPROOT/cli-font-evil.json"
+assert_json "3c CLI reports rejected font key" "$TMPROOT/cli-font-evil.json" \
+  'd["data"]["rejected"].get("fonts")==["body"]'
+assert_json "3d CLI reports rejected scalar section" "$TMPROOT/cli-font-evil.json" \
+  'd["data"]["rejected"].get("google_fonts_import")==["google_fonts_import"]'
+assert_json "3e CLI accepts legitimate shadow + radius" "$TMPROOT/cli-font-evil.json" \
+  '"shadows" not in d["data"]["rejected"] and "radius" not in d["data"]["rejected"]'
+assert_json "3f CLI reports per-section profiles" "$TMPROOT/cli-font-evil.json" \
+  'd["data"]["section_profiles"]["colors"]=="strict" and d["data"]["section_profiles"]["fonts"]=="font-aware"' 
+# An absent/empty scalar is not an override: never counted, never rejected.
+cat > "$TMPROOT/dv-empty-import.json" <<'EOF'
+{"colors": {"background": "#123456"}, "google_fonts_import": ""}
+EOF
+python3 "$GUARD" "$TMPROOT/dv-empty-import.json" > "$TMPROOT/cli-empty.json"
+assert_json "3g CLI skips empty scalar section" "$TMPROOT/cli-empty.json" \
+  'd["data"]["rejected"]=={} and d["data"]["checked"]==1' 
 
 echo "=== wired renderer end-to-end ==="
 WS="$TMPROOT/ws"; mkdir -p "$WS"
@@ -78,11 +192,10 @@ run_render() { python3 "$RENDERER" "$WS" --design-variables "$1" --output "$WS/o
 
 # Malicious color value must not reach the output; renderer must still succeed.
 run_render "$TMPROOT/dv-evil.json"
-if python3 -c 'import json,sys; d=json.load(open("/tmp/render-out.json")); sys.exit(0 if d.get("status")=="ok" else 1)'; then pass "4a malicious render succeeds"; else fail "4a malicious render succeeds"; fi
+assert_json "4a malicious render succeeds" /tmp/render-out.json 'd.get("status")=="ok"'
 assert_lacks "4b </style><script> not in output" '</style><script>' "$WS/out.html"
 assert_has   "4c built-in background applied instead" '#FAFAF8' "$WS/out.html"
-python3 -c 'import json,sys; d=json.load(open("/tmp/render-out.json")); sys.exit(0 if d.get("theme_warnings") else 1)' \
-  && pass "4d rejection surfaced as warning" || fail "4d rejection surfaced as warning"
+assert_json "4d rejection surfaced as warning" /tmp/render-out.json 'd.get("theme_warnings")'
 
 # Safe theme still applies, and the legitimate @import url(...) font path is untouched.
 cat > "$TMPROOT/dv-safe.json" <<'EOF'
@@ -91,6 +204,29 @@ EOF
 run_render "$TMPROOT/dv-safe.json"
 assert_has "4e safe color applied" '#123456' "$WS/out.html"
 assert_has "4f legitimate @import url() font preserved" "@import url('https://fonts.googleapis.com" "$WS/out.html"
+
+# A breakout in google_fonts_import lands at the TOP of the <style> block, before
+# :root — the most exposed slot, and the one that was unguarded until font-aware.
+run_render "$TMPROOT/dv-font-evil.json"
+assert_json "4g font-evil render succeeds" /tmp/render-out.json 'd.get("status")=="ok"'
+assert_lacks "4h @import breakout not in output" '<script>alert(1)</script>' "$WS/out.html"
+assert_lacks "4i font declaration injection not in output" 'background-image: url(https://evil.example' "$WS/out.html"
+assert_json "4j font rejection surfaced as warning" /tmp/render-out.json 'd.get("theme_warnings")'
+# Legitimate rgba shadow and radius from the same fixture must survive.
+assert_has "4k legitimate rgba shadow preserved" 'rgba(0,0,0,0.04)' "$WS/out.html"
+
+# An empty google_fonts_import means "no import" — a valid theme, so no warning.
+run_render "$TMPROOT/dv-empty-import.json"
+assert_json "4l empty import produces no warning" /tmp/render-out.json 'not d.get("theme_warnings")'
+
+# Partial fonts override used to KeyError in render_css (it indexes headers/body/mono).
+cat > "$TMPROOT/dv-partial-fonts.json" <<'EOF'
+{"fonts": {"body": "'Inter', sans-serif"}}
+EOF
+run_render "$TMPROOT/dv-partial-fonts.json"
+assert_json "4m partial fonts override renders" /tmp/render-out.json 'd.get("status")=="ok"'
+assert_has "4n header font backfilled from defaults" "'Bricolage Grotesque'" "$WS/out.html"
+assert_has "4o overridden body font still applied" "'Inter', sans-serif" "$WS/out.html"
 
 echo
 if [ "$failures" -eq 0 ]; then


### PR DESCRIPTION
Closes #1131.

## Summary

- Adds a `font-aware` profile to `cogni-workspace/scripts/sanitize-theme.py`: denylist `<` `>` `{` `}` `;` `@` `\` (strict's set minus the two paren characters), `max_len` 300, plus one anchored acceptance path for a single `@import url(<https-url>);` statement or a bare `https://…` URL. `strict` is untouched and stays the default for `colors`/`status` hex tokens.
- Wires it into `merge_tokens()` in `skills/workspace-dashboard/scripts/generate-dashboard.py` so `fonts.*`, `shadows.*`, `google_fonts_import` and `radius` are vetted before reaching the raw `<style>` sinks in `render_css()`. A rejected value falls back to the built-in default and is surfaced in `theme_warnings`, exactly like the existing `colors`/`status` behaviour.
- Extends the CLI beyond its hardcoded `("colors", "status")` loop to report on all six sections under the profile each one actually uses (additive `section_profiles` field).
- Grows `tests/test-sanitize-theme.sh` from 18 to 63 checks.

## The gap this closes

`render_css()` interpolated `google_fonts_import` **raw as the first line of the stylesheet**, before `:root {` — the most exposed slot on the page — plus `fonts.*`, `radius` and `shadows.*` as raw declaration values. Only `colors`/`status` were vetted. The design-variables JSON is written by the calling LLM instance from a `theme.md` and its schema declares these fields as bare `{"type": "string"}` with no pattern (unlike `colors`, which requires `^#[0-9A-Fa-f]{6}$`), so the schema is a shape contract, not a security boundary.

`strict` could not simply be applied here: it denies `(`, `)`, `@` and `;`, which `rgba(...)` and `@import url('https://fonts.googleapis.com/…')` legitimately need.

## Design decision — widened denylist **plus** a shape gate

A plain denylist widening cannot work with one profile. `@import url('…family=X:wght@400;500&display=swap');` needs `@` and `;` — and once `;` is globally permitted, every `fonts`/`shadows`/`radius` slot becomes a declaration-injection point inside `:root` (`red; background-image: url(https://evil/beacon.png)`), while the top-level `google_fonts_import` slot accepts any number of at-rules and any scheme including `data:text/css`. That would fail the acceptance criterion's own "still rejecting stylesheet/markup breakout" clause even with `<>{}` denied.

The shape gate is therefore the **only** way `@` and `;` can appear. It is consulted only when the denylist path has already failed, so `rgba(...)` shadows and font stacks — which carry no forbidden characters — are accepted without being forced into an `@import` shape.

Honours the maintainer decision on open question E2: external `@import url(...)` / `url()` / `rgba(...)` are **kept, not inlined**, and there is deliberately **no host allowlist**, so self-hosted, Bunny and Adobe font hosts keep working.

**Accepted residual, documented in the module docstring rather than escalated:** a well-formed *https* `@import` from an attacker-chosen host passes. That is precisely what E2 decided to keep; narrowing it to a host allowlist would be a new maintainer policy, not this issue's scope.

## Why 120 could not be reused

The repo's own shipped default at `generate-dashboard.py:88` is **exactly 184 characters**. Reusing `strict`'s `max_len=120` would have made the plugin's own default value fail its own guard.

## Scope decisions

- **`radius` is guarded too**, though the issue names only font/shadow/@import — it sat on the identical unguarded raw-interpolation path, and leaving it as the single remaining hole would have been arbitrary, at zero extra code.
- **Sibling renderers are NOT touched.** None of the five renderers in cogni-consult / cogni-portfolio / cogni-visual ×2 / cogni-website imports the guard today (nor do cogni-trends / cogni-projects); **#1130** owns that wiring. This PR changes only files under `cogni-workspace/`.
- **Forward-compat with #1130:** the profile permits *both* input shapes renderers accept — a full `@import` statement and a bare URL — because `cogni-visual/enrich-report` normalizes bare URLs into `@import` (`generate-enriched-report.py:1095-1097`). #1130 will not meet a profile hostile to one of them. The section→profile mapping lives in the guard as `SECTION_PROFILES`, consumed via `sanitize_section()`, so those five renderers inherit the policy instead of each restating it.
- **Schema unchanged** — duplicating the policy into `design-variables.schema.json` would create a second place to drift.
- **No version bump** in this branch, per repo policy; the post-merge workflow applies it.

## Side effect worth noting

Routing `fonts` through the guard backfills keys the override omits. `render_css` indexes `theme['fonts']['headers'|'body'|'mono']` directly (unlike shadows, which use `.get()`), so a design-variables file supplying only `fonts.body` **used to crash the render with a `KeyError`**. Now covered by tests 2g and 4m/4n/4o.

## Two findings caught by executing rather than reading

1. **Regex anchoring.** The plan proposed `\Z` over `$` to reject a trailing-newline payload. Executing it showed `\Z` alone was still insufficient — a trailing `\s*` re-admits the newline. Both had to go. For shape-gated values this now correctly rejects a trailing declaration, a chained `@import`, and trailing whitespace (tests 1v/1w/1x).
2. **CLI/renderer divergence.** An intermediate version reported `{"radius": ""}` as clean via the CLI but rejected-with-warning via the renderer. Consolidating both onto `sanitize_section()` removed the second copy of the rule; tests 2l/2m pin it.

## Test plan

- [x] `bash cogni-workspace/tests/test-sanitize-theme.sh` — 63/63 pass (18 pre-existing checks unchanged and still green)
- [x] `python3 -m py_compile` on both changed scripts
- [x] `bash cogni-workspace/scripts/verify-theme-backcompat.sh` — required pre-PR check for theme-surface changes, exit 0
- [x] `bash cogni-workspace/scripts/check-skill-names.sh`
- [x] `python3 scripts/check-breadcrumbs.py` — exit 0
- [x] `python3 scripts/check-version-bump.py` — 14 plugins scanned, 0 touched, 0 violations
- [x] Confirmed `strict` did not silently widen (tests 1z/1za: it still rejects `rgba(...)` and the 184-char default import)