### PR TITLE
cogni-consult: split the slug rule into spelling (how) and presence (whether)

### DIFF
--- a/cogni-consult/output-styles/strategy-advisor-de.md
+++ b/cogni-consult/output-styles/strategy-advisor-de.md
@@ -50,15 +50,21 @@ festzuhalten.
   Anglizismus-Kompositum: „Wettbewerbsschutz“ statt „Moat-Richtung“,
   „sichtbarer Beleg durch andere“ statt „Sozialbeweis“, „dauerhaft nutzbarer
   Bestand“ statt „Evergreen-Bestand“.
-- Kein Deliverable per Datei-Slug im Fließtext benennen — den Klarnamen
-  verwenden: nicht „channel-acquisition-model“, sondern „das Kanalmodell“.
+- Kein Deliverable per Datei-Slug benennen — den Klarnamen verwenden: nicht
+  „channel-acquisition-model“, sondern „das Kanalmodell“. Das gilt auf jeder
+  Oberfläche: Fließtext, Tabellenzellen und Spaltenüberschriften gleichermaßen.
 - Nummerierte Rückverweise tragen ihren Namen mit: „Teillösung 2 (die freie
   Content-Schicht)“, nicht „bei 2“.
 - Englisch bleiben dürfen die etablierten Domänenbegriffe (Deliverable, Design
   Thinking, Persona) sowie Datei- und Skill-Namen, CLI-Befehle und Slugs in
-  Codeform. Im Fließtext haben Slugs nichts verloren. „Action Field“ gehört
-  nicht dazu — es ist eine plugin-eigene Prägung, kein etablierter deutscher
-  Beratungsbegriff, und heißt auf deutschen Oberflächen „Handlungsfeld“.
+  Codeform. Ein Slug erscheint nur dort, wo er zum Handeln gebraucht wird, und
+  dann nur in Codeform — nie als Spaltenüberschrift, nie als Name eines
+  Deliverables — auf jeder Oberfläche, nicht nur im Fließtext. Wie ein Bezeichner
+  geschrieben wird, sobald er erscheint, regelt
+  `references/interaction-language.md`.
+  „Action Field“ gehört nicht dazu — es ist eine plugin-eigene Prägung, kein
+  etablierter deutscher Beratungsbegriff, und heißt auf deutschen Oberflächen
+  „Handlungsfeld“.
 
 ## Systemvokabular bleibt im System
 Engine-Begriffe — Cascade, Graph, Kante, `depends_on`, Gate, Slug, Zustandswerte

--- a/cogni-consult/output-styles/strategy-advisor-de.md
+++ b/cogni-consult/output-styles/strategy-advisor-de.md
@@ -57,14 +57,13 @@ festzuhalten.
   Content-Schicht)“, nicht „bei 2“.
 - Englisch bleiben dürfen die etablierten Domänenbegriffe (Deliverable, Design
   Thinking, Persona) sowie Datei- und Skill-Namen, CLI-Befehle und Slugs in
-  Codeform. Ein Slug erscheint nur dort, wo er zum Handeln gebraucht wird, und
-  dann nur in Codeform — nie als Spaltenüberschrift, nie als Name eines
-  Deliverables — auf jeder Oberfläche, nicht nur im Fließtext. Wie ein Bezeichner
-  geschrieben wird, sobald er erscheint, regelt
-  `references/interaction-language.md`.
-  „Action Field“ gehört nicht dazu — es ist eine plugin-eigene Prägung, kein
-  etablierter deutscher Beratungsbegriff, und heißt auf deutschen Oberflächen
-  „Handlungsfeld“.
+  Codeform. „Action Field“ gehört nicht zu diesen etablierten Begriffen — es ist
+  eine plugin-eigene Prägung, kein etablierter deutscher Beratungsbegriff, und
+  heißt auf deutschen Oberflächen „Handlungsfeld“.
+  Ein Slug erscheint nur dort, wo er zum Handeln gebraucht wird, und dann nur in
+  Codeform — nie als Spaltenüberschrift, nie als Name eines Deliverables — auf
+  jeder Oberfläche, nicht nur im Fließtext. Wie ein Bezeichner geschrieben wird,
+  sobald er erscheint, regelt `references/interaction-language.md`.
 
 ## Systemvokabular bleibt im System
 Engine-Begriffe — Cascade, Graph, Kante, `depends_on`, Gate, Slug, Zustandswerte

