### PR TITLE
cogni-marketing: clear the two check-frontmatter.sh offenders

### DIFF
--- a/cogni-marketing/agents/content-writer.md
+++ b/cogni-marketing/agents/content-writer.md
@@ -8,29 +8,11 @@ description: >
   for batch generation.
 
   <example>
-  Context: The thought-leadership skill needs to generate a blog post
-  user: "Generate a thought leadership blog post about AI predictive maintenance for DACH mid-market"
-  assistant: "I'll use the content-writer agent to generate this blog post."
-  <commentary>
-  The thought-leadership skill delegates individual content generation to this agent with full context.
-  </commentary>
-  </example>
-
-  <example>
   Context: The demand-generation skill needs 4 LinkedIn posts in parallel
   user: "Create 4 LinkedIn posts promoting different angles of the cloud-native theme"
   assistant: "I'll launch 4 content-writer agents in parallel, each with a different angle."
   <commentary>
   Parallel generation for batch content — each agent gets a unique angle to ensure variety.
-  </commentary>
-  </example>
-
-  <example>
-  Context: The lead-generation skill needs a whitepaper
-  user: "Generate a whitepaper on sustainability reporting ROI"
-  assistant: "I'll use the content-writer agent to generate the whitepaper."
-  <commentary>
-  Long-form content is delegated to keep the main skill context clean.
   </commentary>
   </example>
 model: sonnet

--- a/cogni-marketing/skills/content-strategy/SKILL.md
+++ b/cogni-marketing/skills/content-strategy/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: content-strategy
 description: "This skill should be used when the user asks to plan a content strategy, build a content matrix, decide what content to create, map content to funnel stages, prioritize a content backlog, or plan GTM content. Trigger phrases include: 'plan content strategy', 'content matrix', 'what content should we create', 'content planning', 'marketing strategy', 'funnel mapping', 'content roadmap', 'content backlog', 'content prioritization', 'what should we write next', 'map GTM paths to content', 'marketing plan'. It builds a 3D matrix (market × GTM path × content type) with auto-recommended formats."
-version: "1.0"
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep, Agent
 ---
 


### PR DESCRIPTION
Closes #1250. Child 3 of 3 under epic tracker #1246; the `version:` half ships here per that epic's resolved open questions (skill-level `version:` is a retired convention and a defect; no allowlist entry).

## Summary

- `cogni-marketing/agents/content-writer.md` — delete `<example>` 1 and `<example>` 3 together with their separator blank lines. The intro/dispatch-trigger paragraph and `<example>` 2 (the parallel-batch case) survive. Resolved `description:` goes from **1463 to 762** chars against the 1024 cap: 376 (intro) + 1 (blank line, which the `>` resolver renders as a single `\n`) + 385 (example 2).
- `cogni-marketing/skills/content-strategy/SKILL.md` — delete `version: "1.0"`. No replacement key, no allowlist file; remaining frontmatter keys (`name`, `description`, `allowed-tools`) unchanged.
- No `tools:` / `allowed-tools:` grant changed. `model: sonnet` and `color: green` unchanged. No version bump in either manifest.

Net diff: **2 files, 19 deletions, 0 insertions.**

## Verification

`check-frontmatter.sh cogni-marketing` on this branch:

```json
{"clean": true, "count": 0, "offenders": [],
 "files_scanned": 14, "companions_scanned": 0, "allowlisted": 0, "schema_version": "4"}
```

`files_scanned` is still **14** — identical to base — so `count: 0` was not bought by deleting or renaming a scanned unit. `allowlisted: 0` in that same run, with no `FRONTMATTER_ALLOWLIST` override, and `cogni-marketing/scripts/` does not exist (there is no allowlist file to add to). `python3 scripts/check-breadcrumbs.py` exits 0.

## Scope decisions

**Which example survives (example 2).** No two-example combination fits without cutting *inside* an example, and the issue asks for examples to be cut, not hollowed out. Measured with the gate's own folding rule:

| Retention | Resolved | Verdict |
|---|---|---|
| intro + ex1 | 769 | pass |
| **intro + ex2** | **762** | **chosen** |
| intro + ex3 | 684 | pass |
| intro + ex2 + ex3 | 1070 | fail |
| intro + ex1 + ex3 | 1077 | fail |
| intro + ex1 + ex2 | 1155 | fail |

