### PR TITLE
cogni-portfolio: regenerate README markets callout from registry

### DIFF
--- a/cogni-portfolio/README.md
+++ b/cogni-portfolio/README.md
@@ -4,7 +4,7 @@
 
 > **insight-wave readiness (Claude Code desktop)** — Claude Code desktop is the recommended interface for insight-wave today. Cowork is a secondary path and is not yet production-ready for insight-wave workflows because of context-window and Pencil-MCP fidelity gaps — see the [deployment guide](../docs/deployment-guide.md) for detail. This guidance will flip when those gaps close upstream.
 
-> **Markets covered.** 25 pluggable regions — single-country (DE, FR, IT, ES, NL, PL, AT, CZ, SK, HU, RO, HR, GR, MK), composite (DACH, EU, Nordics, US/NA, APAC, LATAM, MEA), extended (CN, JP), and global (UK, Global) — market-segmented propositions, competitors, and customer personas — not one-size-fits-all.
+> **Markets covered.** 25 pluggable regions — single-country, composite, extended, and global — DACH (BDEW, BDI, BITKOM), plus EU, UK, US, NA, Nordics, APAC, LATAM, and MEA — market-segmented propositions, competitors, and customer personas — not one-size-fits-all.
 
 > **Start here.** Run `/cogni-portfolio:portfolio-resume` for project status and next-step guidance — whether you're starting fresh or returning to an in-progress project.
 


### PR DESCRIPTION
Closes #1208.

## Summary

Replaces the drifted 25-region enumeration on `cogni-portfolio/README.md:7` with the render the doc-generate **Markets Callout** template (Step 2d) actually derives from `cogni-workspace/references/supported-markets-registry.json`.

`callout_lede` and `tail_clause` already matched the registry verbatim and are preserved byte-for-byte; only the middle market-enumeration slot changes.

```diff
-> **Markets covered.** 25 pluggable regions — single-country (DE, FR, IT, ES, NL, PL, AT, CZ, SK, HU, RO, HR, GR, MK), composite (DACH, EU, Nordics, US/NA, APAC, LATAM, MEA), extended (CN, JP), and global (UK, Global) — market-segmented propositions, competitors, and customer personas — not one-size-fits-all.
+> **Markets covered.** 25 pluggable regions — single-country, composite, extended, and global — DACH (BDEW, BDI, BITKOM), plus EU, UK, US, NA, Nordics, APAC, LATAM, and MEA — market-segmented propositions, competitors, and customer personas — not one-size-fits-all.
```

One file, one line.

## Scope decisions

**Hand-applied, not via a full `/doc-generate cogni-portfolio` run.** That skill's callout recompute is unconditional and cannot be narrowed with `--section`, so a run would also regenerate Components / Architecture / Dependencies / What-it-does / Quick-start / Installation. `doc-audit` Check 15 validates the callout slot-by-slot (lede, market list, authority-name membership, exact `tail_clause`) rather than by whole-string compare, so a targeted edit passes on the same terms a generated one would. The template was read as reference only — hence no `routing[]` entry, since dispatching `cogni-docs:doc-generate` even "as reference" executes the regeneration this change deliberately avoids.

**Tail rendered in short form** (`EU, UK, US, NA, Nordics, APAC, LATAM, MEA`) — these are exactly the tier `anglo`/`composite` markets whose `consumed_by[]` includes cogni-portfolio. The template's own example renders `plus EU, Nordics, NA, APAC`, and the one in-repo precedent (`cogni-trends/README.md:7`) renders `plus US and UK`, so short forms rather than full `market.name` values are the established shape.

**Why only DACH carries authority parentheses.** The registry's `primary_regions_shown_in_callout` for this plugin lists ten tokens, but the template's tier rules resolve them to a single expandable market: `US/NA` matches no registry key (there are separate `us` and `na`); `Nordics`/`APAC`/`LATAM`/`MEA`/`JP` carry zero `authority_sources`; `EU`/`Nordics`/`UK`/`APAC`/`LATAM`/`MEA` are tier `anglo` or `composite` and so already belong to the independently-computed tail; `CN`/`JP` are tier `extended`, which the template counts in the lede but never expands individually. That leaves `DACH` — tier `primary`, 29 authorities, first three being BDEW, BDI, BITKOM.

**Not added:** the `See [Supported markets & languages](…)` sentence `cogni-trends` carries. The anchor resolves, but that sentence is not part of the doc-generate template, so adding it would put cogni-portfolio ahead of the generator rather than in sync with it.

**Not touched:** the registry itself, and any version field (the post-merge workflow owns bumps).

## Open questions

- **The registry array this renders from is itself malformed**, in four independent ways (unresolvable `US/NA`; five zero-authority members; six members that double-render against the tail; two extended-tier members). A faithful render therefore expands one market where the template envisages six to eight. This PR ships the faithful render; repairing the array is a positioning decision about which regions cogni-portfolio features, and belongs to cogni-workspace. Tracked in #1214 — **that decision does not block this PR**, but a reviewer who disagrees with shipping the thin render should say so here.

## Follow-up issues

- #1214 — cogni-workspace: repair the cogni-portfolio `primary_regions_shown_in_callout` registry array

## Test plan

- [x] `git diff --stat` → 1 file, 1 insertion, 1 deletion; the change is line 7 only.
- [x] Lede `25 pluggable regions — single-country, composite, extended, and global` matches `plugins.cogni-portfolio.callout_lede` verbatim.
- [x] Tail clause `market-segmented propositions, competitors, and customer personas — not one-size-fits-all` matches `plugins.cogni-portfolio.tail_clause` verbatim.
- [x] `BDEW, BDI, BITKOM` are the first three `markets.dach.authority_sources[].name`.
- [x] Tail markets resolve exactly to the tier `anglo`/`composite` set with `cogni-portfolio` in `consumed_by[]` — `{eu, uk, us, na, nordics, apac, latam, mea}`.
- [x] `grep -c 'Markets covered' cogni-portfolio/README.md` → 1.
- [x] `python3 scripts/check-version-bump.py` → `clean: true`, 0 violations.
- [x] `python3 scripts/check-breadcrumbs.py` → 0 new breadcrumbs.
- [ ] `/cogni-docs:doc-audit cogni-portfolio` Check 15 passes (reviewer to confirm — cogni-docs is an external plugin, not runnable as a repo CI gate).

## Note for the reviewer

Two "corrections" posted on #1208 during triage were **wrong and have been retracted on the issue** — they claimed doc-generate does not own this callout and that the render shows regions rather than authorities. Both stemmed from a repo-only grep that could not see `cogni-docs`, which is an externally-installed plugin rather than one of the 14 in `marketplace.json`. The retraction comment and the plan record carry the corrected reasoning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)