### PR TITLE
cogni-projects: projects-backfill roll-off recommender skill

### DIFF
--- a/cogni-projects/CLAUDE.md
+++ b/cogni-projects/CLAUDE.md
@@ -3,8 +3,9 @@
 Partner-facing project-portfolio steering for consulting firms. Models
 consultants, projects, and staffing so partners can match people to work by
 availability, profile fit, and strategic impact. The data model, entity
-authoring, the staffing match engine, and the read-only portfolio dashboard
-have landed; the backfilling recommender arrives in later roadmap children.
+authoring, the staffing match engine, the read-only portfolio dashboard, and the
+backfilling recommender have landed; cross-plugin bridges arrive in later
+roadmap children.
 
 ## Plugin Architecture
 
@@ -17,7 +18,8 @@ cogni-projects/
 │   ├── projects-setup/SKILL.md         Initialize a portfolio directory (entry point)
 │   ├── projects-entities/SKILL.md      Author + register one consultant/project/assignment
 │   ├── projects-staff/SKILL.md         Rank candidate consultants per open project role
-│   └── projects-dashboard/SKILL.md     Render a partner-meeting portfolio dashboard (read-only)
+│   ├── projects-dashboard/SKILL.md     Render a partner-meeting portfolio dashboard (read-only)
+│   └── projects-backfill/SKILL.md      Rank next roles for a rolling-off consultant + replacements
 ├── scripts/
 │   ├── _projects_lib.py                Shared loader for the hyphen-named validate-entities.py
 │   ├── portfolio-init.sh               Idempotent portfolio scaffolder (stdlib-only)
@@ -55,7 +57,7 @@ bash-level assertions, so they do not source it.
 
 Planned (not yet scaffolded — see the roadmap epic):
 
-- `skills/` for the backfilling recommender.
+- Cross-plugin bridges to cogni-consult and cogni-portfolio.
 
 ## Data Model
 
@@ -72,6 +74,12 @@ A portfolio is one `cogni-projects/<portfolio-slug>/` directory:
   array. Also holds `staffing-recommendations.json` — the last-run staffing
   scorer output snapshot (overwritten each run, **not** an append-only log) that
   the backfilling recommender and dashboard read.
+- `backfill-log.json` — `projects-backfill`'s own append-only log, an object
+  `{"backfills": [...]}`. `portfolio-init.sh` does **not** seed it, so that skill
+  creates it on demand with that exact envelope. It also writes
+  `backfill-recommendations.json`, its last-run snapshot, kept distinct from the
+  `projects-staff`-owned `staffing-recommendations.json` so neither skill
+  clobbers the other.
 
 ## Conventions
 

--- a/cogni-projects/README.md
+++ b/cogni-projects/README.md
@@ -4,7 +4,7 @@
 
 > **insight-wave readiness (Claude Code desktop recommended)** — Claude Code desktop is the recommended interface for insight-wave today. Cowork is a secondary path and is not yet production-ready for insight-wave workflows because of context-window and Pencil-MCP fidelity gaps — see the [deployment guide](../docs/deployment-guide.md) for detail. This guidance will flip when those gaps close upstream.
 
-Partner project-portfolio steering for consulting firms on Claude Code. cogni-projects gives partners one place to model consultants, projects, and staffing — so they can match the right people to the right work by availability, profile fit, and strategic impact. The portfolio scaffold, entity authoring, the staffing match engine, and a read-only partner-meeting dashboard have shipped; the backfilling recommender arrives in a later release.
+Partner project-portfolio steering for consulting firms on Claude Code. cogni-projects gives partners one place to model consultants, projects, and staffing — so they can match the right people to the right work by availability, profile fit, and strategic impact. The portfolio scaffold, entity authoring, the staffing match engine, a read-only partner-meeting dashboard, and the backfilling recommender have shipped; cross-plugin bridges arrive in a later release.
 
 ## Why this exists
 
