### PR TITLE
cogni-projects: shared tests/ harness with an exit-code-safe runner

### DIFF
--- a/cogni-projects/CLAUDE.md
+++ b/cogni-projects/CLAUDE.md
@@ -26,6 +26,7 @@ cogni-projects/
 │   ├── staffing-score.py               Deterministic staffing scorer (availability/fit/impact)
 │   └── render-dashboard.py             Portfolio health + value HTML render (read-only, stdlib-only)
 ├── tests/
+│   ├── fixtures/test_helpers.sh        Shared bash assertion harness + exit-code-safe runner
 │   ├── test_portfolio_init.sh          Portfolio scaffolder idempotency + no-debris suite
 │   ├── test_register_entity.sh         Atomic-write + idempotency regression suite
 │   ├── test_validate_entities_refs.sh  Assignment ref-integrity + single-file regression suite
@@ -44,6 +45,13 @@ bash cogni-projects/tests/test_validate_entities_refs.sh
 bash cogni-projects/tests/test_staffing_score.sh
 bash cogni-projects/tests/test-render-dashboard.sh
 ```
+
+`test_portfolio_init.sh`, `test_staffing_score.sh` and `test-render-dashboard.sh`
+source `tests/fixtures/test_helpers.sh` for their assertions and their script
+runner; the runner captures the invoked script's own exit status rather than a
+pipeline's, which is what makes an exit-code assertion meaningful. The other two
+suites assert inside a single inline `python3 - <<'PY'` heredoc and define no
+bash-level assertions, so they do not source it.
 
 Planned (not yet scaffolded — see the roadmap epic):
 

--- a/cogni-projects/tests/fixtures/test_helpers.sh
+++ b/cogni-projects/tests/fixtures/test_helpers.sh
@@ -1,0 +1,139 @@
+# test_helpers.sh — shared bash assertion harness sourced by cogni-projects/tests/*.
+#
+# Source via:
+#   . "$TESTS_DIR/fixtures/test_helpers.sh"
+#
+# The POSIX dot, not `source`, and no shebang: this file is sourced, never
+# executed. It lives under fixtures/ rather than beside the suites so a
+# `tests/test_*.sh` sweep never collects a non-suite file as a suite.
+#
+# `set -u` is deliberately NOT set here — it is a per-suite preamble line that
+# must precede this source. Nor is there a shared summary/exit tail: the suites
+# print different completion lines.
+#
+# Bash 3.2 compatible (the macOS default these suites run under).
+
+failures=0
+pass() { printf 'OK   %s\n' "$1"; }
+fail() { printf 'FAIL %s: %s\n' "$1" "$2" >&2; failures=$((failures + 1)); }
+
+# init_tmproot — set TMPROOT to a fresh temp dir and arm its cleanup trap.
+# TMPROOT is a global on purpose: run_script defaults its stdout/stderr sinks
+# underneath it, and the suites reference it directly when building fixtures.
+# The chmod is what lets a fixture leave a read-only (0555) directory behind
+# without defeating cleanup; it is a harmless no-op for suites that never do.
+init_tmproot() {
+  TMPROOT="$(mktemp -d)"
+  trap 'chmod -R u+rwx "$TMPROOT" 2>/dev/null; rm -rf "$TMPROOT"' EXIT
+}
+
+# assert_json <label> <python-bool-expr over `d`> — pipes the last stdout line
+# (the envelope) into python3 and checks the expression is truthy.
+assert_json() {
+  local label="$1" expr="$2"
+  if printf '%s' "$LAST_JSON" | python3 -c "import json,sys
+d = json.loads(sys.stdin.read())
+sys.exit(0 if ($expr) else 1)" 2>/dev/null; then
+    pass "$label"
+  else
+    fail "$label" "expr false: $expr | json=$LAST_JSON"
+  fi
+}
+
+# The crash signature belongs in one place — widening it later should be one
+# edit. Every "the script degraded instead of crashing" fixture needs it.
+assert_no_traceback() {
+  local label="$1" file="$2"
+  if grep -qF 'Traceback' "$file"; then
+    fail "$label" "traceback present: $(head -3 "$file")"
+  else
+    pass "$label"
+  fi
+}
+
+assert_exit() {
+  local label="$1" want="$2" got="$3"
+  if [ "$want" = "$got" ]; then
+    pass "$label"
+  else
+    fail "$label" "want exit $want, got $got"
+  fi
+}
+
+seed_portfolio() {
+  # $1 = portfolio dir. Seeds a manifest + entity subdirs. The manifest's ref
+  # lists stay empty on purpose: _load_entities then falls back to scanning the
+  # subdirectories, which is the path a hand-authored record takes.
+  #
+  # Never call this from a suite that exercises portfolio-init.sh — creating
+  # this layout is that script's job, and seeding it would pre-empt the
+  # behaviour under test.
+  local pf="$1"
+  mkdir -p "$pf"/{consultants,projects,assignments,.metadata}
+  cat > "$pf/projects-portfolio.json" <<'EOF'
+{"slug":"test","name":"Test Portfolio","language":"en","consultants":[],"projects":[],"assignments":[],"created":"2026-01-01","updated":"2026-01-01"}
+EOF
+}
+
+write_entity() { # $1 = path; body heredoc'd by the caller on stdin
+  cat > "$1"
+}
+
+# write_latin1 <path> — body heredoc'd by the caller on stdin as UTF-8, written
+# out latin-1-encoded. python3 does the write in wb mode because bash printf
+# parses a leading '---' as options; the encoded bytes are invalid UTF-8 start
+# bytes by design, which is the whole point of the fixture. stdin is read as
+# binary and decoded explicitly so a C/POSIX locale cannot change the result.
+#
+# The encode happens before the file is opened, and a failure is reported rather
+# than swallowed. Both matter: a character outside latin-1 (say 'ł') would
+# otherwise leave a 0-byte file, which the loaders skip as frontmatter-less — so
+# the very regression fixture that exists to prove non-UTF-8 records are
+# tolerated would pass while testing nothing.
+write_latin1() {
+  if ! python3 -c "
+import sys
+body = sys.stdin.buffer.read().decode('utf-8')
+blob = body.encode('latin-1')
+open(sys.argv[1], 'wb').write(blob)" "$1"; then
+    fail "write_latin1 $1" "payload is not latin-1 encodable"
+    return 1
+  fi
+}
+
+# run_script <command> [args...] — invoke a script and capture its envelope and
+# its own exit status. The whole command line is positional, so the runner is
+# interpreter-agnostic: `run_script python3 "$SCRIPT" ...` and
+# `run_script bash "$SCRIPT" ...` both work.
+#
+# Sets LAST_JSON (the last stdout line) and RUN_CODE (the command's status).
+# Redirecting to a file rather than piping into `tail` is load-bearing: after a
+# `$(... | tail -n 1)` substitution, `$?` is tail's status, which is always 0,
+# so every exit-code assertion would pass vacuously.
+#
+# Two optional globals tune a single call, and both are ONE-SHOT — consumed and
+# cleared here, so a fixture cannot leak its setting into the next run:
+#   RUN_ERRFILE  stderr sink for this call (default "$TMPROOT/stderr.txt")
+#   RUN_CWD      run the command in this directory, leaving the caller's cwd
+#                untouched; the redirections and the status capture stay in the
+#                caller's shell, so RUN_CODE is still the command's own.
+# Clearing them here is what keeps every caller on one discipline: set it on the
+# line above the call, and never think about resetting it. The sink FILE of
+# course survives — only the variable is cleared — so an assertion reading it
+# after the call still works.
+#
+# init_tmproot must have run first — the default sink dereferences TMPROOT.
+run_script() {
+  local outfile="$TMPROOT/stdout.txt"
+  local errfile="${RUN_ERRFILE:-$TMPROOT/stderr.txt}"
+  local cwd="${RUN_CWD:-}"
+  RUN_ERRFILE=""
+  RUN_CWD=""
+  if [ -n "$cwd" ]; then
+    ( cd "$cwd" && "$@" ) >"$outfile" 2>"$errfile"
+  else
+    "$@" >"$outfile" 2>"$errfile"
+  fi
+  RUN_CODE=$?
+  LAST_JSON="$(tail -n 1 "$outfile")"
+}

--- a/cogni-projects/tests/test-render-dashboard.sh
+++ b/cogni-projects/tests/test-render-dashboard.sh
@@ -23,25 +23,9 @@ if [ ! -f "$SCRIPT" ]; then
   exit 1
 fi
 
-TMPROOT="$(mktemp -d)"
-trap 'rm -rf "$TMPROOT"' EXIT
+. "$TESTS_DIR/fixtures/test_helpers.sh"
 
-failures=0
-pass() { printf 'OK   %s\n' "$1"; }
-fail() { printf 'FAIL %s: %s\n' "$1" "$2" >&2; failures=$((failures + 1)); }
-
-# assert_json <label> <python-bool-expr over `d`> — pipes the last stdout line
-# (the envelope) into python3 and checks the expression is truthy.
-assert_json() {
-  local label="$1" expr="$2"
-  if printf '%s' "$LAST_JSON" | python3 -c "import json,sys
-d = json.loads(sys.stdin.read())
-sys.exit(0 if ($expr) else 1)" 2>/dev/null; then
-    pass "$label"
-  else
-    fail "$label" "expr false: $expr | json=$LAST_JSON"
-  fi
-}
+init_tmproot
 
 assert_html() {
   local label="$1" needle="$2" file="$3"
@@ -63,34 +47,10 @@ assert_html_lacks() {
   fi
 }
 
-# Every "the renderer degraded instead of crashing" fixture needs this, and the
-# crash signature belongs in one place — widening it later should be one edit.
-assert_no_traceback() {
-  local label="$1" file="$2"
-  if grep -qF 'Traceback' "$file"; then
-    fail "$label" "traceback present: $(head -3 "$file")"
-  else
-    pass "$label"
-  fi
-}
-
-seed_portfolio() {
-  # $1 = portfolio dir. Seeds a manifest + entity subdirs.
-  local pf="$1"
-  mkdir -p "$pf"/{consultants,projects,assignments,.metadata}
-  cat > "$pf/projects-portfolio.json" <<'EOF'
-{"slug":"test","name":"Test Portfolio","language":"en","consultants":[],"projects":[],"assignments":[],"created":"2026-01-01","updated":"2026-01-01"}
-EOF
-}
-
-write_entity() { # $1 = path, $2 = frontmatter body (heredoc'd by caller)
-  cat > "$1"
-}
-
-# run [args...] — invoke the renderer with any arguments (including none) and
-# capture the last stdout line, which is the envelope, into LAST_JSON.
+# run [args...] — invoke the renderer with any arguments (including none),
+# binding the interpreter and script path the shared runner needs.
 run() {
-  LAST_JSON="$(python3 "$SCRIPT" "$@" 2>/dev/null | tail -n 1)"
+  run_script python3 "$SCRIPT" "$@"
 }
 
 # ---------------------------------------------------------------------------
@@ -167,6 +127,7 @@ assert_json "1k envelope carries projects_detail"        "len(d['data']['project
 assert_json "1l projects_detail carries per-project health" "all('health_label' in p and 'health_sev' in p for p in d['data']['projects_detail'])"
 assert_json "1m envelope carries value_by_impact"        "d['data']['value_by_impact']['5'] == 1 and d['data']['value_by_impact']['2'] == 1"
 assert_json "1n named at-risk project pinned with its flag" "any(p['name'] == 'Compliance Audit' and p['health_label'] == 'unstaffed' and p['health_sev'] == 'risk' for p in d['data']['projects_detail'])"
+assert_exit "1o happy render exits zero" 0 "$RUN_CODE"
 
 # ---------------------------------------------------------------------------
 # Fixture 2 — idempotent re-render: running twice rewrites the same file and
@@ -327,15 +288,19 @@ open_roles:
 # open_roles present but empty — still unknown, not an assertion of zero
 EOF
 # A genuinely non-UTF-8 file: a latin-1 encoded byte that is invalid UTF-8.
-# Written via python3 because bash printf parses a leading '---' as options.
-python3 -c "
-import sys
-open(sys.argv[1], 'wb').write(
-    '---\ntype: project\nslug: latin1\nname: Caf\xe9 Rollout\nstatus: active\n---\n'.encode('latin-1')
-)" "$PF6/projects/latin1.md"
+write_latin1 "$PF6/projects/latin1.md" <<'EOF'
+---
+type: project
+slug: latin1
+name: Café Rollout
+status: active
+---
+EOF
 
+# Its own stderr sink, as 6g asserts on the absence of a traceback.
 STDERR6="$TMPROOT/stderr6.txt"
-LAST_JSON="$(python3 "$SCRIPT" "$PF6" 2>"$STDERR6" | tail -n 1)"
+RUN_ERRFILE="$STDERR6"
+run "$PF6"
 
 assert_json "6a malformed set still succeeds"  "d['success'] is True"
 assert_json "6b marked partial"                "d['data']['partial'] is True"
@@ -367,6 +332,7 @@ run
 assert_json "7a no-args still prints envelope" "d['success'] is False"
 assert_json "7b no-args error names usage"     "'usage' in d['error']"
 assert_json "7c usage names the real argument" "'portfolio_dir' in d['error']"
+assert_exit "7d usage error exits 2" 2 "$RUN_CODE"
 
 # ---------------------------------------------------------------------------
 # Fixture 8 — a design-variables value that would break out of the <style>
@@ -520,10 +486,10 @@ status: 1
 # assignment
 EOF
 
-# The shared run() helper discards stderr, so invoke directly the way Fixture 6
-# does — 10g asserts on the absence of a traceback.
+# Its own stderr sink, as 10g asserts on the absence of a traceback.
 STDERR10="$TMPROOT/stderr10.txt"
-LAST_JSON="$(python3 "$SCRIPT" "$PF10" 2>"$STDERR10" | tail -n 1)"
+RUN_ERRFILE="$STDERR10"
+run "$PF10"
 
 assert_json "10a non-string status still succeeds" "d['success'] is True"
 assert_json "10b marked partial"                   "d['data']['partial'] is True"
@@ -677,10 +643,10 @@ status: active
 # assignment
 EOF
 
-# Direct invoke for the same reason Fixture 10 does it — run() discards stderr
-# and 11i asserts a traceback never reached it.
+# Its own stderr sink, as 11i asserts a traceback never reached it.
 STDERR11="$TMPROOT/stderr11.txt"
-LAST_JSON="$(python3 "$SCRIPT" "$PF11" 2>"$STDERR11" | tail -n 1)"
+RUN_ERRFILE="$STDERR11"
+run "$PF11"
 HTML11="$PF11/output/dashboard.html"
 
 assert_json "11a non-string role still succeeds" "d['success'] is True"

--- a/cogni-projects/tests/test_portfolio_init.sh
+++ b/cogni-projects/tests/test_portfolio_init.sh
@@ -29,34 +29,19 @@ if [ ! -f "$SCRIPT" ]; then
   exit 1
 fi
 
-TMPROOT="$(mktemp -d)"
-trap 'chmod -R u+rwx "$TMPROOT" 2>/dev/null; rm -rf "$TMPROOT"' EXIT
+. "$TESTS_DIR/fixtures/test_helpers.sh"
 
-failures=0
-pass() { printf 'OK   %s\n' "$1"; }
-fail() { printf 'FAIL %s: %s\n' "$1" "$2" >&2; failures=$((failures + 1)); }
-
-# assert_json <label> <python-bool-expr over `d`> — pipes the captured last
-# stdout line (the envelope) into python3 and checks the expression is truthy.
-assert_json() {
-  local label="$1" expr="$2"
-  if printf '%s' "$LAST_JSON" | python3 -c "import json,sys
-d = json.loads(sys.stdin.read())
-sys.exit(0 if ($expr) else 1)" 2>/dev/null; then
-    pass "$label"
-  else
-    fail "$label" "envelope assertion failed on: $LAST_JSON"
-  fi
-}
+init_tmproot
 
 # --- Fixture 1: happy path -------------------------------------------------
 # A clean run emits {success:true} and writes projects-portfolio.json last.
+# The script is invoked from inside the work dir, so the shared runner gets
+# RUN_CWD rather than a directory argument.
 WORK1="$TMPROOT/happy"
 mkdir -p "$WORK1"
-OUT1="$(cd "$WORK1" && bash "$SCRIPT" demo "Demo Portfolio" 2>/dev/null)"
-RC1=$?
-LAST_JSON="$(printf '%s\n' "$OUT1" | tail -n 1)"
-if [ "$RC1" -eq 0 ]; then pass "1a happy path exits zero"; else fail "1a happy path exits zero" "rc=$RC1"; fi
+RUN_CWD="$WORK1"
+run_script bash "$SCRIPT" demo "Demo Portfolio"
+assert_exit "1a happy path exits zero" 0 "$RUN_CODE"
 assert_json "1b happy path envelope success:true" "d['success'] is True"
 if [ -f "$WORK1/cogni-projects/demo/projects-portfolio.json" ]; then
   pass "1c manifest written"
@@ -75,10 +60,9 @@ else
   WORK2="$TMPROOT/failure"
   mkdir -p "$WORK2/cogni-projects/demo/.metadata"
   chmod 0555 "$WORK2/cogni-projects/demo/.metadata"
-  OUT2="$(cd "$WORK2" && bash "$SCRIPT" demo "Demo Portfolio" 2>/dev/null)"
-  RC2=$?
-  LAST_JSON="$(printf '%s\n' "$OUT2" | tail -n 1)"
-  if [ "$RC2" -ne 0 ]; then pass "2a write failure exits non-zero"; else fail "2a write failure exits non-zero" "rc=$RC2"; fi
+  RUN_CWD="$WORK2"
+  run_script bash "$SCRIPT" demo "Demo Portfolio"
+  if [ "$RUN_CODE" -ne 0 ]; then pass "2a write failure exits non-zero"; else fail "2a write failure exits non-zero" "rc=$RUN_CODE"; fi
   assert_json "2b failure envelope parses"          "isinstance(d, dict)"
   assert_json "2c failure envelope success:false"   "d['success'] is False"
   assert_json "2d failure envelope carries error"   "isinstance(d.get('error'), str) and len(d['error']) > 0"

--- a/cogni-projects/tests/test_staffing_score.sh
+++ b/cogni-projects/tests/test_staffing_score.sh
@@ -25,72 +25,15 @@ if [ ! -f "$SCRIPT" ]; then
   exit 1
 fi
 
-TMPROOT="$(mktemp -d)"
-trap 'rm -rf "$TMPROOT"' EXIT
+. "$TESTS_DIR/fixtures/test_helpers.sh"
 
-failures=0
-pass() { printf 'OK   %s\n' "$1"; }
-fail() { printf 'FAIL %s: %s\n' "$1" "$2" >&2; failures=$((failures + 1)); }
+init_tmproot
 
-# assert_json <label> <python-bool-expr over `d`> — pipes the last stdout line
-# (the envelope) into python3 and checks the expression is truthy.
-assert_json() {
-  local label="$1" expr="$2"
-  if printf '%s' "$LAST_JSON" | python3 -c "import json,sys
-d = json.loads(sys.stdin.read())
-sys.exit(0 if ($expr) else 1)" 2>/dev/null; then
-    pass "$label"
-  else
-    fail "$label" "expr false: $expr | json=$LAST_JSON"
-  fi
-}
-
-# The crash signature belongs in one place — widening it later should be one
-# edit. This is the assertion the whole suite exists for.
-assert_no_traceback() {
-  local label="$1" file="$2"
-  if grep -qF 'Traceback' "$file"; then
-    fail "$label" "traceback present: $(head -3 "$file")"
-  else
-    pass "$label"
-  fi
-}
-
-assert_exit() {
-  local label="$1" want="$2" got="$3"
-  if [ "$want" = "$got" ]; then
-    pass "$label"
-  else
-    fail "$label" "want exit $want, got $got"
-  fi
-}
-
-seed_portfolio() {
-  # $1 = portfolio dir. Seeds a manifest + entity subdirs. The manifest's ref
-  # lists stay empty on purpose: _load_entities then falls back to scanning the
-  # subdirectories, which is the path a hand-authored record takes.
-  local pf="$1"
-  mkdir -p "$pf"/{consultants,projects,assignments,.metadata}
-  cat > "$pf/projects-portfolio.json" <<'EOF'
-{"slug":"test","name":"Test Portfolio","language":"en","consultants":[],"projects":[],"assignments":[],"created":"2026-01-01","updated":"2026-01-01"}
-EOF
-}
-
-write_entity() { # $1 = path; body heredoc'd by the caller on stdin
-  cat > "$1"
-}
-
-# run_score <stderr-file> [args...] — invoke the scorer, setting LAST_JSON to the
-# last stdout line (the envelope) and RUN_CODE to the script's own exit status.
-# Redirecting to a file rather than piping into `tail` is load-bearing: after a
-# `$(... | tail -n 1)` substitution, `$?` is tail's status, which is always 0, so
-# every exit-code assertion would pass vacuously.
+# run_score <stderr-file> [args...] — invoke the scorer with this fixture's own
+# stderr sink, binding the interpreter and script path for the shared runner.
 run_score() {
-  local errfile="$1"; shift
-  local outfile="$TMPROOT/stdout.txt"
-  python3 "$SCRIPT" "$@" >"$outfile" 2>"$errfile"
-  RUN_CODE=$?
-  LAST_JSON="$(tail -n 1 "$outfile")"
+  RUN_ERRFILE="$1"; shift
+  run_script python3 "$SCRIPT" "$@"
 }
 
 # Seed two valid consultants and one active project with an open role. Shared by
@@ -175,13 +118,19 @@ PFB="$TMPROOT/latin1"
 seed_portfolio "$PFB"
 seed_entities "$PFB"
 
-# Written via python3 in wb mode because bash printf parses a leading '---' as
-# options; \xe9 is 'é' in latin-1 and an invalid UTF-8 start byte here.
-python3 -c "
-import sys
-open(sys.argv[1], 'wb').write(
-    '---\ntype: consultant\nslug: cesar\nname: C\xe9sar Rossi\nseniority: senior\nskills: [cloud]\navailable_from: 2026-01-01\navailable_until: 2026-12-31\n---\n'.encode('latin-1')
-)" "$PFB/consultants/cesar.md"
+# Latin-1 encoded, so the 'é' lands as a byte that is an invalid UTF-8 start
+# byte here — which is the record this fixture exists for.
+write_latin1 "$PFB/consultants/cesar.md" <<'EOF'
+---
+type: consultant
+slug: cesar
+name: César Rossi
+seniority: senior
+skills: [cloud]
+available_from: 2026-01-01
+available_until: 2026-12-31
+---
+EOF
 
 STDERRB="$TMPROOT/stderr-b.txt"
 run_score "$STDERRB" "$PFB"


### PR DESCRIPTION
Closes #1182.

## Summary

Three of the five `cogni-projects/tests/` suites inlined the same bash assertion harness byte-identically, and the copies had **already drifted on a correctness-relevant detail**: `test_staffing_score.sh`'s runner redirects stdout to a file, while `test-render-dashboard.sh`'s piped into `tail`. After a `$(... | tail -n 1)` substitution `$?` is tail's status — always 0 — so `test-render-dashboard.sh` could not express an exit-code assertion at all, and any it had grown would have passed vacuously.

- Adds `cogni-projects/tests/fixtures/test_helpers.sh`, following the in-repo precedent `cogni-knowledge/tests/fixtures/test_helpers.sh` — **pattern, not content**: a `fixtures/` helper sourced via the POSIX dot idiom, bash 3.2 compatible, no shebang. It lives under `fixtures/` so a non-recursive `tests/test_*.sh` sweep can never collect it as a suite.
- Exposes `failures`/`pass()`/`fail()`, `assert_json()`, `assert_no_traceback()`, `assert_exit()`, `seed_portfolio()`, `write_entity()`, `write_latin1()`, `init_tmproot()` and the canonical runner `run_script`.
- `run_script` captures the invoked script's **own** exit status into `RUN_CODE` by redirecting stdout to a file instead of piping into `tail`, and takes its whole command line positionally — so it serves the two `python3` suites and the `bash portfolio-init.sh` suite alike.
- `test-render-dashboard.sh` gains its first exit-code assertions: `1o` (happy render exits 0) and `7d` (no-args usage exits 2). `render-dashboard.py` pins `Exit: 0 ok / 2 usage or environment failure`, and the no-args path reaches 2 through `_fail(...)`, not argparse's own exit.

Net: three copies of the harness collapse to one (−154/+200 lines, of which 139 are the new shared file), and the suite that structurally could not assert an exit code now does.

## Why the call sites are untouched

The two pre-existing runner signatures collide: in `run()` arg 1 is the first CLI argument to the target script, while in `run_score()` arg 1 is consumed as the stderr sink. Merging onto one positional signature would have silently collapsed every render-dashboard fixture into the no-args usage path. So the sink and the optional cwd move into **one-shot globals** (`RUN_ERRFILE`, `RUN_CWD` — consumed and cleared by `run_script`, so a fixture cannot leak its setting into the next run), and each suite keeps a thin wrapper. All 9 `run` and 5 `run_score` call sites are byte-identical to before.

## Scope decision — AC 1 is met as "every suite that uses the bash assertion harness"

The issue's AC 1 says "all five suites". Only **three** are bash-assertion suites. `test_register_entity.sh` and `test_validate_entities_refs.sh` hand off entirely to a single inline `python3 - <<'PY'` heredoc whose assertions are a Python `check()`; neither defines any bash `pass`/`fail`/`assert_json`. A sourced bash helper cannot be reached from inside that subprocess, so a `source` line there would be inert. They are deliberately left untouched, and `cogni-projects/CLAUDE.md` now records which suites source the harness and why the other two do not. This was flagged at triage before any code was written — see the triage comment on #1182.

**Reviewer note:** this is the one place the PR diverges from the issue text as literally written. Every other acceptance criterion is delivered in full, so the PR links `Closes`.

## Verification

- All five suites green: **136 assertions** (134 baseline + the 2 new exit-code ones), every suite exit 0.
- **Negative control** — flipping `7d` to expect exit 0 makes the suite fail (`want exit 0, got 2`) and exit non-zero; reverting restores 136/exit 0. This is the proof the new assertion is not vacuous, which the old piped `run()` could not have provided.
- `check-breadcrumbs.py` 0 violations · `check-version-bump.py` 0 touched, 0 violations · `check-skill-names.sh` clean.
- No `plugin.json` / `marketplace.json` change — the post-merge workflow owns the bump.

A pre-commit quality pass raised, and this PR fixes, one defect the extraction itself introduced: `write_latin1` originally swallowed a failed encode, leaving a 0-byte file that the loaders skip as frontmatter-less — so the very regression fixture that exists to prove non-UTF-8 records are tolerated would have gone green while testing nothing. It now encodes before opening the file and reports the failure, verified against a Polish `ł` payload.

## Out of scope, noted for future work

Not deferred slices of this issue — every acceptance criterion above is delivered here:

- Deduplicating the identical Python `check()` across the two heredoc suites (needs a shared *Python* module, not a bash helper).
- Giving `test_portfolio_init.sh` real stderr capture so it could assert `assert_no_traceback` — it currently discards stderr. A latent coverage hole, not a regression.
- Aligning this harness's grep-assertion argument order with `cogni-knowledge`'s `assert_grep(pattern, file, description)`, and folding `test-render-dashboard.sh`'s local `assert_html`/`assert_html_lacks` into that shape.