### PR TITLE
cogni-workspace: pin every sanitize-theme denylist character

### DIFF
--- a/cogni-workspace/tests/test-sanitize-theme.sh
+++ b/cogni-workspace/tests/test-sanitize-theme.sh
@@ -120,6 +120,15 @@ assert_py "1mf radius section rejects the injection payload" \
 # exactly one character with the denylist, so it fails iff '@' is dropped.
 assert_py "1mg font-aware rejects a bare @ carrying no other denylisted character" \
   'g.is_safe_value("@import url(https://evil.example/x.css)", "font-aware") is False'
+# Generalises 1mg to the whole table: "a" + c shares exactly one character with
+# the profile's denylist, so it is rejected iff that character is still listed.
+# Hardcoded on purpose — reading the sets from g._PROFILES would walk the table
+# a mutation edits, so a removed character would silently stop being tested.
+# Two-char payloads clear every max_len, and import-aware's shape gate (anchored
+# on '@import url(' / 'https://') cannot match a value starting with 'a'.
+# Pins removals only: a character or profile ADDED to _PROFILES is not covered.
+assert_py "1mh every denylist character is independently rejected" \
+  'all(g.is_safe_value("a" + c, p) is False for p, cs in {"strict": "<>{}();@\\", "font-aware": "<>{};@\\", "import-aware": "<>{};@\\"}.items() for c in cs)'
 assert_py "1n style breakout still rejected" \
   'g.is_safe_value("</style><script>alert(1)</script>", "font-aware") is False'
 assert_py "1o declaration injection rejected" \


### PR DESCRIPTION
Closes #1184.

## Summary

- Adds one data-driven check `1mh` to `cogni-workspace/tests/test-sanitize-theme.sh`, inserted after `1mg` inside the font-aware/import-aware block, asserting `g.is_safe_value("a" + c, profile) is False` for every character `c` of every profile's denylist.
- The expected character sets are **hardcoded literals in the test**, never read from `g._PROFILES` — deriving them from the module under test would be vacuous by construction, since the loop would walk the same table a mutation edits.
- Leaves `1mg` in place as the named regression for the `@`/font-aware clause.
- No guard change: the denylists in `scripts/sanitize-theme.py` are correct. This closes a test-coverage gap, not a guard defect.

**Counting note.** `_PROFILES` holds 9 + 7 + 7 = **23** pairs, not the 21 the issue title states. Mutation-testing the suite during exploration also found a third pair already pinned (`;`/font-aware, caught incidentally by 11 checks) alongside `@`/font-aware (`1mg`) and `\`/import-aware (`2w`). So the real gap was **20 of 23**, not 19 of 21. The new check pins all 23 either way, and no file in the repo states a pair count, so nothing else needed correcting.

## Verification

Acceptance criteria, each checked:

| Criterion | Result |
|---|---|
| A single check pins every (profile, denylist character) pair | 23/23 |
| Expected sets hardcoded, not read from `_PROFILES` | the `1mh` expression contains no `_PROFILES` reference |
| Removing any one character from any one profile turns it RED | 23/23 (in-process, evaluating the check's verbatim expression against a mutated table) |
| Suite still green end to end | `All sanitize-theme tests passed.` |

Four of the 23 mutations were additionally driven end to end at the source level — dropping `;` from `strict`, the backslash from `strict`, `<` from `font-aware`, and `@` from `import-aware` — each making the real suite exit 1 with `FAIL 1mh`. The backslash case matters because it is the one the fragile quoting protects.

**Quoting mechanic, deliberate — please do not "fix" it.** The expression stays in bash **single** quotes with **two** backslashes per literal. `assert_py` splices `$expr` into an unquoted heredoc via parameter expansion, whose result is not re-scanned for escapes, so single quotes mean only Python's own escaping applies and two source backslashes yield the one literal backslash `_PROFILES` carries. Nearby check `2w` is double-quoted and therefore needs four; copying that spelling here would be wrong.

## Scope decisions

- **Out:** the independent hand-rolled copy of the strict denylist at `cogni-projects/scripts/render-dashboard.py:88` — a different plugin that does not import this guard. A real pre-existing drift vector, but not an acceptance criterion here.
- **Out:** the legacy-stub fixture's `_FORBIDDEN` copy later in this same test file. It fabricates a *stale* guard for the degradation tests, so it must deliberately not track the live table.
- **Out:** the prose restatements in the module docstring and `references/design-variables-pattern.md`.
- **Not bumped:** no `plugin.json` / `marketplace.json` version change — the post-merge workflow owns the patch bump.

## Known coverage boundary

`1mh` pins **removals**, not additions: a character or a whole profile *added* to `_PROFILES` later would go unpinned with the suite still green. The check's comment says so explicitly rather than overselling itself. The root-cause plan considered in the plan record proposed a companion check pinning the hardcoded table against `_PROFILES`' key set to close that direction; it was not adopted here because both candidate plans touched the identical file set, so the pick rubric's tie-breaks resolved to the minimal-surgical plan. It remains a coherent follow-up if the profile table grows.

## Open questions

- *(avoidable — recorded, not blocking)* `cogni-projects/scripts/render-dashboard.py:88` keeps an independent hand-rolled copy of the strict denylist (`_THEME_VALUE_FORBIDDEN = set("<>{}();@\\")`) and does not import `sanitize-theme.py`, so it can silently drift from `_PROFILES`. Deliberately left out of this PR (different plugin, not an acceptance criterion); surfaced so a human can decide whether it warrants its own issue.

Plan record: https://github.com/cogni-work/insight-wave/issues/1184#issuecomment-5169251574