### PR TITLE
cogni-projects: portfolio-scoped ref gate on entity registration

### DIFF
--- a/cogni-projects/scripts/register-entity.py
+++ b/cogni-projects/scripts/register-entity.py
@@ -183,22 +183,25 @@ def main(argv):
     # Placed after the type is known but before the portfolio-escape check below,
     # which is harmless: an entity outside the portfolio never appears in the
     # walk, so the filter is empty and that check still raises its own error.
-    # _ref_errors itself is raise-free — it reads through read_frontmatter,
-    # which returns (None, exc) rather than raising. _entity_files is not: its
-    # os.listdir walk is unguarded, so an unreadable portfolio subdirectory
-    # escapes as an OSError. The __main__ catch-all below would convert that to
-    # an envelope for CLI callers, but not for the in-process callers (the test
-    # harness among them) that call main() directly, so the guard belongs here.
+    # Neither helper is trusted to be raise-free, matching validate-entities.py's
+    # own main(), which wraps this identical call because the envelope is the
+    # contract. _entity_files' os.listdir walk is unguarded, so an unreadable
+    # subdirectory raises OSError; and read_frontmatter calls parse_frontmatter
+    # outside its try, so a parser fault (int() on an over-long digit scalar)
+    # surfaces as ValueError. The __main__ catch-all below would convert either
+    # to an envelope for CLI callers, but not for the in-process callers (the
+    # test harness among them) that call main() directly — hence the guard here.
     if entity_type == "assignment":
         try:
             ref_errors = [
                 e for e in _ve._ref_errors(_ve._entity_files(portfolio_dir))
                 if _same_file(e["file"], entity_file)
             ]
-        except OSError as exc:
+        except Exception as exc:  # noqa: BLE001 — the envelope is the contract
             # Default code 2 (environment failure), never code 1 — the entity
             # did not fail validation; the portfolio could not be read.
-            return _fail("cannot scan portfolio for refs: %s" % exc)
+            return _fail("cannot scan portfolio for refs: %s: %s"
+                         % (type(exc).__name__, exc))
         if ref_errors:
             return _fail(
                 "entity failed ref validation (%d error(s)) — a consultant or "

--- a/cogni-projects/scripts/register-entity.py
+++ b/cogni-projects/scripts/register-entity.py
@@ -24,6 +24,11 @@ swap, since mkstemp would otherwise force every target to 0600.
 
 Validates before registering, via validate-entities.py, so the manifest cannot
 take an entity the validator rejects even when this script is invoked directly.
+An assignment's consultant / project refs are additionally resolved against the
+whole portfolio directory — the pass the validator runs only for a directory
+argument, never for the single file this script hands it — so a dangling ref is
+refused here rather than surfacing later as a role that silently reads unfilled.
+Each unresolved ref is reported in data.errors[].
 
 Stdlib-only (no PyYAML).
 
@@ -68,11 +73,37 @@ REF_FIELDS = {
 }
 
 
-def _fail(message, code=2):
+def _fail(message, code=2, data=None):
     print(json.dumps(
-        {"success": False, "data": {}, "error": message}, ensure_ascii=False
+        {"success": False, "data": data or {}, "error": message},
+        ensure_ascii=False,
     ))
     return code
+
+
+def _same_file(a, b):
+    """True when `a` and `b` name the same file on disk.
+
+    Never a string compare: the ref errors carry the path _entity_files built
+    from the caller's raw portfolio-dir argument, while the entity file is an
+    independent raw argument, so the two spellings of one file routinely differ
+    (relative vs absolute, a trailing "/.", a symlinked portfolio root).
+
+    samefile rather than the realpath equality used for the portfolio-escape
+    check below, because realpath does not case-fold: on a case-insensitive
+    filesystem a case-variant path to the same file compares unequal, which
+    would drop the registered entity's own ref error and let the gate fail
+    OPEN — registering exactly the dangling assignment it exists to refuse.
+    Comparing (st_dev, st_ino) is also correct through a hard link.
+
+    Both paths exist whenever this is called, so the OSError branch is only a
+    concurrent-unlink race; falling back keeps the helper raise-free for the
+    imported-main callers the __main__ catch-all does not cover.
+    """
+    try:
+        return os.path.samefile(a, b)
+    except OSError:
+        return os.path.realpath(a) == os.path.realpath(b)
 
 
 def _intended_mode(path):
@@ -136,6 +167,37 @@ def main(argv):
             % (entity_type, ", ".join(sorted(REF_FIELDS))),
             code=1,
         )