@@ -20,7 +20,7 @@ Consulting partners steer a portfolio of projects and people with spreadsheets a
 
 cogni-projects is a Claude Code plugin that holds a **self-contained project portfolio**: a directory of consultants, projects, and assignments rooted by a single manifest. It is the 14th plugin in the insight-wave ecosystem and the home for partner-facing portfolio steering.
 
-It provides the `projects-setup` skill that scaffolds a portfolio directory, the `projects-entities` skill that authors and registers validated consultant/project/assignment records, the `projects-staff` staffing match engine that ranks candidate consultants per open role, and the read-only `projects-dashboard` skill that renders a partner-meeting portfolio snapshot. Backfilling builds on top of these.
+It provides the `projects-setup` skill that scaffolds a portfolio directory, the `projects-entities` skill that authors and registers validated consultant/project/assignment records, the `projects-staff` staffing match engine that ranks candidate consultants per open role, the read-only `projects-dashboard` skill that renders a partner-meeting portfolio snapshot, and the `projects-backfill` skill that steers a rolling-off consultant into their next role while ranking replacements for the one they vacate. Backfilling builds on the same scorer as staffing.
 
 ## What it does
 
@@ -28,12 +28,13 @@ It provides the `projects-setup` skill that scaffolds a portfolio directory, the
 - **projects-entities** — author one consultant, project, or assignment record and register it in the portfolio manifest, with structural validation.
 - **projects-staff** — rank candidate consultants for every open project role on availability, profile fit, and strategic impact, and write a staffing-recommendations artifact.
 - **projects-dashboard** — render a read-only partner-meeting snapshot of the portfolio: staffing coverage per project, at-risk projects, and portfolio value by strategic impact.
+- **projects-backfill** — when a consultant rolls off, rank the open roles that best fit them next and rank replacement candidates for the role they vacate, reusing the staffing scorer.
 
-_More skills (backfilling recommender) land in later roadmap releases._
+_Cross-plugin bridges to cogni-consult and cogni-portfolio land in later roadmap releases._
 
 ## What it means for you
 
-You get one durable, browsable home for your project portfolio — the foundation every staffing and steering capability writes into. Author your consultants and projects, then run the staffing engine to get a defensible ranked shortlist for each open role, then render a partner-meeting dashboard over it; later backfilling plugs into the same directory as it ships.
+You get one durable, browsable home for your project portfolio — the foundation every staffing and steering capability writes into. Author your consultants and projects, then run the staffing engine to get a defensible ranked shortlist for each open role, then render a partner-meeting dashboard over it, and when someone rolls off, backfill from the same directory — their next role and their replacement, ranked together.
 
 ## Installation
 
@@ -84,6 +85,7 @@ The manifest holds portfolio identity (`slug`, `name`, `language`, timestamps) p
 | Skill | `projects-entities` | Author + register a consultant/project/assignment record |
 | Skill | `projects-staff` | Rank candidate consultants per open project role |
 | Skill | `projects-dashboard` | Render a read-only partner-meeting portfolio snapshot |
+| Skill | `projects-backfill` | Rank next roles for a rolling-off consultant and replacements for the vacated role |
 | Script | `_projects_lib.py` | Shared loader for the sibling hyphen-named validate-entities.py |
 | Script | `portfolio-init.sh` | Idempotent portfolio scaffolder |
 | Script | `validate-entities.py` | Entity validator (frontmatter + assignment refs) |
@@ -96,11 +98,12 @@ The manifest holds portfolio identity (`slug`, `name`, `language`, timestamps) p
 ```
 cogni-projects/
 ├── .claude-plugin/plugin.json          Plugin manifest
-├── skills/                             4 portfolio skills
+├── skills/                             5 portfolio skills
 │   ├── projects-setup/                 Initialize a portfolio directory (entry point)
 │   ├── projects-entities/              Author + register one consultant/project/assignment
 │   ├── projects-staff/                 Rank candidate consultants per open project role
-│   └── projects-dashboard/             Render a partner-meeting portfolio dashboard (read-only)
+│   ├── projects-dashboard/             Render a partner-meeting portfolio dashboard (read-only)
+│   └── projects-backfill/              Rank next roles for a rolling-off consultant + replacements
 ├── scripts/                            6 stdlib-only utilities
 │   ├── _projects_lib.py                Shared loader for the hyphen-named validate-entities.py
 │   ├── portfolio-init.sh               Idempotent portfolio scaffolder
@@ -113,7 +116,7 @@ cogni-projects/
 └── references/                         Consultant / project / assignment entity schemas
 ```
 