--- a/cogni-consult/output-styles/strategy-advisor.md
+++ b/cogni-consult/output-styles/strategy-advisor.md
@@ -44,13 +44,13 @@ changed in the engagement — never what the tooling did to record it.
   layer)", not "at 2".
 - The established domain terms that may stay English in another language are
   Deliverable, Design Thinking, and Persona — plus file and skill names, CLI
-  commands, and slugs in code form. A slug appears only where the reader needs it
-  to *act*, and then only in code form — never as a column header, never as a
-  deliverable's name — on every surface, not only running prose. How an
-  identifier is spelled once it does appear is owned by
-  `references/interaction-language.md`.
-  "Action Field" is not on that list: it is this plugin's own coinage rather
-  than an established term, so a German surface reads "Handlungsfeld".
+  commands, and slugs in code form. "Action Field" is not among those
+  established terms: it is this plugin's own coinage, so a German surface reads
+  "Handlungsfeld".
+  A slug appears only where the reader needs it to *act*, and then only in code
+  form — never as a column header, never as a deliverable's name — on every
+  surface, not only running prose. How an identifier is spelled once it does
+  appear is owned by `references/interaction-language.md`.
 
 ## System vocabulary stays in the system
 Engine nouns — cascade, graph, edge, `depends_on`, gate, slug, state values

--- a/cogni-consult/output-styles/strategy-advisor.md
+++ b/cogni-consult/output-styles/strategy-advisor.md
@@ -37,13 +37,18 @@ changed in the engagement — never what the tooling did to record it.
 - Spell out every acronym once at first use (ICP, OMTM, UVP), then use it freely.
 - Where an established term exists in the reader's language, it beats the
   anglicised compound ("Wettbewerbsschutz", not "Moat-Richtung").
-- Never name a deliverable by its file slug in prose — use its plain name
-  (`channel-acquisition-model` → "the channel model").
+- Never name a deliverable by its file slug — use its plain name
+  (`channel-acquisition-model` → "the channel model"), on every surface: running
+  prose, table cells, and column headers alike.
 - Numbered back-references carry their name: "sub-solution 2 (the free content
   layer)", not "at 2".
 - The established domain terms that may stay English in another language are
   Deliverable, Design Thinking, and Persona — plus file and skill names, CLI
-  commands, and slugs in code form. Slugs have no place in running prose.
+  commands, and slugs in code form. A slug appears only where the reader needs it
+  to *act*, and then only in code form — never as a column header, never as a
+  deliverable's name — on every surface, not only running prose. How an
+  identifier is spelled once it does appear is owned by
+  `references/interaction-language.md`.
   "Action Field" is not on that list: it is this plugin's own coinage rather
   than an established term, so a German surface reads "Handlungsfeld".
 

--- a/cogni-consult/references/interaction-language.md
+++ b/cogni-consult/references/interaction-language.md
@@ -32,8 +32,15 @@ Resolve it the same way `cogni-help:cogni-issues` does, in this order:
 3. **Fallback** — if neither source is present and the message language is
    unclear, default to English.
 
-Conduct the entire conversation in the resolved interaction language; technical
-terms, slugs, skill names, CLI commands, and file names stay English regardless.
+Conduct the entire conversation in the resolved interaction language. Technical
+terms, slugs, skill names, CLI commands, and file names are identifiers: once one
+is surfaced at all, it keeps the exact form the system writes it in — never
+translated, never re-cased, never Title-Cased. `scope_state` stays `scope_state`;
+rendering it as `Scope` is the defect this rule forbids.
+
+That governs *how* an identifier is spelled, not *whether* it belongs on the
+surface at all. The whether question is owned by
+`references/user-facing-output.md`, where the default answer is **no**.
 
 ## Subagents do not inherit it
 
