### PR TITLE
cogni-workspace: theme value-guard docs + guard coverage gaps

### DIFF
--- a/cogni-workspace/references/design-variables-pattern.md
+++ b/cogni-workspace/references/design-variables-pattern.md
@@ -18,13 +18,13 @@ Every design-variables file should include at minimum:
 | `colors` | `text_muted`, `text_light`, `surface2`, `surface_dark` | Derived variants |
 | `colors` | `accent_muted`, `accent_dark` | Accent variants for hover/active states |
 | `fonts` | `headers`, `body`, `mono` | Font stacks with system fallbacks |
-| `google_fonts_import` | Full `@import url(<https-url>);` statement, or a bare `https://` URL | Empty string if using system fonts |
+| `google_fonts_import` | Full `@import url(<https-url>);` statement, or a bare `https://` URL | Empty string if using system fonts. The bare-URL form is canonicalized only by renderers wired to `cogni-workspace/scripts/sanitize-theme.py` (today only cogni-workspace `workspace-dashboard`) — elsewhere emit the full terminated `@import url(...);` statement |
 
 Optional but recommended: `radius`, `shadows` (sm/md/lg/xl), `status` (success/warning/danger/info).
 
 ## Value Guard
 
-Design-variables values reach the stylesheet as raw text, so a renderer that consumes `cogni-workspace/scripts/sanitize-theme.py` vets every value before it is interpolated. A rejected value is **silently replaced by the built-in default** and reported in that renderer's output envelope under `theme_warnings` — so a theme that renders is not necessarily a theme that was honoured in full. Check `theme_warnings` when a token appears to have no effect.
+Design-variables values reach the stylesheet as raw text, so a renderer that consumes `cogni-workspace/scripts/sanitize-theme.py` — today only cogni-workspace `workspace-dashboard`; the sibling dashboards in cogni-website, cogni-visual, cogni-trends, cogni-portfolio and cogni-consult are not yet wired — vets every value before it is interpolated. A rejected value is **silently replaced by the built-in default** and reported in that renderer's output envelope under `theme_warnings` — so a theme that renders is not necessarily a theme that was honoured in full. Check `theme_warnings` when a token appears to have no effect.
 
 Each section is vetted under one of three profiles:
 

--- a/cogni-workspace/references/design-variables-pattern.md
+++ b/cogni-workspace/references/design-variables-pattern.md
@@ -18,9 +18,23 @@ Every design-variables file should include at minimum:
 | `colors` | `text_muted`, `text_light`, `surface2`, `surface_dark` | Derived variants |
 | `colors` | `accent_muted`, `accent_dark` | Accent variants for hover/active states |
 | `fonts` | `headers`, `body`, `mono` | Font stacks with system fallbacks |
-| `google_fonts_import` | Full `@import url(...)` string | Empty string if using system fonts |
+| `google_fonts_import` | Full `@import url(<https-url>);` statement, or a bare `https://` URL | Empty string if using system fonts |
 
 Optional but recommended: `radius`, `shadows` (sm/md/lg/xl), `status` (success/warning/danger/info).
+
+## Value Guard
+
+Design-variables values reach the stylesheet as raw text, so a renderer that consumes `cogni-workspace/scripts/sanitize-theme.py` vets every value before it is interpolated. A rejected value is **silently replaced by the built-in default** and reported in that renderer's output envelope under `theme_warnings` — so a theme that renders is not necessarily a theme that was honoured in full. Check `theme_warnings` when a token appears to have no effect.
+
+Each section is vetted under one of three profiles:
+
+| Profile | Governs | Policy |
+|---------|---------|--------|
+| `strict` | `colors`, `status` | Denylist `<>{}();@\`, max 120 chars — rejects markup breakout and the `url()` / `@import` external-fetch surface |
+| `font-aware` | `fonts`, `shadows`, `radius` | `strict`'s denylist minus the two paren characters, max 300, no shape gate — font stacks and shadow values legitimately need parens |
+| `import-aware` | `google_fonts_import` alone | `font-aware`'s denylist and bound, plus a second anchored path accepting one `@import url(<https-url>);` statement or one bare `https://` URL, re-emitted in canonical terminated form |
+
+`sanitize-theme.py` is the implementation and runs standalone against a design-variables file, with an optional `--profile=` override, to ask what a given profile would reject.
 
 ## Domain Extension Guidance
 

