### PR TITLE
cogni-projects: one case-insensitive treatment of project status in the dashboard

### DIFF
--- a/cogni-projects/references/data-model.md
+++ b/cogni-projects/references/data-model.md
@@ -133,6 +133,14 @@ Valid `status` values:
 | `active` | In delivery |
 | `closed` | Delivered or lost |
 
+The dashboard and the staffing scorer both read `status` case-insensitively,
+after stripping surrounding whitespace, so the two agree on which projects are
+still live; the dashboard additionally reports any record it had to normalize
+and renders the normalized value. The schema is the stricter of the two and
+admits only the lowercase spellings above, so `status: Closed` is still a
+validation failure — the readers' tolerance keeps one hand-edited record from
+skewing a partner meeting, it does not widen what the record may say.
+
 `open_roles` is a list of role labels the project still needs staffed.
 
 The staffing engine matches an `open_roles` label against a consultant's
@@ -190,6 +198,9 @@ Valid `status` values:
 | `planned` | Committed but not yet started |
 | `active` | Consultant currently on the project |
 | `completed` | Assignment finished |
+
+The dashboard reads this `status` the way it reads a project's, so a hand-edited
+`Active` still counts the assignment as covering its role.
 
 ---
 

--- a/cogni-projects/scripts/render-dashboard.py
+++ b/cogni-projects/scripts/render-dashboard.py
@@ -70,6 +70,12 @@ DEFAULT_THEME = {
 # completed assignment no longer staffs an open role.
 ACTIVE_ASSIGNMENT_STATES = ("planned", "active")
 
+# Named so a status *comparison* is distinguishable at a glance from a status
+# *label* the renderer prints — "closed" is both, and only the comparison
+# depends on _status_text having normalized its input. See _status_text.
+PROJECT_STATUS_CLOSED = "closed"
+PROJECT_STATUS_ACTIVE = "active"
+
 # Theme values are interpolated into the <style> block rather than into escaped
 # text nodes, so a value carrying CSS-structural or markup characters could
 # close the stylesheet and inject arbitrary markup into the self-contained HTML.
@@ -202,7 +208,7 @@ def _project_health(filled, open_roles, status):
     the same green as a fully staffed project would show an unstaffed project as
     healthy on a partner's decision surface, so it gets its own warn state.
     """
-    if status == "closed":
+    if status == PROJECT_STATUS_CLOSED:
         return ("closed", "muted")
     if open_roles is None:
         return ("staffing unknown", "warn")
@@ -211,7 +217,7 @@ def _project_health(filled, open_roles, status):
         return ("no open roles", "ok")
     if filled >= total:
         return ("fully staffed", "ok")
-    if filled == 0 and status == "active":
+    if filled == 0 and status == PROJECT_STATUS_ACTIVE:
         return ("unstaffed", "risk")
     return ("%d/%d roles open" % (total - filled, total), "warn")
 
@@ -219,19 +225,11 @@ def _project_health(filled, open_roles, status):
 def _is_closed(status):
     """Whether a project status means the work is over — delivered or lost.
 
-    Matches case-insensitively, the way staffing-score.py does, so the dashboard
-    and the staffing shortlist agree on which projects are still live.
-
-    Two older checks in this file — _project_health's `status == "closed"` and
-    the warning gate in _compute — compare the literal case-sensitively and are
-    deliberately left alone here, since switching them changes what a row
-    renders. That means a non-conforming `status: Closed` is read as closed by
-    this predicate but not by those two, so the tile and the row would disagree.
-    The schema only admits lowercase `closed`, so that split needs a record that
-    already failed validation; unify the three when one is willing to take the
-    rendering change.
+    Takes a status _status_text has already normalized — this compares, it does
+    not fold. Passing a raw frontmatter value here reads a mixed-case `Closed`
+    as still live.
     """
-    return str(status or "").strip().lower() == "closed"
+    return status == PROJECT_STATUS_CLOSED
 
 
 def _text_field(raw, field, label, warnings):
@@ -276,8 +274,33 @@ def _text_field(raw, field, label, warnings):
 
 
 def _status_text(raw, label, warnings):
-    """Read an entity's `status` as text. See _text_field for the why."""
-    return _text_field(raw, "status", label, warnings)
+    """Read an entity's `status` as normalized text. See _text_field for the why.
+
+    The single place a status is folded to lower case, so the health flag, the
+    missing-open_roles gate, _is_closed, the assignment-state check and the
+    rendered row all read one string. Folding at each site instead would satisfy
+    the same tests while rebuilding the drift this exists to remove. Only
+    `status` is folded — role labels and open_roles entries are free text
+    matched by exact equality, so case-folding them would change what counts as
+    a filled role.
+
+    A status that had to be normalized is reported, like every other
+    schema-deviating record here: the schema admits only the lowercase value, so
+    `Closed` is a record to fix, not a spelling to accept quietly.
+
+    The isinstance guard keeps one defect to one warning. _text_field returns
+    str(raw).strip() for a non-string and has already warned about it, and a
+    list-valued `status: [Closed]` arrives as "['Closed']" — whose folded form
+    differs, so ungated it would report the same record twice.
+    """
+    text = _text_field(raw, "status", label, warnings)
+    normalized = text.lower()
+    if isinstance(raw, str) and normalized != text:
+        warnings.append(
+            "%s has a non-lowercase status %r — normalized to %r; fix the record"
+            % (label, text, normalized)
+        )
+    return normalized
 
 
 def _open_role_demand(projects):
@@ -323,7 +346,7 @@ def _compute(entities, warnings):
         # declared count.
         open_roles = [_text_field(r, "open_roles entry", label, warnings) for r in (declared_roles or [])]
         status = _status_text(proj.get("status"), label, warnings)
-        if declared_roles is None and status != "closed":
+        if declared_roles is None and status != PROJECT_STATUS_CLOSED:
             warnings.append("%s has no open_roles — staffing status unknown" % label)
 
         covered = set()
@@ -333,6 +356,8 @@ def _compute(entities, warnings):
             if a.get("project") != slug:
                 continue
             a_label = "assignment %s" % (a.get("_file") or a.get("slug") or "(unknown)")
+            # Normalized too, deliberately: exempting assignment status would
+            # rebuild the split one call site over.
             if _status_text(a.get("status"), a_label, warnings) in ACTIVE_ASSIGNMENT_STATES:
                 role = _text_field(a.get("role"), "role", a_label, warnings)
                 if role:

--- a/cogni-projects/skills/projects-dashboard/SKILL.md
+++ b/cogni-projects/skills/projects-dashboard/SKILL.md
@@ -155,13 +155,15 @@ never from this example:
 - **Partial snapshots are expected mid-authoring.** Any of these is reported in
   the warnings list, not treated as an error: a project without a
   `strategic_impact`, a project that omits `open_roles`, an entity whose
-  `status`, role label, or `open_roles` entry is not text, or an entity file
-  that cannot be read or decoded. A non-text value — `status: 2026`, `role: 2`,
-  or `open_roles: [2]` — is read as a number, then coerced back to text. Both
-  sides of the role comparison are coerced, so a numeric role still matches its
-  numeric `open_roles` entry and still counts as filled: such a warning says to
-  fix the record, not that the coverage figure beside it is wrong. One bad
-  record never costs the rest of the portfolio.
+  `status`, role label, or `open_roles` entry is not text, an entity whose
+  `status` is text but not lowercase, or an entity file that cannot be read or
+  decoded. A non-text value — `status: 2026`, `role: 2`, or `open_roles: [2]` —
+  is read as a number, then coerced back to text; a `status: Closed` is read
+  case-insensitively and reported normalized. Both sides of the role comparison
+  are coerced, so a numeric role still matches its numeric `open_roles` entry
+  and still counts as filled. The non-text warning and the not-lowercase warning
+  both say to fix the record, not that the coverage figure or flag beside it is
+  wrong. One bad record never costs the rest of the portfolio.
 - **Theming is optional.** The dashboard renders with a built-in palette;
   pass `--design-variables <path.json>` to override colors when a themed look is
   wanted.

--- a/cogni-projects/skills/projects-dashboard/SKILL.md
+++ b/cogni-projects/skills/projects-dashboard/SKILL.md
@@ -158,12 +158,13 @@ never from this example:
   `status`, role label, or `open_roles` entry is not text, an entity whose
   `status` is text but not lowercase, or an entity file that cannot be read or
   decoded. A non-text value — `status: 2026`, `role: 2`, or `open_roles: [2]` —
-  is read as a number, then coerced back to text; a `status: Closed` is read
-  case-insensitively and reported normalized. Both sides of the role comparison
-  are coerced, so a numeric role still matches its numeric `open_roles` entry
-  and still counts as filled. The non-text warning and the not-lowercase warning
-  both say to fix the record, not that the coverage figure or flag beside it is
-  wrong. One bad record never costs the rest of the portfolio.
+  is read as a number, then coerced back to text. A status authored in mixed
+  case — `status: Closed` — is read case-insensitively and reported normalized.
+  Both sides of the role comparison are coerced, so a numeric role still matches
+  its numeric `open_roles` entry and still counts as filled. The non-text warning
+  and the not-lowercase warning both say to fix the record, not that the coverage
+  figure or flag beside it is wrong. One bad record never costs the rest of the
+  portfolio.
 - **Theming is optional.** The dashboard renders with a built-in palette;
   pass `--design-variables <path.json>` to override colors when a themed look is
   wanted.

--- a/cogni-projects/tests/test-render-dashboard.sh
+++ b/cogni-projects/tests/test-render-dashboard.sh
@@ -688,8 +688,8 @@ assert_html "11l clean sibling project still rendered" "Clean Delivery" "$HTML11
 # before and after. The assignment's `status: Active` is the case that changes
 # the total.
 #
-# 12d is row-scoped on purpose. `Clean Closed` renders `<td>closed</td>` and
-# `>closed</span>` on base too, so either needle alone would pass against the
+# 12d and 12s are row-scoped on purpose. `Clean Closed` renders `<td>closed</td>`
+# and `>closed</span>` on base too, so either needle alone would pass against the
 # unfixed script while pinning nothing.
 #
 # 12j is the control for the other direction: _text_field already strips, so a
@@ -771,6 +771,20 @@ status: Closed
 ---
 # Roleless Cased
 EOF
+# The padded spelling with no open_roles at all. Roleless Cased deviates by case
+# and Padded Only declares roles, so neither one reaches the missing-open_roles
+# gate by way of padding — this record is the one that does.
+write_entity "$PF12/projects/roleless-padded.md" <<'EOF'
+---
+type: project
+slug: roleless-padded
+name: Roleless Padded
+client: PadRolelessCo
+strategic_impact: 2
+status: ' closed '
+---
+# Roleless Padded
+EOF
 write_entity "$PF12/projects/cased-active.md" <<'EOF'
 ---
 type: project
@@ -794,6 +808,20 @@ status: Prospective
 open_roles: [scout-lead]
 ---
 # Cased Prospective
+EOF
+# The schema-conforming spelling of the same state. Without it the active-only
+# allowlist regression is guarded for `Prospective` but not for `prospective`.
+write_entity "$PF12/projects/plain-prospective.md" <<'EOF'
+---
+type: project
+slug: plain-prospective
+name: Plain Prospective
+client: PipelineCo
+strategic_impact: 3
+status: prospective
+open_roles: [pipeline-lead]
+---
+# Plain Prospective
 EOF
 write_entity "$PF12/projects/statusless.md" <<'EOF'
 ---
@@ -834,7 +862,7 @@ status: Active
 # assignment
 EOF
 
-# Its own stderr sink, as 12o asserts a traceback never reached it.
+# Its own stderr sink, as 12r asserts a traceback never reached it.
 STDERR12="$TMPROOT/stderr12.txt"
 RUN_ERRFILE="$STDERR12"
 run "$PF12"
@@ -846,17 +874,17 @@ assert_json "12c every cased-closed spelling reads as closed" \
   "all(any(p['name'] == n and p['health_label'] == 'closed' and p['health_sev'] == 'muted' for p in d['data']['projects_detail']) for n in ('Cased Closed', 'Shouty Closed', 'Padded Closed'))"
 # Scoped to the Cased Closed row: the status cell is a bare <td>%s</td> right
 # after the name cell, so this pins the rendered value for one known project.
-assert_json "12e envelope reports the normalized status" \
-  "any(p['name'] == 'Cased Closed' and p['status'] == 'closed' for p in d['data']['projects_detail'])"
 assert_html "12d Status column renders the normalized value" \
   "<td><strong>Cased Closed</strong><div class='sub'>CasedCo</div></td><td>closed</td>" "$HTML12"
-# Six closed projects drop out, Roleless Cased declares none, and the host's one
-# role is filled by an assignment whose 'Active' now normalizes — leaving Cased
-# Active, Cased Prospective and Statusless.
+assert_json "12e envelope reports the normalized status" \
+  "any(p['name'] == 'Cased Closed' and p['status'] == 'closed' for p in d['data']['projects_detail'])"
+# Seven closed projects drop out, two of which declare no roles at all, and the
+# host's one role is filled by an assignment whose 'Active' now normalizes —
+# leaving Cased Active, Cased Prospective, Plain Prospective and Statusless.
 assert_json "12f open roles exclude every closed spelling" \
-  "d['data']['open_roles'] == 3"
+  "d['data']['open_roles'] == 4"
 assert_html "12g tile agrees with the envelope" \
-  '<div class="n">3</div><div class="l">Open roles</div>' "$HTML12"
+  '<div class="n">4</div><div class="l">Open roles</div>' "$HTML12"
 assert_json "12h cased-closed project without open_roles is not nagged" \
   "sum('staffing status unknown' in w and 'Roleless Cased' in w for w in d['data']['warnings']) == 0"
 assert_json "12i normalization reported once for the deviating record" \
@@ -879,8 +907,23 @@ assert_html "12o risk flag rendered" "unstaffed" "$HTML12"
 # per project while `any(...)` stayed green.
 assert_json "12p cased assignment fills its role and says it was normalized" \
   "any(p['name'] == 'Cased Assignment Host' and p['roles_filled'] == 1 for p in d['data']['projects_detail']) and sum('normalized to' in w and 'cased-assignment.md' in w for w in d['data']['warnings']) == 1"
-assert_json "12q every project still counted"    "d['data']['projects'] == 10"
+assert_json "12q every project still counted"    "d['data']['projects'] == 12"
 assert_no_traceback "12r no traceback on stderr" "$STDERR12"
+# The health flag is the other half of what 12d pins, and #9aa7b4 is
+# DEFAULT_THEME['muted'], so reaching the closing tag pins the rendered severity
+# in HTML the way 12c pins it in the envelope. `migration-lead, data-engineer`
+# is unique to this row, so anchoring there scopes the needle without coupling
+# it to the name markup, star glyph or coverage format.
+assert_html "12s mixed-case closed row renders the closed health flag" \
+  "<td>migration-lead, data-engineer</td><td><span class='flag' style='color:#9aa7b4'>closed</span>" "$HTML12"
+# The schema-conforming half of 12m — same divergence, spelled the way the
+# schema asks for, so the allowlist regression is pinned for both spellings.
+assert_json "12t plain prospective is live demand too" \
+  "any(p['name'] == 'Plain Prospective' and p['roles_total'] - p['roles_filled'] == 1 for p in d['data']['projects_detail'])"
+# A control in 12j's sense: padding alone was always stripped, so this passes on
+# base too. It exists to pin that the padded spelling reaches the gate at all.
+assert_json "12u padded closed without open_roles is not nagged either" \
+  "sum('staffing status unknown' in w and 'Roleless Padded' in w for w in d['data']['warnings']) == 0 and any(p['name'] == 'Roleless Padded' and p['health_label'] == 'closed' for p in d['data']['projects_detail'])"
 
 echo
 if [ "$failures" -eq 0 ]; then

--- a/cogni-projects/tests/test-render-dashboard.sh
+++ b/cogni-projects/tests/test-render-dashboard.sh
@@ -674,6 +674,214 @@ assert_html "11k open-roles tile agrees with the envelope" \
   '<div class="n">0</div><div class="l">Open roles</div>' "$HTML11"
 assert_html "11l clean sibling project still rendered" "Clean Delivery" "$HTML11"
 
+# ---------------------------------------------------------------------------
+# Fixture 12 — a status whose case does not match the schema. The file used to
+# read `status` three ways: the health flag and the missing-open_roles gate
+# compared the literal case-sensitively, while _is_closed lower-cased first. So
+# one `status: Closed` record was dropped from the open-roles total and
+# simultaneously rendered as not-closed — the tile and the row disagreed about
+# the same project. Every status now goes through one normalizing reader.
+#
+# 12f is the discriminator, and the assignment is what makes it one: the closed
+# projects were already excluded on base (_is_closed lower-cased them), so a
+# fixture built only from mixed-case *projects* would have counted the same
+# before and after. The assignment's `status: Active` is the case that changes
+# the total.
+#
+# 12d is row-scoped on purpose. `Clean Closed` renders `<td>closed</td>` and
+# `>closed</span>` on base too, so either needle alone would pass against the
+# unfixed script while pinning nothing.
+#
+# 12j is the control for the other direction: _text_field already strips, so a
+# padding-only status normalized silently before this change and must keep
+# doing so. Without it a reader could take the new warning to mean whitespace.
+# ---------------------------------------------------------------------------
+PF12="$TMPROOT/mixed-case-status"
+seed_portfolio "$PF12"
+write_entity "$PF12/projects/cased-closed.md" <<'EOF'
+---
+type: project
+slug: cased-closed
+name: Cased Closed
+client: CasedCo
+strategic_impact: 4
+status: Closed
+open_roles: [migration-lead, data-engineer]
+---
+# Cased Closed
+EOF
+write_entity "$PF12/projects/shouty-closed.md" <<'EOF'
+---
+type: project
+slug: shouty-closed
+name: Shouty Closed
+client: ShoutCo
+strategic_impact: 3
+status: CLOSED
+open_roles: [ops-lead]
+---
+# Shouty Closed
+EOF
+# Quoted so the frontmatter parser keeps the inner spaces — it strips the raw
+# value before it strips the quotes, so an unquoted padding never survives.
+write_entity "$PF12/projects/padded-closed.md" <<'EOF'
+---
+type: project
+slug: padded-closed
+name: Padded Closed
+client: PadCo
+strategic_impact: 2
+status: ' Closed '
+open_roles: [qa-lead]
+---
+# Padded Closed
+EOF
+write_entity "$PF12/projects/padded-only.md" <<'EOF'
+---
+type: project
+slug: padded-only
+name: Padded Only
+client: OnlyCo
+strategic_impact: 2
+status: ' closed '
+open_roles: [ops-analyst]
+---
+# Padded Only
+EOF
+write_entity "$PF12/projects/clean-closed.md" <<'EOF'
+---
+type: project
+slug: clean-closed
+name: Clean Closed
+client: CleanCo
+strategic_impact: 3
+status: closed
+open_roles: [doc-lead]
+---
+# Clean Closed
+EOF
+write_entity "$PF12/projects/roleless-cased.md" <<'EOF'
+---
+type: project
+slug: roleless-cased
+name: Roleless Cased
+client: RolelessCo
+strategic_impact: 2
+status: Closed
+---
+# Roleless Cased
+EOF
+write_entity "$PF12/projects/cased-active.md" <<'EOF'
+---
+type: project
+slug: cased-active
+name: Cased Active
+client: ActiveCo
+strategic_impact: 5
+status: Active
+open_roles: [architect]
+---
+# Cased Active
+EOF
+write_entity "$PF12/projects/cased-prospective.md" <<'EOF'
+---
+type: project
+slug: cased-prospective
+name: Cased Prospective
+client: ProspectCo
+strategic_impact: 3
+status: Prospective
+open_roles: [scout-lead]
+---
+# Cased Prospective
+EOF
+write_entity "$PF12/projects/statusless.md" <<'EOF'
+---
+type: project
+slug: statusless
+name: Statusless
+client: NoStatusCo
+strategic_impact: 2
+open_roles: [analyst]
+---
+# Statusless
+EOF
+write_entity "$PF12/projects/assign-host.md" <<'EOF'
+---
+type: project
+slug: assign-host
+name: Cased Assignment Host
+client: HostCo
+strategic_impact: 4
+status: active
+open_roles: [engineer]
+---
+# Cased Assignment Host
+EOF
+# The project is spelled correctly and the role matches, so the assignment's own
+# status is the only thing that decides whether the role reads as filled.
+write_entity "$PF12/assignments/cased-assignment.md" <<'EOF'
+---
+type: assignment
+slug: rio--assign-host
+consultant: rio
+project: assign-host
+role: engineer
+start_date: 2026-02-01
+end_date: 2026-08-01
+status: Active
+---
+# assignment
+EOF
+
+# Its own stderr sink, as 12o asserts a traceback never reached it.
+STDERR12="$TMPROOT/stderr12.txt"
+RUN_ERRFILE="$STDERR12"
+run "$PF12"
+HTML12="$PF12/output/dashboard.html"
+
+assert_json "12a mixed-case portfolio still succeeds" "d['success'] is True"
+assert_json "12b marked partial"                      "d['data']['partial'] is True"
+assert_json "12c every cased-closed spelling reads as closed" \
+  "all(any(p['name'] == n and p['health_label'] == 'closed' and p['health_sev'] == 'muted' for p in d['data']['projects_detail']) for n in ('Cased Closed', 'Shouty Closed', 'Padded Closed'))"
+# Scoped to the Cased Closed row: the status cell is a bare <td>%s</td> right
+# after the name cell, so this pins the rendered value for one known project.
+assert_json "12e envelope reports the normalized status" \
+  "any(p['name'] == 'Cased Closed' and p['status'] == 'closed' for p in d['data']['projects_detail'])"
+assert_html "12d Status column renders the normalized value" \
+  "<td><strong>Cased Closed</strong><div class='sub'>CasedCo</div></td><td>closed</td>" "$HTML12"
+# Six closed projects drop out, Roleless Cased declares none, and the host's one
+# role is filled by an assignment whose 'Active' now normalizes — leaving Cased
+# Active, Cased Prospective and Statusless.
+assert_json "12f open roles exclude every closed spelling" \
+  "d['data']['open_roles'] == 3"
+assert_html "12g tile agrees with the envelope" \
+  '<div class="n">3</div><div class="l">Open roles</div>' "$HTML12"
+assert_json "12h cased-closed project without open_roles is not nagged" \
+  "sum('staffing status unknown' in w and 'Roleless Cased' in w for w in d['data']['warnings']) == 0"
+assert_json "12i normalization reported once for the deviating record" \
+  "sum('normalized to' in w and 'Cased Closed' in w for w in d['data']['warnings']) == 1"
+assert_json "12j conforming status reports nothing" \
+  "sum('normalized to' in w and 'Clean Closed' in w for w in d['data']['warnings']) == 0"
+assert_json "12k padding alone was always stripped, and still says nothing" \
+  "sum('normalized to' in w and 'Padded Only' in w for w in d['data']['warnings']) == 0 and any(p['name'] == 'Padded Only' and p['health_label'] == 'closed' for p in d['data']['projects_detail'])"
+assert_json "12l absent status is not closed and needs no normalizing" \
+  "sum('normalized to' in w and 'Statusless' in w for w in d['data']['warnings']) == 0 and any(p['name'] == 'Statusless' and p['status'] == 'unknown' for p in d['data']['projects_detail'])"
+# prospective is live demand, not an active-only allowlist — the same
+# divergence in the other direction _open_role_demand's docstring warns about.
+assert_json "12m cased prospective still counts as demand" \
+  "any(p['name'] == 'Cased Prospective' and p['roles_total'] - p['roles_filled'] == 1 for p in d['data']['projects_detail'])"
+assert_json "12n cased active still reaches the risk branch" \
+  "any(p['name'] == 'Cased Active' and p['health_sev'] == 'risk' for p in d['data']['projects_detail'])"
+assert_html "12o risk flag rendered" "unstaffed" "$HTML12"
+# Counted for the same reason as 10e and 11c: the assignment status is read
+# inside _compute's per-project slug filter, so hoisting it out would warn once
+# per project while `any(...)` stayed green.
+assert_json "12p cased assignment fills its role and says it was normalized" \
+  "any(p['name'] == 'Cased Assignment Host' and p['roles_filled'] == 1 for p in d['data']['projects_detail']) and sum('normalized to' in w and 'cased-assignment.md' in w for w in d['data']['warnings']) == 1"
+assert_json "12q every project still counted"    "d['data']['projects'] == 10"
+assert_no_traceback "12r no traceback on stderr" "$STDERR12"
+
 echo
 if [ "$failures" -eq 0 ]; then
   echo "All render-dashboard tests passed."


### PR DESCRIPTION
Closes #1160.

## Summary

`_status_text` becomes the single normalization site: it reads the field through `_text_field` (which already strips and warns on a non-string), folds the result to lower case, and appends one `… has a non-lowercase status 'Closed' — normalized to 'closed'; fix the record` warning when the folded value differs from what was authored. A conforming status emits nothing. This is the only `.lower()` in the file.

Because `_compute`'s `status = _status_text(proj.get("status"), …)` is the **single** read of raw frontmatter status, that one change propagates to all four sites the issue names: `_project_health`'s two literals, the missing-`open_roles` gate, and — via the stored `"status"` value — `_is_closed`. The rendered Status column and `data.projects_detail[].status` show the normalized value for the same reason: both already read that one local.

The two surviving literal comparisons now read `PROJECT_STATUS_CLOSED` / `PROJECT_STATUS_ACTIVE`, declared beside `ACTIVE_ASSIGNMENT_STATES`, and `_is_closed` compares the already-normalized value instead of folding again. Its stale rationale paragraph — *"deliberately left alone here … unify the three when one is willing to take the rendering change"* — is replaced by a statement of the now-unified rule and the precondition it depends on.

## Scope decisions

- **Direction: case-insensitive + stripped**, per the ratified decision — what `staffing-score.py` already does, so the dashboard headline and the staffing shortlist stay in agreement. `staffing-score.py` is therefore not touched.
- **The assignment-status site is normalized too — this is the explicit call the acceptance criteria left open.** `_status_text` is the single reader for both project and assignment status; exempting one would rebuild the split one call site over. Consequence: an assignment authored `status: Active` now fills its role and reports one normalization warning. Assertion `12p` pins it, and a comment at the call site records the decision. Lowercase behaviour is unchanged, so Fixture 1's `1h` and Fixture 11's `11f`/`11g` stay green.
- **The `isinstance(raw, str)` guard on the new warning is load-bearing.** `_text_field` returns `str(raw).strip()` for a non-string and has already warned about it; a list-valued `status: [Closed]` arrives as `"['Closed']"`, whose folded form differs. Ungated, one record collects two warnings for one defect — demonstrated below.
- **Stripping is not new.** The parser preserves the inner spaces of a quoted `status: ' closed '`, but `_text_field` already strips them, so a padding-only status normalized silently before this change and still does. A control project pins that, so the new warning is not misread as a whitespace rule.
- **Not touched:** `validate-entities.py` — `status: Closed` must and does still **fail** validation. The reader's tolerance keeps one hand-edited record from skewing a partner meeting; it does not widen what a record may say.
- **Not case-folded:** role labels and `open_roles` entries. They are free text matched by exact equality; one-sided coercion there would report a filled role as open (Fixture 11 is the tripwire).
- **No version bump** — the patch bump is applied post-merge per touched plugin.
- **Partner-visible:** any hand-edited record with a mixed-case status now renders its normalized value and takes the closed/active branch the demand total already counted it under. That is the point of the change, and it ships with a warning row so the operator can fix the record.

### Grep note for the reviewer

After this change `grep -nE '"closed"|"active"'` still shows four hits: the two constant definitions, the `("planned", "active")` assignment-state tuple, and `_project_health`'s `return ("closed", "muted")` — the last is a display **label**, not a comparison. That collision is exactly why the constants exist: they make a status *comparison* distinguishable at a glance from the identically-spelled label. No comparison reads an un-normalized `proj.get("status")`.

## Test plan

New **Fixture 12** (ten projects + one assignment) covers `Closed` / `CLOSED` / `' Closed '` / `' closed '` / `closed` / absent / `Active` / `Prospective`, warning cardinality in both directions, and the assignment case.

- [x] `bash cogni-projects/tests/test-render-dashboard.sh` exits 0, prints `All render-dashboard tests passed.`
- [x] The other four cogni-projects suites all exit 0.
- [x] **Mutation check A** — Fixture 12 against the unmodified `origin/main` script: **9 assertions fail** (`12c 12d 12e 12f 12g 12h 12i 12n 12p`). The fixture pins something real.
- [x] **Mutation check B** — dropping the `isinstance(raw, str)` guard makes a `status: [Closed]` record collect two warnings for one defect (`non-string status …` *and* `non-lowercase status "['Closed']" — normalized to "['closed']"`). With the guard, one.
- [x] `grep -n 'lower()' cogni-projects/scripts/render-dashboard.py` → exactly one match, inside `_status_text`.
- [x] A project authored `status: Closed` still **fails** `validate-entities.py`: `invalid value 'Closed' (allowed: prospective, active, closed)`.
- [x] `python3 scripts/check-version-bump.py` → `0 touched, 0 violation(s)`.
- [x] `python3 scripts/check-breadcrumbs.py` → 0 violations.
- [x] `check-frontmatter.sh` exit 0.
- [x] Fixture 9's `9h`/`9i` and Fixture 10's `10a`–`10h` present and unmodified.

## Review notes

Two things surfaced during the quality passes that are **not** addressed here, deliberately:

1. **`staffing-score.py` parity has no mechanism behind it.** This PR unifies four call sites inside `render-dashboard.py`, but the peer normalization in `staffing-score.py` is still inline at its comparison site — the same shape, one level up. The docs now assert the two agree, with nothing enforcing it. The deep version is a pure `normalize_status(raw) -> str` in the existing `_projects_lib.py` seam. It is out of scope here: this issue's acceptance criteria hold `staffing-score.py` out of the diff unless the unification went case-*sensitively*, which it did not. Worth its own issue.

2. **`skills/projects-dashboard/SKILL.md`'s warning enumeration is incomplete beyond this change.** The skill-quality gate flagged it, and checking the renderer confirms more gaps than it named: the list omits a non-numeric or out-of-range `strategic_impact` (`render-dashboard.py:177`, `:180`), an assignment role label matching no `open_roles` entry (`:369`), and a non-numeric `allocation_pct` (`:404`) — all of which Step 4 is told to relay. This PR adds only the class it ships and fixes an ambiguous referent it introduced; completing the enumeration is pre-existing drift and would half-fix in a way that implies the list is now exhaustive. Flagged for a follow-up rather than folded in.