### PR TITLE
cogni-consult: plugin-owned anglicism lexicon + closed disposition set

### DIFF
--- a/cogni-consult/CLAUDE.md
+++ b/cogni-consult/CLAUDE.md
@@ -31,7 +31,8 @@ cogni-consult/
 │   │                              verbatim into every dispatched agent
 │   ├── user-facing-output.md      Main-loop register contract (surface scope,
 │   │                              state lexicon, table rules, step announcements,
-│   │                              tool-call description copy)
+│   │                              tool-call description copy, prose anglicism
+│   │                              lexicon)
 │   ├── personas/                  Packaged default advisors (consulting-partner,
 │   │                              project-manager)
 │   ├── methods/

--- a/cogni-consult/output-styles/strategy-advisor-de.md
+++ b/cogni-consult/output-styles/strategy-advisor-de.md
@@ -55,8 +55,10 @@ festzuhalten.
 - Nummerierte Rückverweise tragen ihren Namen mit: „Teillösung 2 (die freie
   Content-Schicht)“, nicht „bei 2“.
 - Englisch bleiben dürfen die etablierten Domänenbegriffe (Deliverable, Design
-  Thinking, Persona, Action Field) sowie Datei- und Skill-Namen, CLI-Befehle
-  und Slugs in Codeform. Im Fließtext haben Slugs nichts verloren.
+  Thinking, Persona) sowie Datei- und Skill-Namen, CLI-Befehle und Slugs in
+  Codeform. Im Fließtext haben Slugs nichts verloren. „Action Field“ gehört
+  nicht dazu — es ist eine plugin-eigene Prägung, kein etablierter deutscher
+  Beratungsbegriff, und heißt auf deutschen Oberflächen „Handlungsfeld“.
 
 ## Systemvokabular bleibt im System
 Engine-Begriffe — Cascade, Graph, Kante, `depends_on`, Gate, Slug, Zustandswerte

--- a/cogni-consult/output-styles/strategy-advisor.md
+++ b/cogni-consult/output-styles/strategy-advisor.md
@@ -41,6 +41,11 @@ changed in the engagement — never what the tooling did to record it.
   (`channel-acquisition-model` → "the channel model").
 - Numbered back-references carry their name: "sub-solution 2 (the free content
   layer)", not "at 2".
+- The established domain terms that may stay English in another language are
+  Deliverable, Design Thinking, and Persona — plus file and skill names, CLI
+  commands, and slugs in code form. Slugs have no place in running prose.
+  "Action Field" is not on that list: it is this plugin's own coinage rather
+  than an established term, so a German surface reads "Handlungsfeld".
 
 ## System vocabulary stays in the system
 Engine nouns — cascade, graph, edge, `depends_on`, gate, slug, state values

--- a/cogni-consult/references/orchestration/test-persona-challenge.md
+++ b/cogni-consult/references/orchestration/test-persona-challenge.md
@@ -57,7 +57,11 @@ After the merge, `consult-personas` applies exactly these writes:
   (`{"action_field", "deliverable", "action": "challenged", "date"}`).
 - Append (or update) a consolidated `## Persona Challenges` section in the
   deliverable artifact summarizing each persona's challenge and the consultant's
-  disposition (accepted / revised / rejected with reason).
+  disposition. The disposition triple is prose, not a stored field, and renders
+  per `references/user-facing-output.md` — übernommen / überarbeitet / begründet
+  verworfen, or accepted / revised / rejected with reason. The set is closed at
+  exactly those three: there is no fourth state, and one offered is an invention
+  rather than a value to pass through.
 - When the field's manifest entry carries a `persona_review` field, advance it
   (`pending` → `in-progress` when challenges start, → `complete` only once every
   challenge is dispositioned); when it doesn't, the `work_log` entries and the

--- a/cogni-consult/references/subagent-output-contract.md
+++ b/cogni-consult/references/subagent-output-contract.md
@@ -28,3 +28,9 @@ the operator of this system, so these rules bind everything you write.
   internal. Report the business consequence instead.
 - Never name a deliverable, action field, or persona by its file slug in prose.
   Use its plain name. Slugs belong in structured fields, not in sentences.
