### PR TITLE
cogni-consult: one ranked close offer and a six-line close budget

### DIFF
--- a/cogni-consult/references/orchestration/close-kb-deposit.md
+++ b/cogni-consult/references/orchestration/close-kb-deposit.md
@@ -8,7 +8,10 @@ loop points here; the contract below is authoritative.
 **Knowledge-base deposit is elected, not automatic.** When this session moved
 the deliverable to `complete`, the completed artifact can compound the
 engagement's bound knowledge base so future engagements' gap-checks and research
-reuse its distilled findings. Offer to deposit it — default-on, the same
+reuse its distilled findings. Offer to deposit it when it is the top-ranked
+offer for this close under the design-thinking loop's one-offer-per-close rule
+(it ranks first, so it usually is; otherwise it surfaces on a later turn) —
+default-on, the same
 elected-not-automatic posture as the Close-stage publishing mention in the
 design-thinking loop: in auto-walk mode deposit without
 pausing; in interactive mode confirm first; never auto-fire without offering.

--- a/cogni-consult/skills/consult-design-thinking/SKILL.md
+++ b/cogni-consult/skills/consult-design-thinking/SKILL.md
@@ -492,50 +492,71 @@ an earlier stage is permitted) and continue; `state` stays `in-progress`.
 ### 8. Close the Session
 
 Summarize in business terms, not raw state values or log ids: the deliverable is
-finished, the artifact path (kept as a path — it is there to look up), what was
-decided and why, which personas challenged it, and the Test-stage promote-check
-outcome (assumptions promoted to the registry, or a recorded opt-out). Recommend
-the next step — the next unstarted deliverable in the WBS (via the WBS dashboard
-skill when present in the plugin, or by reading the field manifests directly).
+finished, the artifact path (kept as a path), what was decided and why, which
+personas challenged it, and the Test-stage promote-check outcome (assumptions
+promoted to the registry, or a recorded opt-out). Recommend the next step — the
+next unstarted deliverable in the WBS (via the WBS dashboard skill when present,
+or by reading the field manifests directly).
+
+**Close budget: at most six lines** — one result, at most three substance, one
+artifact, one next-step. Six is the ceiling on the whole close: a trailing offer
+spends one of the substance lines rather than adding a seventh, so a close that
+makes an offer carries at most two other substance lines. At most one table, and
+only at four or five rows — section (d) of
+`$CLAUDE_PLUGIN_ROOT/references/user-facing-output.md`; anything smaller is
+prose, and its overflow line spends a substance line too. Announce before *or* report after, never both — section (e) of
+that same register. The next-step line carries exactly one recommendation,
+generalizing `$CLAUDE_PLUGIN_ROOT/skills/consult-resume/SKILL.md`
+`## Important Notes` ("One recommendation") to every close.
 
 **Milestone actions.** When this session moved the deliverable's `state` to
 `"complete"` (or the delegated persona challenge closed its `persona_review`),
-the engagement's status changed — refresh the two derived views below. The two
-elective rungs after them fire only on the `state` → `"complete"` leg, never on
-a persona-review close.
+refresh the two derived views below. The two elective rungs after them fire only
+on the `state` → `"complete"` leg, never on a persona-review close.
 
-**Milestone dashboard refresh.** Offer the consultant a
-fresh visual dashboard. If the engagement already has
-`output/design-variables.json` (a prior `consult-dashboard` run set up a theme),
-regenerate the HTML without prompting by delegating to the
-`consult-dashboard-refresher` agent with
-`engagement_dir: <engagement-dir>` and `plugin_root: $CLAUDE_PLUGIN_ROOT`; the
-agent runs the read-only generator and opens `output/dashboard.html`. If no
-theme is configured yet, point the consultant at `/cogni-consult:consult-dashboard`
-to set one up — a lightweight snapshot of the engagement at this checkpoint,
-which is what the consultant wants before picking the next deliverable.
+**One offer per close.** A consultant-facing *offer* is a trailing item asking
+the consultant to decide this turn — at most one per close. Rank the available
+offers and emit the top-ranked one: 1. knowledge-base deposit, 2. publishing, 3.
+dashboard theme setup — because a deferred deposit stops compounding into the
+next deliverable's gap-check, while publishing loses nothing by waiting. The
+rest go unmentioned and surface next turn if the emitted one is declined; an
+offer already declined on the record (a logged `kb-deposit-waiver`) leaves the
+ranking rather than resurfacing every close. An item that fires without asking
+is a result, not an offer, and belongs on the artifact line. Rank from the live
+conversation only, never from a stored field — `### Interaction mode` keeps the
+mode ephemeral. The next-deliverable recommendation is the next-step line, not
+an offer.
+
+**Milestone dashboard refresh.** If the engagement already has
+`output/design-variables.json` (a theme is configured), regenerate the HTML
+without prompting: delegate to the `consult-dashboard-refresher` agent with
+`engagement_dir: <engagement-dir>` and `plugin_root: $CLAUDE_PLUGIN_ROOT`; it
+runs the read-only generator and opens `output/dashboard.html`. If no theme is
+configured yet, pointing the consultant at `/cogni-consult:consult-dashboard` to
+set one up is the rank-3 offer.
 
 **Milestone README refresh.** Also run
 `python3 $CLAUDE_PLUGIN_ROOT/scripts/generate-engagement-readme.py "<engagement-dir>"` —
