### PR TITLE
cogni-projects: collapse the three duplicated validator loaders

### DIFF
--- a/cogni-projects/CLAUDE.md
+++ b/cogni-projects/CLAUDE.md
@@ -19,6 +19,7 @@ cogni-projects/
 │   ├── projects-staff/SKILL.md         Rank candidate consultants per open project role
 │   └── projects-dashboard/SKILL.md     Render a partner-meeting portfolio dashboard (read-only)
 ├── scripts/
+│   ├── _projects_lib.py                Shared loader for the hyphen-named validate-entities.py
 │   ├── portfolio-init.sh               Idempotent portfolio scaffolder (stdlib-only)
 │   ├── validate-entities.py            Entity validator: frontmatter + assignment refs
 │   ├── register-entity.py              Slug-keyed manifest upsert + execution-log append

--- a/cogni-projects/README.md
+++ b/cogni-projects/README.md
@@ -82,6 +82,7 @@ The manifest holds portfolio identity (`slug`, `name`, `language`, timestamps) p
 | Skill | `projects-entities` | Author + register a consultant/project/assignment record |
 | Skill | `projects-staff` | Rank candidate consultants per open project role |
 | Skill | `projects-dashboard` | Render a read-only partner-meeting portfolio snapshot |
+| Script | `_projects_lib.py` | Shared loader for the sibling hyphen-named validate-entities.py |
 | Script | `portfolio-init.sh` | Idempotent portfolio scaffolder |
 | Script | `validate-entities.py` | Entity validator (frontmatter + assignment refs) |
 | Script | `register-entity.py` | Slug-keyed manifest upsert + execution-log append |

--- a/cogni-projects/scripts/_projects_lib.py
+++ b/cogni-projects/scripts/_projects_lib.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""
+_projects_lib.py — shared primitives for cogni-projects scripts.
+
+Single source of truth for loading `validate-entities.py`. That file carries a
+hyphen, so it is not an importable module name and every consumer has to load it
+by file location instead.
+
+Never prints and never exits: `load_validator()` returns `None` and the caller
+owns the envelope, the exit code, and the timing. That separation is what lets
+callers with genuinely different failure contracts share one loader — baking any
+one of those policies in here would silently change the others.
+
+stdlib-only. Python 3.8+.
+"""
+
+import importlib.util
+import os
+
+# Anchored on this file, so it holds however the consumer was invoked.
+VALIDATOR_PATH = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), "validate-entities.py"
+)
+
+
+def load_validator():
+    """Load the sibling validate-entities.py by file location.
+
+    Returns the loaded module, or None when the spec cannot be built — the
+    caller owns the error envelope, the exit code, and the timing.
+    """
+    spec = importlib.util.spec_from_file_location("validate_entities", VALIDATOR_PATH)
+    if spec is None or spec.loader is None:
+        return None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module

--- a/cogni-projects/scripts/register-entity.py
+++ b/cogni-projects/scripts/register-entity.py
@@ -41,25 +41,27 @@ Exit: 0 ok / 1 the entity failed validation / 2 usage or environment failure.
 """
 
 import datetime
-import importlib.util
 import json
 import os
 import sys
 import tempfile
 
-# validate-entities.py is not an importable module name (hyphens), so load it by
-# file location rather than duplicating its rules here — this script must gate on
-# exactly the schema the validator enforces.
-_v_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "validate-entities.py")
-_spec = importlib.util.spec_from_file_location("validate_entities", _v_path)
-if _spec is None or _spec.loader is None:
+# Anchored on __file__ rather than the CWD, and load-bearing rather than
+# decorative: tests/test_register_entity.sh loads this script through importlib
+# from a heredoc, where sys.path[0] is the temp working directory, so a bare
+# `from _projects_lib import ...` would raise ModuleNotFoundError under test.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from _projects_lib import VALIDATOR_PATH, load_validator  # noqa: E402
+
+# This script must gate on exactly the schema the validator enforces, so the load
+# stays at module scope and fails before main()'s own usage check ever runs.
+_ve = load_validator()
+if _ve is None:
     print(json.dumps({
         "success": False, "data": {},
-        "error": "cannot load validator module: %s" % _v_path,
+        "error": "cannot load validator module: %s" % VALIDATOR_PATH,
     }))
     sys.exit(2)
-_ve = importlib.util.module_from_spec(_spec)
-_spec.loader.exec_module(_ve)
 
 # The summary-ref fields each type carries into the manifest (see
 # references/data-model.md "Manifest registration"). These are an editorial