+- Prefer the established word in the reader's language over the anglicism
+  compound — in German, *Übergabe* not *Handoff*, *Freigabepunkt* (or nothing at
+  all) not *Gate*, *Handlungsfeld* not *Action Field*. And never invent a system
+  term that does not exist: an invented term is worse than a leaked one, because
+  a real value can be looked up somewhere and an invented one nowhere. If no
+  term fits, describe what happened in plain language.

--- a/cogni-consult/references/user-facing-output.md
+++ b/cogni-consult/references/user-facing-output.md
@@ -53,10 +53,17 @@ Four notes travel with the table:
   entry — never conflated with `pending`, which means not started. Surface the
   warning's substance; do not pass the token through.
 - The disposition triple is **prose vocabulary**, not a stored field. It names
-  how the consultant answered a persona challenge; no JSON key carries it.
+  how the consultant answered a persona challenge; no JSON key carries it. It is
+  also **closed**: exactly three values, and a fourth is an invention rather than
+  a gap to add. The row-gap rule above admits values the engine actually writes;
+  a disposition the engine never writes has no row to add, so reach for one of
+  the three or rewrite the sentence.
 - Design-thinking stage names (`empathize` → `define` → `ideate` → `prototype` →
   `test`) are method terms: proper-case them for display (`ideate` → `Ideate`),
-  do not translate them.
+  do not translate them. The casing is what carries the meaning: lower-cased,
+  they read as engine values — the consultant sees a stored token rather than
+  the name of a method stage, which is exactly the failure proper-casing
+  prevents.
 
 Where an English display string happens to equal the engine token, that is a
 coincidence of vocabulary, not an exemption — the value still passes through the
@@ -128,6 +135,67 @@ Worked pair: `Discover cogni-consult engagements` → `Laufende Engagements hole
 
 A description failing any of the five is a defect on the same footing as a raw
 engine value in a table cell. This is a surface, not a debug channel.
+
+## (g) Prose anglicisms
+
+(c) governs how a **stored engine token** is displayed. This section governs the
+**prose word the consultant reads** — vocabulary that carries no backing field
+and so has no row to look up. Of the terms below only `Stale` is also a (c) row
+(`lineage_status.status: "stale"`); `Cascade` and `Gate` are engine vocabulary
+governed by the rule delegated at the end of this file. Where both apply they
+agree, so there is nothing to reconcile.
+
+Before reaching for the table, run the three-step test — the method comes from
+cogni-copywriting's German-style principles, cited here rather than loaded,
+because nothing in this plugin loads that file:
+
+1. Does an equally precise German word exist? If yes, use it.
+2. Is the anglicism established with no good German equivalent (*Meeting*,
+   *Software*, *Update*)? If yes, keep it.
+3. Is it a hyphenated English compound? Those almost always have a German
+   rendering — replace them.
+
+The table is what step 3 resolves to for this plugin's own coinages:
+
+| English | German | Note |
+|---|---|---|
+| Front-Door | Einstiegsseite | |
+| Ramp | Anlaufphase | |
+| Slip-Signal | Verzugssignal | |
+| Base-Case / Base-Fall | Basisfall | |
+| Promote-Check | Annahmenprüfung | |
+| Gate | Freigabepunkt | usually cut entirely rather than translated — name what the consultant decides, not the checkpoint |
+| Cascade | als überholt markieren | |
+| Stale | überholt | |
+| Rollup | Gesamtstand | |
+| Handoff | Übergabe | |
+| Waiver | begründete Ausnahme | |
+| WBS | Arbeitsstruktur | |
+
+`Action Field` is this plugin's own coinage, not an established German
+consulting term, so on a German surface it reads **Handlungsfeld**. The English
+table templates keep `Action Field` deliberately — that is the two-language
+split doing its job, not a leak.
+
+**Never invent a system term that does not exist.** An invented term is worse
+than a leaked one: a leaked engine value can at least be looked up in the
+system, while an invented one resolves nowhere the consultant can reach — not in
+the artifact, not in a manifest, not in this file. The observed instance is
+`Routed`, offered as a fourth disposition alongside the three real ones; the
+plugin has never written it. When a word is needed for a state, take it from
+(c), or describe what happened in plain language.
+
+This table is owned here rather than borrowed. cogni-copywriting's German-style
+table addresses sales and go-to-market vocabulary and shares no term with the
+list above; it transliterates its umlauts to ASCII, which contradicts the
+orthography this plugin mandates; and no load path reaches it from here. The
+method above is worth citing, the vocabulary is not worth importing.
+
+The naming discipline in this section has a subagent counterpart —
+`references/subagent-output-contract.md` (`## Register`) carries it, because an
+agent's envelope prose is exactly where an invented term surfaces. Unlike (f),
+which is main-loop-only by its own terms, a rule changed here is checked against
+that file.
 
 ## What binds here but lives elsewhere
 


