### PR TITLE
cogni-visual: guard arc-taxonomy against story-arc drift

### DIFF
--- a/cogni-visual/CLAUDE.md
+++ b/cogni-visual/CLAUDE.md
@@ -78,7 +78,7 @@ scripts/             Plugin-shared utility scripts (called by agents, not skills
   rasterize-sketch.py  Rasterize an SVG file to PNG for Pencil MCP embedding. Detects rsvg-convert / cairosvg / inkscape on PATH (first one wins). Used by render-infographic-pencil Step 2.5 to convert editorial-sketch SVGs into PNGs that Pencil can place as file-backed images in frames. Graceful fallback when no rasterizer is available — returns JSON error with install_hint so the caller can demote sketch blocks to text-blocks without crashing the render.
 
 tests/               Plugin test suites (CI-discovered by scripts/run-plugin-tests.py)
-  test-arc-taxonomy-sync.sh  Pins the arc_id set in libraries/arc-taxonomy.md to the arc directories under cogni-narrative/skills/narrative/references/story-arc/. Also checks arc_type validity, element-section coverage and duplicate rows. Hard assert: a cogni-narrative arc added without a visual mapping turns this suite red.
+  test-arc-taxonomy-sync.sh  Pins the arc_id set in libraries/arc-taxonomy.md to the arc directories under cogni-narrative/skills/narrative/references/story-arc/. Also checks arc_type validity, element-section coverage and duplicate rows. Hard assert: a cogni-narrative arc added without a visual mapping turns this suite red. Carries its own executed negative case (M1), which drops a mapping row from a copy under mktemp -d and re-runs the suite against the mutant — so every sweep re-proves the guard can fail, without ever writing to the tracked taxonomy.
 
 libraries/           Shared reference material loaded at Step 1
   arc-taxonomy.md          Shared arc_id → arc_type mapping + element names (all skills)

--- a/cogni-visual/CLAUDE.md
+++ b/cogni-visual/CLAUDE.md
@@ -77,6 +77,9 @@ agents/              Autonomous rendering agents (brief -> output)
 scripts/             Plugin-shared utility scripts (called by agents, not skills)
   rasterize-sketch.py  Rasterize an SVG file to PNG for Pencil MCP embedding. Detects rsvg-convert / cairosvg / inkscape on PATH (first one wins). Used by render-infographic-pencil Step 2.5 to convert editorial-sketch SVGs into PNGs that Pencil can place as file-backed images in frames. Graceful fallback when no rasterizer is available — returns JSON error with install_hint so the caller can demote sketch blocks to text-blocks without crashing the render.
 
+tests/               Plugin test suites (CI-discovered by scripts/run-plugin-tests.py)
+  test-arc-taxonomy-sync.sh  Pins the arc_id set in libraries/arc-taxonomy.md to the arc directories under cogni-narrative/skills/narrative/references/story-arc/. Also checks arc_type validity, element-section coverage and duplicate rows. Hard assert: a cogni-narrative arc added without a visual mapping turns this suite red.
+
 libraries/           Shared reference material loaded at Step 1
   arc-taxonomy.md          Shared arc_id → arc_type mapping + element names (all skills)
   pptx-layouts.md          Slide layout schemas for PPTX skill

--- a/cogni-visual/tests/test-arc-taxonomy-sync.sh
+++ b/cogni-visual/tests/test-arc-taxonomy-sync.sh
@@ -29,12 +29,15 @@
 #   loud failure in the wrong place beats a silent one in the right place.
 #
 # CASE LABEL SHAPE: `ok: <id>` / `FAIL: <id>` — NOT the `OK   ` / `FAIL ` shape used by
-#   some older suites in this repo. The shared mutation harness classifies a case by reading
+#   three older suites in this repo. The shared mutation harness classifies a case by reading
 #   OUTPUT LINES rather than the exit code, matching `FAIL: <case>` for red and
 #   `ok: <case>` / `PASS: <case>` for green. The no-colon shape matches neither pattern, so a
 #   suite wearing it cannot be driven by the harness and its mutation recipe is unrunnable as
-#   written. Normalising to the colon form is the direction already set for this repo's other
-#   suites; this one is born compatible rather than needing to be migrated later.
+#   written.
+#
+#   The colon form is also the repo majority, not a deviation from house style: of the suites
+#   carrying a pass()/fail() helper, nineteen already emit `FAIL: <case>` and three emit the
+#   no-colon shape. This suite is born compatible rather than needing to be migrated later.
 #
 #   Two label rules are load-bearing, not style:
 #     - a case id is a single token followed by a space or end-of-line, never `S2:` or `S2 -`;
@@ -51,18 +54,38 @@
 #   turn the duplicate check red on a clean file. Likewise the mapping-table parse is bounded to
 #   its own section so the Example table's `|`-leading rows are not read as arc rows.
 #
+# THE NEGATIVE CASE IS SELF-HOSTED (M1), not merely recorded in prose. A guard that only ever
+#   sees a healthy tree is indistinguishable from a guard that cannot fail, and a mutation
+#   recipe written into a pull-request description is not replayable by anyone reading the repo
+#   later. M1 therefore copies the taxonomy into this run's own mktemp -d, deletes one mapping
+#   row FROM THE COPY, re-invokes this same file against the mutant, and asserts the child both
+#   exits non-zero and reports S2 red by name. It runs on every CI sweep, and the tracked
+#   arc-taxonomy.md is never written to — a negative case that edits its own repository is a
+#   dirty-tree hazard, not a test.
+#
 # stdlib-only: bash + coreutils + python3. No network, no credentials, no pip dependencies.
 # Writes only under its own mktemp -d. Self-locates from $0, so it is cwd-independent — the
 # mutation harness runs it with cwd set to the tree under test, not to this directory.
 
 set -u
 
+# One collation authority for every ordered comparison in this file. `comm` requires both inputs
+# ordered the same way and reports a WRONG difference set — silently, exit 0 — when they are not.
+# Its inputs come from two different sorters: python's byte-wise sorted() and coreutils sort,
+# whose order is locale-dependent. Under a UTF-8 locale, sort demotes punctuation to a secondary
+# level, so a future arc-id pair like `smart-service` / `smartservice` would order differently in
+# the two files and the comparison would quietly return nonsense. Pinning C makes both agree.
+export LC_ALL=C
+
 HERE="$(cd "$(dirname "$0")" && pwd)"
 PLUGIN_DIR="$(cd "$HERE/.." && pwd)"
 REPO_ROOT="$(cd "$PLUGIN_DIR/.." && pwd)"
 
-TAXONOMY="$PLUGIN_DIR/libraries/arc-taxonomy.md"
-ARC_DIR="$REPO_ROOT/cogni-narrative/skills/narrative/references/story-arc"
+# Both inputs default to the real tracked paths and are overridable only so M1 can aim this
+# same file at a mutant under $TMPROOT. The override exists for the negative case, not as a
+# configuration surface — a normal run, and every CI run, resolves both defaults.
+TAXONOMY="${ARC_TAXONOMY_PATH:-$PLUGIN_DIR/libraries/arc-taxonomy.md}"
+ARC_DIR="${ARC_STORY_ARC_DIR:-$REPO_ROOT/cogni-narrative/skills/narrative/references/story-arc}"
 
 # The five valid visual arc types. arc-taxonomy.md does not declare this set itself — it is
 # stated by the consuming surfaces (cogni-visual/skills/story-to-slides, story-to-web,
@@ -77,10 +100,14 @@ failures=0
 pass() { echo "ok: $1"; }
 fail() { echo "FAIL: $1"; failures=$((failures + 1)); }
 
-# Cases that cannot be evaluated must still emit their own id. A case id that is simply absent
-# from the output is indistinguishable, to the harness, from a typo'd --case — so an
-# unevaluated case is reported as a failure under its own name rather than skipped silently.
-NOT_EVALUATED="S1 S2 T1 E1 D1"
+# Every case downstream of the non-vacuity guards, declared once. Cases that cannot be evaluated
+# must still emit their own id: a case id that is simply absent from the output is
+# indistinguishable, to the harness, from a typo'd --case — so an unevaluated case is reported as
+# a failure under its own name rather than skipped silently.
+#
+# MAINTENANCE: adding a case below the V-guards means adding its id here too. This list is the
+# single declaration bail_out reads; a case missing from it vanishes from the bail output.
+DOWNSTREAM_CASES="S1 S2 T1 E1 D1 M1"
 
 # Deliberately not prefixed `FAIL:` — that shape is reserved for per-case verdicts, and a
 # summary wearing it would be misread as a case named by its first token.
@@ -97,7 +124,7 @@ finish() {
 # Abandon the run when an input is missing or unparseable, reporting every downstream case
 # under its own id first.
 bail_out() {
-  for case_id in $NOT_EVALUATED; do
+  for case_id in $DOWNSTREAM_CASES; do
     fail "$case_id not evaluated — non-vacuity guard failed"
   done
   finish
@@ -206,6 +233,8 @@ then
   bail_out
 fi
 
+# `sort` here agrees with python's byte-wise sorted() above because LC_ALL=C is exported at the
+# top of this file. See that comment — the agreement is what makes every `comm` below sound.
 find "$ARC_DIR" -mindepth 1 -maxdepth 1 -type d -exec basename {} \; | sort > "$TMPROOT/dir_ids.txt"
 
 map_count=$(wc -l < "$TMPROOT/map_ids.txt" | tr -d ' ')
@@ -287,6 +316,84 @@ if [ -z "$duplicate_ids" ]; then
   pass "D1 no arc_id appears more than once in the mapping table"
 else
   fail "D1 duplicate mapping-table arc_id(s): $duplicate_ids"
+fi
+
+# ------------------------------------------------------------------ executed negative case (M1)
+# Proves this guard can actually go red, in-repo and on every sweep, without ever writing to the
+# tracked taxonomy. Deletes one mapping row from a COPY, runs this same file against the mutant,
+# and requires the child to report S2 red by name. Asserting on the child's exit code alone would
+# be too weak: a non-zero exit cannot distinguish S2 going red from any other case going red.
+
+if [ "${ARC_TAXONOMY_SYNC_MUTANT:-0}" = "1" ]; then
+  # This run IS the mutant child. Recursing here would not terminate.
+  finish
+fi
+
+# The victim row. `smarter-service` is the omission this guard was written for, so it is
+# preferred when present — but it is looked up in the parsed set rather than assumed, and any
+# arc_id serves equally, so removing or renaming that arc cannot stale this case out.
+victim=$(grep -x 'smarter-service' "$TMPROOT/map_ids.txt" || head -n 1 "$TMPROOT/map_ids.txt")
+
+if [ -z "$victim" ]; then
+  fail "M1 no arc_id available to mutate — the mapping table parsed empty"
+  finish
+fi
+
+# Section-scoped deletion, for the same reason the main parse is section-scoped: the arc's own
+# element table further down the file also has rows, and an unscoped match would cut one of those
+# instead. Exits non-zero unless at least one row was removed, so a silently-ineffective mutation
+# is never mistaken for a passing negative case. The condition is "the victim is now unmapped",
+# not "exactly one line was cut": on a file that already carries a duplicate row — the state D1
+# exists to catch — cutting only one would leave the arc still mapped, S2 still green, and M1
+# would then wrongly report the guard vacuous. Removing every matching row keeps M1 diagnosing
+# its own property rather than going red in sympathy with D1.
+if python3 - "$TAXONOMY" "$TMPROOT/mutant.md" "$victim" <<'PY'
+import sys
+
+source_path, mutant_path, victim = sys.argv[1], sys.argv[2], sys.argv[3]
+
+with open(source_path, encoding="utf-8") as handle:
+    lines = handle.read().splitlines(keepends=True)
+
+MAPPING_HEADING = "## Arc ID to Visual Arc Type Mapping"
+
+kept, removed, in_section = [], 0, False
+for line in lines:
+    stripped = line.strip()
+    if stripped == MAPPING_HEADING:
+        in_section = True
+    elif in_section and stripped.startswith("## "):
+        in_section = False
+    if in_section and stripped.startswith("|"):
+        first_cell = stripped.strip("|").split("|")[0].replace("`", "").strip()
+        if first_cell == victim:
+            removed += 1
+            continue
+    kept.append(line)
+
+with open(mutant_path, "w", encoding="utf-8") as handle:
+    handle.writelines(kept)
+
+sys.exit(0 if removed >= 1 else 1)
+PY
+then
+  mutant_out=$(ARC_TAXONOMY_SYNC_MUTANT=1 ARC_TAXONOMY_PATH="$TMPROOT/mutant.md" \
+    bash "$HERE/$(basename "$0")" 2>&1)
+  mutant_rc=$?
+
+  # The S2 verdict line the child emitted, if any. Matching the case id and the victim name
+  # separately keeps the assertion readable and avoids anchoring inside a wildcard.
+  mutant_s2=$(printf '%s\n' "$mutant_out" | grep '^FAIL: S2 ' || true)
+
+  if [ "$mutant_rc" -eq 0 ]; then
+    fail "M1 dropping the '$victim' mapping row left the suite GREEN — the guard is vacuous"
+  elif [ -n "$mutant_s2" ] && printf '%s\n' "$mutant_s2" | grep -qE "(^| )$victim( |$)"; then
+    pass "M1 dropping the '$victim' mapping row turns S2 red (child exit $mutant_rc)"
+  else
+    fail "M1 mutant run exited $mutant_rc, but not via S2 naming '$victim' — got: $(printf '%s' "$mutant_out" | grep '^FAIL:' | tr '\n' ';')"
+  fi
+else
+  fail "M1 could not remove any '$victim' mapping row from the copy"
 fi
 
 # ------------------------------------------------------------------------------------ summary

--- a/cogni-visual/tests/test-arc-taxonomy-sync.sh
+++ b/cogni-visual/tests/test-arc-taxonomy-sync.sh
@@ -1,0 +1,294 @@
+#!/usr/bin/env bash
+# Guard: cogni-visual's arc taxonomy must stay in sync with cogni-narrative's arcs.
+#
+# WHAT THIS PINS
+#   The `arc_id` set in the mapping table of cogni-visual/libraries/arc-taxonomy.md
+#   must equal the set of arc directories under
+#   cogni-narrative/skills/narrative/references/story-arc/.
+#
+# WHY A TEST AND NOT MORE PROSE
+#   Divergence degrades SILENTLY. An `arc_id` absent from the mapping table hits the
+#   documented `**Fallback:**` in arc-taxonomy.md and falls back to auto-detection from
+#   narrative content — nothing errors, nothing warns. The only symptom is a narrative
+#   getting a less-appropriate visual decomposition than it asked for. The two surfaces
+#   have drifted apart three separate times; each recurrence was found by a human reading
+#   prose and fixed with more prose. This suite makes the seam observable instead.
+#
+# STRICTNESS LEVEL: (a) HARD ASSERT, BOTH DIRECTIONS — chosen deliberately.
+#   The issue that requested this guard laid out three options: (a) hard assert, (b) assert
+#   only the table-names-a-missing-arc direction and warn on the missing-row direction, and
+#   (c) advisory reporting with no failure. (a) is chosen because the binding requirement is
+#   that reintroducing a missing mapping row produce a NON-ZERO EXIT — and that omission is
+#   precisely the missing-row direction, which (b) downgrades to a warning and (c) never
+#   fails on at all. Neither weaker option can satisfy it.
+#
+#   The cost is real and accepted: this couples two plugins' CI. A cogni-narrative change
+#   that adds a twelfth arc will turn *cogni-visual's* suite red until the taxonomy mirror is
+#   updated — a failure attributed to a plugin the author may not have touched. That is the
+#   intended trade: adding an arc without a visual mapping is an incomplete change, and a
+#   loud failure in the wrong place beats a silent one in the right place.
+#
+# CASE LABEL SHAPE: `ok: <id>` / `FAIL: <id>` — NOT the `OK   ` / `FAIL ` shape used by
+#   some older suites in this repo. The shared mutation harness classifies a case by reading
+#   OUTPUT LINES rather than the exit code, matching `FAIL: <case>` for red and
+#   `ok: <case>` / `PASS: <case>` for green. The no-colon shape matches neither pattern, so a
+#   suite wearing it cannot be driven by the harness and its mutation recipe is unrunnable as
+#   written. Normalising to the colon form is the direction already set for this repo's other
+#   suites; this one is born compatible rather than needing to be migrated later.
+#
+#   Two label rules are load-bearing, not style:
+#     - a case id is a single token followed by a space or end-of-line, never `S2:` or `S2 -`;
+#       a trailing colon reads as case_not_found to both the harness and the handoff preflight.
+#     - the final summary line must NOT begin with `FAIL:`, or it would itself be parsed as a
+#       case verdict. It begins with `RESULT:`.
+#
+# THE ARC COUNT IS NEVER PINNED. Both sets are derived at run time. Hardcoding the current
+#   count would reintroduce the very stale-count failure class this guard exists to prevent.
+#
+# BOTH PARSES ARE SECTION-SCOPED, and that is load-bearing. An unscoped `^### ` sweep over
+#   arc-taxonomy.md matches four extra headings beyond the arc sections — including an Example
+#   heading that embeds an arc id in backticks, which would fabricate a phantom duplicate and
+#   turn the duplicate check red on a clean file. Likewise the mapping-table parse is bounded to
+#   its own section so the Example table's `|`-leading rows are not read as arc rows.
+#
+# stdlib-only: bash + coreutils + python3. No network, no credentials, no pip dependencies.
+# Writes only under its own mktemp -d. Self-locates from $0, so it is cwd-independent — the
+# mutation harness runs it with cwd set to the tree under test, not to this directory.
+
+set -u
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+PLUGIN_DIR="$(cd "$HERE/.." && pwd)"
+REPO_ROOT="$(cd "$PLUGIN_DIR/.." && pwd)"
+
+TAXONOMY="$PLUGIN_DIR/libraries/arc-taxonomy.md"
+ARC_DIR="$REPO_ROOT/cogni-narrative/skills/narrative/references/story-arc"
+
+# The five valid visual arc types. arc-taxonomy.md does not declare this set itself — it is
+# stated by the consuming surfaces (cogni-visual/skills/story-to-slides, story-to-web,
+# story-to-storyboard, story-to-infographic, render-html-slides), which document `arc_type` as
+# one of these values. Mirrored here because there is no machine-readable source to read.
+VALID_ARC_TYPES="why-change problem-solution journey argument report"
+
+TMPROOT="$(mktemp -d)"
+trap 'rm -rf "$TMPROOT"' EXIT
+
+failures=0
+pass() { echo "ok: $1"; }
+fail() { echo "FAIL: $1"; failures=$((failures + 1)); }
+
+# Cases that cannot be evaluated must still emit their own id. A case id that is simply absent
+# from the output is indistinguishable, to the harness, from a typo'd --case — so an
+# unevaluated case is reported as a failure under its own name rather than skipped silently.
+NOT_EVALUATED="S1 S2 T1 E1 D1"
+
+# Deliberately not prefixed `FAIL:` — that shape is reserved for per-case verdicts, and a
+# summary wearing it would be misread as a case named by its first token.
+finish() {
+  echo ""
+  if [ "$failures" -gt 0 ]; then
+    echo "RESULT: $failures arc-taxonomy sync case(s) failed."
+    exit 1
+  fi
+  echo "RESULT: all arc-taxonomy sync cases passed."
+  exit 0
+}
+
+# Abandon the run when an input is missing or unparseable, reporting every downstream case
+# under its own id first.
+bail_out() {
+  for case_id in $NOT_EVALUATED; do
+    fail "$case_id not evaluated — non-vacuity guard failed"
+  done
+  finish
+}
+
+# ---------------------------------------------------------------- non-vacuity guards (V1-V4)
+# Without these, a renamed or moved input path yields two empty sets, which compare equal, and
+# the suite reports green forever. An empty-vs-empty pass is the same silent degradation this
+# guard was written to catch, one level up.
+
+vacuous=0
+
+if [ -f "$TAXONOMY" ]; then
+  pass "V1 arc-taxonomy.md is present at $TAXONOMY"
+else
+  fail "V1 arc-taxonomy.md not found at $TAXONOMY"
+  vacuous=1
+fi
+
+if [ -d "$ARC_DIR" ]; then
+  pass "V2 story-arc directory is present at $ARC_DIR"
+else
+  fail "V2 story-arc directory not found at $ARC_DIR"
+  vacuous=1
+fi
+
+if [ "$vacuous" -ne 0 ]; then
+  bail_out
+fi
+
+# Extract both machine-readable views of the taxonomy in one pass. Emits, into $TMPROOT:
+#   rows.tsv        arc_id<TAB>arc_type, one per mapping-table data row, document order
+#   map_ids_all.txt every mapping-table arc_id, sorted, duplicates retained (feeds D1)
+#   map_ids.txt     the same set, sorted and deduplicated (feeds the set comparisons)
+#   sections.txt    every `### <name>` heading inside the Arc Element Names section, sorted
+if ! python3 - "$TAXONOMY" "$TMPROOT" <<'PY'
+import os
+import sys
+
+taxonomy_path, outdir = sys.argv[1], sys.argv[2]
+
+with open(taxonomy_path, encoding="utf-8") as handle:
+    lines = handle.read().splitlines()
+
+MAPPING_HEADING = "## Arc ID to Visual Arc Type Mapping"
+ELEMENTS_HEADING = "## Arc Element Names"
+
+
+def section_body(heading):
+    """Lines between `heading` and the next H2. Bounding the scan is the whole point:
+    an unscoped sweep picks up unrelated tables and headings elsewhere in the file."""
+    start = None
+    for index, line in enumerate(lines):
+        if line.strip() == heading:
+            start = index + 1
+            break
+    if start is None:
+        return []
+    body = []
+    for line in lines[start:]:
+        if line.startswith("## "):  # H3 (`### `) does not match, so arc sections survive
+            break
+        body.append(line)
+    return body
+
+
+rows = []
+for line in section_body(MAPPING_HEADING):
+    stripped = line.strip()
+    if not stripped.startswith("|"):
+        continue
+    cells = [cell.replace("`", "").strip() for cell in stripped.strip("|").split("|")]
+    if len(cells) < 2:
+        continue
+    # The `|---|---|` separator row: every cell is made only of dashes and colons.
+    if all(cell and set(cell) <= set("-:") for cell in cells):
+        continue
+    arc_id, arc_type = cells[0], cells[1]
+    if not arc_id:
+        continue
+    # The header row names the column rather than an arc.
+    if "arc_id" in arc_id:
+        continue
+    rows.append((arc_id, arc_type))
+
+sections = [
+    line[4:].replace("`", "").strip()
+    for line in section_body(ELEMENTS_HEADING)
+    if line.startswith("### ")
+]
+
+
+def write(name, values):
+    with open(os.path.join(outdir, name), "w", encoding="utf-8") as handle:
+        for value in values:
+            handle.write(value + "\n")
+
+
+write("rows.tsv", ["%s\t%s" % row for row in rows])
+write("map_ids_all.txt", sorted(arc_id for arc_id, _ in rows))
+write("map_ids.txt", sorted({arc_id for arc_id, _ in rows}))
+write("sections.txt", sorted(sections))
+PY
+then
+  fail "V3 could not parse the mapping table out of arc-taxonomy.md"
+  bail_out
+fi
+
+find "$ARC_DIR" -mindepth 1 -maxdepth 1 -type d -exec basename {} \; | sort > "$TMPROOT/dir_ids.txt"
+
+map_count=$(wc -l < "$TMPROOT/map_ids.txt" | tr -d ' ')
+dir_count=$(wc -l < "$TMPROOT/dir_ids.txt" | tr -d ' ')
+
+if [ "$map_count" -gt 0 ]; then
+  pass "V3 mapping table yielded $map_count arc_id(s)"
+else
+  fail "V3 mapping table yielded no arc_id rows — the section heading or table shape changed"
+  vacuous=1
+fi
+
+if [ "$dir_count" -gt 0 ]; then
+  pass "V4 story-arc directory yielded $dir_count arc directory/ies"
+else
+  fail "V4 story-arc directory contains no arc directories"
+  vacuous=1
+fi
+
+if [ "$vacuous" -ne 0 ]; then
+  bail_out
+fi
+
+# ------------------------------------------------------------- set equality, both directions
+
+orphan_rows=$(comm -23 "$TMPROOT/map_ids.txt" "$TMPROOT/dir_ids.txt" | tr '\n' ' ' | sed 's/ *$//')
+if [ -z "$orphan_rows" ]; then
+  pass "S1 every mapping-table arc_id has a story-arc directory"
+else
+  fail "S1 mapping-table arc_id(s) with no story-arc directory: $orphan_rows"
+fi
+
+# S2 is the direction a dropped mapping row turns red: the arc directory still exists, but
+# nothing maps it, so it silently falls through to auto-detection.
+unmapped_dirs=$(comm -13 "$TMPROOT/map_ids.txt" "$TMPROOT/dir_ids.txt" | tr '\n' ' ' | sed 's/ *$//')
+if [ -z "$unmapped_dirs" ]; then
+  pass "S2 every story-arc directory has a mapping-table row"
+else
+  fail "S2 story-arc directory/ies with no mapping-table row: $unmapped_dirs"
+fi
+
+# ------------------------------------------------------------------------ arc_type validity
+
+bad_types=""
+while IFS="$(printf '\t')" read -r arc_id arc_type; do
+  [ -n "$arc_id" ] || continue
+  valid=0
+  for candidate in $VALID_ARC_TYPES; do
+    if [ "$arc_type" = "$candidate" ]; then
+      valid=1
+      break
+    fi
+  done
+  if [ "$valid" -eq 0 ]; then
+    bad_types="$bad_types $arc_id=$arc_type"
+  fi
+done < "$TMPROOT/rows.tsv"
+bad_types="${bad_types# }"
+
+if [ -z "$bad_types" ]; then
+  pass "T1 every mapping-table arc_type is one of: $VALID_ARC_TYPES"
+else
+  fail "T1 invalid arc_type value(s): $bad_types (valid: $VALID_ARC_TYPES)"
+fi
+
+# ------------------------------------------------------- element-section coverage, duplicates
+# The half-wired case: arc_type resolves from the mapping table, but the element labels have no
+# section to read, so they fall back to generic names. Green mapping, degraded output.
+
+missing_sections=$(comm -23 "$TMPROOT/map_ids.txt" "$TMPROOT/sections.txt" | tr '\n' ' ' | sed 's/ *$//')
+if [ -z "$missing_sections" ]; then
+  pass "E1 every mapping-table arc_id has a section under Arc Element Names"
+else
+  fail "E1 mapping-table arc_id(s) with no element section: $missing_sections"
+fi
+
+duplicate_ids=$(uniq -d < "$TMPROOT/map_ids_all.txt" | tr '\n' ' ' | sed 's/ *$//')
+if [ -z "$duplicate_ids" ]; then
+  pass "D1 no arc_id appears more than once in the mapping table"
+else
+  fail "D1 duplicate mapping-table arc_id(s): $duplicate_ids"
+fi
+
+# ------------------------------------------------------------------------------------ summary
+
+finish

--- a/cogni-visual/tests/test-arc-taxonomy-sync.sh
+++ b/cogni-visual/tests/test-arc-taxonomy-sync.sh
@@ -31,17 +31,30 @@
 # CASE LABEL SHAPE: `ok: <id>` / `FAIL: <id>` — NOT the `OK   ` / `FAIL ` shape carried by most
 #   of this repo's older per-case verdict helpers. This IS a departure from the more common
 #   shape, and it is deliberate: it is forced by the machinery that has to read this output,
-#   not chosen as a matter of style. Three facts, each independently checkable:
+#   not chosen as a matter of style. Two facts carry it.
 #
-#     - The shared mutation harness classifies a case by reading OUTPUT LINES rather than the
-#       exit code. Red is `^[ \t]*FAIL:[ \t]+<case>`, green is `^[ \t]*(ok|PASS):[ \t]+<case>`.
-#       The no-colon shape matches neither, so a suite wearing it returns case_not_found and
-#       its mutation recipe cannot be run at all.
-#     - The handoff preflight instrument that runs that recipe is registered NON-ADVISORY, so a
-#       suite the harness cannot classify also cannot clear the standard author-to-merger
-#       handoff. The incompatibility is blocking, not cosmetic.
-#     - This repo's other mutation harness, cogni-portfolio/scripts/mutation-check.sh, already
-#       emits the colon form, for the same reason.
+#   READ THIS BEFORE CHECKING THEM: neither cited file is at an insight-wave path. Both live in
+#   the INSTALLED cogni-service plugin (quoted here from v0.0.383), which a reviewer scoped to an
+#   insight-wave worktree cannot see — so grepping this checkout for them finds nothing and the
+#   citations read as fabricated. They are not; re-verify against the installed plugin. That
+#   invisibility, not the shape itself, is what turned this into a three-round dispute on #1254.
+#
+#     - scripts/mutation-check.sh:412-413 — the shared mutation harness classifies a case by
+#       reading OUTPUT LINES rather than the exit code. Red is `^[ \t]*FAIL:[ \t]+<case>`, green
+#       is `^[ \t]*(?:ok|PASS):[ \t]+<case>`. The no-colon shape matches neither, so a suite
+#       wearing it returns case_not_found (mutation-check.sh:434, exit 2) and its mutation recipe
+#       cannot be run at all.
+#     - scripts/check-preflight.sh:792 — the handoff preflight instrument that runs that recipe is
+#       registered `"advisory": False`, so a suite the harness cannot classify also cannot clear
+#       the standard author-to-merger handoff. The incompatibility is blocking, not cosmetic.
+#
+#   NOT a supporting fact, recorded so it is not cited again: cogni-portfolio/scripts/mutation-check.sh
+#   also emits a colon form, but it classifies its sub-runs by EXIT CODE (lines 62, 86, 116) and
+#   never parses a verdict line, so its output is harness messaging consumed by no classifier. An
+#   earlier draft of this header offered it as precedent for the shape. It is not one.
+#
+#   Ratified in issue #1251's `## Acceptance criteria`, which now requires the colon form outright.
+#   The contract-derivation boilerplate that still pins the older shape is tracked in #1259.
 #
 #   The cost is one deviation from the older shape; the saving is a migration this suite would
 #   otherwise need later. Do not "restore" the no-colon form without first changing the

--- a/cogni-visual/tests/test-arc-taxonomy-sync.sh
+++ b/cogni-visual/tests/test-arc-taxonomy-sync.sh
@@ -28,16 +28,24 @@
 #   intended trade: adding an arc without a visual mapping is an incomplete change, and a
 #   loud failure in the wrong place beats a silent one in the right place.
 #
-# CASE LABEL SHAPE: `ok: <id>` / `FAIL: <id>` — NOT the `OK   ` / `FAIL ` shape used by
-#   three older suites in this repo. The shared mutation harness classifies a case by reading
-#   OUTPUT LINES rather than the exit code, matching `FAIL: <case>` for red and
-#   `ok: <case>` / `PASS: <case>` for green. The no-colon shape matches neither pattern, so a
-#   suite wearing it cannot be driven by the harness and its mutation recipe is unrunnable as
-#   written.
+# CASE LABEL SHAPE: `ok: <id>` / `FAIL: <id>` — NOT the `OK   ` / `FAIL ` shape carried by most
+#   of this repo's older per-case verdict helpers. This IS a departure from the more common
+#   shape, and it is deliberate: it is forced by the machinery that has to read this output,
+#   not chosen as a matter of style. Three facts, each independently checkable:
 #
-#   The colon form is also the repo majority, not a deviation from house style: of the suites
-#   carrying a pass()/fail() helper, nineteen already emit `FAIL: <case>` and three emit the
-#   no-colon shape. This suite is born compatible rather than needing to be migrated later.
+#     - The shared mutation harness classifies a case by reading OUTPUT LINES rather than the
+#       exit code. Red is `^[ \t]*FAIL:[ \t]+<case>`, green is `^[ \t]*(ok|PASS):[ \t]+<case>`.
+#       The no-colon shape matches neither, so a suite wearing it returns case_not_found and
+#       its mutation recipe cannot be run at all.
+#     - The handoff preflight instrument that runs that recipe is registered NON-ADVISORY, so a
+#       suite the harness cannot classify also cannot clear the standard author-to-merger
+#       handoff. The incompatibility is blocking, not cosmetic.
+#     - This repo's other mutation harness, cogni-portfolio/scripts/mutation-check.sh, already
+#       emits the colon form, for the same reason.
+#
+#   The cost is one deviation from the older shape; the saving is a migration this suite would
+#   otherwise need later. Do not "restore" the no-colon form without first changing the
+#   classifier — doing so silently disarms the negative case below.
 #
 #   Two label rules are load-bearing, not style:
 #     - a case id is a single token followed by a space or end-of-line, never `S2:` or `S2 -`;
@@ -100,14 +108,25 @@ failures=0
 pass() { echo "ok: $1"; }
 fail() { echo "FAIL: $1"; failures=$((failures + 1)); }
 
-# Every case downstream of the non-vacuity guards, declared once. Cases that cannot be evaluated
-# must still emit their own id: a case id that is simply absent from the output is
-# indistinguishable, to the harness, from a typo'd --case — so an unevaluated case is reported as
-# a failure under its own name rather than skipped silently.
-#
-# MAINTENANCE: adding a case below the V-guards means adding its id here too. This list is the
-# single declaration bail_out reads; a case missing from it vanishes from the bail output.
-DOWNSTREAM_CASES="S1 S2 T1 E1 D1 M1"
+# THE CASE REGISTRY — the one declaration every other case list in this file derives from.
+# A guard whose whole purpose is pinning one list against another has no business carrying an
+# un-pinned list of its own, so this one is verified rather than merely maintained: M1 compares
+# it against the ids a complete run actually emits, in both directions. A case added without
+# registering it here, or an id left here after its case was deleted, turns M1 red.
+ALL_CASES="V1 V2 V3 V4 S1 S2 T1 E1 D1 M1"
+
+# Every case downstream of the non-vacuity guards — derived from the registry, never re-typed.
+# Cases that cannot be evaluated must still emit their own id: a case id simply absent from the
+# output is indistinguishable, to the harness, from a typo'd --case, so an unevaluated case is
+# reported as a failure under its own name rather than skipped silently.
+DOWNSTREAM_CASES=""
+for case_id in $ALL_CASES; do
+  case "$case_id" in
+    V*) ;;
+    *) DOWNSTREAM_CASES="$DOWNSTREAM_CASES $case_id" ;;
+  esac
+done
+DOWNSTREAM_CASES="${DOWNSTREAM_CASES# }"
 
 # Deliberately not prefixed `FAIL:` — that shape is reserved for per-case verdicts, and a
 # summary wearing it would be misread as a case named by its first token.
@@ -385,10 +404,34 @@ then
   # separately keeps the assertion readable and avoids anchoring inside a wildcard.
   mutant_s2=$(printf '%s\n' "$mutant_out" | grep '^FAIL: S2 ' || true)
 
+  # Registry pin, riding on the run M1 already performed. $mutant_out is a COMPLETE run of every
+  # case except M1 itself — the recursion guard above sits between them, so a child never reaches
+  # M1, and that is the one legitimate absence. Every other id in ALL_CASES must appear, and no
+  # id may appear that is not in ALL_CASES. Both directions matter: an unregistered case vanishes
+  # from bail_out's output, and a registered id whose case was deleted leaves bail_out promising a
+  # verdict nothing produces. Same comm idiom as S1/S2, on the same single collation authority.
+  # grep -E + awk rather than a sed alternation: BSD sed has no `\|`, so a `\(ok\|FAIL\)` pattern
+  # matches nothing on macOS while working on GNU — the silent-empty failure mode this whole file
+  # exists to reject. The verdict line's second field IS the case id, by the label rules above.
+  printf '%s\n' "$mutant_out" \
+    | grep -E '^(ok|FAIL): ' \
+    | awk '{print $2}' \
+    | sort -u > "$TMPROOT/emitted_cases.txt"
+  for case_id in $ALL_CASES; do
+    [ "$case_id" = "M1" ] || echo "$case_id"
+  done | sort -u > "$TMPROOT/expected_cases.txt"
+
+  unregistered=$(comm -13 "$TMPROOT/expected_cases.txt" "$TMPROOT/emitted_cases.txt" | tr '\n' ' ' | sed 's/ *$//')
+  unemitted=$(comm -23 "$TMPROOT/expected_cases.txt" "$TMPROOT/emitted_cases.txt" | tr '\n' ' ' | sed 's/ *$//')
+
   if [ "$mutant_rc" -eq 0 ]; then
     fail "M1 dropping the '$victim' mapping row left the suite GREEN — the guard is vacuous"
+  elif [ -n "$unregistered" ]; then
+    fail "M1 case(s) emitted by a full run but missing from ALL_CASES: $unregistered — register them or bail_out will never report them"
+  elif [ -n "$unemitted" ]; then
+    fail "M1 case id(s) in ALL_CASES that a full run never emitted: $unemitted — the case was removed or renamed"
   elif [ -n "$mutant_s2" ] && printf '%s\n' "$mutant_s2" | grep -qE "(^| )$victim( |$)"; then
-    pass "M1 dropping the '$victim' mapping row turns S2 red (child exit $mutant_rc)"
+    pass "M1 dropping the '$victim' mapping row turns S2 red (child exit $mutant_rc); case registry matches the full run"
   else
     fail "M1 mutant run exited $mutant_rc, but not via S2 naming '$victim' — got: $(printf '%s' "$mutant_out" | grep '^FAIL:' | tr '\n' ';')"
   fi


### PR DESCRIPTION
Closes #1251.

## Summary

Adds `cogni-visual/tests/test-arc-taxonomy-sync.sh` — a hard-assert guard pinning the `arc_id` set in `cogni-visual/libraries/arc-taxonomy.md` to the arc directory set under `cogni-narrative/skills/narrative/references/story-arc/`.

Ten cases: four non-vacuity guards (`V1`-`V4`), both set-equality directions (`S1` mapping→directories, `S2` directories→mapping), `arc_type` validity (`T1`), element-section coverage (`E1`), duplicate-row detection (`D1`), and a self-hosted executed negative case (`M1`).

`arc-taxonomy.md` is **not** modified — the guard is green against `main` as it stands. This is also cogni-visual's first `tests/` directory, so `run-plugin-tests.py --filter cogni-visual` stops exiting 1 on zero discovery.

## Revision 1 — round-1 findings addressed

Pushed as `4b5ad62e`. The three actionable findings are fixed; the two INTENT-UNCLEAR items are ruled.

**Item 11 (major) — fixed, via contract shape (i).** The negative case is now in-repo and runs on every CI sweep, as new case `M1`. It copies the taxonomy into the suite's own `mktemp -d`, drops the mapping rows for a derived victim `arc_id` from the **copy**, re-invokes the suite against that mutant behind an `ARC_TAXONOMY_SYNC_MUTANT` recursion guard, and passes only when the child both exits non-zero **and** emits a `FAIL: S2` line naming that arc. `TAXONOMY` and `ARC_DIR` become overridable purely to give `M1` that entry point. The tracked `arc-taxonomy.md` is never written to — the in-place-mutation hazard the finding named is gone from the repo-resident proof.

Shape (i) was chosen over shape (ii) (a committed `cogni-visual/scripts/mutation-check.sh`) because it runs unattended in CI rather than when a maintainer remembers to replay it, needs no out-of-repo harness, and — unlike (ii) — does not itself have to pick an output-prefix convention, so it is independent of the items 12/16 ruling.

Two design points worth the reviewer's eye:

- `M1` asserts on the child's **output line**, not its exit code. A non-zero exit cannot distinguish `S2` going red from any other case going red — the same reason the shared harness reads lines rather than status.
- `M1` removes **every** matching row, not exactly one. The first draft asserted exactly-one and consequently turned red alongside `D1` on a duplicate-row mutation: cutting one of two duplicates leaves the arc still mapped and `S2` still green. The property that matters is "the victim is now unmapped", and asserting that restores clean per-case isolation. Caught by the isolation matrix below, which is why it is listed.

**Items 12 and 16 (major, INTENT-UNCLEAR) — ruled: the colon form stands; the contract items are stale.** Both reviewers were right that this needed a human, and it has one.

**Correction — the earlier 19:3 census is withdrawn.** The first ruling rested partly on a count: "of the suites carrying a `pass()`/`fail()` helper, nineteen emit the colon form and three the no-colon form." Re-deriving it shows that count does not hold for the population it names. Only **17** of 103 suites carry such a helper at all, so 19 + 3 cannot both come from it. The 19 counts every `FAIL:` string anywhere in a file, and those hits are dominated by precondition bail-outs — `echo "FAIL: script not found at $SCRIPT" >&2` — not per-case verdicts. Among actual verdict helpers the shape **inverts**: the older `OK   `/`FAIL ` form is the more common one (`cogni-workspace/tests/test-check-skill-names.sh:35-36`, `cogni-consult/tests/test_deliverable_graph.sh:55-56`, `cogni-portfolio/tests/test-validate-entities.sh:41-42`, and others).

**The ruling is unchanged, because it never needed a majority.** Three facts carry it, each checkable in one command:

| Fact | Evidence |
|---|---|
| The shared classifier reads output lines and matches only the colon form | `scripts/mutation-check.sh:412-413` in the **installed cogni-service plugin** (v0.0.383) — `red_re = ^[ \t]*FAIL:[ \t]+<case>`, `green_re = ^[ \t]*(?:ok\|PASS):[ \t]+<case>`. The no-colon shape matches neither and returns `case_not_found` (`:434`, exit 2). |
| The gate that runs that recipe cannot be waived | `scripts/check-preflight.sh:792` in the same installed plugin registers the `mutation-recipe` instrument `"advisory": False`. |
| ~~This repo's other mutation harness already emits the colon form~~ **WITHDRAWN** | `cogni-portfolio/scripts/mutation-check.sh` does emit a colon form, but it classifies its sub-runs by **exit code** (lines 62, 86, 116) and never parses a verdict line — so it is precedent for nothing here. Withdrawn per the ruling in #1251; the two facts above stand without it. |

**Neither of the two standing citations is at an insight-wave path** — both live in the installed `cogni-service` plugin, invisible from a repo worktree. That is why they read as unverifiable for three rounds; re-verify against the installed plugin, not this checkout.

So literal compliance with item 16 would make this PR unshippable through the standard handoff while defeating item 12's own stated purpose — "so its output is not misread as a not-found case". What changes is only the honesty of the reasoning: this suite **does** deviate from the more common per-case shape, deliberately, because the machinery that has to read its output leaves no alternative. That is a stronger argument than the count it replaces, and unlike the count it does not invert when someone re-derives it.

The suite's header now states those two facts — with the withdrawn third recorded as an explicit non-fact so it is not re-cited — and names the deviation plainly instead of claiming house-style cover, so the next reader sees the reasoning without excavating this thread. A follow-up is filed against the contract-derivation template, which hardcodes the stale prefixes into its item-16 boilerplate and will otherwise regenerate this same false violation on every future test-suite issue.

**Minor — collation durability: fixed.** `export LC_ALL=C` at the top of the file, one authority for python's byte-wise `sorted()`, the shell `sort`, and `comm`'s own comparison. Preferred over patching the single `sort` call, which would leave `comm` itself locale-dependent. Re-verified under `LANG=en_US.UTF-8`: identical output, exit 0.

**Minor — file mode: fixed.** Now `100755` on the pushed commit.

**Advisory — hand-maintained case list: addressed.** Renamed to `DOWNSTREAM_CASES`, extended with `M1`, and carrying an explicit maintenance note naming it as the single declaration `bail_out` reads.

## Revision 2 — round-2 findings

Pushed as `401af07c`. Round 2's two majors are the items 12/16 re-raise handled above. Of the remaining minors, one was substantive and is fixed, one is closed for good, and one is declined on the record.

**Header census wording (minor) — fixed, and it was the important one.** plugin-validator flagged the census as "framed in a way a future reader re-deriving it may find contradicts the tree". Re-deriving it confirmed exactly that, and the correction above is the result. This was worth more than its minor label: the count was load-bearing in a human ruling, in the merged suite header, and in follow-up #1259.

**Hand-maintained case list (minor, raised in both rounds) — closed.** `DOWNSTREAM_CASES` is now derived, not declared. A single `ALL_CASES` registry is the one declaration, and `M1` pins it against the ids a complete run actually emits — comparing both directions with the same `comm` idiom as `S1`/`S2`, on data `M1` already had in hand. `M1` itself is the one legitimate absence, because the recursion guard sits above it; that exception is documented at the assertion.

This catches strictly more than the suggested fix. "Assert every registered id appeared" catches a registered id whose case was deleted; it does not catch a new case never registered, which is the drift the finding actually named. Both now fail `M1` by name.

The pin earned its keep before it shipped: the first draft extracted case ids with a `sed -n 's/^\(ok\|FAIL\): .../'` alternation, which BSD sed does not support. It matched nothing on macOS while working under GNU sed — a silent-empty failure exactly like the class this suite exists to reject. The check caught it; the extraction is now `grep -E` + `awk`.

**Diff size (minor) — declined.** The bound is 400 changed lines; this diff is 447, up from 404. It is one cohesive test suite plus a two-line `CLAUDE.md` entry. Splitting it would put the suite's negative case in a different PR from the suite, which is a worse review unit, not a better one. The growth is the cost of closing the registry finding, and I would rather own that trade than leave a twice-raised advisory open a third round.

## Scope decisions

**Strictness: (a) hard assert, both directions.** The issue offered (a) hard assert, (b) warn on the missing-row direction, (c) advisory. AC 2 requires a *non-zero exit* when a `smarter-service`-shaped omission is reintroduced — and that omission **is** the missing-row direction, which (b) downgrades to a warning and (c) never fails on. Neither weaker option can satisfy the binding AC. The chosen level and the accepted cross-plugin coupling cost are stated in the suite's header per AC 4.

**Case labels are `ok: <id>` / `FAIL: <id>`, not this repo's older `OK   ` / `FAIL ` shape.** This is the one non-obvious decision in the PR, and it is load-bearing rather than cosmetic. The shared `mutation-check.sh` classifies a case by reading *output lines*, not the exit code:

```
RED    ^[[:space:]]*FAIL:[[:space:]]+<case>([[:space:]]|$)
GREEN  ^[[:space:]]*(ok|PASS):[[:space:]]+<case>([[:space:]]|$)
```

The no-colon shape matches neither, so a suite wearing it returns `case_not_found` (exit 2) and its mutation recipe is unrunnable *as written*. Since this diff creates `*/tests/test-*.sh`, the blocking `mutation-recipe` handoff instrument fires and the recipe has to actually run. #1239 documents this identical collision — it blocked the handoff preflight on #1236 — and names the colon form as the canonical target. This suite is therefore **born** compatible instead of needing migration later. cogni-portfolio's suites are deliberately untouched: that is #1239's scope, and cogni-portfolio is held by an in-flight PR.

Two label rules follow from that and are enforced in the file: a case id is a bare token followed by whitespace or end-of-line (never `S2:`), and the summary line begins `RESULT:` so it is never itself parsed as a case verdict.

**Both parses are section-scoped**, which is also load-bearing. An unscoped `^### ` sweep over `arc-taxonomy.md` matches **15** headings, not 11 — the four extras being Priority Chain, Chapter-to-Element Mapping, Role-Based Mapping, and an Example heading that embeds `` `industry-transformation` `` in backticks, which would fabricate a phantom duplicate and turn `D1` red on a clean file. The mapping-table parse is bounded to its own section for the same reason: the Example table's rows also start with `|`.

**`arc-registry.md` is excluded structurally** via `find -type d`, never by filename blacklist — so a future non-directory sibling cannot silently rejoin the arc set.

**The arc count is never pinned.** Both sets are derived at run time; a hardcoded count would reintroduce the stale-count class this guard exists to prevent.

**Non-vacuity is a first-class case, not a comment.** Two empty sets compare equal, so a renamed input path would otherwise report green forever. `V1`-`V4` fail loudly, and the downstream cases still emit their own ids (`FAIL: S2 not evaluated — …`) so an unevaluated case is never simply *absent* from the output — absence is indistinguishable from a typo'd `--case`.

## Mutation recipe

Run from the repo root. `mutation-check.sh` is the cogni-service shared harness; substitute its absolute path.

```bash
bash mutation-check.sh --root . --file cogni-visual/libraries/arc-taxonomy.md --expr 's/^\|[^\n]*smarter-service[^\n]*\n//m' --test 'bash cogni-visual/tests/test-arc-taxonomy-sync.sh' --case S2
```

**Executed, not just recorded.** Actual output:

```json
{
  "case": "S2",
  "expr_applied": "s/^\\|[^\\n]*smarter-service[^\\n]*\\n//m",
  "mutated_result": "red",
  "restored_result": "green",
  "verdict": "guard_verified"
}
```

Exit 0. Verified beforehand that exactly one line in `arc-taxonomy.md` both starts with `|` and contains `smarter-service` (the mapping row at L37), so the expression removes precisely that row and nothing else — the arc's element-name rows contain only Forces/Impact/Horizons/Foundations, and the prose sentence naming it does not start with `|`.

## Verification

All run in the branch worktree.

| Check | Result |
|---|---|
| Suite green on unmodified base | exit 0, **10/10** cases `ok:`, including `M1` |
| Registry falsifier: id removed from `ALL_CASES` while its case runs | `M1` red — "case(s) emitted by a full run but missing from ALL_CASES: D1" |
| Registry falsifier: phantom id added to `ALL_CASES` | `M1` red — "case id(s) in ALL_CASES that a full run never emitted: Z9" |
| `git status` immediately after a suite run | empty — `M1` never writes to the tracked taxonomy |
| `M1` falsifier: deletion made a no-op | `M1` red — "could not remove any 'smarter-service' mapping row" |
| `M1` falsifier: child aimed at the pristine file | `M1` red — "left the suite GREEN — the guard is vacuous" |
| `M1` falsifier: child red for a different case | `M1` red — "not via S2 naming 'smarter-service'" |
| Delete the `smarter-service` mapping row | exit 1, **only** `S2` red |
| Set an `arc_type` to a bogus value | exit 1, only `T1` red |
| Delete a `### <arc_id>` element section | exit 1, only `E1` red |
| Duplicate a mapping row | exit 1, only `D1` red (`M1` stays green — see the revision note) |
| Rename an arc directory | exit 1, `S1`, `S2` **and** `M1` red — both set directions fire, and `M1` reports honestly rather than passing on a tree whose baseline is already red. Confirmed pre-existing at `4b5ad62e`, not introduced by this revision |
| Move `story-arc/` away entirely | exit 1, `V2` red + all six downstream cases reported `not evaluated` |
| cwd-independence | exit 0 from `/`, from `cogni-visual/`, and from `cogni-visual/tests/` |
| Locale durability | exit 0 under `LANG=en_US.UTF-8` — output identical |
| bash 3.2.57 (`/bin/bash`) | exit 0 — no bash-4 idioms |
| `run-plugin-tests.py --filter cogni-visual` | exit 0, 1 suite discovered and passed |
| Full repo sweep `run-plugin-tests.py` | **All 103 suite(s) passed** |
| Recorded mutation recipe, replayed at this head | `verdict: guard_verified`, `mutated_result: red`, exit 0 |
| `check-breadcrumbs.py` | 0 new breadcrumbs (45 baselined, 50 scanned) |
| `check-version-bump.py` | ok — 14 plugins scanned, 1 touched, 0 violations |
| `git diff` on `arc-taxonomy.md` | empty — AC 3 |
| File mode on the pushed commit | `100755` |

Every mutation restores its target; the tree is clean after each, verified by `git status --short`.

## Note for the reviewer

cogni-visual carries **14 pre-existing** `check-frontmatter.sh` offenders at base. They are not in this PR's scope and do not block it: the handoff preflight's `frontmatter` instrument is touched-file scoped, and this diff touches no `SKILL.md` or `agents/*.md`, so that instrument records `skip: not_applicable`. Flagging it because it is the same defect class epic #1246 tracks for cogni-help / cogni-portfolio / cogni-marketing — cogni-visual is not currently in that epic's scope and arguably should be.