--- a/cogni-projects/scripts/render-dashboard.py
+++ b/cogni-projects/scripts/render-dashboard.py
@@ -15,8 +15,8 @@ a hard failure, because a partial snapshot is more useful than no snapshot to a
 partner reviewing a portfolio that is still being authored.
 
 Stdlib-only (no PyYAML). Reuses validate-entities.py's read_frontmatter and
-_entity_files by file-path load rather than re-implementing a reader or a
-directory walk — the same idiom register-entity.py uses.
+_entity_files via the shared _projects_lib loader rather than re-implementing a
+reader or a directory walk.
 
 Usage:
   python3 render-dashboard.py <portfolio-dir> [--design-variables <path.json>]
@@ -29,25 +29,24 @@ Exit: 0 ok / 2 usage or environment failure.
 import argparse
 import datetime
 import html
-import importlib.util
 import json
 import os
 import sys
 
-# validate-entities.py is not an importable module name (hyphens), so load it by
-# file location and reuse its parser + entity-file discovery — the same idiom
-# register-entity.py uses, so the dashboard reads exactly the shape the
-# validator enforces rather than duplicating (and drifting from) those rules.
-_v_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "validate-entities.py")
-_spec = importlib.util.spec_from_file_location("validate_entities", _v_path)
-if _spec is None or _spec.loader is None:
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from _projects_lib import VALIDATOR_PATH, load_validator  # noqa: E402
+
+# Reusing the validator's parser + entity-file discovery means the dashboard
+# reads exactly the shape the validator enforces rather than duplicating (and
+# drifting from) those rules. The envelope and exit code stay here: this check
+# fires at import time, before argparse, and that timing is part of the contract.
+_ve = load_validator()
+if _ve is None:
     print(json.dumps({
         "success": False, "data": {},
-        "error": "cannot load validator module: %s" % _v_path,
+        "error": "cannot load validator module: %s" % VALIDATOR_PATH,
     }))
     sys.exit(2)
-_ve = importlib.util.module_from_spec(_spec)
-_spec.loader.exec_module(_ve)
 
 
 # The built-in palette. The dashboard renders with this whenever no

--- a/cogni-projects/scripts/staffing-score.py
+++ b/cogni-projects/scripts/staffing-score.py
@@ -31,8 +31,8 @@ fixed precision, projects order by strategic impact then slug, candidate ties
 break on the consultant slug, and no wall-clock value enters the result.
 
 Reads entity frontmatter with the same stdlib reader the validator uses
-(`validate-entities.py:read_frontmatter`, loaded by file location as
-`register-entity.py` does) — no duplicated reader, no PyYAML.
+(`validate-entities.py:read_frontmatter`, obtained through the shared
+`_projects_lib` loader) — no duplicated reader, no PyYAML.
 
 Usage:
   python3 staffing-score.py <portfolio-dir>
@@ -47,10 +47,12 @@ install) / 2 usage (wrong argument count).
 """
 
 import datetime
-import importlib.util
 import json
 import os
 import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from _projects_lib import load_validator  # noqa: E402
 
 # --- Scoring weights (defensible MVP defaults; tunable is a follow-up concern) ---
 # The combined score ranks candidates WITHIN a role, so it blends only the two
@@ -98,21 +100,17 @@ def _fail(message, code):
 
 
 def _load_read_frontmatter():
-    """Load read_frontmatter from the sibling validate-entities.py by file path.
+    """Reuse the validator's canonical frontmatter reader.
 
-    validate-entities.py is not an importable module name (hyphens), so — exactly
-    as register-entity.py does — load it by location to reuse the one canonical
-    frontmatter reader rather than duplicating the open/read/parse/guard sequence.
     Returns the callable, or None if the validator module cannot be loaded.
+
+    Deliberately kept lazy, at function scope: main() calls it after its argument
+    and portfolio-dir preflight, so a bad-args invocation still reports the usage
+    error (exit 2) and a broken install stays a domain failure (exit 1).
     """
-    v_path = os.path.join(
-        os.path.dirname(os.path.abspath(__file__)), "validate-entities.py"
-    )
-    spec = importlib.util.spec_from_file_location("validate_entities", v_path)
-    if spec is None or spec.loader is None:
+    module = load_validator()
+    if module is None:
         return None
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
     return getattr(module, "read_frontmatter", None)
 
 


### PR DESCRIPTION
Closes #1181.

## Summary