### PR DESCRIPTION
Closes #1144.

## Summary

- Add `## (g) Prose anglicisms` to `cogni-consult/references/user-facing-output.md`: the three-step replacement test (method cited from cogni-copywriting, not loaded), a twelve-row `old → new` table whose `Gate` row states the term is usually cut entirely rather than translated, the `Action Field` → `Handlungsfeld` rule with the deliberate English-template carve-out preserved, and the normative rule **never invent a system term that does not exist** with its reason and `Routed` named as the observed instance.
- Record why cogni-copywriting's German-style table is not reusable — zero lexical overlap (sales/GTM vs strategy-engagement vocabulary), ASCII-transliterated umlauts contradicting this plugin's orthography mandate, and no cross-plugin load path — while adopting its three-step test as the method.
- Close the disposition triple to **exactly three values** in section (c), and mirror the German display forms into the second source line, `references/orchestration/test-persona-challenge.md`, so the write contract and the display contract are read together at both.
- Give the existing design-thinking stage-casing note its missing reason: lower-cased, the stage names read as engine values.
- Mirror the naming discipline into `references/subagent-output-contract.md` — one self-contained bullet, no table.
- Narrow the German allowlist to `Deliverable, Design Thinking, Persona` and add the matching enumeration to the English sibling, which carried none.

## Load-bearing decisions a reviewer should check

**The section is appended as (g), not inserted as a new (d).** Nine `consult-*` Step-0 blocks, `CLAUDE.md`, and `interaction-language.md` all name "section (f)" literally, and `tests/test_step0_register_block.sh` byte-compares those blocks. Renumbering would break all of them; appending keeps every reference valid. Sections (a)–(f) are untouched.

**AC4's English half is an addition, not a symmetric edit.** The issue assumes `strategy-advisor.md:35-43` carries an allowlist to narrow. It does not — the English `## Lexicon` had four bullets and no enumeration at all. The bullet is added rather than skipped because the plugin's own `CLAUDE.md` records that the two style files share no reference and must be kept in step deliberately, and the queued style-collapse work folds both over this register.

**Two lockstep updates the issue does not name, both verified before adoption:**
- `references/subagent-output-contract.md` states at its head "Keep this in step with `references/user-facing-output.md` — the two are one contract with two delivery paths, not two contracts." Section (f) is exempt only via an explicit main-loop-only carve-out; (g)'s naming discipline has no such property, and a dispatched agent's envelope prose is precisely where an invented term surfaces. One self-contained bullet is added — not the table, since this file is injected verbatim into every dispatch and must stay small. The `## Register` heading is left intact (`tests/test_subagent_start_hook.sh` asserts it).
- `CLAUDE.md`'s repo-tree entry enumerates what the register governs; adding (g) would otherwise leave that list stale.

