### PR TITLE
cogni-help: bound the label-validation query in gh-issues-helper

### DIFF
--- a/cogni-help/skills/cogni-issues/scripts/gh-issues-helper.sh
+++ b/cogni-help/skills/cogni-issues/scripts/gh-issues-helper.sh
@@ -137,7 +137,10 @@ print(json.dumps({
     [ -z "$BODY_FILE" ] && { emit_error "create: --body-file is required"; exit 1; }
     [ ! -f "$BODY_FILE" ] && { emit_error "create: body file not found" path "$BODY_FILE"; exit 1; }
     if [ -n "$LABELS_CSV" ]; then
-      EXISTING_LABELS=$(gh label list --repo "$REPO" --json name --jq '.[].name' 2>/dev/null || true)
+      # --limit is required: gh label list defaults to 30, so on a repo with more
+      # labels than that the ones past the first page read as missing and the
+      # check below rejects a label that exists.
+      EXISTING_LABELS=$(gh label list --repo "$REPO" --limit 1000 --json name --jq '.[].name' 2>/dev/null || true)
       MISSING=""
       IFS=',' read -r -a LABEL_ARR <<< "$LABELS_CSV"
       for LBL in "${LABEL_ARR[@]}"; do


### PR DESCRIPTION
Closes #1199.

## Description

`cogni-issues`' create path validates requested labels against the target repo before invoking `gh issue create`, so a missing label fails fast instead of half-creating an issue without its type label. That validation query was unbounded:

```bash
EXISTING_LABELS=$(gh label list --repo "$REPO" --json name --jq '.[].name' 2>/dev/null || true)
```

`gh label list` defaults to `--limit 30`. On any repo with more than 30 labels, every label past the first page is absent from `EXISTING_LABELS`, the membership check at `:146` records it as missing, and `:153` emits `create: label(s) missing from repo` and exits **before** `gh issue create` runs — so the issue is never filed at all.

The failure is silent in the sense that matters: the error names labels that do exist, so the reported cause is wrong and the suggested remedy ("Create the label on GitHub or omit it from `--labels`") is the opposite of what's needed.

**This repo is affected.** `cogni-work/insight-wave` carries 50 labels, so 20 of them sit past the cut — and they are disproportionately the ones the service pipeline passes to `create`:

| Position | Label |
|---|---|
| 32 | `svc:plan-recorded` |
| 38 | `svc:deferred` |
| 39 | `svc:has-followups` |
| 42 | `cogni-consult` |
| 44 | `svc:needs-review` |
| 48 | `svc:needs-human-review` |

Measured live:

```
$ gh label list --repo cogni-work/insight-wave --json name --jq 'length'
30
$ gh label list --repo cogni-work/insight-wave --limit 1000 --json name --jq 'length'
50
```

The severity labels sort early (`bug` 1, `enhancement` 4, `S3-minor` 17) and so were never affected — which is why the bug reads as intermittent rather than total: filing with a severity label alone succeeds, and adding any `svc:*` or plugin label fails with a wrong diagnosis.

## Changes

- `cogni-help/skills/cogni-issues/scripts/gh-issues-helper.sh:140` — pass `--limit 1000` so the validator sees the repo's whole label set, with a comment recording why the flag is load-bearing.

This was the only unbounded `gh` list call in the script; the `list` (`:208`, via `GH_ARGS`) and `search` (`:241`) paths already pass `--limit` explicitly. No behaviour change for repos at or under 30 labels.

No version bump — the post-merge workflow owns it.

## Testing

**Stub run.** `gh` was not available when this change was written, so the create path was first exercised against a stub reproducing gh's documented default: a 45-label repo, `label list` honouring `--limit` and defaulting to 30, with the requested labels sorting past the first page.

Against the pre-fix script (`git show HEAD:…`):

```json
{"error": "create: label(s) missing from repo", "repo": "cogni-work/managed-service", "missing_labels": "enhancement,S3-minor", "hint": "Create the label on GitHub or omit it from --labels"}
exit=1
```

Against the fixed script, same stub, same arguments:

```json
{"status": "created", "number": 708, "url": "https://github.com/cogni-work/managed-service/issues/708", "title": "T", "labels": ["enhancement", "S3-minor"]}
exit=0
```

`bash -n` clean.

**Live verification (added after the fact).** The stub was built against an *inferred* failure, not an observed one, and the inference was wrong in its specifics: on `cogni-work/managed-service` (45 labels), `enhancement` and `S3-minor` sit at positions **4** and **24** — both inside the first page. That pair would not have tripped the bug. The stub still validates the fix, but the scenario it modelled did not occur.

What the truncation does do, verified against both repos:

```
$ gh label list --repo cogni-work/managed-service --json name --jq 'length'
30
$ gh label list --repo cogni-work/managed-service --limit 1000 --json name --jq 'length'
45

$ gh label list --repo cogni-work/insight-wave --json name --jq 'length'
30
$ gh label list --repo cogni-work/insight-wave --limit 1000 --json name --jq 'length'
50
```

`gh label list --repo <r> --json name --jq 'length'` returning exactly 30 is the tell that a repo is affected. Both repos this pipeline manages are.

## Not fixed here

The `2>/dev/null || true` on the same line means a *failed* `gh label list` (auth expiry, network, bad repo) also yields an empty set and produces this same misleading "label(s) missing" error for an unrelated cause. Deliberately out of scope for this one-line fix; filed separately as #1198.

## Checklist

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md)
- [x] My changes follow the existing code style
- [ ] I have updated documentation where applicable — none needed; `SKILL.md`'s description of the validation behaviour stays accurate, and is now true in a case where it previously wasn't
- [x] I have tested my changes

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