`validate-entities.py` carries a hyphen, so it is not an importable module name and every consumer loaded it by file location. That idiom was copied into three scripts and the copies diverged.

This adds `cogni-projects/scripts/_projects_lib.py` exposing `VALIDATOR_PATH` and `load_validator()`, and routes all three call sites through it.

**The design decision the issue asked for: the loader is shared, the failure contract stays per-script.** `load_validator()` never prints and never exits — it returns the module, or `None` where all three sites already branched. That is what lets callers with genuinely different contracts share one loader:

| Site | Scope | Behaviour on load failure | Changed? |
|---|---|---|---|
| `render-dashboard.py` | module | envelope + `sys.exit(2)` at import, before argparse | no |
| `register-entity.py` | module | envelope + `sys.exit(2)` at import, before `main()`'s usage check | no |
| `staffing-score.py` | function | returns `None`; `main()` `_fail`s with exit 1 *after* its argv/portfolio-dir preflight | no |

It returns the **module**, not a callable: `register-entity.py` alone reaches for `validate_file`, `read_frontmatter`, `_ref_errors`, `_entity_files` and `SCHEMA`.

## The load-bearing detail

The per-caller `sys.path.insert` is anchored on `__file__`, not the CWD, and is not decoration. `tests/test_register_entity.sh:22` pipes a heredoc into `python3 -` and loads the script via `spec_from_file_location`, so `sys.path[0]` is a temp directory — a bare `from _projects_lib import ...` raises `ModuleNotFoundError` under test. `test_validate_entities_refs.sh` uses the same style.

## Verification

All five suites pass, before and after:

```
test-render-dashboard.sh  PASS      test_staffing_score.sh          PASS
test_portfolio_init.sh    PASS      test_validate_entities_refs.sh  PASS
test_register_entity.sh   PASS
```

Behaviour preserved, checked differentially against `origin/main` rather than by inspection:

- **No-args usage path** — exit code and stdout byte-identical for all three scripts (exit 2 each).
- **Missing `validate-entities.py`** — exit code and stdout byte-identical for all three (exit 1, empty stdout). Only the stderr traceback differs, by one frame through `_projects_lib.py`.
- The `spec is None` guard still returns `None`, so the callers' envelope + `sys.exit(2)` path is intact where it can fire.
- `check-breadcrumbs.py` and `check-version-bump.py` both clean; no plugin version touched (post-merge workflow owns the bump).

## Two things worth a reviewer's eye

1. **The envelope + `exit 2` path is narrower than the issue implies.** `spec_from_file_location` returns a *valid* spec for a nonexistent path — the failure surfaces later, at `exec_module`, as an uncaught `FileNotFoundError`. So a merely missing validator has always exited **1** in all three scripts, not 2, and the envelope never prints. That is pre-existing and this PR preserves it exactly; flagging it because the issue's table describes the intended behaviour rather than the observed one. Adding a `try/except` around `exec_module` would fix it but is a deliberate behaviour change, so it is out of scope here.
2. **A latent envelope inconsistency, not touched.** The three `_fail` helpers pass `ensure_ascii=False`; the two module-scope inline envelopes do not. Under the repo's per-language character rules a non-ASCII path would escape to `\uXXXX` in one and not the other. Extracting a shared emitter would fix it — but it would also pull exit-code policy back into the shared module, undoing this PR's main point, so it is left alone.

## Scope

- **In:** all three production call sites plus one loader. AC 1 is not satisfiable by converting a subset, so this closes the issue rather than slicing it.
- **Out:** the two test-harness loader copies in `tests/`. #1182 owns the shared `tests/` harness.
- **Out:** renaming `validate-entities.py` to an importable name. Measured: 32 occurrences across 12 files, 5 load-bearing. Rejected because it would **not** remove the `sys.path` bootstrap — the test harness loads the *caller* by path, so the callee's filename is irrelevant — while breaking the directory's kebab-case convention and changing a CLI invocation documented in `projects-entities/SKILL.md`.
- **Out:** promoting `_entity_files` / `_ref_errors` to public names — already load-bearing cross-file API, unrelated change.
- Nothing deferred.

## Note for doc-audit

`_projects_lib.py` is added to both the `CLAUDE.md` scripts tree and the `README.md` components table, since that table enumerates every script in `scripts/`. It is the first underscore-prefixed row in any plugin README — `cogni-knowledge` mentions `_knowledge_lib` only in its directory-tree line, but it has no components table, so there is no counter-precedent. Flagging in case `doc-generate` would render it differently.