-cogni-projects is standalone at this stage. Its portfolio directory is the shared substrate for its skills (entity authoring, staffing match, dashboard) and for later ones (backfilling), and for planned cross-plugin bridges to cogni-consult and cogni-portfolio.
+cogni-projects is standalone at this stage. Its portfolio directory is the shared substrate for its skills (entity authoring, staffing match, dashboard, backfilling) and for planned cross-plugin bridges to cogni-consult and cogni-portfolio.
 
 ## Dependencies
 

--- a/cogni-projects/skills/projects-backfill/SKILL.md
+++ b/cogni-projects/skills/projects-backfill/SKILL.md
@@ -1,0 +1,268 @@
+---
+name: projects-backfill
+description: |
+  This skill should be used when a consultant is leaving a project and the
+  partner needs both halves of the resulting gap answered: which open roles the
+  freed consultant should move to next, and who replaces them on the role they
+  vacated. Trigger on: "roll-off", "rolls off", "rolling off", "is coming off",
+  "backfill", "backfill this role", "who replaces", "find a replacement for",
+  "next assignment", "what should they work on next", "where do we put them
+  next", "fill the vacated role", "re-staff this role", "minimize bench time",
+  or any request to move a consultant between projects on a cogni-projects
+  portfolio — even if the user does not name the portfolio.
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep
+---
+
+# Projects Backfill
+
+Answer a roll-off from both sides at once. When a consultant comes off a project,
+two questions open together: **where does that consultant go next**, and **who
+takes the role they left**. This skill answers both from one scorer run, so a
+partner can move people between projects with minimal bench time and defend each
+move with the same visible sub-scores the staffing engine produces.
+
+The ranking itself is not recomputed here. `scripts/staffing-score.py` — the same
+deterministic scorer `projects-staff` uses — produces every score, and this skill
+selects, filters, and reorders its output. Reusing the scorer is deliberate: a
+second ranking implementation would drift from the first, and two contradictory
+shortlists for the same portfolio is worse than none.
+
+## Core concept
+
+One scorer run yields a candidate x role matrix for the whole portfolio. A
+roll-off is two different reads of that same matrix:
+
+- **Direction (a) — the freed consultant.** Hold the consultant fixed and vary
+  the role: walk every open role in the portfolio and keep the rows where the
+  departing consultant appears as a candidate. This produces their ranked
+  next-assignment options.
+- **Direction (b) — the vacated role.** Hold the role fixed and vary the
+  consultant: take the vacated role's candidate list and drop the departing
+  consultant. This produces the replacement shortlist.
+
+On top of the scorer's own ranking this skill applies **one exclusion the scorer
+does not make**: a consultant whose `allocation_pct` is `100` is already fully
+committed and must never be proposed. Read the section below before assuming the
+scorer covers this — it does not.
+
+### What the scorer excludes, and what it does not
+
+The scorer drops a consultant from a project's ranking **only** when their
+`available_from` / `available_until` window has zero overlap with the project
+window. Those consultants never appear in `candidates[]` at all; they surface
+only as the per-role `excluded_count`, and are never proposed.
+
+Full allocation is a different matter. A consultant at `allocation_pct: 100`
+still overlaps the project window, so the scorer keeps ranking them — their
+capacity merely lowers the availability sub-score. Proposing them would be wrong.
+Apply the filter in Step 3 explicitly; do not treat `excluded_count` as if it
+already covered full allocation.
+
+The field contract for the records these read lives in
+[`../../references/data-model.md`](../../references/data-model.md).
+
+## Workflow
+
+### Step 1: Locate the portfolio and pin the roll-off
+
+Find the portfolio directory the user means. If they name a slug, use
+`cogni-projects/<portfolio-slug>/`. Otherwise glob
+`cogni-projects/*/projects-portfolio.json` and, when more than one portfolio
+exists, ask which one. If none exists, direct the user to
+`/cogni-projects:projects-setup` — this skill steers an existing portfolio, it
+does not scaffold one.
+
+Then pin three inputs: the **departing consultant** slug, the **project** they
+are leaving, and the **role** they vacate. Ask for whichever the user did not
+supply rather than guessing.
+
+Resolve each against the portfolio before running anything. When a named
+consultant, project, or role does not exist in the portfolio, report the
+unresolved name as a portfolio-data gap and stop — the fix is to author or
+correct the record with `/cogni-projects:projects-entities`, not to proceed
+against a guess.
+
+The vacated role is frequently **not** present in the project's `open_roles` at
+this point: a role only becomes open once someone declares it open, and a
+roll-off is usually what makes it open. Treat this as the expected case, not an
+error. Direction (b) needs the role to be open in order to have a candidate list,
+so instruct the user to add it to the project's `open_roles` via
+`/cogni-projects:projects-entities` and re-run; alternatively, deliver direction
+(a) alone and say plainly that the replacement half is pending that edit.
+
+### Step 2: Run the scorer
+
+Run `staffing-score.py` against the portfolio directory and capture its JSON:
+
+```bash
+python3 "${CLAUDE_PLUGIN_ROOT:-$(ls -td "$HOME"/.claude/plugins/cache/*/cogni-projects/*/ 2>/dev/null | head -1)}/scripts/staffing-score.py" "cogni-projects/<portfolio-slug>"
+```
+
+It returns `{"success", "data", "error"}` (exit 0 ok / 1 domain failure / 2 usage
+or unexpected failure). On `success: false`, surface `error` to the user and
+stop. A domain failure (exit 1) usually means the portfolio directory or its
+manifest is unreadable — but an `error` naming `validate-entities.py` instead
+means a broken or partial plugin install, not a portfolio-data problem; say so
+rather than pointing the user at their entities.
+
+On success, `data.projects[]` holds the non-closed projects, each with an
+`open_roles[]` array whose entries carry a `candidates[]` list already ranked by
+combined score and a per-role `excluded_count`.
+
+Read the scorer output only. Both `staffing-recommendations.md` and
+`.metadata/staffing-recommendations.json` belong to `projects-staff`; consult
+them for context if useful, but never write or overwrite either from this skill.
+
+### Step 3: Apply the full-allocation filter
+
+A scorer candidate carries `consultant`, `name`, and `scores` — it does **not**
+carry `allocation_pct`. Read that field from the consultant's own record at
+`cogni-projects/<portfolio-slug>/consultants/<slug>.md`.
+
+Drop every candidate whose `allocation_pct` is a number `>= 100` from both
+directions' output.
+
+Key the filter on the **raw** `allocation_pct` value, never on the scorer's
+internal headroom calculation. Headroom returns zero for a present-but-non-numeric
+`allocation_pct` as well as for a genuinely full one, so filtering on it would
+silently discard a typo as though it were a booked consultant. Instead, treat a
+present-but-non-numeric value as a data-quality finding: keep the candidate,
+and report the malformed field so someone can fix the record. An absent
+`allocation_pct` means no committed allocation is recorded — do not filter it.
+
+**The departing consultant is exempt from this filter in direction (a).** They
+are rolling off, so their recorded `allocation_pct` still reflects the assignment
+they are leaving; filtering them out would remove the one person the
+recommendation exists to place.
+
+State that exemption's limitation in the output rather than hiding it: the
+departing consultant's freed capacity is **assumed, not computed**. The scorer
+never reads `assignments/` at all, so nothing nets the vacated assignment out of
+their recorded allocation. A partner reading the recommendation should know the
+freed capacity is taken on faith.
+
+### Step 4: Direction (a) — rank the freed consultant's next roles
+
+Walk `data.projects[].open_roles[].candidates[]` across every project and keep
+the entries whose `consultant` equals the departing consultant's slug. Each
+surviving entry becomes one row: the project, the role, and that candidate's
+sub-scores.
+
+Order the rows by **`candidates[].scores.strategic_impact` descending first**
+(equivalently the project-level `strategic_impact_norm` — they carry the same
+normalized value), then `scores.combined` descending, then project slug ascending
+and role label ascending as the deterministic tiebreak.
+
+Lead with strategic impact deliberately. It is a project attribute, identical for
+every candidate within a role, so it cannot discriminate inside one role's
+shortlist — but this table compares roles *across* projects, which is the one
+ranking where it does discriminate. Sorting on `scores.combined` alone would
+silently discard the firm's own priority ordering at the exact moment it becomes
+meaningful. Render both columns so a partner can re-read the table by fit alone.
+
+Key the missing-value decision on the **raw** `data.projects[].strategic_impact`
+being null, not on the normalized score — the normalized value is `0.0` for both
+an absent value and a raw `1`, so it cannot distinguish "missing" from
+"tactical". Render an em dash (`—`) in the Strategic impact column for those
+rows; they tie at `0.0` with genuinely tactical projects, and the project-slug
+tiebreak settles the order.
+
+Exclude the role the consultant is vacating from their own next-assignment list.
+
+When the list is empty after filtering, say so and name the reason — usually no
+open role anywhere overlaps the consultant's availability window. That is a
+portfolio-data gap, not a scoring failure.
+
+### Step 5: Direction (b) — rank replacements for the vacated role
+
+Take the vacated role's `candidates[]` list. Drop the departing consultant's own
+entry, keyed on `candidates[].consultant` matching their slug. Apply the
+full-allocation filter from Step 3 — with **no** exemption here, since a fully
+committed consultant genuinely cannot take the role.
+
+Preserve the scorer's within-role ordering for the survivors; that ordering is
+already the combined-score ranking and re-sorting it would diverge from
+`projects-staff` for the same role.
+
+When the candidate list is empty after exclusions, report that explicitly rather
+than rendering an empty table, and give the count that was excluded for no
+availability overlap alongside the count dropped for full allocation — the two
+have different fixes.
+
+### Step 6: Write the backfill artifact
+
+Render both directions into
+`cogni-projects/<portfolio-slug>/backfill-recommendations.md`, and write the
+selected raw JSON alongside it at
+`cogni-projects/<portfolio-slug>/.metadata/backfill-recommendations.json`.
+
+Give that file a fixed shape so a later dashboard can read it without sniffing:
+an object with `portfolio`, `departing_consultant`, `vacated_project`,
+`vacated_role`, `next_assignments[]` (the direction (a) rows, in rendered order)
+and `replacements[]` (the direction (b) rows, in rendered order), each row
+carrying the candidate's `consultant`, `name`, and `scores` object copied
+unchanged from the scorer plus the row's `project` and `role`. Copying `scores`
+verbatim keeps the JSON and the markdown provably the same numbers.
+
+```markdown
+# Backfill — <consultant name> off <project name>
+
+## Next assignments for <consultant name> (`<slug>`)
+
+| Rank | Project | Role | Strategic impact | Availability | Profile fit | Combined |
+|------|---------|------|------------------|--------------|-------------|----------|
+| 1 | <project> | `<role>` | 0.75 | 0.84 | 0.53 | 0.70 |
+
+_Freed capacity is assumed, not computed: the recorded allocation still includes
+the assignment being left._
+
+## Replacements for `<role>` on <project name>
+
+| Rank | Consultant | Availability | Profile fit | Strategic impact | Combined |
+|------|-----------|--------------|-------------|------------------|----------|
+| 1 | <name> (`<slug>`) | 0.80 | 0.61 | 0.75 | 0.71 |
+
+_<n> excluded for no availability overlap; <m> dropped as fully allocated._
+```
+
+Show the sub-scores separately in both tables. The per-factor breakdown is what a
+partner defends the move with — never collapse it to one opaque number.
+
+### Step 7: Append a run record
+
+Record the run in `cogni-projects/<portfolio-slug>/.metadata/backfill-log.json`,
+an object with a `backfills` array. The portfolio scaffolder seeds only the
+execution, staffing, and decision logs, so this file will usually be absent on
+first run: create it with exactly `{"backfills": []}`, then read-append-write.
+Preserve that envelope on every subsequent run — never overwrite it with a bare
+array.
+
+Each record captures `portfolio`, `departing_consultant`, `vacated_project`,
+`vacated_role`, `ranked_role_count`, `replacement_candidate_count`, and
+`artifact_path`. Record no wall-clock value: the log stays reproducible.
+
+### Step 8: Summarize
+
+Report the artifact path, the top next-assignment for the departing consultant,
+and the top replacement for the vacated role. Keep it short. Call out any empty
+list and its reason, and repeat the assumed-capacity caveat once.
+
+## Notes
+
+- **The scorer is the source of truth for scoring.** This skill selects, filters,
+  and reorders; it never re-weights or recomputes. To change how candidates are
+  scored, change `scripts/staffing-score.py`, not this skill. No scoring weight
+  or constant is redeclared here.
+- **The full-allocation filter belongs to this skill, not the scorer.** The
+  scorer excludes only on zero availability-window overlap. Keeping the filter
+  here leaves `projects-staff` output unchanged.
+- **Freed capacity is assumed.** Nothing reads `assignments/` to net a departing
+  consultant's vacated allocation out of their recorded `allocation_pct`. Netting
+  live assignments is a separate capability.
+- **Deterministic output.** Identical portfolio inputs always yield the same
+  recommendation: ties break deterministically — consultant slug ascending
+  within a role (the scorer's own tiebreak, preserved in direction (b)), and
+  project slug then role label ascending across roles in direction (a) — and no
+  wall-clock value enters the artifact or the log.
+- **`projects-staff` artifacts are read-only here.** This skill writes only its
+  own `backfill-*` files.


### PR DESCRIPTION
Closes #1115.

## Summary

When a consultant rolls off a project, two questions open together: **where they go next**, and **who takes the role they left**. This adds `cogni-projects/skills/projects-backfill/SKILL.md`, which answers both from a single `staffing-score.py` run.

- **Direction (a)** walks `data.projects[].open_roles[].candidates[]` and keeps the rows whose `consultant` matches the departing consultant's slug — one ranked row per open role.
- **Direction (b)** takes the vacated role's `candidates[]` and drops the departing consultant, keyed on `candidates[].consultant`.

## The two non-obvious decisions

**Direction (a) leads on `strategic_impact`, not `scores.combined`.** Strategic impact is a per-project constant *within* a role, so it cannot discriminate inside one role's shortlist — but this table compares roles *across* projects, which is the one ranking where it does. Sorting on `combined` alone would silently drop the firm's own priority ordering at the exact moment it becomes meaningful. Ordering is `strategic_impact` desc → `scores.combined` desc → project slug → role label. A null raw `strategic_impact` renders an em dash and is keyed on the **raw** field, since the normalized value is `0.0` for both an absent value and a raw `1`.

**AC-3 is an explicit filter, not scorer behavior.** The scorer excludes a consultant only on **zero availability-window overlap** — a consultant at `allocation_pct: 100` still overlaps the window and is still ranked, merely with a lower availability sub-score. So the skill applies its own filter, and reads `allocation_pct` from the **raw consultant record**, because a scorer candidate carries only `consultant`, `name`, and `scores`. It deliberately does **not** key on the scorer's headroom: `_headroom()` returns `0.0` for a present-but-non-numeric `allocation_pct` as well as a genuinely full one, so filtering on it would discard a typo as though it were a booked consultant. Malformed values surface as data-quality findings instead.

The departing consultant is **exempt** from that filter in direction (a) — they are the one person the recommendation exists to place. That exemption's limitation is stated in the skill and in its output rather than hidden: their freed capacity is **assumed, not computed**, because `staffing-score.py` never reads `assignments/` (`_load_entities` is called only for consultants and projects).

## Scope decisions

- **Prose-only; no executable change.** The ratified acceptance criteria sanction either, and state that when the mechanism is carried entirely in SKILL.md prose the test item passes on its explicit prose branch. `scripts/staffing-score.py` is byte-identical to base, so the *projects-staff not regressed* criterion passes trivially — verify with `git diff --stat origin/main -- cogni-projects/scripts/ cogni-projects/tests/` (empty).
- **No scoring constant is duplicated.** `git grep -nE 'W_AVAILABILITY|W_PROFILE_FIT|SENIORITY_NORM|TOKEN_OVERLAP_DISCOUNT' cogni-projects` hits only `scripts/staffing-score.py`.
- **Own artifacts and own log.** `backfill-recommendations.md` + `.metadata/backfill-recommendations.json` (fixed shape, documented), plus `.metadata/backfill-log.json` with a create-if-absent instruction and its exact `{"backfills": []}` seed — the scaffolder seeds only the execution, staffing, and decision logs. The `projects-staff`-owned `staffing-recommendations*` files are referenced read-only and never written.
- **Doc scope is wider than the criteria enumerate.** Beyond the listed surfaces this also corrects the opening paragraph, the "more skills land later" italic, the MEANS paragraph, the `## Architecture` tree count and entries, the standalone-scope sentence in `README.md`, and the `.metadata/` bullet in `CLAUDE.md`. Each is a one-sentence truth edit inside a file already being touched; a surviving "backfilling is not built yet" sentence would just be a review finding.
- **No version bump.** `plugin.json` and `marketplace.json` both stay at `0.0.24`; the post-merge workflow owns the bump. (The issue text asserting `0.0.13` is stale — the binding intent is do-not-touch.)
- Nothing deferred; the issue ships whole.

## Verification

All run against the branch:

| Gate | Result |
|---|---|
| `run-plugin-tests.py --filter cogni-projects` | 5/5 suites pass |
| `check-frontmatter.sh cogni-projects` | clean, 0 offenders, `files_scanned` 4 to 5 |
| `check-breadcrumbs.py` | 0 violations |
| `check-version-bump.py` | 0 plugins touched |
| `check-skill-names.sh` | pass — domain-prefixed `projects-backfill` |
| `measure-skill-length.sh` | `chars_body` 13041 vs `cap_chars` 24000, `over_cap: false` |
| `check-token-scope.sh --strict` | exit 0 |

Criterion-anchored greps against the new body, all hitting: `open_roles`, `candidates`, `candidates[].consultant`, `strategic_impact`, `allocation_pct`, `excluded_count`, `available_from`, `staffing-score.py`. Every `staffing-recommendations` mention is read-only phrasing.

**Not applicable: `## Mutation recipe`.** The touched set contains no `*/tests/test-*.sh` and no `*/scripts/check-*.sh`, so `check-preflight.sh`'s only gating instrument records `not_applicable`.

## Review notes

A `skill-quality-reviewer` pass returned `needs_revision` with **zero structural issues** and four auto-fixable polish items; all four were applied before commit — a fixed shape for the `.metadata` JSON artifact, the null-`strategic_impact` rendering rule, a fuller determinism statement naming both tiebreaks, and `"roll-off"` added to the trigger list.

The prose-simplifier pass was deliberately skipped: the body sits at 54% of its cap so there is no net-growth pressure, and several acceptance criteria require specific sentences to remain individually findable (the exemption sentence, the assumed-capacity limitation, the headroom rule-out, and four distinct degenerate-case sentences). A functionality-preserving prose editor cannot reliably distinguish those from ordinary redundancy.