### PR TITLE
cogni-projects: warn on orphan assignment project references

### DIFF
--- a/cogni-projects/scripts/render-dashboard.py
+++ b/cogni-projects/scripts/render-dashboard.py
@@ -388,6 +388,63 @@ def _compute(entities, warnings):
             "health_sev": health_sev,
         })
 
+    # Orphan assignments: an assignment whose `project` names no project in the
+    # portfolio — a typo, or a project file since deleted. It matches no slug on
+    # any iteration of the loop above, so without this it is skipped silently by
+    # every one of them and reduces role coverage with nothing said.
+    #
+    # One pass over `assignments`, deliberately OUTSIDE that loop: nested inside
+    # it this would warn once per project per orphan, because an orphan is
+    # precisely the assignment every project fails to match. One warning per
+    # assignment, not one per project iteration.
+    #
+    # Status is never read here. A `completed` assignment naming a project that
+    # does not exist is still a broken reference, so the check must not narrow
+    # to ACTIVE_ASSIGNMENT_STATES the way the coverage filter above does.
+    known_slugs = set()
+    for p in entities["project"]:
+        raw_slug = p.get("slug")
+        # Dropped on `is None` or empty, deliberately not on truthiness — same
+        # reasoning as _text_field's guard, so a real falsy slug stays a known
+        # project. Without the drop, a project whose slug is absent would adopt
+        # every assignment whose `project` is absent, masking two bad records.
+        if raw_slug is None or raw_slug == "":
+            continue
+        try:
+            known_slugs.add(raw_slug)
+        except TypeError:
+            # An unhashable slug can never be matched by an assignment anyway,
+            # and raising here would cost the entire render — see below.
+            continue
+    for a in assignments:
+        proj_ref = a.get("project")
+        try:
+            known = proj_ref in known_slugs
+        except TypeError:
+            # A list- or dict-valued `project:` is unhashable, so `in` raises
+            # before it can miss. Nothing unhashable is ever a valid slug, so
+            # read it as unresolved: letting it propagate would reach the
+            # module-level catch-all, which discards every warning collected so
+            # far and fails the whole render over one hand-edited record.
+            known = False
+        if known:
+            continue
+        # Both sides stay raw, never routed through _text_field. The borrowed
+        # parser coerces an all-digit scalar to int for `slug` and `project`
+        # alike, and the coverage filter above compares raw to raw — coercing
+        # only this side would turn `2026` into "2026", miss its own int slug,
+        # and report a legitimately matched assignment as an orphan.
+        #
+        # validate-entities.py reports the same dangling ref, but resolves it
+        # through str() and fails hard. That divergence is deliberate: the
+        # renderer never runs the validator, and matching its coercion here
+        # would break the raw-to-raw symmetry the filter above depends on.
+        a_label = "assignment %s" % (a.get("_file") or a.get("slug") or "(unknown)")
+        warnings.append(
+            "%s names no known project %r — fix the assignment's project ref "
+            "or add the project" % (a_label, proj_ref)
+        )
+
     # Utilization: a simple average of consultant allocation_pct, plus a count of
     # consultants at or above 100%. Consultants with no allocation_pct are
     # excluded from the average rather than counted as zero, so a thinly authored

--- a/cogni-projects/scripts/render-dashboard.py
+++ b/cogni-projects/scripts/render-dashboard.py
@@ -413,8 +413,12 @@ def _compute(entities, warnings):
         try:
             known_slugs.add(raw_slug)
         except TypeError:
-            # An unhashable slug can never be matched by an assignment anyway,
-            # and raising here would cost the entire render — see below.
+            # An unhashable slug cannot be held in a set, so it is dropped from
+            # known_slugs. Where an assignment's equally unhashable `project`
+            # still matches it via the `!=` filter above, that record is warned
+            # as unresolved anyway — a false positive over two hand-edited
+            # malformed records, accepted over letting TypeError reach the
+            # module-level catch-all and discard every warning — see below.
             continue
     for a in assignments:
         proj_ref = a.get("project")

--- a/cogni-projects/skills/projects-dashboard/SKILL.md
+++ b/cogni-projects/skills/projects-dashboard/SKILL.md
@@ -156,13 +156,17 @@ never from this example:
   the warnings list, not treated as an error: a project without a
   `strategic_impact`, a project that omits `open_roles`, an entity whose
   `status`, role label, or `open_roles` entry is not text, an entity whose