@@ -61,3 +68,6 @@ language per this file, but whose own copy constraints are owned by section (f)
 of `references/user-facing-output.md`. Deliberately not restated here: a fourth
 copy of the specifics is the drift this split exists to prevent. Look for a copy
 rule there, not here.
+
+The same split governs identifiers: this file says how one is spelled once it
+appears, and `references/user-facing-output.md` says whether it may appear.

--- a/cogni-consult/references/interaction-language.md
+++ b/cogni-consult/references/interaction-language.md
@@ -34,9 +34,14 @@ Resolve it the same way `cogni-help:cogni-issues` does, in this order:
 
 Conduct the entire conversation in the resolved interaction language. Technical
 terms, slugs, skill names, CLI commands, and file names are identifiers: once one
-is surfaced at all, it keeps the exact form the system writes it in — never
-translated, never re-cased, never Title-Cased. `scope_state` stays `scope_state`;
-rendering it as `Scope` is the defect this rule forbids.
+is surfaced *as an identifier* — in code form, the way the system writes it — it
+keeps that exact form: never translated, never re-cased, never Title-Cased.
+`scope_state` stays `scope_state`; rendering it as `Scope` is the defect this
+rule forbids. The one carve-out is the design-thinking stage names, which
+`references/user-facing-output.md` (c) note 4 mandates be proper-cased for
+display (`ideate` → `Ideate`) because there the casing is what carries the
+meaning — a method term surfacing as a method term, not an identifier surfacing
+as an identifier.
 
 That governs *how* an identifier is spelled, not *whether* it belongs on the
 surface at all. The whether question is owned by

--- a/cogni-consult/references/user-facing-output.md
+++ b/cogni-consult/references/user-facing-output.md
@@ -202,10 +202,15 @@ that file.
 These rules are not restated in this file; they hold on every surface named in
 (b) all the same:
 
-- Audience framing, executive register and compression discipline, the
-  engine-vocabulary-stays-internal rule, and the no-slug-in-prose rule —
+- Audience framing, executive register and compression discipline, and the
+  engine-vocabulary-stays-internal rule —
   `references/subagent-output-contract.md` (`## Register`) and
   `output-styles/strategy-advisor.md` / `strategy-advisor-de.md`.
+- The slug-presence rule — code form only, only where the reader needs it to act,
+  never a column header, never a deliverable's name —
+  `output-styles/strategy-advisor.md` / `strategy-advisor-de.md`.
+  `references/subagent-output-contract.md` still scopes its own slug rule to
+  prose; everywhere else (d).7 above is what binds.
 - German orthography (ß/ss, Umlaute) — `output-styles/strategy-advisor-de.md`.
 
 One boundary: the generated HTML dashboard document follows the engagement's

--- a/cogni-consult/references/user-facing-output.md
+++ b/cogni-consult/references/user-facing-output.md
@@ -206,11 +206,10 @@ These rules are not restated in this file; they hold on every surface named in
   engine-vocabulary-stays-internal rule —
   `references/subagent-output-contract.md` (`## Register`) and
   `output-styles/strategy-advisor.md` / `strategy-advisor-de.md`.
-- The slug-presence rule — code form only, only where the reader needs it to act,
-  never a column header, never a deliverable's name —
-  `output-styles/strategy-advisor.md` / `strategy-advisor-de.md`.
-  `references/subagent-output-contract.md` still scopes its own slug rule to
-  prose; everywhere else (d).7 above is what binds.
+- The slug-presence rule — (d).7 above owns it;
+  `output-styles/strategy-advisor.md` / `strategy-advisor-de.md` carry it on the
+  styled path. `references/subagent-output-contract.md` still scopes its own
+  slug rule to prose.
 - German orthography (ß/ss, Umlaute) — `output-styles/strategy-advisor-de.md`.
 
 One boundary: the generated HTML dashboard document follows the engagement's


### PR DESCRIPTION
Closes #1145.

Two shipped rules contradicted each other. `references/interaction-language.md` said identifiers "stay English regardless" — readable as licensing a slug column — while the registers forbade slugs only "in prose" / "im Fließtext", readable as not covering tables. They were answering different questions, spelling versus presence, without saying so. Each file now answers exactly one and names the other as owner of the one it does not.

## Summary

