### PR TITLE
cogni-visual: fix README architecture tree drift

### DIFF
--- a/cogni-visual/README.md
+++ b/cogni-visual/README.md
@@ -143,7 +143,7 @@ In the second phase, a rendering agent consumes the brief and produces the outpu
 
 ```
 cogni-visual/                              # 7 skills · 19 agents · 6 commands · 1 hook
-├── .claude-plugin/                        Plugin manifest (v0.16.26)
+├── .claude-plugin/                        Plugin manifest
 ├── skills/                               7 visual skills (4 brief generators · 1 renderer · 1 enricher · 1 reviewer)
 │   ├── story-to-slides/
 │   ├── story-to-web/
@@ -155,8 +155,8 @@ cogni-visual/                              # 7 skills · 19 agents · 6 commands
 ├── agents/                               19 agents (orchestration · rendering · workers)
 ├── commands/                             6 slash commands (including /render-infographic dispatcher + 2 direct variants)
 ├── hooks/                                1 PreToolUse hook (Excalidraw canvas auto-start)
-├── scripts/                              Utility scripts (rasterize-sketch.py, cartographic-outline.py)
-├── references/                           Reference data (cartographic-data/)
+├── scripts/                              Utility scripts (rasterize-sketch.py, cartographic-outline.py, load-theme-component.py)
+├── references/                           Reference data (cartographic-data/, theme-component-loader.md)
 ├── evals/                                Evaluation harnesses (render-infographic)
 └── libraries/                            17 shared reference files
     ├── arc-taxonomy.md                   arc ID → visual arc type mapping


### PR DESCRIPTION
Closes #1209.

## Summary

Three lines of the `cogni-visual` README architecture tree made false claims about what ships in the plugin. One file changed, three lines, no code and no manifest.

| Line | Before | After |
|---|---|---|
| 158 | `Utility scripts (rasterize-sketch.py, cartographic-outline.py)` | adds `load-theme-component.py` |
| 159 | `Reference data (cartographic-data/)` | adds `theme-component-loader.md` |
| 146 | `Plugin manifest (v0.16.26)` | `Plugin manifest` — pin removed |

## The issue reported two gaps; the audit found three

The issue names `load-theme-component.py` and `theme-component-loader.md` together, but the second omission is on a **different line** than the one it cites: `README.md:158` is the `scripts/` line, while `theme-component-loader.md` belongs to `references/` on `:159`. A fix touching only the cited line 158 would have left half the reported drift in place.

A full audit of the tree block (lines 144-179) against `git ls-tree` at the base ref surfaced a third, unreported drift at line 146 — the README pinned `v0.16.26` while `plugin.json` is at `0.16.27`. Everything else in the block checked out and is untouched: 7 skills, 19 agents, 6 commands, 1 hook, `evals/render-infographic`, and all 17 `libraries/` entries.

## Two decisions worth your attention

**The version pin is deleted, not refreshed.** Writing `v0.16.27` would be stale the moment this lands: merging this PR touches `cogni-visual/`, which fires the post-merge auto-bump workflow and moves the plugin to `0.16.28`. That is exactly how the current drift arose — PR #1203 wrote `v0.16.26`, and a later auto-bump moved `plugin.json` past it. A hand-written fact that re-invalidates itself on every merge is a drift generator, not an instance of drift, so it is removed rather than re-pinned. Nothing is lost: `plugin.json` remains the source of truth, `README.md:3` already carries the maturity band (`**Preview** (v0.x)`), and 9 of the 14 plugin READMEs already write a bare `Plugin manifest` line.

Neither `cogni-visual/.claude-plugin/plugin.json` nor the root `.claude-plugin/marketplace.json` is edited — both stay at `0.16.27`, per the repo's branch-time version-bump prohibition. `check-version-bump.py` enumerates versions only from those two manifests, so README prose cannot trip `version-touched` or `version-mirror-desync`; the gate was run and reports `0 touched, 0 violations`.

**Hand-edit, not `/doc-generate`.** The issue proposes `/doc-generate cogni-visual --section=architecture`. `cogni-docs` is not in this repository — no tree entry at the base ref, and absent from `marketplace.json`'s 14 plugins. A reviewer with a fresh checkout cannot reproduce that command, so a hand-edit is the only reproducible fix. This is a manual correction of a section repo `CLAUDE.md` nominally classes as auto-generated, because the generator lives outside the repo. The result is what the generator would produce, so a later `/doc-generate` run from an environment that has the plugin will not conflict.

## Style

Kept the existing parenthetical-enumeration form and made it exhaustive, appending rather than reordering so the diff stays minimal. An alternative plan proposed restyling both lines to a count-plus-list form (`3 utility scripts (…)`), on the argument that the missing count is what let the drift go unnoticed. It was not taken: `cogni-visual`'s tree already uses count-plus-enumeration at `libraries/` and bare enumeration here, and converting only these two lines would add a third style to one block. Sibling plugins have no single convention to conform to (surveyed: cogni-consult, cogni-portfolio, cogni-knowledge, cogni-trends — four different styles).

## Verification

- Both directions checked programmatically: every file in `cogni-visual/scripts/` and `cogni-visual/references/` is named on its line, and neither line names anything that does not exist.
- `check-version-bump.py` — exit 0, 14 plugins scanned, 0 touched, 0 violations.
- `check-breadcrumbs.py` — exit 0, 0 findings.
- All 5 repo-root `tests/*.sh` suites pass.
- `cogni-workspace/tests/test-sanitize-theme.sh` — the only suite that mentions `cogni-visual` (in a comment) — passes.
- `git diff --check` clean; no trailing whitespace, column alignment preserved (the block has two alignment groups, description column 44 on lines 145-146 and 43 on 147/155-161).

`cogni-visual` has no `tests/` directory, so there is no plugin-level suite to run; the full-repo sweep exceeded a 10-minute budget and was replaced by the targeted runs above.

## Not in this PR

No in-repo guard would have caught this drift — the generator is out-of-repo and there is no doc-drift harness for `cogni-visual`. That is a tooling gap rather than part of this issue's criterion, and is recorded here rather than filed as a speculative follow-up.