-  `status` is text but not lowercase, or an entity file that cannot be read or
-  decoded. A non-text value — `status: 2026`, `role: 2`, or `open_roles: [2]` —
-  is read as a number, then coerced back to text. A status authored in mixed
-  case — `status: Closed` — is read case-insensitively and reported normalized.
-  Both sides of the role comparison are coerced, so a numeric role still matches
-  its numeric `open_roles` entry and still counts as filled. The non-text warning
-  and the not-lowercase warning both say to fix the record, not that the coverage
+  `status` is text but not lowercase, an assignment whose `project` names no
+  project in the portfolio, or an entity file that cannot be read or decoded. A
+  non-text value — `status: 2026`, `role: 2`, or `open_roles: [2]` — is read as
+  a number, then coerced back to text. A status authored in mixed case —
+  `status: Closed` — is read case-insensitively and reported normalized. Both
+  sides of the role comparison are coerced, so a numeric role still matches its
+  numeric `open_roles` entry and still counts as filled. An unresolved
+  `project` is named whatever the assignment's status, since a completed
+  assignment pointing at a deleted project is still a broken reference, and it
+  leaves every coverage figure unchanged. The non-text warning and the
+  not-lowercase warning both say to fix the record, not that the coverage
   figure or flag beside it is wrong. One bad record never costs the rest of the
   portfolio.
 - **Theming is optional.** The dashboard renders with a built-in palette;

--- a/cogni-projects/skills/projects-dashboard/SKILL.md
+++ b/cogni-projects/skills/projects-dashboard/SKILL.md
@@ -156,16 +156,16 @@ never from this example:
   the warnings list, not treated as an error: a project without a
   `strategic_impact`, a project that omits `open_roles`, an entity whose
   `status`, role label, or `open_roles` entry is not text, an entity whose
-  `status` is text but not lowercase, an assignment whose `project` names no
-  project in the portfolio, or an entity file that cannot be read or decoded. A
-  non-text value — `status: 2026`, `role: 2`, or `open_roles: [2]` — is read as
-  a number, then coerced back to text. A status authored in mixed case —
-  `status: Closed` — is read case-insensitively and reported normalized. Both
-  sides of the role comparison are coerced, so a numeric role still matches its
-  numeric `open_roles` entry and still counts as filled. An unresolved
-  `project` is named whatever the assignment's status, since a completed
-  assignment pointing at a deleted project is still a broken reference, and it
-  leaves every coverage figure unchanged. The non-text warning and the
+  `status` is text but not lowercase, an assignment whose `project` is absent,
+  unusable, or names no project in the portfolio, or an entity file that cannot
+  be read or decoded. A non-text value — `status: 2026`, `role: 2`, or
+  `open_roles: [2]` — is read as a number, then coerced back to text. A status
+  authored in mixed case — `status: Closed` — is read case-insensitively and
+  reported normalized. Both sides of the role comparison are coerced, so a
+  numeric role still matches its numeric `open_roles` entry and still counts as
+  filled. An unresolved `project` is named whatever the assignment's status — a
+  completed assignment pointing at a deleted project is still a broken
+  reference — and coverage is unchanged. The non-text warning and the
   not-lowercase warning both say to fix the record, not that the coverage
   figure or flag beside it is wrong. One bad record never costs the rest of the
   portfolio.

--- a/cogni-projects/skills/projects-dashboard/SKILL.md
+++ b/cogni-projects/skills/projects-dashboard/SKILL.md
@@ -165,10 +165,15 @@ never from this example:
   numeric role still matches its numeric `open_roles` entry and still counts as
   filled. An unresolved `project` is named whatever the assignment's status — a
   completed assignment pointing at a deleted project is still a broken
-  reference — and coverage is unchanged. The non-text warning and the
-  not-lowercase warning both say to fix the record, not that the coverage
-  figure or flag beside it is wrong. One bad record never costs the rest of the
-  portfolio.
+  reference — and the assignment covers no role until the reference is fixed,
+  so the project it was meant to staff reads as more open than its author
+  intended. Assignments authored before their project files orphan until those
+  projects land — a run of these warnings early in authoring is expected, not
+  portfolio damage. An unusable `project` — `project: [alpha, beta]` — is one
+  the lookup cannot key on at all, and is reported like any other unresolved
+  reference. The non-text warning and the not-lowercase warning both say to fix
+  the record, not that the coverage figure or flag beside it is wrong. One bad
+  record never costs the rest of the portfolio.
 - **Theming is optional.** The dashboard renders with a built-in palette;
   pass `--design-variables <path.json>` to override colors when a themed look is
   wanted.