Example 2 is kept because the intro already carries the content-type vocabulary ("blog posts, LinkedIn posts, whitepapers, battle cards, email sequences"), so each example's marginal value is the dispatch handshake it demonstrates — and example 2 is the only one showing the N-in-parallel launch that the two heaviest dispatch sites actually perform (`skills/demand-generation/SKILL.md:113`, `skills/thought-leadership/SKILL.md:55`). The singular shape kept by examples 1 and 3 is the degenerate case of the fan-out, not the reverse.

Autonomous-trigger recall for a bare "write me a LinkedIn post" degrades from three worked examples to one. The surviving intro still names the content types explicitly, and all five in-plugin dispatch sites resolve the agent by the frontmatter `name:` field, which is untouched.

**Premise correction, recorded rather than inherited.** The issue motivates the description fix partly as being "widely cited as the model" for folded `description:` blocks. No file in the repo quotes this description — `README.md:142` and `CLAUDE.md:22` carry hand-written one-line summaries that already differ, and the wiki pages are stubs linking to source, so documentation drift from this trim is **zero**. The fix still earns its keep — an over-cap file in the copy-me position is a misleading precedent — but the leverage is smaller than the issue states, and this PR says so rather than banking on it.

Worth noting for whoever next touches this area: the sibling `agents/channel-adapter.md` is an already-compliant two-example folded description, but it resolves to **1007 chars — only 17 under the cap**. It is not an offender and is deliberately untouched here, but it is one sentence away from becoming one.

**The `version:` removal is inert.** Nothing in the repo reads a SKILL.md top-level `version:` key; the only two frontmatter parsers are `check-skill-names.sh` (reads `name:` only) and `check-breadcrumbs.py` (matches `vN.N.N` literals in prose, never a frontmatter key). The similarly-valued `"version": "1.0"` at `references/data-model.md:117` is a different thing entirely — the content-strategy.json data-artifact schema version inside a fenced JSON block — and is explicitly left alone.

**cogni-marketing only.** Nine of thirteen plugins are red on this gate at base. The gate instrument is plugin-scoped, so sibling redness is a sibling child's work and must not be graded against this branch; `cogni-help` and `cogni-portfolio` belong to #1248 and #1249.

**Recurrence, and why it is not in this diff.** The root cause is that `check-frontmatter.sh` runs in no CI workflow here — `lint.yml` runs the breadcrumb guard, external-dispatch guard, version-bump gate and plugin test suites — so it bites only through cogni-service's plugin-scoped `check-preflight.sh`, and drift accrues invisibly until an autonomous PR hits it. The durable fix is repo-root CI wiring, which this child's scope boundary excludes and which cannot be switched on yet regardless: nine of thirteen plugins are red at base, so the job would fail on `main` on day one. The in-plugin alternative — a `cogni-marketing/tests/test-frontmatter.sh` guard — was considered and rejected on evidence: `check-frontmatter.sh` does not exist in this repository (it ships with cogni-service), so a suite invoking it would fail the CI test job, and reimplementing the cap constant plus the folded-scalar resolver locally would fork an external gate's semantics. This belongs to the epic as repo-level follow-up, not to this PR.

**No `run-plugin-tests.py --filter cogni-marketing` check.** The plugin has no `tests/` directory and the runner exits non-zero when a filter matches no suites, so such a step would fail on base and on this branch alike.

**No manifest version bump** — the post-merge workflow owns it.

## Test plan

- [x] `check-frontmatter.sh cogni-marketing` reports `clean: true`, `count: 0`, `allowlisted: 0`
- [x] `files_scanned` still 14 (no file deleted or renamed to buy the clean result)
- [x] Resolved `content-writer` description is 762 chars (≤ 1024), with exactly one `<example>`, balanced `<example>`/`</example>` and `<commentary>`/`</commentary>`
- [x] Dispatch-trigger intro paragraph preserved verbatim, not reflowed
- [x] No `<example>` leaked into the agent body below the frontmatter
- [x] `grep -rn '^version:' cogni-marketing` returns nothing
- [x] `references/data-model.md` still carries `"version": "1.0"` (data-artifact schema version preserved)
- [x] No `[+-]` line touching `tools:` or `allowed-tools:` in the diff; `allowed-tools` still ends in `, Agent`
- [x] `cogni-marketing/scripts/frontmatter-allowlist.txt` does not exist
- [x] `python3 scripts/check-breadcrumbs.py` exits 0
- [x] Diff touches exactly 2 files, both under `cogni-marketing/`
- [x] No `plugin.json` / `marketplace.json` in the diff