-not theme-gated (unlike the dashboard refresh above) and non-fatal: on failure,
-warn and continue.
+unconditional within these milestone actions, not theme-gated and
+non-fatal: on failure,
+warn and continue. It emits nothing to the consultant, so it is never an offer
+and never counts against the offer budget.
 
-**Knowledge-base deposit is elected, not automatic.** Offer
-to deposit the completed artifact into the engagement's bound knowledge base
-(default-on: deposit without pausing in auto-walk mode, confirm first in
-interactive mode, never auto-fire without offering) so future gap-checks and
-research reuse its findings; the consultant may decline only on the record via a
-`kb-deposit-waiver`. The full deposit
+**Knowledge-base deposit is elected, not automatic** (rank 1). Offer to deposit
+the completed artifact into the engagement's bound knowledge base (default-on:
+deposit without pausing in auto-walk mode, confirm first in interactive mode,
+never auto-fire without offering) so future gap-checks reuse its findings; the
+consultant may decline only on the record via a `kb-deposit-waiver`. The deposit
 signature (reusing `cogni-knowledge:knowledge-ingest-source` verbatim), the
-provenance carried into the deposit context, and the waiver shape + idempotency
-are in `$CLAUDE_PLUGIN_ROOT/references/orchestration/close-kb-deposit.md`.
+provenance it carries, and the waiver shape + idempotency are in
+`$CLAUDE_PLUGIN_ROOT/references/orchestration/close-kb-deposit.md`.
 
-**Publishing is elected, not automatic.** The consultant
-*may* now turn the deliverable into a presentation-ready brief for Claude Design
-with `/cogni-consult:consult-publish` (slides, web-poster, report, or
-infographic). Mention it as an available next step only — never auto-fire it:
-which deliverables are presentation-worthy, and in which format, is a deliberate
-consultant judgment call; the design-thinking loop ends at `complete`.
+**Publishing is elected, not automatic** (rank 2). The consultant *may* now turn
+the deliverable into a
+presentation-ready brief for Claude Design with `/cogni-consult:consult-publish`
+(slides, web-poster, report, or infographic).
+Mention it as an available next step only — never auto-fire it: format choice
+is the consultant's judgment call, and the loop ends at `complete`.
 
 ## Important Notes
 

--- a/cogni-consult/skills/consult-personas/SKILL.md
+++ b/cogni-consult/skills/consult-personas/SKILL.md
@@ -210,6 +210,17 @@ and by whom, and any challenge the consultant still needs to disposition.
 When a challenged deliverable needs rework, point at its producing route as
 the next step.
 
+**Close budget: at most six lines** — one result line, at most three substance
+lines, one artifact line, one next-step line. At most one table, and only at
+four or five rows: section (d) of
+`$CLAUDE_PLUGIN_ROOT/references/user-facing-output.md` bars a table under four
+rows, so anything smaller is prose. Announce before *or* report after, never
+both — section (e) of that same register owns that rule. The producing-route
+pointer above is that one next-step line: it carries exactly one
+recommendation, generalizing to every close what
+`$CLAUDE_PLUGIN_ROOT/skills/consult-resume/SKILL.md` states for re-entry under
+its `## Important Notes` ("One recommendation").
+
 ## Important Notes
 
 - **Acting, not gating**: personas challenge in their own voice and ground


### PR DESCRIPTION
Closes #1143.

## Summary