--- a/cogni-projects/tests/test-render-dashboard.sh
+++ b/cogni-projects/tests/test-render-dashboard.sh
@@ -925,6 +925,150 @@ assert_json "12t plain prospective is live demand too" \
 assert_json "12u padded closed without open_roles is not nagged either" \
   "sum('staffing status unknown' in w and 'Roleless Padded' in w for w in d['data']['warnings']) == 0 and any(p['name'] == 'Roleless Padded' and p['health_label'] == 'closed' for p in d['data']['projects_detail'])"
 
+# ---------------------------------------------------------------------------
+# Fixture 13: an assignment whose `project` names no project in the portfolio.
+# Every project here is schema-clean — lowercase status, a valid
+# strategic_impact, a declared open_roles — so on the base script this portfolio
+# renders with `warnings == []` and `partial: false`. That is deliberate: it
+# makes 13b and 13k fail on base and pass only once the orphan pass exists,
+# rather than riding on some unrelated record's warning.
+#
+# 13c-13f are counted rather than `any(...)` for the reason 10e, 11c and 12p
+# are: an orphan is precisely the assignment no project matches, so an
+# implementation that checked orphan-ness inside the per-project loop would warn
+# once per project while `any(...)` stayed green. 13k pins the same property
+# from the other side, as an exact total.
+# ---------------------------------------------------------------------------
+PF13="$TMPROOT/orphan-assignment"
+seed_portfolio "$PF13"
+write_entity "$PF13/projects/harbor-crm.md" <<'EOF'
+---
+type: project
+slug: harbor-crm
+name: Harbor CRM
+client: Harbor Co
+strategic_impact: 3
+status: active
+open_roles: [lead]
+---
+# Harbor CRM
+EOF
+# An all-digit slug is int-coerced by the parser, and so is an assignment's
+# all-digit `project`. The name stays text on purpose — an all-digit name would
+# be coerced into the envelope too and muddy what this fixture pins.
+write_entity "$PF13/projects/numeric-slug.md" <<'EOF'
+---
+type: project
+slug: 2026
+name: Numeric Slug Project
+client: NumCo
+strategic_impact: 2
+status: active
+open_roles: [analyst]
+---
+# Numeric Slug Project
+EOF
+write_entity "$PF13/assignments/orphan-active.md" <<'EOF'
+---
+type: assignment
+slug: gia--ghost
+consultant: gia
+project: ghost-crm
+role: lead
+start_date: 2026-02-01
+end_date: 2026-08-01
+status: active
+---
+# assignment
+EOF
+# Status-independence: a completed assignment naming a project that does not
+# exist is still a broken reference, so it must warn like any other orphan.
+write_entity "$PF13/assignments/orphan-completed.md" <<'EOF'
+---
+type: assignment
+slug: hu--ghost
+consultant: hu
+project: ghost-crm
+role: lead
+start_date: 2026-02-01
+end_date: 2026-04-01
+status: completed
+---
+# assignment
+EOF
+# A list-valued `project:` is unhashable — a bare `not in <set>` raises
+# TypeError, the module-level catch-all discards every warning collected so far,
+# and one hand-edited record costs the whole render.
+write_entity "$PF13/assignments/orphan-listval.md" <<'EOF'
+---
+type: assignment
+slug: ivy--ghost
+consultant: ivy
+project: [alpha, beta]
+role: lead
+start_date: 2026-02-01
+end_date: 2026-08-01
+status: active
+---
+# assignment
+EOF
+write_entity "$PF13/assignments/orphan-absent.md" <<'EOF'
+---
+type: assignment
+slug: jo--ghost
+consultant: jo
+role: lead
+start_date: 2026-02-01
+end_date: 2026-08-01
+status: active
+---
+# assignment
+EOF
+# The symmetry control: both sides are int-coerced to 2026, so this resolves and
+# must NOT warn. A one-sided coercion of the assignment's `project` to "2026"
+# would miss its own int slug and report this matched assignment as an orphan.
+write_entity "$PF13/assignments/symmetry-2026.md" <<'EOF'
+---
+type: assignment
+slug: ken--numeric
+consultant: ken
+project: 2026
+role: analyst
+start_date: 2026-02-01
+end_date: 2026-08-01
+status: active
+---
+# assignment
+EOF
+
+# Its own stderr sink, as 13j asserts a traceback never reached it.
+STDERR13="$TMPROOT/stderr13.txt"
+RUN_ERRFILE="$STDERR13"
+run "$PF13"
+
+assert_json "13a orphan assignments still render"  "d['success'] is True"
+assert_json "13b marked partial"                   "d['data']['partial'] is True"
+assert_json "13c orphan surfaced by file, exactly once" \
+  "sum('names no known project' in w and 'orphan-active.md' in w for w in d['data']['warnings']) == 1"
+assert_json "13d completed orphan warns too, exactly once" \
+  "sum('names no known project' in w and 'orphan-completed.md' in w for w in d['data']['warnings']) == 1"
+assert_json "13e unhashable project value warns instead of crashing, exactly once" \
+  "sum('names no known project' in w and 'orphan-listval.md' in w for w in d['data']['warnings']) == 1"
+assert_json "13f absent project is surfaced, exactly once" \
+  "sum('names no known project' in w and 'orphan-absent.md' in w for w in d['data']['warnings']) == 1"
+# Two halves: the matched assignment raises no orphan warning, AND it still
+# fills its role — so a regression that stopped warning by stopping resolving
+# cannot pass this.
+assert_json "13g numeric slug resolves raw-to-raw and fills its role" \
+  "not any('names no known project' in w and 'symmetry-2026.md' in w for w in d['data']['warnings']) and any(p['name'] == 'Numeric Slug Project' and p['roles_filled'] == 1 for p in d['data']['projects_detail'])"
+assert_json "13h orphans invent no project row"    "d['data']['projects'] == 2"
+# Harbor CRM's lead is unfilled; the numeric-slug project's analyst is filled by
+# symmetry-2026. No orphan contributes a role either way.
+assert_json "13i orphans fill no role and add none" "d['data']['open_roles'] == 1"
+assert_no_traceback "13j no traceback on stderr" "$STDERR13"
+assert_json "13k exactly one warning per orphan, four in total" \
+  "len(d['data']['warnings']) == 4"
+
 echo
 if [ "$failures" -eq 0 ]; then
   echo "All render-dashboard tests passed."