--- a/cogni-workspace/skills/workspace-dashboard/schemas/design-variables.schema.json
+++ b/cogni-workspace/skills/workspace-dashboard/schemas/design-variables.schema.json
@@ -56,7 +56,7 @@
     },
     "google_fonts_import": {
       "type": "string",
-      "description": "Full CSS @import statement for Google Fonts (e.g. \"@import url('https://fonts.googleapis.com/...');\")",
+      "description": "Google Fonts import: either a full CSS @import statement (e.g. \"@import url('https://fonts.googleapis.com/...');\") or a bare https:// URL, which is normalized to the canonical terminated @import form. Empty string for system fonts.",
       "default": ""
     },
     "radius": {

--- a/cogni-workspace/tests/test-sanitize-theme.sh
+++ b/cogni-workspace/tests/test-sanitize-theme.sh
@@ -114,6 +114,12 @@ assert_py "1me shadows section rejects the injection payload" \
   "g.sanitize_section('shadows', {'sm':'$INJ_URL'}, {'sm':'0 1px 3px rgba(0,0,0,0.04)'}) == ({'sm':'0 1px 3px rgba(0,0,0,0.04)'}, ['sm'])"
 assert_py "1mf radius section rejects the injection payload" \
   "g.sanitize_section('radius', '$INJ_URL', '12px') == ('12px', ['radius'])"
+# Isolates the '@' clause of the font-aware denylist. 1mb and 1mc both feed
+# payloads carrying a ';' too, so the ';' clause alone accounts for their
+# rejection and neither would notice '@' going missing. This payload shares
+# exactly one character with the denylist, so it fails iff '@' is dropped.
+assert_py "1mg font-aware rejects a bare @ carrying no other denylisted character" \
+  'g.is_safe_value("@import url(https://evil.example/x.css)", "font-aware") is False'
 assert_py "1n style breakout still rejected" \
   'g.is_safe_value("</style><script>alert(1)</script>", "font-aware") is False'
 assert_py "1o declaration injection rejected" \
@@ -269,6 +275,15 @@ python3 "$GUARD" "$TMPROOT/dv-evil.json" > "$TMPROOT/cli-evil.json"
 assert_json "3a CLI reports rejected color key" "$TMPROOT/cli-evil.json" \
   'd["success"] and d["data"]["rejected"].get("colors")==["background"]' 
 python3 "$GUARD" >/dev/null 2>&1 && fail "3b CLI no-arg errors" || pass "3b CLI no-arg errors"
+# The --profile gate rejects only an unknown *forced* profile, so pin the
+# rejecting branch on both its exit status and its envelope. 3fc already covers
+# a valid --profile semantically; 3bc adds the exit-code-0 half no check had.
+python3 "$GUARD" "$TMPROOT/dv-evil.json" --profile=bogus > "$TMPROOT/cli-bogus.json" 2>/dev/null \
+  && fail "3ba CLI unknown profile errors" || pass "3ba CLI unknown profile errors"
+assert_json "3bb CLI unknown profile still prints an envelope" "$TMPROOT/cli-bogus.json" \
+  'd["success"] is False and d["data"] is None and "bogus" in d["error"]'
+python3 "$GUARD" "$TMPROOT/dv-evil.json" --profile=strict >/dev/null 2>&1 \
+  && pass "3bc CLI valid forced profile accepted" || fail "3bc CLI valid forced profile accepted"
 
 # The CLI walks font/shadow/@import/radius too, each under its renderer's profile.
 cat > "$TMPROOT/dv-font-evil.json" <<'EOF'


### PR DESCRIPTION
Closes #1177.

Follow-up to the guard-widening work, which introduced these gaps and carried them deliberately at the merger ruling rather than hold a correct PR on non-blocking findings.

## Summary

- **`references/design-variables-pattern.md`** — new `## Value Guard` section naming the three profiles (`strict`, `font-aware`, `import-aware`), which sections each governs, and the behaviour theme authors now face: a rejected value is silently replaced by the built-in default and reported in the renderer's envelope under `theme_warnings`. The `theme_warnings` claim is scoped to renderers that actually consume `scripts/sanitize-theme.py` — cross-plugin sharing is still a deferred decision in the script's own docstring, so the convention doc must not over-claim.
- **`google_fonts_import` docs** — widened in the core-tokens table row and in `skills/workspace-dashboard/schemas/design-variables.schema.json` to cover the bare `https://` URL form that `import-aware` accepts.
- **CLI profile gate** — `3ba` (unknown profile exits non-zero), `3bb` (that path still prints a valid `success:false` envelope), `3bc` (a valid `--profile=strict` is accepted).
- **Anti-vacuity** — `1mg`, whose payload shares **exactly one** character with the font-aware denylist, so it fails if and only if `@` is dropped from the profile.

## Verification

Each acceptance criterion was checked by running it, not by reading:

| AC | Result |
|---|---|
| Docs name the three profiles + `theme_warnings`; schema covers bare-URL form | Both files updated; schema still parses |
| `test-sanitize-theme.sh` pins `--profile=<unknown>` | `3ba`/`3bb`/`3bc` green |
| Suite green end to end | `exit 0`, no `FAIL` lines |
| Removing `@` from the font-aware denylist turns a case RED | **`1mg` is the only FAIL** — 1ma/1mb/1mc stay green, confirming it is `1mg` that isolates the clause |

Also green: `scripts/verify-theme-backcompat.sh` (5 phases), and the CLI contract — `--profile=bogus` exits 2 with an `unknown profile 'bogus'` envelope, `--profile=strict` exits 0.

## Scope decisions

**No production code change.** Both findings are documentation and coverage gaps, not defects: `--profile=bogus` already exited 2 with an envelope, and `@` is already present in the profile. `scripts/sanitize-theme.py` is untouched.

**One line beyond the literal AC:** check `3bc`. The gate at `sanitize-theme.py:303` is a two-clause condition, and pinning only the rejecting direction would have shipped a fresh unguarded clause in the PR whose purpose is to remove one.

**The three sibling schemas are deliberately untouched.** `cogni-consult`, `cogni-portfolio`, and `cogni-trends` carry the identical stale `google_fonts_import` description, but their descriptions cannot truthfully promise bare-URL acceptance until those renderers are wired to the guard — which is the already-open #1130. No new issue filed because #1130 owns that surface. (`cogni-visual`'s copy has no description text and cannot drift.)

**No version bump** — the post-merge workflow owns the patch increment.

## Follow-up issues

- **#1184** — pin every denylist character in all three profiles.

Found while closing item 3, and outside this issue's scope. `_PROFILES` declares 21 (profile, character) pairs; only two are independently pinned — `@`/`font-aware` (added here) and `\`/`import-aware` (existing `2w`). For the other 19, deleting the character leaves the suite fully green. Reproduced before filing: dropping `;` from `strict` — the default profile guarding `colors` and `status` — exits 0 with zero `FAIL` lines and makes `is_safe_value("red;position:fixed", "strict")` return `True`, i.e. declaration chaining into `:root` from a colors value.

It is filed rather than folded in because widening past the ratified AC would make this change harder to grade against the criteria it was written for. #1177's own scope is complete, so this PR uses `Closes`, not `Refs`.