### PR TITLE
cogni-visual plugin guide: eleven narrative arcs, not six

### DIFF
--- a/docs/plugin-guide/cogni-visual.md
+++ b/docs/plugin-guide/cogni-visual.md
@@ -34,7 +34,7 @@ Briefs use YAML frontmatter for metadata (`type`, `version`, `theme`, `arc_type`
 
 ### Arc Taxonomy
 
-Narrative skills detect the story arc from the source document's `arc_id` frontmatter and map it to a visual arc type via `libraries/arc-taxonomy.md`. Six narrative arcs map to five visual arc types, which control layout ordering, station labels, and section sequencing.
+Narrative skills detect the story arc from the source document's `arc_id` frontmatter and map it to a visual arc type via `libraries/arc-taxonomy.md`. Eleven narrative arcs map to five visual arc types, which control layout ordering, station labels, and section sequencing.
 
 ### Assertion Headlines
 


### PR DESCRIPTION
Closes #1244.

## Summary
- `docs/plugin-guide/cogni-visual.md:37` claimed "Six narrative arcs map to five visual arc types"; ground truth is eleven.
- Single-token edit: `Six` becomes the spelled `Eleven`. Everything else on the line, including `five visual arc types`, is byte-identical to base.
- Ground truth: the mapping table in `cogni-visual/libraries/arc-taxonomy.md` carries 11 `arc_id` rows, and `cogni-visual/CLAUDE.md` states 11 narrative arcs to 5 visual arc types.
- This was the last stale arc-count claim under `docs/` — and repo-wide: `Six narrative arcs` matches nowhere else at base, and no wiki page mirrors this plugin guide.

## Root cause (recommended follow-up, not tracked here)
- This line survived two consecutive arc-count remediation sweeps: one aligned the story-arc counts across `docs/` and both wiki mirrors, the other corrected `cogni-visual/libraries/arc-taxonomy.md` and `cogni-visual/CLAUDE.md`. Neither reached this sentence.
- The mechanism gap: nothing binds `docs/plugin-guide/` prose to the plugin content it describes, and no CI job reads `docs/`. `.github/workflows/lint.yml` runs exactly four jobs — the maintainer-breadcrumb guard (SKILL.md + agents only), the external-dispatch guard, the version-bump gate, and the `tests/*.sh` runner — none of which reference `plugin-guide`. So a count that drifts in a plugin guide drifts silently and is only ever caught by eye.
- A drift check tying plugin-guide counts back to their source tables would close this class. That is a separate change and is deliberately **not** listed as deferred work here: this diff fully satisfies every acceptance criterion of the issue, so the issue closes on merge.

## Scope decisions
- **In:** exactly one file, `docs/plugin-guide/cogni-visual.md`, exactly one changed line. File stays 196 lines.
- **Out (settled at triage, not re-litigated):** regenerating the page via `cogni-docs:doc-generate`. The file carries no generation sentinel and no DO-NOT-EDIT marker, so a regeneration would rewrite 196 lines of LLM prose to correct one word and sweep unrelated drift into a minor fix. For the same reason this change carries no guidance-skill routing — a guidance dispatch here only pulls toward that rejected regeneration path.
- **Out:** the spelled-vs-numeral house-style tension. The same file writes `11` as a numeral where it counts layout types, but the target sentence has intra-sentence parallelism with its own unchanged half (`five visual arc types`), and the sibling page `docs/plugin-guide/cogni-narrative.md` spells "eleven story arc frameworks". Spelled form it is.
- **Out (different defect):** `wiki/wiki/pages/skill-cogni-trends-trend-report.md` and its `cogni-workspace/wiki/` mirror still say "cogni-narrative's 7 story arcs" — an orphaned page for a skill that no longer exists.
- **Out:** no version bump. The post-merge workflow owns that, and no plugin source is touched here anyway.

## Test plan
- [x] `git grep -n "Six narrative arcs" docs/` returns nothing (exit 1)
- [x] Line 37 reads exactly: `Eleven narrative arcs map to five visual arc types, which control layout ordering, station labels, and section sequencing.`
- [x] `grep -c "five visual arc types" docs/plugin-guide/cogni-visual.md` returns 1
- [x] `grep -n "11 narrative arcs" docs/plugin-guide/cogni-visual.md` returns nothing (spelled form, not the numeral)
- [x] `wc -l < docs/plugin-guide/cogni-visual.md` returns 196, unchanged from base
- [x] `git diff --stat` shows exactly `1 file changed, 1 insertion(+), 1 deletion(-)`, no path outside `docs/`
- [x] Version-bump gate: 14 plugins scanned, 0 touched, 0 violations
- [x] Maintainer-breadcrumb guard: exit 0; no issue/PR reference or version token added to the docs prose
- [x] Encoding intact: file decodes as UTF-8, 0 `\uXXXX` escapes, the en dash / em dash / arrow characters elsewhere in the file all survive

## Plan record
https://github.com/cogni-work/insight-wave/issues/1244#issuecomment-5245669752