### PR DESCRIPTION
Closes #1161.

## Summary

- `render-dashboard.py` `_compute` gains a portfolio-wide **orphan pass**: an assignment whose `project:` matches no known project slug now appends exactly one warning naming the assignment by its `_file` relative path (falling back to `slug`, then `(unknown)` — the same idiom the per-project loop uses) and including the unresolved `project` value with `%r`.
- The pass sits **outside** the per-project loop and is **status-independent** — it never reads `status` and never consults `ACTIVE_ASSIGNMENT_STATES`, so a `completed` assignment naming a deleted project is still reported as a broken reference.
- `test-render-dashboard.sh` gains **Fixture 13** covering the active orphan, the completed orphan, an unhashable (list-valued) `project:`, an absent `project:`, and a numeric-slug symmetry control that must **not** warn.
- `projects-dashboard/SKILL.md`'s "Partial snapshots are expected mid-authoring" bullet gains the orphan-assignment case.

## ⚠️ The issue's ratified acceptance criteria carried stale line anchors

Worth knowing before reviewing against the issue body. The `## Acceptance criteria` block was ratified via `/cogni-service:service-groom` against a tree that predates the recently-merged status-case-folding change, which rewrote **exactly** the regions the checklist cites. Every line number in it had gone stale. Re-anchored against `origin/main` at triage time:

| AC cites | Actually at | What is there now |
|---|---|---|
| `render-dashboard.py:341` (label idiom) | `:358` | `a_label = "assignment %s" % (a.get("_file") or a.get("slug") or "(unknown)")` |
| `render-dashboard.py:260-263` (symmetry trap) | `:251-255` in `_text_field`; `_status_text` at `:276` | "Both sides of a comparison must come through here" |
| `render-dashboard.py:602-605` (module catch-all) | `:625` | `except Exception as _exc:  # noqa: BLE001` |
| the AC's quoted "current behavior" one-liner | `:356`–`:361` | split into a guard clause plus a `_status_text` call — the quoted single-expression form no longer exists |
| `SKILL.md:113-122` | `:155-167` | same bullet, extended by the earlier change |

**The criteria themselves remain valid** — only the coordinates moved, and this PR is graded against the re-verified ones. Two consequences:

1. The guard clause's own comment at `:354-355` ("Filter first — an assignment belonging to another project must not have its status read here, or it would warn once per project") already states this change's core design constraint. The new pass matches that reasoning rather than inventing one.
2. The AC's watch-item asking whether `references/data-model.md` still claims entity refs are "never resolved" is **moot** — no such claim exists there now. That file is untouched.

## Scope decisions

