### PR TITLE
cogni-projects: shared read_frontmatter helper (UTF-8 guard)

### DIFF
--- a/cogni-projects/CLAUDE.md
+++ b/cogni-projects/CLAUDE.md
@@ -28,6 +28,7 @@ cogni-projects/
 │   ├── test_portfolio_init.sh          Portfolio scaffolder idempotency + no-debris suite
 │   ├── test_register_entity.sh         Atomic-write + idempotency regression suite
 │   ├── test_validate_entities_refs.sh  Assignment ref-integrity + single-file regression suite
+│   ├── test_staffing_score.sh          Staffing scorer envelope + non-UTF-8 record regression suite
 │   └── test-render-dashboard.sh        Dashboard render regression test (stdlib-only)
 └── references/
     └── data-model.md                   Consultant / project / assignment entity schemas
@@ -39,6 +40,7 @@ Run the tests directly — bash + python3, no pytest or pip:
 bash cogni-projects/tests/test_portfolio_init.sh
 bash cogni-projects/tests/test_register_entity.sh
 bash cogni-projects/tests/test_validate_entities_refs.sh
+bash cogni-projects/tests/test_staffing_score.sh
 bash cogni-projects/tests/test-render-dashboard.sh
 ```
 

--- a/cogni-projects/scripts/register-entity.py
+++ b/cogni-projects/scripts/register-entity.py
@@ -118,10 +118,12 @@ def main(argv):
             code=1,
         )
 
-    try:
-        with open(entity_file, "r", encoding="utf-8") as f:
-            fm = _ve.parse_frontmatter(f.read())
-    except OSError as exc:
+    # Route through the shared reader, not a local open(): it guards
+    # UnicodeDecodeError too, so a latin-1 record reports "cannot read entity
+    # file" rather than the __main__ catch-all's generic message — and the
+    # validate_file gate above rejecting it first stops being load-bearing.
+    fm, exc = _ve.read_frontmatter(entity_file)
+    if exc is not None:
         return _fail("cannot read entity file: %s" % exc)
 
     # `type` is required for every type and the validator errors when it

--- a/cogni-projects/scripts/render-dashboard.py
+++ b/cogni-projects/scripts/render-dashboard.py
@@ -14,8 +14,8 @@ malformed entity field yields a partial snapshot with a surfaced warning, never
 a hard failure, because a partial snapshot is more useful than no snapshot to a
 partner reviewing a portfolio that is still being authored.
 
-Stdlib-only (no PyYAML). Reuses validate-entities.py's parse_frontmatter and
-_entity_files by file-path load rather than re-implementing a parser or a
+Stdlib-only (no PyYAML). Reuses validate-entities.py's read_frontmatter and
+_entity_files by file-path load rather than re-implementing a reader or a
 directory walk — the same idiom register-entity.py uses.
 
 Usage:
@@ -143,15 +143,10 @@ def _read_entities(portfolio_dir):
     warnings = []
     for path in _ve._entity_files(portfolio_dir):
         rel = os.path.relpath(path, portfolio_dir)
-        try:
-            with open(path, "r", encoding="utf-8") as f:
-                fm = _ve.parse_frontmatter(f.read())
-        # UnicodeDecodeError is a ValueError, not an OSError, so it escaped the
-        # original guard: one non-UTF-8 entity file must degrade to a single
-        # warning, not abort the whole render. Named explicitly rather than
-        # widening to ValueError, so a future parser fault still surfaces
-        # instead of being silently reported as an unreadable file.
-        except (OSError, UnicodeDecodeError) as exc:
+        # One unreadable entity file must degrade to a single warning, not abort
+        # the whole render.
+        fm, exc = _ve.read_frontmatter(path)
+        if exc is not None:
             warnings.append("cannot read %s: %s" % (rel, exc))
             continue
         if not fm:

--- a/cogni-projects/scripts/staffing-score.py
+++ b/cogni-projects/scripts/staffing-score.py
@@ -30,9 +30,9 @@ ranking. Output is deterministic for identical inputs — scores are rounded to 
 fixed precision, projects order by strategic impact then slug, candidate ties
 break on the consultant slug, and no wall-clock value enters the result.
 
-Reads entity frontmatter with the same stdlib parser the validator uses
-(`validate-entities.py:parse_frontmatter`, loaded by file location as
-`register-entity.py` does) — no duplicated parser, no PyYAML.
+Reads entity frontmatter with the same stdlib reader the validator uses
+(`validate-entities.py:read_frontmatter`, loaded by file location as
+`register-entity.py` does) — no duplicated reader, no PyYAML.
 
 Usage:
   python3 staffing-score.py <portfolio-dir>
@@ -97,12 +97,12 @@ def _fail(message, code):
     return code
 
 
-def _load_parse_frontmatter():
-    """Load parse_frontmatter from the sibling validate-entities.py by file path.
+def _load_read_frontmatter():
+    """Load read_frontmatter from the sibling validate-entities.py by file path.
 
     validate-entities.py is not an importable module name (hyphens), so — exactly
     as register-entity.py does — load it by location to reuse the one canonical
-    frontmatter parser rather than duplicating the schema-shaped parsing rules.
+    frontmatter reader rather than duplicating the open/read/parse/guard sequence.
     Returns the callable, or None if the validator module cannot be loaded.
     """
     v_path = os.path.join(
@@ -113,18 +113,7 @@ def _load_parse_frontmatter():
         return None
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
-    return getattr(module, "parse_frontmatter", None)
-
-
-def _read_frontmatter(parse_frontmatter, path):
-    """Return the parsed frontmatter dict for an entity file, or {} on any miss."""
-    try:
-        with open(path, "r", encoding="utf-8") as f:
-            text = f.read()
-    except OSError:
-        return {}
-    fm = parse_frontmatter(text)
-    return fm if isinstance(fm, dict) else {}
+    return getattr(module, "read_frontmatter", None)
 
 
 def _overlap_fraction(cf, cu, ps, pe):
@@ -276,7 +265,7 @@ def _round(x):
     return round(x, SCORE_PRECISION)
 
 
-def _load_entities(parse_frontmatter, portfolio_dir, manifest, kind, subdir):
+def _load_entities(read_frontmatter, portfolio_dir, manifest, kind, subdir):
     """Read every entity of one kind into a list of frontmatter dicts.
 
     Prefers the manifest's summary refs (the index later skills scan) for the
@@ -300,13 +289,15 @@ def _load_entities(parse_frontmatter, portfolio_dir, manifest, kind, subdir):
                     files.append(path)
     entities = []
     for path in files:
-        fm = _read_frontmatter(parse_frontmatter, path)
+        # An unreadable or frontmatter-less record is dropped silently — this
+        # script has no warnings channel to report it through.
+        fm, _exc = read_frontmatter(path)
         if fm:
             entities.append(fm)
     return entities
 
 
-def score_portfolio(portfolio_dir, parse_frontmatter):
+def score_portfolio(portfolio_dir, read_frontmatter):
     """Build the ranked-shortlist data structure for a portfolio directory."""
     manifest_path = os.path.join(portfolio_dir, "projects-portfolio.json")
     try:
@@ -317,10 +308,10 @@ def score_portfolio(portfolio_dir, parse_frontmatter):
                            % (manifest_path, exc))
 
     consultants = _load_entities(
-        parse_frontmatter, portfolio_dir, manifest, "consultants", "consultants"
+        read_frontmatter, portfolio_dir, manifest, "consultants", "consultants"
     )
     projects = _load_entities(
-        parse_frontmatter, portfolio_dir, manifest, "projects", "projects"
+        read_frontmatter, portfolio_dir, manifest, "projects", "projects"
     )
 
     # A closed project is delivered or lost — its roles are not open work to
@@ -420,17 +411,17 @@ def main(argv):
             "(run /cogni-projects:projects-setup first)" % portfolio_dir, 1
         )
 
-    parse_frontmatter = _load_parse_frontmatter()
-    if parse_frontmatter is None:
+    read_frontmatter = _load_read_frontmatter()
+    if read_frontmatter is None:
         # A broken/partial install (validator missing), not a caller usage
         # error — so exit 1 (domain failure), reserving exit 2 for bad args.
         return _fail(
-            "cannot load validate-entities.py:parse_frontmatter (expected sibling "
+            "cannot load validate-entities.py:read_frontmatter (expected sibling "
             "of this script) — the cogni-projects install looks broken", 1
         )
 
     try:
-        data = score_portfolio(portfolio_dir, parse_frontmatter)
+        data = score_portfolio(portfolio_dir, read_frontmatter)
     except RuntimeError as exc:
         return _fail(str(exc), 1)
 

--- a/cogni-projects/scripts/validate-entities.py
+++ b/cogni-projects/scripts/validate-entities.py
@@ -202,6 +202,34 @@ def _split_inline_list(inner):
     return [p.strip() for p in parts if p.strip() != ""]
 
 
+def read_frontmatter(path):
+    """Read an entity file and parse its frontmatter. Returns ``(fm, exc)``.
+
+    The one place the open/read/parse sequence lives, so the guard cannot drift
+    between the scripts that need it. It never raises for a read or decode
+    failure: ``exc`` carries the exception instead, so a caller reports it
+    however its own output contract requires — and one that needs the
+    read-vs-decode distinction tests ``isinstance(exc, UnicodeDecodeError)``.
+
+    ``exc`` is None whenever the file was read; ``fm`` is then whatever
+    ``parse_frontmatter`` returned — a dict, or None if the file carries no
+    ``---`` fence. On failure the pair is ``(None, exc)``.
+
+    Entity records are UTF-8 by contract, but a record saved as latin-1 (a DACH
+    name is the usual way in) would otherwise raise past the envelope every path
+    returns. UnicodeDecodeError is a ValueError, not an OSError, so it escapes a
+    bare OSError guard — it is named explicitly rather than widening to
+    ValueError, so a future parser fault still surfaces instead of being
+    silently reported as an unreadable file.
+    """
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            text = f.read()
+    except (OSError, UnicodeDecodeError) as exc:
+        return None, exc
+    return parse_frontmatter(text), None
+
+
 def _entity_files(path):
     """Expand a path to the entity .md files it covers.
 
@@ -241,11 +269,7 @@ def _ref_errors(files):
         etype = SUBDIR_TO_TYPE.get(os.path.basename(os.path.dirname(path)))
         if etype is None:
             continue
-        try:
-            with open(path, "r", encoding="utf-8") as f:
-                fm = parse_frontmatter(f.read())
-        except (OSError, UnicodeDecodeError):
-            continue
+        fm, _exc = read_frontmatter(path)
         if fm is None:
             # Unreadable or frontmatter-less records are already reported by
             # validate_file; naming the same defect a second way here would
@@ -295,20 +319,16 @@ def validate_file(filepath):
             {"entity": entity, "file": rel, "field": field, "message": message}
         )
 
-    try:
-        with open(filepath, "r", encoding="utf-8") as f:
-            text = f.read()
-    except OSError as exc:
-        err("<file>", "cannot read file: %s" % exc)
-        return errors, warnings
-    except UnicodeDecodeError as exc:
-        # Entity records are UTF-8 by contract, but a record saved as latin-1
-        # (a DACH name is the usual way in) would otherwise raise past the
-        # envelope every other path returns.
+    fm, exc = read_frontmatter(filepath)
+    # Decode first: the branch below it is the catch-all, so order is what keeps
+    # the two messages distinct.
+    if isinstance(exc, UnicodeDecodeError):
         err("<file>", "cannot decode file as UTF-8 — re-save it as UTF-8: %s" % exc)
         return errors, warnings
+    if exc is not None:
+        err("<file>", "cannot read file: %s" % exc)
+        return errors, warnings
 
-    fm = parse_frontmatter(text)
     if fm is None:
         err("<frontmatter>", "no YAML frontmatter block found (expected leading --- ... --- fence)")
         return errors, warnings

--- a/cogni-projects/tests/test_staffing_score.sh
+++ b/cogni-projects/tests/test_staffing_score.sh
@@ -1,0 +1,224 @@
+#!/usr/bin/env bash
+# Test staffing-score.py — the ranked-shortlist scorer.
+#
+# Covers:
+#   A. a clean portfolio scores, pinning the counts B compares against,
+#   B. an entity record that is not valid UTF-8 is skipped like any other
+#      unreadable one — the run still returns its {success, data, error}
+#      envelope rather than a bare traceback,
+#   C. usage and preflight errors still report through that envelope, so B
+#      cannot be satisfied by swallowing every failure.
+#
+# stdlib-only (bash + python3, no pytest/pip), matching the house convention.
+#
+# Usage: bash cogni-projects/tests/test_staffing_score.sh
+# Exits non-zero on any assertion failure.
+
+set -u  # NOT -e: a failing assertion must not abort the per-fixture counter.
+
+TESTS_DIR="$(cd "$(dirname "$0")" && pwd)"
+PLUGIN_DIR="$(cd "$TESTS_DIR/.." && pwd)"
+SCRIPT="$PLUGIN_DIR/scripts/staffing-score.py"
+
+if [ ! -f "$SCRIPT" ]; then
+  echo "FAIL: staffing-score.py not found at $SCRIPT" >&2
+  exit 1
+fi
+
+TMPROOT="$(mktemp -d)"
+trap 'rm -rf "$TMPROOT"' EXIT
+
+failures=0
+pass() { printf 'OK   %s\n' "$1"; }
+fail() { printf 'FAIL %s: %s\n' "$1" "$2" >&2; failures=$((failures + 1)); }
+
+# assert_json <label> <python-bool-expr over `d`> — pipes the last stdout line
+# (the envelope) into python3 and checks the expression is truthy.
+assert_json() {
+  local label="$1" expr="$2"
+  if printf '%s' "$LAST_JSON" | python3 -c "import json,sys
+d = json.loads(sys.stdin.read())
+sys.exit(0 if ($expr) else 1)" 2>/dev/null; then
+    pass "$label"
+  else
+    fail "$label" "expr false: $expr | json=$LAST_JSON"
+  fi
+}
+
+# The crash signature belongs in one place — widening it later should be one
+# edit. This is the assertion the whole suite exists for.
+assert_no_traceback() {
+  local label="$1" file="$2"
+  if grep -qF 'Traceback' "$file"; then
+    fail "$label" "traceback present: $(head -3 "$file")"
+  else
+    pass "$label"
+  fi
+}
+
+assert_exit() {
+  local label="$1" want="$2" got="$3"
+  if [ "$want" = "$got" ]; then
+    pass "$label"
+  else
+    fail "$label" "want exit $want, got $got"
+  fi
+}
+
+seed_portfolio() {
+  # $1 = portfolio dir. Seeds a manifest + entity subdirs. The manifest's ref
+  # lists stay empty on purpose: _load_entities then falls back to scanning the
+  # subdirectories, which is the path a hand-authored record takes.
+  local pf="$1"
+  mkdir -p "$pf"/{consultants,projects,assignments,.metadata}
+  cat > "$pf/projects-portfolio.json" <<'EOF'
+{"slug":"test","name":"Test Portfolio","language":"en","consultants":[],"projects":[],"assignments":[],"created":"2026-01-01","updated":"2026-01-01"}
+EOF
+}
+
+write_entity() { # $1 = path; body heredoc'd by the caller on stdin
+  cat > "$1"
+}
+
+# run_score <stderr-file> [args...] — invoke the scorer, setting LAST_JSON to the
+# last stdout line (the envelope) and RUN_CODE to the script's own exit status.
+# Redirecting to a file rather than piping into `tail` is load-bearing: after a
+# `$(... | tail -n 1)` substitution, `$?` is tail's status, which is always 0, so
+# every exit-code assertion would pass vacuously.
+run_score() {
+  local errfile="$1"; shift
+  local outfile="$TMPROOT/stdout.txt"
+  python3 "$SCRIPT" "$@" >"$outfile" 2>"$errfile"
+  RUN_CODE=$?
+  LAST_JSON="$(tail -n 1 "$outfile")"
+}
+
+# Seed two valid consultants and one active project with an open role. Shared by
+# both fixtures so the only difference between them is the latin-1 file.
+seed_entities() {
+  local pf="$1"
+  write_entity "$pf/consultants/anna.md" <<'EOF'
+---
+type: consultant
+slug: anna
+name: Anna Schmidt
+seniority: senior
+skills: [cloud, architecture]
+available_from: 2026-01-01
+available_until: 2026-12-31
+---
+# anna
+EOF
+  write_entity "$pf/consultants/bruno.md" <<'EOF'
+---
+type: consultant
+slug: bruno
+name: Bruno Weber
+seniority: consultant
+skills: [cloud, data]
+available_from: 2026-01-01
+available_until: 2026-12-31
+---
+# bruno
+EOF
+  write_entity "$pf/projects/migration.md" <<'EOF'
+---
+type: project
+slug: migration
+name: Cloud Migration
+client: GoodCo
+strategic_impact: 4
+status: active
+start_date: 2026-02-01
+end_date: 2026-06-30
+open_roles: [cloud]
+---
+# migration
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# Fixture A — control. A clean, fully decodable portfolio scores normally. This
+# is what pins the counts Fixture B compares against: without it, an assertion
+# that the latin-1 run still finds two consultants could pass for the wrong
+# reason (e.g. the scorer silently finding none at all).
+# ---------------------------------------------------------------------------
+PFA="$TMPROOT/clean"
+seed_portfolio "$PFA"
+seed_entities "$PFA"
+
+STDERRA="$TMPROOT/stderr-a.txt"
+run_score "$STDERRA" "$PFA"
+
+assert_exit  "1a clean portfolio exits 0"        0 "$RUN_CODE"
+assert_json  "1b clean portfolio succeeds"       "d['success'] is True"
+assert_json  "1c both consultants loaded"        "d['data']['consultant_count'] == 2"
+assert_json  "1d project loaded"                 "d['data']['project_count'] == 1"
+assert_json  "1e both consultants ranked"        "d['data']['ranked_candidate_count'] == 2"
+# Anna and Bruno share the 'cloud' skill and differ only in seniority, so the
+# ranking is what tells them apart — without this the second consultant is a
+# fixture nothing distinguishes, and the documented deterministic ordering goes
+# unpinned.
+assert_json  "1f candidates ranked deterministically" \
+  "[c['consultant'] for c in d['data']['projects'][0]['open_roles'][0]['candidates']] == ['anna', 'bruno']"
+assert_no_traceback "1g no traceback on stderr"  "$STDERRA"
+
+# ---------------------------------------------------------------------------
+# Fixture B — the regression. Same portfolio plus one consultant record saved as
+# latin-1, which is invalid UTF-8. Before the shared read_frontmatter helper,
+# this raised UnicodeDecodeError out of the scorer: no JSON on stdout at all,
+# just a traceback on stderr, which reads to a caller as neither success nor a
+# reportable failure. The record must now be skipped like any other unreadable
+# one while the rest of the portfolio still scores.
+# ---------------------------------------------------------------------------
+PFB="$TMPROOT/latin1"
+seed_portfolio "$PFB"
+seed_entities "$PFB"
+
+# Written via python3 in wb mode because bash printf parses a leading '---' as
+# options; \xe9 is 'é' in latin-1 and an invalid UTF-8 start byte here.
+python3 -c "
+import sys
+open(sys.argv[1], 'wb').write(
+    '---\ntype: consultant\nslug: cesar\nname: C\xe9sar Rossi\nseniority: senior\nskills: [cloud]\navailable_from: 2026-01-01\navailable_until: 2026-12-31\n---\n'.encode('latin-1')
+)" "$PFB/consultants/cesar.md"
+
+STDERRB="$TMPROOT/stderr-b.txt"
+run_score "$STDERRB" "$PFB"
+
+assert_exit  "2a latin-1 record does not fail the run"  0 "$RUN_CODE"
+assert_json  "2b envelope still returned"               "d['success'] is True"
+# The undecodable consultant is dropped; the two decodable ones still load.
+assert_json  "2c undecodable consultant skipped"        "d['data']['consultant_count'] == 2"
+assert_json  "2d project still scored"                  "d['data']['project_count'] == 1"
+# The assertion this suite exists for: the guard gap surfaced as a raw traceback.
+assert_no_traceback "2e no traceback on stderr"         "$STDERRB"
+
+# ---------------------------------------------------------------------------
+# Fixture C — usage and preflight errors still report through the envelope, so
+# the fix above cannot have been achieved by swallowing every failure.
+# ---------------------------------------------------------------------------
+STDERRC="$TMPROOT/stderr-c.txt"
+
+run_score "$STDERRC"
+assert_exit  "3a no-args exits 2"                2 "$RUN_CODE"
+assert_json  "3b no-args reports usage"          "d['success'] is False and 'usage' in d['error']"
+assert_no_traceback "3c no-args stderr is clean" "$STDERRC"
+
+run_score "$STDERRC" "$TMPROOT/does-not-exist"
+assert_exit  "3d missing dir exits 1"            1 "$RUN_CODE"
+assert_json  "3e missing dir reports envelope"   "d['success'] is False and d['error'] != ''"
+assert_no_traceback "3f missing dir stderr is clean" "$STDERRC"
+
+# A directory that exists but is not a portfolio.
+mkdir -p "$TMPROOT/not-a-portfolio"
+run_score "$STDERRC" "$TMPROOT/not-a-portfolio"
+assert_exit  "3g non-portfolio dir exits 1"      1 "$RUN_CODE"
+assert_json  "3h non-portfolio reports envelope" "d['success'] is False and 'projects-portfolio.json' in d['error']"
+assert_no_traceback "3i non-portfolio stderr is clean" "$STDERRC"
+
+if [ "$failures" -gt 0 ]; then
+  printf '\n%d assertion(s) failed\n' "$failures" >&2
+  exit 1
+fi
+printf '\nAll staffing-score.py assertions passed\n'


### PR DESCRIPTION
Refs #1173. Closes #1180.

## Summary

- Adds a public `read_frontmatter(path) -> (fm, exc)` beside `parse_frontmatter` in `scripts/validate-entities.py`. It owns the open/read/parse sequence and returns the exception instead of raising it, so no caller can be surprised by `OSError` or `UnicodeDecodeError`.
- Routes the three read sites named in the issue through it: `validate_file` and `_ref_errors` (both `validate-entities.py`) and `_read_entities` (`render-dashboard.py`).
- Fixes the actual defect: `staffing-score.py` drops its private `_read_frontmatter` (which guarded `OSError` only) for the shared helper. A latin-1 entity record is now skipped like any other unreadable one instead of raising a bare traceback with **no JSON on stdout at all** — `staffing-score.py` has no top-level `except Exception` envelope guard, unlike its two siblings, so the escape was total.
- Adds `tests/test_staffing_score.sh`, the plugin's first suite for this script.

### Behaviour preserved

- `validate_file` keeps two distinct messages — `cannot read file:` vs `cannot decode file as UTF-8 — re-save it as UTF-8:` — now selected by `isinstance(exc, UnicodeDecodeError)` rather than by two `except` clauses. Text is byte-identical, em dash (U+2014) included. The decode branch must come **first**: the branch below it is the catch-all, so ordering is what keeps the two messages distinct now that they are ordinary `if`s.
- `render-dashboard.py` keeps its `cannot read %s: %s` warning, its `no frontmatter in %s — skipped` warning, and its skip-and-continue degrade. `test-render-dashboard.sh` Fixture 6 is the proof.
- `_ref_errors` keeps silently continuing on both failure modes.
- `parse_frontmatter` stays public and unchanged, which is what keeps `register-entity.py` unaffected.

## On the acceptance criteria

AC 4 asks that all four existing suites stay green. They do — but that bar is **necessary and not sufficient**, because none of the four invokes `staffing-score.py` at all (`grep -l staffing.score cogni-projects/tests/*` returns nothing on `main`). A green four-suite run could not have demonstrated AC 2. That is why a fifth suite is in this diff rather than left for a reviewer to notice.

The new suite was verified to actually catch the bug, not merely to pass: run against `origin/main`'s pre-fix scripts it fails on exactly the reported symptom —

```
FAIL 2a latin-1 record does not fail the run: want exit 0, got 1
FAIL 2b envelope still returned: expr false: d['success'] is True | json=
FAIL 2e no traceback on stderr: traceback present: Traceback (most recent call last):
```

— and passes after. Its fixture C pins that usage and preflight errors still report through the envelope, so AC 2 cannot be satisfied by swallowing every failure.

## Scope decisions

**Included:** the three read sites the issue enumerates, plus `_ref_errors` in `validate-entities.py` — a fourth copy of the same sequence, but it lives in a file this diff already opens, so folding it in costs no extra blast radius and makes AC 1 hold across all three named files. `render-dashboard.py`'s module docstring is corrected in the same file the edit already touches: line 148 was its only `parse_frontmatter` call, so the docstring would otherwise name a function the file never calls. `CLAUDE.md` gains the new suite in its test list; the suites have no CI wiring and are run manually from that list, so an undocumented fifth suite would never actually run.

**Deferred — why this is `Refs`, not `Closes`:** `register-entity.py:121-125` is a fourth *script* carrying the same `OSError`-only guard. It is **not a live defect**: line 113 runs `_ve.validate_file()`, which does guard `UnicodeDecodeError` and returns an error, and line 114 short-circuits to `_fail`, so an undecodable file can never reach line 121. It is pure textual duplication. Because a strict reading of AC 1 ("the only place the sequence lives") could still count that site, this PR does not close the issue.

**No version bump** — the post-merge workflow owns it.

## Test plan

All five suites run green on this branch:

- [x] `bash cogni-projects/tests/test_staffing_score.sh` — 20 assertions, incl. the latin-1 regression and the deterministic candidate ordering
- [x] `bash cogni-projects/tests/test-render-dashboard.sh` — Fixture 6 (6a / 6c / 6f / 6g) still green, which is AC 3
- [x] `bash cogni-projects/tests/test_validate_entities_refs.sh`
- [x] `bash cogni-projects/tests/test_register_entity.sh`
- [x] `bash cogni-projects/tests/test_portfolio_init.sh`
- [x] Manual: a latin-1 entity file in a scratch portfolio → `staffing-score.py` emits one JSON line, exit 0, **0 bytes on stderr**
- [x] Manual: `validate-entities.py` on the same dir still reports `cannot decode file as UTF-8 — re-save it as UTF-8`, distinct from the `cannot read file` wording
- [x] Manual: `render-dashboard.py` on the same dir still emits `cannot read consultants/cesar.md: ...` and `partial: true`
- [x] `scripts/check-breadcrumbs.py` clean
- [x] `git diff --stat` shows no change to `.claude-plugin/plugin.json` or `.claude-plugin/marketplace.json`

## Review notes

A four-angle quality pass ran before the commit. Applied: dropped a redundant `isinstance(fm, dict)` conjunct in `staffing-score.py` (defensive residue from the deleted private wrapper — `parse_frontmatter` returns dict-or-None, so a truthy `fm` is always a dict) and the equivalent redundant disjunct in `_ref_errors`; trimmed comments that restated the helper's docstring or narrated the diff rather than the code; earned the second consultant fixture with a deterministic-ordering assertion; and converted three discarded stderr captures in fixture C into `assert_no_traceback` coverage.

Two findings were **deliberately not applied**, both because they widen scope past a read-guard fix:

1. `_load_read_frontmatter` narrows the loaded module to a single callable and threads it as a parameter through three signatures, where both sibling scripts bind the whole module as `_ve` and call through it. Removing that plumbing belongs with #1181, which already owns the loader blocks.
2. The new suite re-implements ~50 lines of harness (`pass`/`fail`/`assert_json`/`assert_no_traceback`/`seed_portfolio`) byte-identically from `test-render-dashboard.sh`; those helpers are now defined in three of the five suites. Inlining is the current house convention here, and `cogni-knowledge/tests/fixtures/test_helpers.sh` is the in-repo precedent for outgrowing it. Filed as #1182 rather than touching three green suites in this PR.

One thing worth a reviewer's eye: `run_score` in the new suite redirects stdout to a file rather than piping into `tail`, because after a `$(... | tail -n 1)` substitution `$?` is *tail's* status and every exit-code assertion passes vacuously. `test-render-dashboard.sh`'s `run()` still has that shape, which is why that suite asserts no exit codes. Not fixed here — it is the same three-suites-touched problem as #1182.

**On `Refs` vs `Closes` for #1173 — a merger call.** This PR kept `Refs #1173` because AC 1 ("a single `read_frontmatter(path)` helper is the only place the open/read/parse/guard sequence lives") was not strictly satisfied while `register-entity.py` held a fourth copy. Revision `4701fc9f` converts that copy, so on my reading all four of #1173's acceptance criteria are now met and the linking line could be upgraded to `Closes #1173`. I have deliberately **not** upgraded it: #1181 and #1182 are deferred follow-ups that came out of this work, and whether the parent stays open to umbrella them is a scope judgment I would rather the merger make than assume. If the answer is "close it", the edit is one word in the first line of this body.

## Follow-up issues

- ~~#1180~~ — route `register-entity.py`'s fourth read-frontmatter site through the shared helper — **now shipped in this PR** (revision `4701fc9f`, answering the merger verdict's item-8 finding), so it closes on merge
- #1186 — give `staffing-score.py` the sibling module-level catch-all envelope (deferred from the verdict's second, non-gating finding)
- #1181 — collapse the three duplicated importlib validator-loader blocks
- #1182 — extract a shared `tests/` assertion harness