- `consult-design-thinking` Step 8 now **ranks** its trailing offers and emits **at most one** per close — 1. knowledge-base deposit, 2. publishing, 3. dashboard theme setup — with the rest unmentioned, surfacing on the next turn if the emitted one is declined.
- **All three offer capability contracts survive.** The diff changes emission, not capability: the dashboard refresh (`output/design-variables.json`, the `consult-dashboard-refresher` delegation, `output/dashboard.html`), the KB deposit (elected-not-automatic, the auto-walk/interactive branch, `never auto-fire without offering`, the `kb-deposit-waiver`, the `close-kb-deposit.md` pointer) and publishing (`/cogni-consult:consult-publish`, "Mention it as an available next step") are all intact.
- The milestone README refresh stays **unconditional** and non-fatal, emits nothing to the consultant, and is named as **not counting against the offer budget**.
- Both Step 8 and `consult-personas` Step 6 state the close budget — at most six lines (one result, ≤3 substance, one artifact, one next-step) and at most one table at four or five rows — plus the trade rule *announce before or report after, never both*.
- Both **cite** `references/user-facing-output.md` §(d)/§(e) rather than restating them, and Step 8 cites `consult-resume/SKILL.md` `## Important Notes` ("One recommendation") as the principle it generalizes from re-entry to every close.
- `references/orchestration/close-kb-deposit.md` gains a one-clause qualifier — it declares itself authoritative and then said, unqualified, "Offer to deposit it", which would have contradicted the new ranking rule for anyone loading the reference directly.

## Corrections to the issue's premises

Two of the issue's stated premises do not hold against `main`. Both were decidable from the files, so they were resolved rather than escalated:

1. **`consult-personas` Step 6 does not "close the same way".** It emits *zero* trailing offers today, so there is nothing to rank there — its change is a pure addition of the budget and trade rule.
2. **The word "unconditional" was absent** from the README-refresh block, so AC 3's grep could never have passed on the base file. It is now added, scoped as "unconditional within these milestone actions" so it cannot contradict the milestone gate above it. The non-fatal clause is unchanged.

Separately, the issue's line anchors were stale by ~+43 lines (`#1142` shifted the file); all were re-derived from headings before editing.

## Scope decision — third close site left out

`skills/consult-action-fields/SKILL.md` independently emits the dashboard-refresh + README pair and has its own close section. No acceptance criterion names it, and it emits neither KB deposit nor publish, so the ranking rule would be a no-op there. Flagged for the epic rather than silently widened — if the epic wants the six-line budget at *every* close site, that is a separate one-file change.

## Review notes

**`load_bearing_preserved` — net-growth budget not met, deliberately.** `consult-design-thinking/SKILL.md` was **already 5,690 chars over** its measured cap before this PR (32,690 body chars vs a complexity-scaled cap of 27,000). This change leaves it at 34,085, **+1,395**. Net-flat is not reachable: AC 2 forbids deleting any of the three capability contracts, and the budget, trade rule, ranking rule and citations are all AC-mandated additions. A prose-simplifier pass did run over Step 8 and reclaimed 430 chars; most of that was then spent restoring two things the sweep had folded away — `Publishing is elected, not automatic` (a capability posture that `close-kb-deposit.md` cross-references) and the explicit "never counts against the offer budget" clause AC 3 requires be *named*.

**Pre-existing over-cap, not introduced here** (`introduced_by_change: false`). The largest remaining reclaimable block is the Step 7 Test-stage rung prose, which could move behind the `references/orchestration/*.md` pointers that already exist. That is a separate cleanup, not this PR's scope.

## Verification

- [x] All 9 `cogni-consult/tests/*.sh` pass — including `test_step0_register_block.sh` (the Step 0 register block is untouched in both skills). Not CI-discovered; run by hand.
- [x] `scripts/check-breadcrumbs.py` rc=0 — no new issue/PR refs, version tags, or slice codes.
- [x] `scripts/check-version-bump.py` rc=0 — 0 plugins touched, no version bumped in-branch.
- [x] All 17 AC-pinned strings verified present.

⚠️ **Note for whoever writes the acceptance greps:** the clause `on failure, warn and continue` is **wrapped across a line break** in the source and always has been, so a single-line `grep` for it returns 0 *even on an unmodified file*. Verify it with newline normalisation (`tr '\n' ' '`). The same applies to the new `Announce before *or* report after, never both`.

- [ ] Manual acceptance bar (AC 7, needs a live engagement): run `/cogni-consult:consult-personas` through a full challenge round with **no output style active** — the close should be ≤6 lines with exactly one trailing offer.

Plan record: https://github.com/cogni-work/insight-wave/issues/1143#issuecomment-5182451729