**Placement — after the loop, not before it.** Exploration produced two competing proposals; both agreed the pass must be outside the per-project loop (nested, it would warn once per project per orphan), and disagreed only on which side. This PR puts it **after**, immediately before the utilization pass, so every pre-existing warning keeps its position in `data.warnings[]` and the new class appends at the tail; it also sits beside the file's other portfolio-wide pass, so `_compute` reads as "per-project loop, then portfolio-wide passes". All existing assertions are order-independent, so no fixture is affected either way.

**Comparison symmetry — both sides stay raw.** The known-slug set is built from raw parsed `slug` values and is *not* routed through `_text_field`. The borrowed frontmatter parser int-coerces an all-digit scalar for `project.slug` and `assignment.project` alike, and the existing coverage filter already compares raw to raw. Coercing only the assignment side would turn `2026` into `"2026"`, miss its own int slug, and report a legitimately matched assignment as an orphan. Fixture 13g pins this from both directions — no warning **and** the role still reads as filled, so a regression that stopped warning by stopping resolving cannot pass it.

**Falsy-but-real slugs survive.** The collection drops a slug on `is None` or empty, deliberately not on truthiness — the same reasoning `_text_field` documents for its own guard — so a project with `slug: 0` stays a known project, while a project with no slug cannot silently adopt every assignment with no `project:`.

**Unhashable values use `try`/`except TypeError`, not an `isinstance(..., list)` check.** The criterion says "list-valued **or otherwise unhashable**", and a dict-valued `project:` would slip past a list-only check and raise out of `_compute` — where the module-level catch-all discards every warning collected so far and fails the whole render, inverting this script's one-bad-record-costs-a-warning contract. The same guard wraps the slug-set insert.

**Deliberately not touched:** `register-entity.py`, `staffing-score.py`, `validate-entities.py`, and `references/data-model.md` — all zero-diff. `validate-entities.py` does report the same dangling ref, but through `str()` coercion and as a hard error; the renderer never runs the validator, and matching that coercion here would break the raw-to-raw symmetry above. The divergence is intentional and recorded in a code comment so it is not later "fixed" toward the validator's shape. No `plugin.json` / `marketplace.json` version line is touched — the post-merge workflow owns the bump.

## Verification

| Check | Result |
|---|---|
| `test-render-dashboard.sh` | pass — "All render-dashboard tests passed." (13a–13k green) |
| `test_portfolio_init.sh` / `test_register_entity.sh` / `test_validate_entities_refs.sh` / `test_staffing_score.sh` | all pass, rc=0 |
| **Fixture 13 fails on base** | confirmed — 6 assertions (13b, 13c, 13d, 13e, 13f, 13k) fail against `origin/main`'s renderer; base emits `warnings: []` / `partial: false` for these seeds, so 13b is not vacuous |
| `check-version-bump.py` | `ok` — 14 plugins scanned, 0 touched, 0 violations |
| `check-breadcrumbs.py` | success, 0 violations |
| `check-frontmatter.sh` (cogni-projects) | clean |
| `measure-skill-length.sh` | `chars_body` 8761 / cap 16500 (53%), `over_cap: false` |
| `skill-quality-reviewer` | `pass` — 0 auto-fixable, 0 structural issues |
| SKILL.md prose audit | sentence-level diff vs `origin/main` — all 5 other base caveat sentences byte-identical; only the enumeration extended (as the AC asks) plus one new sentence |

Fixture 13 seeds two schema-clean projects on purpose, so the portfolio renders warning-free on base — that is what makes `13b` (`partial is True`) and `13k` (`len(warnings) == 4`) real regression assertions rather than ones riding on an unrelated record's warning.

## Notes for the reviewer

- Two documented pre-commit passes were **skipped with reason**, not silently. `/simplify` (Step 6.4) operates on the session working tree, but these edits live in a separate git worktree, so invoking it would have inspected a clean tree and returned a vacuous "nothing to fix". The Step 6.4b prose simplifier's gate did fire (a `SKILL.md` is touched), but the file sits at 53% of its cap with a purely additive change, and this issue's AC explicitly forbids weakening any pre-existing caveat sentence — an unscoped prose rewrite is the known way that constraint gets broken. The diff was self-audited instead, and the sentence-level audit above is the evidence.
- The Step 6 routing dispatches to `plugin-dev:plugin-structure` were also skipped: that guidance governs plugin directory layout and manifest structure, and this change adds no component and touches no manifest. `plugin-dev:skill-development` guidance is reflected via the Step 6.5 reviewer, which passed.