**A factual error was caught and corrected before the plan locked.** An earlier draft of (g)'s boundary sentence claimed section (c) governs `Cascade` and `Gate`. That is false — (c)'s ten rows are `pending`, `in-progress`, `complete`, `lineage_status.status: "stale"`, `unreadable`, two `personas_gate` rows, adherence, outcome, disposition. Of the twelve anglicisms only `Stale` has a (c) row; `Cascade` and `Gate` are engine vocabulary governed by the rule this file delegates at its end. The shipped sentence says so.

## Two acceptance criteria are in literal tension — how it was resolved

AC2 asks that `grep -rn 'Routed' cogni-consult/` return **no hit**. AC3 asks that the new rule **cite `Routed`** as the observed instance. Both cannot hold at once.

`Routed` returned **zero hits before this change** — it was invented at runtime and never existed in source, so AC2's grep was already satisfied for its actual intent (no leaked or usable `Routed` value). The single hit the grep now returns is the deliberate citation AC3 requires, inside the never-invent rule, marked as a term the plugin has never written. Reading AC2 literally would have meant dropping AC3's citation, which is the more load-bearing of the two — the rule is worth little without its worked instance.

Relatedly, `grep 'Action Field' cogni-consult/output-styles/` still returns two hits. Both are the new prose stating that `Action Field` is **not** allowlisted and reads `Handlungsfeld` on a German surface — the opposite of an allowlist entry. Naming the exclusion is more useful to the model than silently dropping the term.

## Explicitly out of scope

- **No source-wide find-and-replace for the twelve terms.** Six have zero occurrences in committed files (`Front-Door`, `Ramp`, `Slip-Signal`, `Base-Case`, `Base-Fall`, `Rollup`); the rest appear only in internal step/section headings and script comments — none in a rendered user-facing cell or label. The table is preventive naming discipline governing what the model writes at runtime.
- **Both `Handlungsfeld` table headers were already correct**, and the adjacent English-session templates keep `Action Field` deliberately. That two-language split is not inverted here.
- **Stage-casing application** in `consult-resume` Step 5 belongs to the separate open stage-casing issue; this PR sets the rule only.
- **`references/interaction-language.md`** is untouched — its slug clause is the adjacent slug-contradiction issue's fault line.
- **No version bump** in `plugin.json` or `marketplace.json` — the post-merge workflow owns it.

## Verification run by the author

- `cogni-consult/tests/*.sh` — **all 9 pass**, including both guards: `test_step0_register_block.sh` (section (f) and the nine Step-0 blocks unchanged) and `test_subagent_start_hook.sh` (`## Register` heading intact). Note this suite is now CI-enforced via the `Plugin test suites` job.
- `scripts/check-breadcrumbs.py` → OK, 0 new findings.
- `scripts/check-version-bump.py` → `[ok] 14 plugin(s) scanned, 0 touched, 0 violation(s)`.
- Section (g) carries exactly **12** data rows; the `Gate` row states it is usually cut entirely.
- Both disposition source lines carry `übernommen / überarbeitet / begründet verworfen` (checked newline-normalized — the phrase wraps, so a naive single-line grep gives a false negative on `test-persona-challenge.md`).
- Zero ASCII substitutes (`ae`/`oe`/`ue`) in the new section; proper ä/ö/ü/ß throughout.
- Register headings verified unrenumbered: (a) 14, (b) 21, (c) 30, (d) 72, (e) 85, (f) 105, (g) 139.

**Not run by the author:** AC7's acceptance bar — `/cogni-consult:consult-personas` through a full challenge round with no output style active. It requires a live engagement fixture and a fresh session (hooks load from the installed plugin cache, not from a branch), so it cannot be exercised from this branch. Flagging it as the one criterion resting on reviewer judgment rather than a green check.

## Base

Branched from `origin/main` at `2cb473d0`, which advanced mid-run from `a92b39aa`. All cited anchors were re-verified against the newer tip before any edit; the only intervening cogni-consult change was a version bump plus a CI-enforcement note in `CLAUDE.md`, neither of which touches the six edited regions.