### PR TITLE
cogni-narrative: add theme-thesis and smarter-service to arcs table

### DIFF
--- a/cogni-narrative/skills/narrative/SKILL.md
+++ b/cogni-narrative/skills/narrative/SKILL.md
@@ -290,9 +290,11 @@ If any gate fails, fix the specific issue and re-validate all gates (fixes can b
 | `strategic-foresight` | Signals -> Scenarios -> Strategies -> Decisions | Long-range planning, scenario analysis |
 | `industry-transformation` | Forces -> Friction -> Evolution -> Leadership | Industry analysis, regulatory impact |
 | `trend-panorama` | Forces -> Impact -> Horizons -> Foundations (TIPS) | Trend-scout output, TIPS trend reports |
+| `theme-thesis` | Why Change -> Why Now -> Why You -> Why Pay (Corporate Visions adapted for themes) | Theme sections within TIPS trend reports, investment thesis narratives, CxO-level theme justification |
 | `jtbd-portfolio` | Jobs -> Friction -> Portfolio -> Invitation | Portfolio introductions, capability overviews, pre-sales |
 | `company-credo` | Mission -> Conviction -> Credibility -> Promise | About-Us pages, company introductions, brand identity narratives |
 | `engagement-model` | Principles -> Process -> Partnership -> Outcomes | How-We-Work pages, engagement sections of proposals, partner onboarding |
+| `smarter-service` | Forces -> Impact -> Horizons -> Foundations (TIPS, theme-aware) | TIPS trend reports built on an investment-theme value model, theme-anchored CxO reports and foresight briefings |
 
 See [references/story-arc/arc-registry.md](references/story-arc/arc-registry.md) for detection signals, word targets, and extension guidelines.
 


### PR DESCRIPTION
Closes #1240.

## Summary

The `## Available Story Arcs` table in `cogni-narrative/skills/narrative/SKILL.md` listed only 9 of the 11 registered arcs, so `theme-thesis` and `smarter-service` were invisible to a reader choosing an arc from the skill body — while the body's own opening line already claimed "one of 11 story arc frameworks". The file contradicted itself.

This adds the two missing rows in `arc-registry.md` order: `theme-thesis` after `trend-panorama`, `smarter-service` last.

```
+| `theme-thesis` | Why Change -> Why Now -> Why You -> Why Pay (Corporate Visions adapted for themes) | Theme sections within TIPS trend reports, investment thesis narratives, CxO-level theme justification |
+| `smarter-service` | Forces -> Impact -> Horizons -> Foundations (TIPS, theme-aware) | TIPS trend reports built on an investment-theme value model, theme-anchored CxO reports and foresight briefings |
```

Elements and Best For are transcribed from `references/story-arc/arc-registry.md` sections `### 7` and `### 11` rather than restated independently.

## The load-bearing detail

`arc-registry.md` is the mandated content source and uses the Unicode arrow (U+2192) — **89 occurrences**. `SKILL.md` uses ASCII `->` and contained **zero**. A verbatim copy from the registry was the single likeliest defect on this change, so both rows are transliterated and the check below asserts the file still holds zero U+2192.

`smarter-service` shares all four elements with `trend-panorama`, so its row is made self-distinguishing in its own visible text: `(TIPS, theme-aware)` against the existing `(TIPS)`, with a Best For naming the investment-theme value model — the registry's own stated basis for selecting it over `trend-panorama`.

## Verification — all run, not asserted

| Check | Result |
|---|---|
| Diff shape | **2 added / 0 removed**, one file, one hunk |
| Table data rows | **11** |
| Arc-id set vs `references/story-arc/` dirs | **equal**, 11 each, no extras either way |
| Row order vs `arc-registry.md` 1-11 | **matches** |
| U+2192 in SKILL.md | **0** |
| Added-row shape | 4 pipes each, backticked id, no trailing whitespace |
| Existing 9 rows | byte-identical |
| `run-plugin-tests.py` (unfiltered) | **all 103 suites passed** |
| `check-breadcrumbs.py` | clean |
| `check-version-bump.py` | 14 plugins scanned, 1 touched (cogni-narrative), **0 violations** |
| `measure-skill-length.sh` | `chars_body` 19663 / cap 30000 (65.5%), `over_cap: false` |

Gate on the **unfiltered** `run-plugin-tests.py`. The `--filter cogni-narrative` form exits 1 with "no test suites discovered" **at base**, because the plugin ships no `tests/` directory — it cannot serve as a regression signal, and a reviewer who accepts it as the check would falsely block a correct patch.

No `## Mutation recipe` section: the diff touches no `tests/test-*.sh` or `scripts/check-*.sh`, so the instrument does not apply.

## Preflight note for the merger

`check-preflight.sh` initially exited 1 with two violations — `frontmatter` (3 offenders in cogni-narrative) and `version-bump` (1 violation). **Both were artifacts of the `--root` argument, not of this branch**, and each was corroborated independently before being set aside:

- The shared clone is checked out on `feat/issue-1116-projects-dashboard`, an unrelated branch that predates the #1242 whenToUse fix. The instruments read that tree instead of this PR's head.
- `frontmatter`: **0 offenders** at `origin/main` and **0** at this branch's head. The 3 reported offenders are `whenToUse` keys in `agents/narrative-{adapter,reviewer,writer}.md`, which #1242 already removed and which this diff does not touch.
- `version-bump`: this branch's diff touches exactly one file and **no** manifest. The stale branch's diff *does* touch `.claude-plugin/marketplace.json` and `cogni-projects/.claude-plugin/plugin.json` — that is where the violation came from.

Re-run with `--root` pointing at a worktree checked out at this PR's head: **clean, 4 passed / 0 failed / 3 skipped, 0 violations**. Skipped instruments and reasons: `run-tests` (`no_suites_at_base` — cogni-narrative ships no suites at base, nothing to regress from), `agent-length` (`not_applicable` — no touched `agents/*.md`), `mutation-recipe` (`not_applicable` — no touched `*/tests/test-*.sh` or `*/scripts/check-*.sh`).

## Scope decisions

**Included:** exactly two table rows. Nothing else in the file changes.

**Deliberately not touched:**
- The frontmatter `description` (line 3), whose parenthetical trigger list names only 6 arcs. It is a trigger surface, not the arc inventory; expanding it changes skill-trigger semantics and belongs in its own issue.
- Body line 9's arc-count prose — already correct at 11.
- `arc-registry.md` itself — already complete; it is the source, not a target.

**Out of scope, already tracked elsewhere** (recorded here rather than in the plan's `deferred[]`, deliberately: a non-empty `deferred[]` would force this PR to link `Refs #1240` instead of `Closes #1240` and leave a fully-satisfied issue open):
- A `cogni-narrative/tests/*.sh` registry-directory-table parity guard — designed and deliberately not built during the parent fix; the issue's own Related section records that decision.
- The cogni-visual arc-taxonomy siblings — covered by separate open issues for the arc_id sync guard, the consumers-frontmatter gap, and the plugin-guide arc count.

**Repo conventions:** no `plugin.json` / `marketplace.json` version touched (the post-merge workflow owns the bump); the added rows carry no issue/PR reference, version tag, or milestone code.

Base: `origin/main` @ `2e595fa1`. The base advanced from `d7cd6533` mid-run (PR #1238 merging); anchors were re-validated against the new tip and `SKILL.md` was byte-identical, so the plan held.
