### PR TITLE
cogni-projects: catch-all envelope for staffing-score.py

### DIFF
--- a/cogni-projects/scripts/staffing-score.py
+++ b/cogni-projects/scripts/staffing-score.py
@@ -43,7 +43,8 @@ projects-portfolio.json manifest.
 Output: a single JSON line following the repo contract
   {"success": bool, "data": {...}, "error": str}
 Exit: 0 ok / 1 domain failure (bad portfolio / unreadable manifest / broken
-install) / 2 usage (wrong argument count).
+install) / 2 usage (wrong argument count) or an unexpected failure the
+module-level catch-all converted into the envelope.
 """
 
 import datetime
@@ -412,7 +413,7 @@ def main(argv):
     read_frontmatter = _load_read_frontmatter()
     if read_frontmatter is None:
         # A broken/partial install (validator missing), not a caller usage
-        # error — so exit 1 (domain failure), reserving exit 2 for bad args.
+        # error — so exit 1 (domain failure), never exit 2.
         return _fail(
             "cannot load validate-entities.py:read_frontmatter (expected sibling "
             "of this script) — the cogni-projects install looks broken", 1
@@ -430,4 +431,15 @@ def main(argv):
 
 
 if __name__ == "__main__":
-    sys.exit(main(sys.argv[1:]))
+    # Same envelope contract as the sibling scripts: the errors main() knows
+    # about already route through _fail, but anything else — a hand-edited
+    # manifest of the wrong shape, say — would otherwise escape as a
+    # traceback, which reads to callers as neither success nor a reportable
+    # failure.
+    try:
+        _code = main(sys.argv[1:])
+    except Exception as _exc:  # noqa: BLE001 — deliberate catch-all
+        _code = _fail(
+            "unexpected failure: %s: %s" % (type(_exc).__name__, _exc), 2
+        )
+    sys.exit(_code)

--- a/cogni-projects/skills/projects-staff/SKILL.md
+++ b/cogni-projects/skills/projects-staff/SKILL.md
@@ -80,15 +80,16 @@ python3 "${CLAUDE_PLUGIN_ROOT:-$(ls -td "$HOME"/.claude/plugins/cache/*/cogni-pr
 ```
 
 It returns `{"success", "data", "error"}` (exit 0 ok / 1 domain failure / 2
-usage). On `success: false`, surface `error` to the user and stop. A domain
-failure (exit 1) usually means the portfolio directory or its manifest is
-unreadable — but an `error` naming `validate-entities.py` instead means a
-broken or partial plugin install, not a portfolio-data problem; say so rather
-than pointing the user at their entities. On success, `data.projects[]` holds
-only the non-closed projects (closed projects are skipped) and, per project, an
-`open_roles[]` array where each role carries a `candidates[]` list already ranked
-by combined score (best first) and a per-role `excluded_count` of consultants
-dropped for no availability overlap with that project's window.
+usage or unexpected failure). On `success: false`, surface `error` to the user
+and stop. A domain failure (exit 1) usually means the portfolio directory or
+its manifest is unreadable — but an `error` naming `validate-entities.py`
+instead means a broken or partial plugin install, not a portfolio-data
+problem; say so rather than pointing the user at their entities. On success,
+`data.projects[]` holds only the non-closed projects (closed projects are
+skipped) and, per project, an `open_roles[]` array where each role carries a
+`candidates[]` list already ranked by combined score (best first) and a
+per-role `excluded_count` of consultants dropped for no availability overlap
+with that project's window.
 
 ### Step 3: Write the staffing-recommendation artifact
 

--- a/cogni-projects/tests/test_staffing_score.sh
+++ b/cogni-projects/tests/test_staffing_score.sh
@@ -7,7 +7,9 @@
 #      unreadable one — the run still returns its {success, data, error}
 #      envelope rather than a bare traceback,
 #   C. usage and preflight errors still report through that envelope, so B
-#      cannot be satisfied by swallowing every failure.
+#      cannot be satisfied by swallowing every failure,
+#   D. an exception main() has no guard for still reports as an envelope
+#      rather than a bare traceback — the class B pins one instance of.
 #
 # stdlib-only (bash + python3, no pytest/pip), matching the house convention.
 #
@@ -165,6 +167,29 @@ run_score "$STDERRC" "$TMPROOT/not-a-portfolio"
 assert_exit  "3g non-portfolio dir exits 1"      1 "$RUN_CODE"
 assert_json  "3h non-portfolio reports envelope" "d['success'] is False and 'projects-portfolio.json' in d['error']"
 assert_no_traceback "3i non-portfolio stderr is clean" "$STDERRC"
+
+# ---------------------------------------------------------------------------
+# Fixture D — a manifest holding valid JSON of the wrong type parses cleanly,
+# so it survives the manifest-read guard and only fails later, deeper in, with
+# an exception main() has no guard for. Only the module-level catch-all keeps
+# that inside the envelope. No entities are seeded: the failure precedes any
+# entity I/O, so seeding them would imply a dependency that is not there.
+#
+# If a dedicated guard is ever added for a wrong-typed manifest — an
+# isinstance check in score_portfolio would be the natural home, and would
+# report better than the generic catch-all does — this fixture must be
+# re-pointed at an escape that still has no typed home, or it will fail on an
+# improvement rather than a regression.
+# ---------------------------------------------------------------------------
+PFD="$TMPROOT/bad-manifest"
+mkdir -p "$PFD"
+printf '[]' > "$PFD/projects-portfolio.json"
+STDERRD="$TMPROOT/stderr-d.txt"
+
+run_score "$STDERRD" "$PFD"
+assert_exit  "4a wrong-shaped manifest exits 2" 2 "$RUN_CODE"
+assert_json  "4b wrong shape reports envelope"  "d['success'] is False and d['error'].startswith('unexpected failure:')"
+assert_no_traceback "4c wrong shape stderr is clean" "$STDERRD"
 
 if [ "$failures" -gt 0 ]; then
   printf '\n%d assertion(s) failed\n' "$failures" >&2


### PR DESCRIPTION
Closes #1186.

## Summary

`staffing-score.py` was the last of the sibling scripts whose `__main__` called
`main()` bare, so any exception `main()` has no guard for reached the caller as
a traceback instead of the house `{success, data, error}` envelope.

- **The envelope.** `__main__` now wraps `main()` in the same deliberate
  catch-all the siblings carry, emitting
  `{"success": false, "data": {}, "error": "unexpected failure: <Type>: <msg>"}`
  at exit 2. The structural template is `render-dashboard.py`, **not**
  `validate-entities.py` as the issue suggested: the latter's failure `data` is
  `{"errors": [], "warnings": []}`, schema-specific to its own success shape,
  where this script's `_fail` emits bare `{}`. Only the message format and the
  exit code come from the issue's named sibling. This script's `_fail` has no
  default `code`, so `2` is passed explicitly.
- **The regression fixture** pins the *class*, not one path. A manifest holding
  valid JSON of the wrong type (`[]`) parses cleanly, so it survives
  `score_portfolio`'s `except (OSError, ValueError)` manifest-read guard and
  only fails later at `_load_entities`' `manifest.get(...)` with an
  `AttributeError` — which `main()`'s `except RuntimeError` does not catch.
  Verified both ways: the fixture fails red on the unpatched script (exit 1,
  empty stdout, traceback) and green with the change.
- **Two exit-code statements this diff falsifies** are corrected in the same PR:
  the module docstring and `skills/projects-staff/SKILL.md` Step 2 both scoped
  exit 2 to "usage (wrong argument count)".

## Scope decisions

**Included beyond the acceptance criteria:** the docstring and SKILL.md
exit-code corrections. This PR is what makes them wrong — shipping the
behaviour change and deferring the one-clause documentation fix would leave the
plugin's own contract documentation contradicting its code. The SKILL.md edit is
a single in-place clause substitution plus the reflow it forces.

**Considered and deliberately excluded — a shared `unexpected_failure(exc)`
formatter in `_projects_lib.py`.** Four scripts now restate the same message
literal, and `_projects_lib.py` is the declared home for shared primitives, so
this is a real consolidation. It is not done here because it would touch
`validate-entities.py`, `render-dashboard.py`, `register-entity.py` and
`_projects_lib.py` — four files outside this change's scope — and the
`try/except` *structure* genuinely resists sharing, since the four sites do not
agree on a `_fail` signature or a failure `data` shape. Worth its own change.

**Also excluded:** a dedicated fixture for the `exec_module` failure the issue
names as an example. The catch-all now covers it as a class, but forcing it in a
test means corrupting the real sibling script on disk, which makes it a poor
regression vector.

**No version bump** — the post-merge workflow owns that, per repo convention.

## A note for the reviewer

Fixture D asserts the *generic* catch-all message for a failure that arguably
deserves a typed guard of its own: an `isinstance(manifest, dict)` check inside
`score_portfolio`'s existing `try` would report "manifest is not a JSON object"
rather than `AttributeError: 'list' object has no attribute 'get'`. That would
be a genuine improvement, and it would break `4a`/`4b`. The fixture's comment
says so explicitly, so a future editor re-points it at an escape that still has
no typed home rather than reading the failure as a regression. Flagging it here
because it is the one place this PR pins behaviour that a later change should be
free to improve.

## Test plan

- [x] `bash cogni-projects/tests/test_staffing_score.sh` — green, including the
      new `4a`/`4b`/`4c`.
- [x] Red-check: with only the `__main__` change reverted, `4a`/`4b`/`4c` all
      fail (exit 1, empty stdout, traceback on stderr). The fixture does not
      pass vacuously.
- [x] The four sibling suites still pass — `test-render-dashboard.sh`,
      `test_portfolio_init.sh`, `test_register_entity.sh`,
      `test_validate_entities_refs.sh`. `tests/fixtures/test_helpers.sh` is
      untouched.
- [x] Manual: a wrong-shaped manifest prints one envelope line on stdout, zero
      bytes on stderr, exit 2.
- [x] Handled paths unchanged: no-args still exits 2 with the `usage:` envelope,
      a missing directory still exits 1 — the catch-all did not swallow the
      existing `_fail` contract.
- [x] Gates: `check-breadcrumbs.py` clean (0 violations), `check-version-bump.py`
      `ok` (0 plugins touched), `check-frontmatter.sh` clean (0 offenders),
      `measure-skill-length.sh` 9,335 / 18,000 chars (`over_cap: false`).