+
+    # Resolve this assignment's refs against the portfolio. validate_file is
+    # single-file by design and so runs no ref pass; without this, an assignment
+    # naming a misspelled consultant passes the gate above, lands in the
+    # manifest, and then reads as an unfilled role with no error anywhere.
+    #
+    # The batch must be the whole portfolio, never [entity_file]: the known-slug
+    # sets are built from the consultant and project records in the batch, so a
+    # single-file expansion resolves nothing and every ref would dangle. That is
+    # also why this is scoped to assignments — they are the only type carrying
+    # refs, and the walk is O(portfolio), so running it for a consultant or a
+    # project would read every record to build a result that cannot be non-empty.
+    #
+    # Placed after the type is known but before the portfolio-escape check below,
+    # which is harmless: an entity outside the portfolio never appears in the
+    # walk, so the filter is empty and that check still raises its own error.
+    # _ref_errors reads through read_frontmatter, which returns (None, exc)
+    # rather than raising, so no guard is needed here.
+    if entity_type == "assignment":
+        ref_errors = [
+            e for e in _ve._ref_errors(_ve._entity_files(portfolio_dir))
+            if _same_file(e["file"], entity_file)
+        ]
+        if ref_errors:
+            return _fail(
+                "entity failed ref validation (%d error(s)) — a consultant or "
+                "project ref does not resolve within this portfolio; fix each "
+                "data.errors[] entry before registering" % len(ref_errors),
+                code=1,
+                data={"errors": ref_errors},
+            )
 
     array_name = _ve.SCHEMA[entity_type]["subdir"]
     slug = str(fm["slug"])

--- a/cogni-projects/scripts/register-entity.py
+++ b/cogni-projects/scripts/register-entity.py
@@ -183,13 +183,22 @@ def main(argv):
     # Placed after the type is known but before the portfolio-escape check below,
     # which is harmless: an entity outside the portfolio never appears in the
     # walk, so the filter is empty and that check still raises its own error.
-    # _ref_errors reads through read_frontmatter, which returns (None, exc)
-    # rather than raising, so no guard is needed here.
+    # _ref_errors itself is raise-free — it reads through read_frontmatter,
+    # which returns (None, exc) rather than raising. _entity_files is not: its
+    # os.listdir walk is unguarded, so an unreadable portfolio subdirectory
+    # escapes as an OSError. The __main__ catch-all below would convert that to
+    # an envelope for CLI callers, but not for the in-process callers (the test
+    # harness among them) that call main() directly, so the guard belongs here.
     if entity_type == "assignment":
