### PR TITLE
cogni-workspace: repair cogni-portfolio callout region array

### DIFF
--- a/cogni-workspace/references/supported-markets-registry.json
+++ b/cogni-workspace/references/supported-markets-registry.json
@@ -49,16 +49,7 @@
       "market_count_claim": 25,
       "callout_lede": "25 pluggable regions — single-country, composite, extended, and global",
       "primary_regions_shown_in_callout": [
-        "DACH",
-        "EU",
-        "Nordics",
-        "UK",
-        "US/NA",
-        "APAC",
-        "LATAM",
-        "MEA",
-        "CN",
-        "JP"
+        "DACH"
       ],
       "tail_clause": "market-segmented propositions, competitors, and customer personas — not one-size-fits-all"
     }


### PR DESCRIPTION
Closes #1214.

Plan record: https://github.com/cogni-work/insight-wave/issues/1214#issuecomment-5247722548

## Summary

- Shrinks `plugins.cogni-portfolio.primary_regions_shown_in_callout` in `cogni-workspace/references/supported-markets-registry.json` from ten tokens to the one that passes all four registry filters: `DACH`.
- Removes `US/NA` (not a registry key — the `markets` map holds separate `us` and `na`), the zero-`authority_sources[]` tokens (`Nordics`, `APAC`, `LATAM`, `MEA`, `JP`), the tail-duplicate tokens (`EU`, `UK`), and the extended-tier token (`CN`).
- Edited surgically on the array lines only — no `json.load`/`json.dump` round-trip, so the four literal em-dashes stay literal instead of becoming `\uXXXX` escapes file-wide.
- `DACH` becomes the array's last element, so its trailing comma is dropped; the file still parses.
- No version bump in this branch — the post-merge workflow owns the patch bump.

Net diff: **one file, one hunk, +1/-10.**

## Scope decisions

Two results below look like defects on first read and are both intentional.

**(a) The one-element array is the maintainer-accepted outcome, not a regression.** The decision recorded on the issue (option C) is: keep the global framing, do not invent authority data, and do not narrow the featured set to European single-country markets — shrink the array to the members that can legitimately expand and let the callout tail carry the rest. Applying the four filters to the registry leaves `DACH` alone: it is a real key, tier `primary` (so it cannot double-render in the anglo/composite tail), and it has a non-empty `authority_sources[]` (29 entries; the callout renders the first three — BDEW/BDI/BITKOM). Backfilling authority bodies for Nordics/APAC/LATAM/MEA/JP is explicitly out of scope and must not be satisfied with plausible-looking inventions — the seven empty `authority_sources[]` arrays in the `markets` map are unchanged by this PR.

**(b) `cogni-portfolio/README.md:7` is deliberately NOT edited.** The `plus …` tail of the Markets-covered callout is computed independently of this array — it is the set of markets whose tier is `anglo`/`composite` and whose `consumed_by[]` contains cogni-portfolio (`eu`, `uk`, `us`, `na`, `nordics`, `apac`, `latam`, `mea`). Re-deriving the four Check 15 render steps against the post-fix registry reproduces the current line token-for-token: the lede matches verbatim, the array render yields exactly `DACH (BDEW, BDI, BITKOM)`, the tail yields the same eight markets already listed and in the same order (registry key order is the README's order), and `tail_clause` matches verbatim.

AC 4 is therefore satisfied by the README already being correct. **A diff on line 7 would be the regression, not the fix.** This also explains why the double-render defect was invisible in the shipped README: the duplicated members failed to expand for an unrelated reason (no authorities), so the render was accidentally correct. This change makes it structurally correct.

Observed and left alone: `docs/plugin-guide/cogni-portfolio.md:341` also lists `US/NA` in tier-taxonomy prose. That is a different generated doc, not the Check 15 callout, and the acceptance criteria name only `README.md:7`.

## Verification run on this branch

| Check | Result |
|---|---|
| `json.load` on the registry | **parses** |
| Total lines | **2162** (was 2171 — the expected 9-line net deletion) |
| Literal em-dashes | **4** — unchanged from base |
| `\uXXXX` escapes | **0** — unchanged from base |
| `US/NA` occurrences | **0** (was 1) |
| Array value | `["DACH"]` |
| `market_count_claim` | **25** — unchanged (the lede counts registry markets, not expanded members) |
| `callout_lede` / `tail_clause` | unchanged |
| Empty `authority_sources[]` in `markets` | **7** — unchanged, no backfill |
| `cogni-portfolio/README.md` in diff | **0 files** |
| `python3 scripts/run-plugin-tests.py --filter cogni-workspace` | **green** — `test-check-skill-names.sh` and `test-sanitize-theme.sh` both pass, rc=0 |

**`/cogni-docs:doc-audit cogni-portfolio` Check 15 was NOT run — it is not runnable from this repository.** cogni-docs is an external plugin living in `cogni-work/managed-service`; it is not vendored here, so neither the audit nor its `section-templates.md` resolves to any file in this working tree. Rather than assert a pass I could not execute, the Check 15 criterion is discharged above by re-deriving the four documented render steps by hand against the post-fix registry and confirming the result equals the shipped `README.md:7` byte-for-byte.

## Reviewer notes

- The registry has **no in-repo consumer of this key** — a whole-tree scan returns one hit, the definition itself. The two in-repo readers of this registry (`cogni-workspace/scripts/get-market-config.py`, `cogni-workspace/skills/workspace-dashboard/scripts/generate-dashboard.py`) touch only the `markets` map, never the `plugins` block. So this change has no runtime blast radius inside insight-wave.
- The pre-commit `/simplify` quality pass was **skipped by reason, not silently**: the diff is a ten-line deletion inside a JSON data array and that pass's remit is code quality (reuse / efficiency / altitude). There is no code in this diff for it to act on.
- Nothing in the repo prevents this array from re-drifting from the `markets` map — there is no validator in `cogni-workspace/scripts/` and no `tests/*.sh` covering the registry. This is the second issue in the #1208 chain caused by that gap. Adding a guard is outside the maintainer-set scope here, but it is a reasonable follow-up for a human to decide on.