### PR TITLE
cogni-help: report a failed repo-label query as its own error

### DIFF
--- a/cogni-help/skills/cogni-issues/SKILL.md
+++ b/cogni-help/skills/cogni-issues/SKILL.md
@@ -313,6 +313,9 @@ The helper returns:
 Capture `number` and `url` for the next step. If the helper exits non-zero, surface the
 JSON error to the user and stop — never retry blindly. Common errors:
 
+- `could not read repo labels` → the label query itself failed, so nothing is known about
+  the repo's label set; surface the `detail` field and have the user check network access,
+  that the repo exists, and that their token has repo scope.
 - `label(s) missing from repo` → tell the user which labels are missing and ask whether
   to file without them or to create the labels first.
 - `gh issue create failed` → surface the `detail` field; usually a network or auth issue.

--- a/cogni-help/skills/cogni-issues/scripts/gh-issues-helper.sh
+++ b/cogni-help/skills/cogni-issues/scripts/gh-issues-helper.sh
@@ -140,7 +140,17 @@ print(json.dumps({
       # --limit is required: gh label list defaults to 30, so on a repo with more
       # labels than that the ones past the first page read as missing and the
       # check below rejects a label that exists.
-      EXISTING_LABELS=$(gh label list --repo "$REPO" --limit 1000 --json name --jq '.[].name' 2>/dev/null || true)
+      #
+      # A failed query is told apart by exit status, never by an empty result: a
+      # repo whose label set is genuinely empty is a legitimate empty set and must
+      # still reach the "missing from repo" error below, not this one. Merging
+      # stderr into the capture is safe here even though it becomes the label set
+      # the whole-line match below reads, because gh's notices only print when
+      # stdout and stderr are both terminals, which command substitution prevents.
+      if ! EXISTING_LABELS=$(gh label list --repo "$REPO" --limit 1000 --json name --jq '.[].name' 2>&1); then
+        emit_error "create: could not read repo labels" repo "$REPO" detail "$EXISTING_LABELS" hint "Check network access, that the repo exists and is visible to you, and that the token has repo scope (gh auth status)"
+        exit 1
+      fi
       MISSING=""
       IFS=',' read -r -a LABEL_ARR <<< "$LABELS_CSV"
       for LBL in "${LABEL_ARR[@]}"; do


### PR DESCRIPTION
Closes #1198.

## Summary

The `create` path validated `--labels` against the repo's label set with a query whose failure was swallowed:

```bash
EXISTING_LABELS=$(gh label list --repo "$REPO" --limit 1000 --json name --jq '.[].name' 2>/dev/null || true)
```

`2>/dev/null` discarded gh's stderr and `|| true` discarded its exit status, so every failure mode — network loss, a repo the token cannot see, a scopeless or SSO-unauthorized token, an API 5xx — produced an empty `EXISTING_LABELS`. Every requested label then failed the whole-line `grep -qx` check, and the user was told `create: label(s) missing from repo` with a hint to go create labels that already exist. The remedy suggested was the opposite of the one needed, and because the branch exits before `gh issue create`, the issue was never filed.

The query now discriminates on **exit status, not emptiness**, using the same `if ! VAR=$(...); then` form the file already uses for `gh issue create`:

- A **failed** query emits a new, distinct `create: could not read repo labels`, carrying gh's own stderr in `detail` and a hint naming network access, repo visibility, and token scope.
- A **successful** query that returns nothing is unchanged — a repo whose label set is genuinely empty is a legitimate empty set and still reaches the existing `create: label(s) missing from repo` error.
- `--limit 1000` and its three-line comment are preserved verbatim. That flag is load-bearing: this repo carries 50 labels against gh's default page size of 30.

`SKILL.md`'s "Common errors" list gains a matching bullet, placed first so the list stays in the order the errors can actually fire.

## Verified behaviour

Both paths were exercised against the real `gh` CLI, not reasoned about:

| Case | Result |
|---|---|
| Failed query (nonexistent repo) | `{"error": "create: could not read repo labels", "repo": "…", "detail": "GraphQL: Could not resolve to a Repository with the name '…'. (repository)", "hint": "Check network access, …"}` · exit 1 |
| Genuinely absent label (real repo) | `{"error": "create: label(s) missing from repo", "repo": "cogni-work/insight-wave", "missing_labels": "…", …}` · exit 1 — unchanged |

Before this change the first row produced the second row's error.

## Scope decisions

**Kept the merged-stream `2>&1`; deliberately added no temp-file machinery.** This deserves recording, because the idiom is borrowed from a site where it is safe into a site where it might not be. At the `gh issue create` precedent the capture is only regex-parsed for a URL, but here the capture *becomes* the label set that `grep -qx` matches line by line — so a stderr line leaking in on a **successful** call could in principle read as an existing label. Adjudicated as negligible on evidence:

- In this exact invocation shape — command substitution, so stdout is a pipe — `gh label list --json name --jq` writes zero bytes to stderr on success. gh's update notifier prints only when stdout and stderr are *both* terminals, which command substitution structurally prevents.
- Even given a leak, `grep -qx` demands a whole-line exact match against a requested label name, and gh's notice lines are multi-word sentences and URLs.
- A leaked blank line cannot match either — empty requested labels are skipped by the guard above the check.

The failure mode is bounded to a false *accept*, never a false reject, and only against a label literally named after a gh notice line. An `mktemp` + cleanup dance would add its own failure mode, and its own JSON-error path for `mktemp` itself failing, to defend a compound improbability. The reasoning is recorded in a comment at the call site so the next reader does not have to re-derive it.

**Hint wording narrowed.** `check_gh` already runs `command -v gh` and `gh auth status` and exits before the label query is reached, so plain "not authenticated" is not a reachable cause here. The hint names network, repo visibility, and token scope instead of leading with `gh auth status`.

**Audited, not widened.** Every `gh` call site in the file was re-checked. The `gh --version` / `gh api user` probes swallow failure *by design* — they sit inside the `check` command, documented as the one command that probes without exiting on failure. The `gh auth status`, `gh issue create`, `gh issue list`, `gh issue view`, and search calls all handle status correctly. The label query was the sole masking site.

**No test added.** `cogni-help` has no `tests/` directory, no suite anywhere in this repo mocks or stubs the `gh` CLI, and CI runs no test job at all. Building the first `gh`-mocking harness is new infrastructure rather than a rider on a one-line bug fix — so this ships with the manual verification above instead. Flagging the gap explicitly rather than leaving it implied.

**Out of repo.** The same masking pattern reported in a sibling repository is a different repository, as the issue itself states.

## Checks run

| Check | Result |
|---|---|
| `bash -n` on the script | pass |
| Failed-query path | new error, exit 1 — verified live |
| Genuine-miss path | unchanged error, exit 1 — verified live |
| `--limit 1000` preserved | confirmed in diff |
| `check-breadcrumbs.py` | 0 violations |
| `check-version-bump.py` | `ok` — 14 plugins scanned, 0 touched, 0 violations |
| `check-frontmatter.sh cogni-help` | clean |
| `measure-skill-length.sh` | `chars_body` 17382 / cap 45000, `over_cap: false` |
| `plugin.json` / `marketplace.json` | absent from the diff — the post-merge workflow owns the bump |