- **`references/interaction-language.md`** — the closing paragraph of "Resolving the interaction language" becomes a spelling-only rule: once an identifier is surfaced at all it keeps the exact form the system writes it in, never translated, never re-cased, never Title-Cased. It cites the concrete forbidden case (`scope_state` must never render as `Scope`) and defers *whether* an identifier belongs on the surface to `references/user-facing-output.md`, naming **no** as the default. One pointer sentence extends the existing `## What this file does not own` section to identifiers.
- **`output-styles/strategy-advisor.md`** and **`output-styles/strategy-advisor-de.md`** — both become presence rules binding every surface, not only prose: a slug appears only in code form and only where the reader needs it to act, never as a column header, never as a deliverable's name. Each names `references/interaction-language.md` as owner of the spelling question.
- **`references/user-facing-output.md`** — the cross-reference label "the no-slug-in-prose rule" is relabelled to the surface-wide presence framing.

## Two things the issue did not name, found while planning

1. **Each style file carried two prose-scoped clauses, not one.** The issue names `strategy-advisor.md:40` and `strategy-advisor-de.md:59`, but `strategy-advisor.md:46` ("Slugs have no place in running prose.") and `strategy-advisor-de.md:53` ("Kein Deliverable per Datei-Slug im Fließtext benennen") carry the same scoping. Editing only the named clause would have left the table loophole open in both files, so all four were reworded.

2. **`references/user-facing-output.md:206` was made stale by this change** — and already contradicted its own table contract rule (d).7 in the same file, which states the surface-wide presence rule correctly. AC5's no-contradiction bar cannot hold while the deferral target mislabels the rule being deferred to, so the one-bullet relabel is included. Its attribution is deliberately narrowed to the two output styles only: `references/subagent-output-contract.md` still scopes its own slug rule to prose, so naming it as an owner of the surface-wide rule would have replaced a stale claim with a false one.

## Scope decisions

- **Full scope.** All six acceptance criteria in one PR — the three passages only stop contradicting each other when all three change together.
- **Out of scope, flagged not deferred:** `references/subagent-output-contract.md:29-30` carries the same prose-scoped slug rule on the subagent delivery path. It sits outside all six acceptance criteria and belongs to the epic's rule-widening child (#1146), which this issue blocks. No issue was filed for it because #1146 already owns that surface. This PR changes no rule *body* in `references/user-facing-output.md` — only a pointer label — so the "one contract, two delivery paths" invariant does not drift.
- **Out of scope:** `hooks/on-subagent-start.sh`, which hardcodes its own independent stay-English string with no read path from these files and is deliberately non-aligned per its own comment.
- **Deliberately untouched:** three unrelated "prose" occurrences inside the edited files — `interaction-language.md` (subagent inheritance), `strategy-advisor.md` (work narration), and this register's own section headings. None is a slug rule.
- No version bump — the post-merge workflow owns it.

## Verification run

- All 9 `cogni-consult/tests/*.sh` suites pass (`scripts/run-plugin-tests.py --filter cogni-consult`, exit 0). No suite string-matches any reworded passage; `test_step0_register_block.sh` pins section (f) strings this PR does not touch, and `test_subagent_start_hook.sh` pins headings only.
- `grep -r` confirms all four removal targets are gone plugin-wide: "stay English regardless", "Slugs have no place in running prose", "Im Fließtext haben Slugs nichts verloren", "no-slug-in-prose".
- `references/interaction-language.md` carries the `scope_state` → `Scope` example and names `references/user-facing-output.md`; both style files name `references/interaction-language.md`.
- `git diff --name-only origin/main` lists exactly the four files — no `plugin.json`, no `marketplace.json`.
- German orthography intact (ä/ö/ü/ß, „…“ quotes), no ASCII substitutes.

**Not verified here:** the issue's sixth acceptance criterion is a behavioural bar — re-run `/cogni-consult:consult-resume` in a German workspace with no output style active and confirm no slug column and no Title-Cased field identifier as a column header. That needs a live German engagement, so it is left for the reviewer.

## Plan record

Resolution plan: https://github.com/cogni-work/insight-wave/issues/1145#issuecomment-5185636110