-        ref_errors = [
-            e for e in _ve._ref_errors(_ve._entity_files(portfolio_dir))
-            if _same_file(e["file"], entity_file)
-        ]
+        try:
+            ref_errors = [
+                e for e in _ve._ref_errors(_ve._entity_files(portfolio_dir))
+                if _same_file(e["file"], entity_file)
+            ]
+        except OSError as exc:
+            # Default code 2 (environment failure), never code 1 — the entity
+            # did not fail validation; the portfolio could not be read.
+            return _fail("cannot scan portfolio for refs: %s" % exc)
         if ref_errors:
             return _fail(
                 "entity failed ref validation (%d error(s)) — a consultant or "

--- a/cogni-projects/skills/projects-entities/SKILL.md
+++ b/cogni-projects/skills/projects-entities/SKILL.md
@@ -39,7 +39,10 @@ are separate tool calls, not a transaction — an interrupted run can leave an
 entity file on disk that the manifest does not yet reference. That state is
 repaired by **re-running the skill for the same slug**: registration is
 idempotent (`register-entity.py` upserts keyed on `slug`), so a repeated run
-never double-registers.
+never double-registers. A registration *refused* for an unresolved consultant /
+project ref is a different case — a precondition failure, not an interrupted
+run — and re-running fails identically until the ref itself resolves; Step 5
+covers what to fix.
 
 ## Workflow
 
@@ -76,7 +79,8 @@ assignment, read the referenced consultant and project records first and confirm
 each record's frontmatter `slug` equals the value going into `consultant` /
 `project`. The validator resolves a ref against the record's `slug`, not its
 filename, so a file that merely exists under a similar name still dangles — that
-slug match, not the file's existence, is the guard.
+slug match, not the file's existence, is what makes the ref resolve; Step 5's
+registration is what refuses one that does not.
 
 ### Step 3: Read siblings, then write the entity file
 
@@ -159,8 +163,10 @@ It returns the same `{"success", "data", "error"}` envelope; `data.action` is
 `created` or `updated`, which is how a re-run reports that it replaced an
 existing ref rather than adding a second one.
 
-A registration that fails on a dangling ref wrote nothing — fix the misspelled
-slug (or author the missing record) and re-run this same command.
+A registration that fails on a dangling ref leaves the manifest and the
+execution log untouched; the entity file written in Step 3 stays on disk. So only
+the ref needs fixing — correct the misspelled slug (or author the missing
+record) and re-run this same command.
 
 When the entity was an assignment, follow the successful registration with the
 portfolio-directory sweep described in Step 4 — it is only worth running once

--- a/cogni-projects/skills/projects-entities/SKILL.md
+++ b/cogni-projects/skills/projects-entities/SKILL.md
@@ -116,9 +116,10 @@ enums, slug casing, ISO dates and their ordering, numeric ranges. It resolves an
 assignment's `consultant` / `project` slugs against the `consultants/` and
 `projects/` records only when given a whole portfolio directory — that is what
 collects the records to resolve against. This step passes a single file, so no
-ref check runs here and a passing run is not evidence the refs exist; confirming
-in Step 2 that each record's frontmatter `slug` equals the ref remains the guard
-against a dangling reference.
+ref check runs here and a passing run is not evidence the refs exist. Step 5's
+registration is the gate that enforces ref resolution; confirming in Step 2 that
+each record's frontmatter `slug` equals the ref catches the problem earlier,
+before a file is written.
 
 When the user asks for a portfolio-wide audit rather than a single authoring
 run, sweep for dangling refs with a separate invocation — not this gate: pass
@@ -130,18 +131,25 @@ unchanged. Its `success: false` covers every entity in the portfolio, not only
 the one just authored — locate the relevant entries by each error's `file`.
 
 Authoring an assignment is the one case worth sweeping unprompted rather than on
-request: it is the only entity type that carries refs, so a portfolio-directory
-run right after Step 5 is what turns Step 2's read-and-compare into a checked
-fact. Keep it after registration and never in place of the Step 4 gate — the
-single-file gate's behaviour is unchanged.
+request: it is the only entity type that carries refs. Step 5's registration
+already checks the refs of the assignment it registers, so the sweep covers the
+*rest* of the portfolio, where a record renamed or removed since it was authored
+can leave an older assignment dangling. Run it after registration, never in
+place of the Step 4 gate — that gate runs no ref check.
 
 ### Step 5: Register in the manifest and log the transition
 
 Once validation passes, register the entity. Do not hand-edit
 `projects-portfolio.json` — run the script, which upserts the summary ref keyed
 on `slug`, bumps the manifest `updated` date, and appends the
-`.metadata/execution-log.json` transition in a single invocation (it re-runs the
-validator itself, so it refuses an entity the Step 4 gate would have caught):
+`.metadata/execution-log.json` transition in a single invocation. It re-runs the
+validator, so it refuses an entity the Step 4 gate would have caught — but it
+reports those shape failures only as an error count, which is why Step 4 is
+still the run that surfaces the per-field detail. For an assignment it
+additionally resolves the `consultant` / `project` refs against the whole
+portfolio, catching a dangling ref the single-file gate passes; each unresolved
+ref comes back as a full `data.errors[]` entry naming the offending field and
+the missing referent.
 
 ```bash
 python3 "${CLAUDE_PLUGIN_ROOT:-$(ls -td "$HOME"/.claude/plugins/cache/*/cogni-projects/*/ 2>/dev/null | head -1)}/scripts/register-entity.py" "cogni-projects/<portfolio-slug>" "cogni-projects/<portfolio-slug>/<subdir>/<entity>.md"
@@ -151,11 +159,12 @@ It returns the same `{"success", "data", "error"}` envelope; `data.action` is
 `created` or `updated`, which is how a re-run reports that it replaced an
 existing ref rather than adding a second one.
 
+A registration that fails on a dangling ref wrote nothing — fix the misspelled
+slug (or author the missing record) and re-run this same command.
+
 When the entity was an assignment, follow the successful registration with the
-portfolio-directory sweep described in Step 4 — that run is what turns Step 2's
-slug comparison into a checked fact. The Step 4 gate above stays as written; this
-is the sweep, and it belongs here because it is only worth running once the
-assignment is in the manifest.
+portfolio-directory sweep described in Step 4 — it is only worth running once
+the assignment is in the manifest.
 
 ### Step 6: Summarize
 

--- a/cogni-projects/tests/test_register_entity.sh
+++ b/cogni-projects/tests/test_register_entity.sh
@@ -365,6 +365,26 @@ else:
     finally:
         os.chmod(os.path.join(root5, "consultants"), 0o755)
 
+# The scan is not trusted to raise only OSError: read_frontmatter calls
+# parse_frontmatter outside its own try, so a parser fault surfaces as
+# ValueError. The envelope is the contract for every exception type, not just
+# the one that happened to be found first.
+_real_ref_errors = reg._ve._ref_errors
+try:
+    def _boom(_files):
+        raise ValueError("simulated parser fault")
+    reg._ve._ref_errors = _boom
+    code, env = register(root5, resolving)
+    check("refs: a non-OSError from the ref scan still returns the envelope",
+          env.get("success") is False and code == 2, "code=%s env=%s" % (code, env))
+    check("refs: the envelope names the failing exception type",
+          "ValueError" in (env.get("error") or ""), str(env))
+except Exception as exc:
+    check("refs: a non-OSError from the ref scan still returns the envelope",
+          False, "main() raised %s: %s" % (type(exc).__name__, exc))
+finally:
+    reg._ve._ref_errors = _real_ref_errors
+
 print()
 if failures:
     print("%d check(s) failed." % failures)

--- a/cogni-projects/tests/test_register_entity.sh
+++ b/cogni-projects/tests/test_register_entity.sh
@@ -82,6 +82,45 @@ def make_consultant(root, slug, name):
     return path
 
 
+def make_project(root, slug, name):
+    # make_portfolio creates only consultants/ and .metadata/, so the subdir has
+    # to be made here — and exist_ok because a portfolio takes several records.
+    os.makedirs(os.path.join(root, "projects"), exist_ok=True)
+    path = os.path.join(root, "projects", slug + ".md")
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(
+            "---\n"
+            "type: project\n"
+            "slug: %s\n"
+            "name: %s\n"
+            "client: Northwind\n"
+            "strategic_impact: 4\n"
+            "---\n\n# %s\n" % (slug, name, name)
+        )
+    return path
+
+
+def make_assignment(root, consultant_ref, project_ref):
+    """Write an assignment. Its refs are whatever the caller passes, so a
+    dangling one is written without disturbing the records it points at."""
+    os.makedirs(os.path.join(root, "assignments"), exist_ok=True)
+    slug = "%s--%s" % (consultant_ref, project_ref)
+    path = os.path.join(root, "assignments", slug + ".md")
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(
+            "---\n"
+            "type: assignment\n"
+            "slug: %s\n"
+            "consultant: %s\n"
+            "project: %s\n"
+            "role: Lead Engineer\n"
+            "start_date: 2026-02-01\n"
+            "end_date: 2026-08-01\n"
+            "---\n\n# %s\n" % (slug, consultant_ref, project_ref, slug)
+        )
+    return path
+
+
 def register(root, entity_file):
     """Run register-entity.main and return (exit_code, parsed_envelope)."""
     buf = io.StringIO()
@@ -199,6 +238,59 @@ check("modes: upsert succeeded", env.get("success") is True, str(env))
 man_mode2 = os.stat(os.path.join(root4, "projects-portfolio.json")).st_mode & 0o777
 check("modes: upsert preserves the existing mode",
       man_mode2 == 0o640, "%o != 0o640" % man_mode2)
+
+# --- Portfolio ref resolution on the write path ------------------------------
+# validate_file is single-file and runs no ref pass, so before the gate an
+# assignment naming a misspelled consultant registered clean and then read as an
+# unfilled role. Every record below is on disk before the first register call:
+# the project case only proves the gate leaves non-assignments alone if a
+# dangling assignment is already sitting in the same portfolio.
+root5 = make_portfolio("refs")
+make_consultant(root5, "ana-silva", "Ana Silva")
+proj = make_project(root5, "nordic-erp", "Nordic ERP")
+# Misspelled but still kebab-valid: an underscore would fail the composite-slug
+# rule and the assertions below would be measuring a shape error, not a ref one.
+dangling = make_assignment(root5, "ana-silvaa", "nordic-erp")
+
+
+def registered_assignments():
+    with open(os.path.join(root5, "projects-portfolio.json"), encoding="utf-8") as f:
+        return json.load(f)["assignments"]
+
+
+code, env = register(root5, proj)
+check("refs: a project still registers while a dangling assignment exists",
+      env.get("success") is True, str(env))
+
+code, env = register(root5, dangling)
+errs = env.get("data", {}).get("errors", [])
+assigns = registered_assignments()
+check("refs: dangling consultant ref fails registration",
+      env.get("success") is False and code == 1, "code=%s env=%s" % (code, env))
+check("refs: the offending ref comes back in data.errors[]", len(errs) == 1, str(env))
+check("refs: the error keeps the standard {entity, file, field, message} shape",
+      bool(errs) and set(errs[0]) == {"entity", "file", "field", "message"}
+      and errs[0]["entity"] == "assignment" and errs[0]["field"] == "consultant",
+      str(errs))
+check("refs: nothing was written to the manifest", assigns == [], str(assigns))
+
+# The filter compares files, not path strings. Passing the portfolio as
+# "<root>/." makes _entity_files emit "<root>/./assignments/..." — a string
+# compare matches none of the errors, the gate fails open, the registration
+# succeeds, and this goes red.
+code, env = register(os.path.join(root5, "."), dangling)
+assigns = registered_assignments()
+check("refs: still rejected when the portfolio is passed as <root>/.",
+      env.get("success") is False and code == 1 and assigns == [],
+      "code=%s assignments=%s env=%s" % (code, assigns, env))
+
+# The dangling assignment stays on disk, so this also proves the filter reports
+# only the entity being registered rather than the whole portfolio's errors.
+resolving = make_assignment(root5, "ana-silva", "nordic-erp")
+code, env = register(root5, resolving)
+check("refs: an assignment whose refs resolve registers unaffected",
+      env.get("success") is True
+      and env.get("data", {}).get("action") == "created", str(env))
 
 print()
 if failures:

--- a/cogni-projects/tests/test_register_entity.sh
+++ b/cogni-projects/tests/test_register_entity.sh
@@ -258,10 +258,37 @@ def registered_assignments():
         return json.load(f)["assignments"]
 
 
+# A rejected registration must leave both write targets untouched. The parsed
+# assignments[] check alone is too weak: it would still pass if the manifest were
+# rewritten with equivalent JSON, and it never looks at the execution log at all.
+def manifest_bytes():
+    with open(os.path.join(root5, "projects-portfolio.json"), "rb") as f:
+        return f.read()
+
+
+def transition_count():
+    # No missing-file fallback on purpose: every caller runs after a successful
+    # registration, so an absent log is a real regression and should raise here
+    # rather than read as a legitimate count of zero.
+    path = os.path.join(root5, ".metadata", "execution-log.json")
+    with open(path, encoding="utf-8") as f:
+        return len(json.load(f).get("transitions", []))
+
+
+def check_untouched(tag, man_before, trans_before):
+    """Assert a rejected registration wrote to neither the manifest nor the log."""
+    trans_after = transition_count()
+    check("refs: %s leaves the manifest byte-identical" % tag,
+          manifest_bytes() == man_before, "manifest changed")
+    check("refs: %s leaves execution-log transitions[] unchanged" % tag,
+          trans_after == trans_before, "%d != %d" % (trans_after, trans_before))
+
+
 code, env = register(root5, proj)
 check("refs: a project still registers while a dangling assignment exists",
       env.get("success") is True, str(env))
 
+man_before, trans_before = manifest_bytes(), transition_count()
 code, env = register(root5, dangling)
 errs = env.get("data", {}).get("errors", [])
 assigns = registered_assignments()
@@ -273,24 +300,70 @@ check("refs: the error keeps the standard {entity, file, field, message} shape",
       and errs[0]["entity"] == "assignment" and errs[0]["field"] == "consultant",
       str(errs))
 check("refs: nothing was written to the manifest", assigns == [], str(assigns))
+check_untouched("a dangling consultant ref", man_before, trans_before)
 
 # The filter compares files, not path strings. Passing the portfolio as
 # "<root>/." makes _entity_files emit "<root>/./assignments/..." — a string
 # compare matches none of the errors, the gate fails open, the registration
 # succeeds, and this goes red.
+man_before, trans_before = manifest_bytes(), transition_count()
 code, env = register(os.path.join(root5, "."), dangling)
 assigns = registered_assignments()
 check("refs: still rejected when the portfolio is passed as <root>/.",
       env.get("success") is False and code == 1 and assigns == [],
       "code=%s assignments=%s env=%s" % (code, assigns, env))
+check_untouched("a non-canonical portfolio path", man_before, trans_before)
 
-# The dangling assignment stays on disk, so this also proves the filter reports
+# _ref_errors loops over both ref fields, so the consultant case above exercises
+# only half of it. A resolving consultant with a misspelled project covers the
+# other half — and again kebab-valid, so this measures a ref error, not a shape one.
+dangling_project = make_assignment(root5, "ana-silva", "nordic-erpp")
+man_before, trans_before = manifest_bytes(), transition_count()
+code, env = register(root5, dangling_project)
+errs = env.get("data", {}).get("errors", [])
+check("refs: dangling project ref fails registration",
+      env.get("success") is False and code == 1, "code=%s env=%s" % (code, env))
+check("refs: the dangling project is the single reported error",
+      len(errs) == 1 and errs[0]["entity"] == "assignment"
+      and errs[0]["field"] == "project", str(errs))
+assigns = registered_assignments()
+check("refs: nothing was written to the manifest for a dangling project",
+      assigns == [], str(assigns))
+check_untouched("a dangling project ref", man_before, trans_before)
+
+# The dangling assignments stay on disk, so this also proves the filter reports
 # only the entity being registered rather than the whole portfolio's errors.
 resolving = make_assignment(root5, "ana-silva", "nordic-erp")
 code, env = register(root5, resolving)
 check("refs: an assignment whose refs resolve registers unaffected",
       env.get("success") is True
       and env.get("data", {}).get("action") == "created", str(env))
+# Length, not just success: a duplicate append would satisfy the check above.
+assigns = registered_assignments()
+check("refs: the resolving assignment is registered exactly once",
+      len(assigns) == 1, str(assigns))
+
+# The ref scan walks the portfolio, so an unreadable subdirectory raises inside
+# _entity_files. main() must still answer with the envelope: the __main__
+# catch-all only covers CLI callers, and register() here calls main() directly —
+# exactly the in-process caller that would otherwise get a traceback.
+if os.geteuid() == 0:
+    print("SKIP: refs: unreadable subdir (running as root — mode bits do not deny)")
+else:
+    os.chmod(os.path.join(root5, "consultants"), 0o000)
+    try:
+        code, env = register(root5, resolving)
+        # code 2 (environment failure), never 1 — the entity did not fail
+        # validation; the portfolio could not be read.
+        check("refs: an unreadable portfolio subdir returns the envelope, not a traceback",
+              env.get("success") is False and code == 2, "code=%s env=%s" % (code, env))
+        check("refs: the unreadable-subdir error names the ref scan",
+              "cannot scan portfolio for refs" in (env.get("error") or ""), str(env))
+    except OSError as exc:
+        check("refs: an unreadable portfolio subdir returns the envelope, not a traceback",
+              False, "main() raised %s: %s" % (type(exc).__name__, exc))
+    finally:
+        os.chmod(os.path.join(root5, "consultants"), 0o755)
 
 print()
 if failures:

--- a/cogni-projects/tests/test_validate_entities_refs.sh
+++ b/cogni-projects/tests/test_validate_entities_refs.sh
@@ -6,7 +6,10 @@
 # from that same directory, while a single file argument — which carries no
 # portfolio-wide collection — keeps its shape-only behaviour. The single-file
 # case is the regression guard for projects-entities Step 4 and for
-# register-entity.py, which both hand the validator one file at a time.
+# register-entity.py, which both hand the validator one file at a time. That
+# still describes what they hand validate_file; register-entity.py additionally
+# runs its own portfolio-scoped ref pass on top of this gate, so a clean result
+# here is not evidence that registration accepts the entity.
 #
 # Also covers the pass's edges: an assignment dangling on both fields is
 # reported once per field; a portfolio missing the consultants/ subdirectory
@@ -141,9 +144,11 @@ if errs:
           "grace-hopper" in e["message"], e["message"])
 
 # --- 3. Single-file invocation on the SAME dangling assignment -----------
-# The guard for projects-entities Step 4 and register-entity.py: with no
-# portfolio-wide collection there is nothing to resolve against, so the file
-# must still validate clean.
+# The guard for projects-entities Step 4 and for the validate_file call inside
+# register-entity.py: with no portfolio-wide collection there is nothing to
+# resolve against, so the file must still validate clean. Registration refuses
+# this assignment anyway — it runs its own portfolio-scoped ref pass after this
+# gate — which is precisely why that behaviour is asserted there, not here.
 code, env = run(assignment)
 check("single-file invocation runs no ref check",
       env["success"] is True and code == 0, json.dumps(env["data"]["errors"]))


### PR DESCRIPTION
Closes #1172.

`register-entity.py` owns portfolio-scoped integrity on the **write** path, but gated only on `_ve.validate_file(entity_file)` — a single-file entry point that by design runs no cross-entity ref resolution. An assignment carrying a misspelled `consultant` slug passed that gate, was registered into `projects-portfolio.json`, and then read as an unfilled role in `render-dashboard.py` with no error anywhere.

## Summary

- **`register-entity.py`** — at the registration gate, resolve the entity's refs against the whole portfolio via `_ve._ref_errors(_ve._entity_files(portfolio_dir))`, keeping only the entries belonging to the entity being registered. `_fail` gains an optional `data=` payload so the raw `{entity, file, field, message}` dicts ride in `data.errors[]`; every existing call site stays byte-identical.
- **`tests/test_register_entity.sh`** — the suite had **zero** assignment coverage (no `make_project` / `make_assignment`, never created an `assignments/` dir). Adds both fixtures and a block covering rejection, the path-spelling guard, and the two unaffected paths.
- **`tests/test_validate_entities_refs.sh`** — comment-only. Its header and section-3 comment framed `register-entity.py` as ref-free, which this change falsifies. No assertion touched.
- **`skills/projects-entities/SKILL.md`** — corrects the Step 4 and Step 5 prose that documented the write path as unable to check refs.

## The three decisions worth reviewing

**1. Scoped to assignments.** `_ref_errors` structurally can only emit `entity == "assignment"` errors, and the filter keeps only the registered file — so running the batch for a consultant or project reads every record in the portfolio to build a result that cannot be non-empty. The gate sits after `entity_type` is derived and guards on `entity_type == "assignment"`. Measured on a synthetic 60-record portfolio, the ref pass is ~3.0 ms of the 5.1 ms `main()` does; scoping removes that entirely for two of the three entity types. Verified live: 0 `_ref_errors` calls when registering a consultant, 1 when registering an assignment.

**2. The batch must be the whole portfolio.** `_ref_errors([entity_file])` would resolve nothing — the known-slug sets are built from the consultant and project records *in the batch*, so a single-file expansion leaves them empty and every ref spuriously dangles. `_entity_files(portfolio_dir)` is required, not incidental.

**3. Path identity is `samefile`, not `==` and not `realpath`.** `_ref_errors` builds its `file` key from the raw `portfolio_dir` argument, while `entity_file` is an independent raw argument — so the two spellings of one file routinely differ. A string compare is the obvious bug. Less obviously, **bare `realpath` equality is also wrong**: `realpath` does not case-fold, so on a case-insensitive filesystem a case-variant path yields inequality, the filter drops the entity's own ref error, and the gate **fails open** — registering exactly the dangling assignment it exists to refuse. `os.path.samefile` compares `(st_dev, st_ino)`, which is also hardlink-correct, with a `realpath` fallback on `OSError` (only reachable under a concurrent unlink) to keep the helper raise-free for the imported-`main()` callers the `__main__` catch-all does not cover.

A test registers through a `<root>/.` portfolio argument specifically to pin this. It has teeth — verified directly: with that argument `_entity_files` emits `<root>/./assignments/x.md`, so a naive `==` matches **0 of 1** errors and the gate would pass the dangling assignment through.

## Ordering

The gate sits after the shape gate (a missing `consultant` key is a required-key error, not a dangling ref, and must report as the former) and before the portfolio-escape check. That ordering is benign in the escape direction: an entity outside the portfolio never appears in `_entity_files`' walk, so the filter is empty and the escape check still raises its own correct error.

## Test plan

- [x] `test_register_entity.sh` — 27 checks pass (20 pre-existing + 7 new)
- [x] `test_validate_entities_refs.sh`, `test_portfolio_init.sh`, `test_staffing_score.sh`, `test-render-dashboard.sh` — all green
- [x] AC 1 — dangling `consultant` returns `success: false`, exit 1, `data.errors[0]` carrying all four keys with `entity == "assignment"` / `field == "consultant"`; manifest `assignments[]` untouched
- [x] AC 2 — a project registers cleanly *while a dangling assignment sits in the same portfolio*
- [x] AC 3 — an assignment whose refs both resolve registers `created`, with the dangling one still on disk (so this also pins that the filter reports only the registered entity)
- [x] AC 4 — existing suite green, unmodified
- [x] Version-bump gate: 14 plugins scanned, 0 touched. Breadcrumb guard: 0 violations.

## Note for the reviewer (not addressed here)

This makes `register-entity.py` the second out-of-module consumer of `validate-entities.py`'s underscore-prefixed helpers (`render-dashboard.py` already uses `_entity_files`). The honest fix is a rename to drop the underscore on both symbols — smaller than a wrapper, and it corrects the actual defect, which is naming rather than layering. Deliberately left out of this PR as unrelated to the issue's scope; flagging it rather than filing it, since it is a judgment about the module's public surface.

An alternative plan adding a public `portfolio_ref_errors(portfolio_dir, entity_file=None)` seam was considered and rejected: it would serve exactly one caller, and `validate-entities.py`'s own `main()` would not use it (it already holds a realpath-deduped batch reused across both passes, so routing through the seam would re-walk every directory).