### PR TITLE
cogni-consult: move consult-resume rendering contracts to references

### DIFF
--- a/cogni-consult/CLAUDE.md
+++ b/cogni-consult/CLAUDE.md
@@ -16,6 +16,8 @@ cogni-consult/
 │   ├── dependency-model.md        Deliverable dependency graph: edge schema,
 │   │                              validation, cascade + topological refresh
 │   ├── deliverable-types.md       Deliverable-type catalog (field-type affinity)
+│   ├── engagement-dashboard-rendering.md  Step-4 action-field dashboard rendering contract
+│   ├── engagement-list-rendering.md  Step-2 engagement-list rendering + the shared bilingual contract
 │   ├── evaluation-criteria.md     Six criteria from the replacement evaluation,
 │   │                              each with a concrete pass signal
 │   ├── frameworks-registry.md     Consulting-framework catalog backing the Define/

--- a/cogni-consult/README.md
+++ b/cogni-consult/README.md
@@ -180,6 +180,8 @@ cogni-consult/
 │   ├── deliverable-types.md       Deliverable-type catalog (field-type affinity)
 │   ├── dependency-model.md        Deliverable dependency graph: edge schema,
 │   │                              validation, cascade + topological refresh
+│   ├── engagement-dashboard-rendering.md  Step-4 action-field dashboard rendering contract
+│   ├── engagement-list-rendering.md  Step-2 engagement-list rendering + the shared bilingual contract
 │   ├── evaluation-criteria.md     Six criteria from the dogfood replacement evaluation
 │   ├── frameworks-registry.md     Consulting-framework catalog backing the Define/
 │   │                              Prototype framework lens

--- a/cogni-consult/references/engagement-dashboard-rendering.md
+++ b/cogni-consult/references/engagement-dashboard-rendering.md
@@ -1,0 +1,71 @@
+# Engagement-Dashboard Rendering
+
+How `consult-resume` renders the action-field dashboard in step 4, in either
+interaction language. This document is authoritative for that table's columns,
+row order, naming, counts and next-deliverable rule. The bilingual seeding
+principle and the `last_activity` / date resolution it reuses are authoritative
+in `$CLAUDE_PLUGIN_ROOT/references/engagement-list-rendering.md`; read that
+alongside this one. The offers that follow the table — the visual dashboard, the
+project-plan pointer, the README and assumption-register refreshes — stay in the
+skill body.
+
+Lead with the key question, then one table row per action field:
+
+```
+Engagement: <name> — zuletzt bearbeitet <TT.MM.JJJJ>
+Schlüsselfrage: <key_question>
+
+| Handlungsfeld | Stand | Deliverables | Nächstes Deliverable |
+|---------------|-------|--------------|----------------------|
+| Market Evidence | fertig | 2/2 fertig | — |
+| Portfolio Fit | in Arbeit | 1/3 fertig | Competitor map (Ideate · pyramid-principle) |
+| Go-to-Market | offen | 0/2 fertig | Channel strategy (Empathize · —) |
+```
+
+That is a German session. `Deliverables` is the same token in both header
+rows — the established German loanword, not an untranslated leftover, so leave
+it. The one carve-out is the action-field and deliverable names in the table
+above — stored titles, here English, because stored titles keep their technical
+terms whatever the session language. That carve-out covers those names and
+nothing else; it is not a licence for English elsewhere in the table.
+
+The parenthesised pair's stage is a display label, so it takes proper casing
+(`Empathize`, `Define`, `Ideate`, `Prototype`, `Test`) in either session.
+
+An English session renders the same table, seeded by example too: preamble
+labels `Engagement: <name> — last worked on <DD.MM.YYYY>` and
+`Key question: <key_question>`, header
+`| Action Field | Status | Deliverables | Next Deliverable |`, `Status` values
+`complete`, `in progress` and `pending` — the shapes
+`generate-engagement-readme.py`'s `STATE_LABEL` already renders, so the two
+surfaces agree — counts `2/2 complete` and `0/2 complete`. Dates keep the
+day-first shape the engagement-list table uses, per
+`$CLAUDE_PLUGIN_ROOT/references/engagement-list-rendering.md`. The columns, the row order and the
+one-row-per-action-field rule are identical in both languages.
+
+Name action fields by the `title` read from
+`<engagement-path>/action-fields/<slug>/field.json` — step 3's rollup carries a
+field's `slug` but not its title — and deliverables by the `title` the rollup
+passes through with each deliverable. Fall back to the slug only when no title
+is stored — slugs are storage keys, not display names, and titles are rendered
+as stored, never translated.
+`zuletzt bearbeitet` is the same discovery-supplied `last_activity` for the
+selected engagement, resolved and rendered exactly as the engagement list does —
+that rule is authoritative in
+`$CLAUDE_PLUGIN_ROOT/references/engagement-list-rendering.md` and covers this
+table too: its column headers, status cells, preamble labels and the date shape.
+
+`Deliverables` counts deliverables at `complete` over the field total — that
+`complete` is the engine state being counted, not the word to print; the cell
+renders its count in the interaction language (`2/2 fertig` / `2/2 complete`).
+`Nächstes Deliverable` / `Next Deliverable` names the
+first non-complete deliverable with its `dt_stage` and stored
+`chosen_framework` in parentheses (`<stage> · <framework>`), or the
+first whose `persona_review` is still open when everything else is done.
+The framework is the stored `chosen_framework` surfaced verbatim, read-only — a
+registry slug that keeps its stored spelling in either session; for a
+`combo:<slugA>+<slugB>` pairing, join the two slugs as `<slugA> + <slugB>` (the
+stored `combo:` prefix dropped for display); render `—` when no framework is
+stored (legacy deliverables) — never inferred here.
+Keep it to this one table — the deep WBS view (planning deliverable sets,
+splitting fields) belongs to `consult-action-fields`, not here.

--- a/cogni-consult/references/engagement-list-rendering.md
+++ b/cogni-consult/references/engagement-list-rendering.md
@@ -1,0 +1,61 @@
+# Engagement-List Rendering
+
+How `consult-resume` renders the engagement-selection list in step 2, in either
+interaction language. This document is authoritative for that table's columns,
+sort, cap, re-render and `last_activity` resolution, and for the bilingual
+seeding principle both consult-resume tables share — both languages seeded by
+verbatim example, day-first dates, identical columns and row order. The
+list-and-stop obligation that decides *whether* to render it stays in the skill
+body; everything about *how* it renders is below.
+
+Render the engagement list as this table — never as raw field names:
+
+```
+# | Engagement                                                  | Zuletzt bearbeitet
+1 | Lean-Canvas-Schärfung cogni-work                            | 13.07.2026
+2 | Benchmark Skill- & Agent-Entwicklung · noch nicht geschärft | 11.07.2026
+3 | Marktzugang Mittelstand                                     | 02.07.2026
+4 | Serviceportfolio Nord                                       | 28.06.2026
+5 | Digitalisierung Werk 2 · noch nicht geschärft               | 21.06.2026
+
+Weitere 6 — sag „alle“ für die vollständige Liste.
+
+Nummer oder Name genügt. Danach zeige ich dir den Stand und einen nächsten Schritt.
+```
+
+Pad the name column to the widest rendered cell so the date column lines up —
+the suffixed rows usually set that width.
+
+Sort by last activity, newest first, breaking ties on engagement name ascending
+so the numbering is stable across a re-render. Number the rendered rows `1`,
+`2`, `3` — bare, never `#1`. Cap the table at five rows: with five or fewer
+engagements render every one and omit the overflow line entirely (never
+`Weitere 0`); above five, render the top five and set `N` to the remainder. On
+an „alle“ reply, re-render every engagement with continuous numbering and no
+overflow line — the closing line still applies, and the list-and-stop
+obligation in the skill's step 2 still holds.
+
+The number is a reply index into the list as most recently rendered, not a new
+pre-list skip signal — the skill's step-2 matcher is unchanged and still selects on a
+name or slug the user types. The table carries no slug and no `Scope` column;
+instead, where `scope_state` (the scoping-phase status, not the engagement's
+scope) is not `complete`, append ` · noch nicht geschärft` inside the
+engagement's name cell.
+
+`Zuletzt bearbeitet` is the `last_activity` field discovery already returns per
+engagement — the newest transition timestamp from that engagement's execution
+log, falling back to its root `updated` only when that log is absent, empty, or
+unreadable; per `$CLAUDE_PLUGIN_ROOT/references/data-model.md`, "Deliverable work never touches
+it", so root `updated` tracks scope edits, not engagement freshness. Never read
+that log here. Values arrive raw and heterogeneous (a full timestamp or a bare
+date), so render and sort on the date part alone; an empty `last_activity`
+sorts last and renders `—`.
+
+German sessions render the strings above and dates as `TT.MM.JJJJ`. An English
+session renders the same table, so it is seeded by example too rather than left
+to improvise: header `# | Engagement | Last worked on`, row suffix
+` · not yet scoped`, overflow line `N more — say “all” for the full list.`, and
+closing line `A number or a name is enough. Then I'll show you where it stands
+and one next step.` Dates keep the same day-first shape, so a date reads the
+same way in either session. The columns, sort, cap, and the list-and-stop
+obligation are identical in both languages.

--- a/cogni-consult/skills/consult-resume/SKILL.md
+++ b/cogni-consult/skills/consult-resume/SKILL.md
@@ -74,57 +74,13 @@ setup owns scaffolding and the knowledge-base binding.
   substitute for the user's choice or override the list-and-stop obligation.
   Only a name or slug explicitly named in the user's message may skip the list.
 
-Render that list as this table — never as raw field names:
-
-```
-# | Engagement                                                  | Zuletzt bearbeitet
-1 | Lean-Canvas-Schärfung cogni-work                            | 13.07.2026
-2 | Benchmark Skill- & Agent-Entwicklung · noch nicht geschärft | 11.07.2026
-3 | Marktzugang Mittelstand                                     | 02.07.2026
-4 | Serviceportfolio Nord                                       | 28.06.2026
-5 | Digitalisierung Werk 2 · noch nicht geschärft               | 21.06.2026
-
-Weitere 6 — sag „alle“ für die vollständige Liste.
-
-Nummer oder Name genügt. Danach zeige ich dir den Stand und einen nächsten Schritt.
-```
-
-Pad the name column to the widest rendered cell so the date column lines up —
-the suffixed rows usually set that width.
-
-Sort by last activity, newest first, breaking ties on engagement name ascending
-so the numbering is stable across a re-render. Number the rendered rows `1`,
-`2`, `3` — bare, never `#1`. Cap the table at five rows: with five or fewer
-engagements render every one and omit the overflow line entirely (never
-`Weitere 0`); above five, render the top five and set `N` to the remainder. On
-an „alle“ reply, re-render every engagement with continuous numbering and no
-overflow line — the closing line still applies, and the list-and-stop
-obligation above still holds.
-
-The number is a reply index into the list as most recently rendered, not a new
-pre-list skip signal — the matcher above is unchanged and still selects on a
-name or slug the user types. The table carries no slug and no `Scope` column;
-instead, where `scope_state` (the scoping-phase status, not the engagement's
-scope) is not `complete`, append ` · noch nicht geschärft` inside the
-engagement's name cell.
-
-`Zuletzt bearbeitet` is the `last_activity` field discovery already returns per
-engagement — the newest transition timestamp from that engagement's execution
-log, falling back to its root `updated` only when that log is absent, empty, or
-unreadable; per `references/data-model.md`, "Deliverable work never touches
-it", so root `updated` tracks scope edits, not engagement freshness. Never read
-that log here. Values arrive raw and heterogeneous (a full timestamp or a bare
-date), so render and sort on the date part alone; an empty `last_activity`
-sorts last and renders `—`.
-
-German sessions render the strings above and dates as `TT.MM.JJJJ`. An English
-session renders the same table, so it is seeded by example too rather than left
-to improvise: header `# | Engagement | Last worked on`, row suffix
-` · not yet scoped`, overflow line `N more — say “all” for the full list.`, and
-closing line `A number or a name is enough. Then I'll show you where it stands
-and one next step.` Dates keep the same day-first shape, so a date reads the
-same way in either session. The columns, sort, cap, and the list-and-stop
-obligation are identical in both languages.
+Render that list as the table defined in
+`$CLAUDE_PLUGIN_ROOT/references/engagement-list-rendering.md` — never as raw
+field names — which is authoritative for its columns, padding, sort, five-row
+cap and overflow line, the „alle“ re-render, the reply-index rule, the
+`scope_state` name-cell suffix, the `last_activity` resolution, and both
+language seeds. Read it before rendering. The list-and-stop obligation above
+still holds.
 
 ### 3. Read the Engagement Status
 
@@ -143,62 +99,12 @@ display string, not the raw value.
 
 ### 4. Present the Dashboard
 
-Lead with the key question, then one table row per action field:
-
-```
-Engagement: <name> — zuletzt bearbeitet <TT.MM.JJJJ>
-Schlüsselfrage: <key_question>
-
-| Handlungsfeld | Stand | Deliverables | Nächstes Deliverable |
-|---------------|-------|--------------|----------------------|
-| Market Evidence | fertig | 2/2 fertig | — |
-| Portfolio Fit | in Arbeit | 1/3 fertig | Competitor map (Ideate · pyramid-principle) |
-| Go-to-Market | offen | 0/2 fertig | Channel strategy (Empathize · —) |
-```
-
-That is a German session. `Deliverables` is the same token in both header
-rows — the established German loanword, not an untranslated leftover, so leave
-it. The one carve-out is the action-field and deliverable names in the table
-above — stored titles, here English, because stored titles keep their technical
-terms whatever the session language. That carve-out covers those names and
-nothing else; it is not a licence for English elsewhere in the table.
-
-The parenthesised pair's stage is a display label, so it takes proper casing
-(`Empathize`, `Define`, `Ideate`, `Prototype`, `Test`) in either session.
-
-An English session renders the same table, seeded by example too: preamble
-labels `Engagement: <name> — last worked on <DD.MM.YYYY>` and
-`Key question: <key_question>`, header
-`| Action Field | Status | Deliverables | Next Deliverable |`, `Status` values
-`complete`, `in progress` and `pending` — the shapes
-`generate-engagement-readme.py`'s `STATE_LABEL` already renders, so the two
-surfaces agree — counts `2/2 complete` and `0/2 complete`. Dates keep the
-day-first shape of step 2. The columns, the row order and the
-one-row-per-action-field rule are identical in both languages.
-
-Name action fields by the `title` read from
-`<engagement-path>/action-fields/<slug>/field.json` — step 3's rollup carries a
-field's `slug` but not its title — and deliverables by the `title` the rollup
-passes through with each deliverable. Fall back to the slug only when no title
-is stored — slugs are storage keys, not display names, and titles are rendered
-as stored, never translated.
-`zuletzt bearbeitet` is the same discovery-supplied `last_activity` for the
-selected engagement, resolved and rendered exactly as in step 2 — that step's
-rendering rule covers this table too: its column headers, status cells,
-preamble labels and the date shape.
-
-`Deliverables` counts deliverables at `complete` over the field total — that
-`complete` is the engine state being counted, not the word to print; the cell
-renders its count in the interaction language (`2/2 fertig` / `2/2 complete`).
-`Nächstes Deliverable` / `Next Deliverable` names the
-first non-complete deliverable with its `dt_stage` and stored
-`chosen_framework` in parentheses (`<stage> · <framework>`), or the
-first whose `persona_review` is still open when everything else is done.
-The framework is the stored `chosen_framework` surfaced verbatim, read-only — a
-registry slug that keeps its stored spelling in either session; for a
-`combo:<slugA>+<slugB>` pairing, join the two slugs as `<slugA> + <slugB>` (the
-stored `combo:` prefix dropped for display); render `—` when no framework is
-stored (legacy deliverables) — never inferred here.
+Lead with the key question, then one table row per action field, rendered per
+`$CLAUDE_PLUGIN_ROOT/references/engagement-dashboard-rendering.md`, which is
+authoritative for the table's columns, row order, action-field and deliverable
+naming, the completion counts, the next-deliverable and `chosen_framework`
+display rules, and both language seeds. Read that file before emitting the
+table.
 Keep it to this one table — the deep WBS view (planning deliverable sets,
 splitting fields) belongs to `consult-action-fields`, not here.
 

--- a/cogni-consult/tests/test_reference_pointers.sh
+++ b/cogni-consult/tests/test_reference_pointers.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# Guard: every absolute reference pointer in cogni-consult resolves, the extracted
+# rendering contracts stay extracted, and neither can be silently re-inlined.
+#
+# Label vocabulary is deliberately NOT the sibling suites' `OK   ` shape. The
+# shared mutation harness classifies a case by matching `FAIL: <case>` (red) and
+# `ok: <case>` / `PASS: <case>` (green), each requiring whitespace or end-of-line
+# immediately after the case token. So a case id is a single whitespace-free
+# token and any detail is separated with " - ", never a glued colon: `PASS:
+# goes-red: ...` would match neither pattern, and a recipe recorded against this
+# suite would return case_not_found instead of a verdict.
+#
+# Scope note: the pointer scan keys ONLY on the absolute
+# `$CLAUDE_PLUGIN_ROOT/references/...` form. A bare-relative `references/...`
+# mention predates this guard elsewhere in the plugin; keying on those would make
+# this suite red for reasons unrelated to whether a pointer resolves.
+
+set -u
+
+TESTS_DIR="$(cd "$(dirname "$0")" && pwd)"
+PLUGIN_DIR="$(cd "$TESTS_DIR/.." && pwd)"
+NESTED=0
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --root) PLUGIN_DIR="$2"; NESTED=1; shift 2 ;;
+    *) echo "unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+failures=0
+pass() { printf 'PASS: %s\n' "$1"; }
+fail() { printf 'FAIL: %s - %s\n' "$1" "$2" >&2; failures=$((failures + 1)); }
+
+LIST_REF="references/engagement-list-rendering.md"
+DASH_REF="references/engagement-dashboard-rendering.md"
+RESUME_SKILL="skills/consult-resume/SKILL.md"
+
+# --- case 1: pointers-resolve ------------------------------------------------
+# Every absolute pointer resolves. A token ending in "/" is a directory target.
+pointer_tokens() {
+  grep -rho --include='*.md' --include='*.sh' --include='*.json' \
+    '\$CLAUDE_PLUGIN_ROOT/references/[A-Za-z0-9._/-]*' \
+    "$PLUGIN_DIR/skills" "$PLUGIN_DIR/agents" "$PLUGIN_DIR/references" \
+    "$PLUGIN_DIR/hooks" "$PLUGIN_DIR/output-styles" 2>/dev/null \
+    | sed 's/[.,;:)]*$//' | sort -u
+}
+
+tokens="$(pointer_tokens)"
+if [ -z "$tokens" ]; then
+  # A vacuous scan must never read as success — it would make this case pass by
+  # finding nothing to check.
+  fail "pointers-resolve" "no absolute reference pointers found under $PLUGIN_DIR (vacuous scan)"
+else
+  dangling=""
+  while IFS= read -r tok; do
+    rest="${tok#\$CLAUDE_PLUGIN_ROOT/}"
+    [ -e "$PLUGIN_DIR/$rest" ] || dangling="$dangling $rest"
+  done <<< "$tokens"
+  if [ -n "$dangling" ]; then
+    fail "pointers-resolve" "dangling:$dangling"
+  else
+    pass "pointers-resolve"
+  fi
+fi
+
+# --- case 2: pointers-absolute ----------------------------------------------
+# In the extracted contracts and in the skill body they were extracted from,
+# every references/ mention uses the absolute form — so the relocation cannot
+# erode back toward relative paths in the files it actually touched.
+before=$failures
+for rel in "$LIST_REF" "$DASH_REF" "$RESUME_SKILL"; do
+  f="$PLUGIN_DIR/$rel"
+  if [ ! -f "$f" ]; then
+    fail "pointers-absolute" "missing $rel"
+    continue
+  fi
+  all="$(grep -o 'references/' "$f" 2>/dev/null | wc -l)"
+  abs="$(grep -o 'CLAUDE_PLUGIN_ROOT/references/' "$f" 2>/dev/null | wc -l)"
+  [ "$all" -ne "$abs" ] &&
+    fail "pointers-absolute" "$rel has $all references/ mentions but only $abs absolute"
+done
+[ "$failures" -eq "$before" ] && pass "pointers-absolute"
+
+# --- case 3: reference-anchored ---------------------------------------------
+# An extracted contract nobody points at is orphaned prose. Scoped to skill
+# bodies on purpose: a reference cited only by another reference is still orphaned
+# from the default path.
+before=$failures
+for rel in "$LIST_REF" "$DASH_REF"; do
+  grep -rq "\$CLAUDE_PLUGIN_ROOT/$rel" "$PLUGIN_DIR/skills" 2>/dev/null ||
+    fail "reference-anchored" "$rel is not pointed at by any skill body"
+done
+[ "$failures" -eq "$before" ] && pass "reference-anchored"
+
+# --- case 4: contract-relocated ---------------------------------------------
+# The rendering contracts must live in the references, not back in the skill
+# body. The subject is derived, not sampled: every non-empty line of every fenced
+# example in the two references must be absent from the skill body, so
+# re-inlining any part of either rendered table fails CI.
+fenced_lines() { awk '/^```/ { inf = !inf; next } inf && NF' "$1"; }
+
+before=$failures
+for rel in "$LIST_REF" "$DASH_REF"; do
+  [ -f "$PLUGIN_DIR/$rel" ] || continue
+  while IFS= read -r line; do
+    grep -qF -- "$line" "$PLUGIN_DIR/$RESUME_SKILL" 2>/dev/null &&
+      fail "contract-relocated" "rendered example line re-inlined into $RESUME_SKILL: $line"
+  done <<< "$(fenced_lines "$PLUGIN_DIR/$rel")"
+done
+# Explicit presence half, which the derived check above cannot make: grep -F pins
+# the umlauts, so an ASCII-folded copy of a relocated rule fails to match.
+for tok in 'Weitere' 'TT.MM.JJJJ' 'Nächstes Deliverable' 'Schlüsselfrage:'; do
+  grep -qF -- "$tok" "$PLUGIN_DIR/$LIST_REF" "$PLUGIN_DIR/$DASH_REF" 2>/dev/null ||
+    fail "contract-relocated" "token absent from both reference files: $tok"
+done
+[ "$failures" -eq "$before" ] && pass "contract-relocated"
+
+# --- case 5: goes-red -------------------------------------------------------
+# Skipped under --root so the nested fixture runs cannot recurse.
+if [ "$NESTED" -eq 0 ]; then
+  TMPROOT="$(mktemp -d)"
+  trap 'rm -rf "$TMPROOT"' EXIT
+
+  build_fixture() {
+    mkdir -p "$1"
+    for d in skills agents references hooks output-styles; do
+      [ -d "$PLUGIN_DIR/$d" ] && cp -R "$PLUGIN_DIR/$d" "$1/"
+    done
+  }
+
+  # Each fixture gets its own tree named for the case it proves, so a botched
+  # mutation cannot leak into the next case and turn it red for the wrong reason.
+  expect_red() {
+    case_id="$1"; shift
+    fixture="$TMPROOT/$case_id"
+    build_fixture "$fixture"
+    "$@" "$fixture"
+    if bash "$0" --root "$fixture" >/dev/null 2>&1; then
+      fail "$case_id" "the mutated fixture did not fail the guard"
+    else
+      pass "$case_id"
+    fi
+  }
+
+  mutate_dangle() {
+    f="$1/$RESUME_SKILL"
+    sed 's|references/engagement-list-rendering\.md|references/no-such-reference.md|g' \
+      "$f" > "$f.new" && mv "$f.new" "$f"
+  }
+
+  mutate_reinline() {
+    printf '\nWeitere 6 — sag „alle“ für die vollständige Liste.\n' >> "$1/$RESUME_SKILL"
+  }
+
+  expect_red goes-red mutate_dangle
+  expect_red goes-red-reinline mutate_reinline
+fi
+
+if [ "$failures" -gt 0 ]; then
+  echo "$failures assertion(s) failed" >&2
+  exit 1
+fi
+echo "All reference-pointer assertions passed"


### PR DESCRIPTION
Closes #1263.

## Summary

- Move `skills/consult-resume/SKILL.md` lines 77-127 (Step 2 engagement-list rendering, 15 rules + the German fenced example) verbatim into the new `references/engagement-list-rendering.md`.
- Move lines 146-203 (Step 4 dashboard rendering, 15 rules + the German fenced example) verbatim into the new `references/engagement-dashboard-rendering.md`.
- Leave a directive, absolute `$CLAUDE_PLUGIN_ROOT/references/...` pointer at each site, paired with `authoritative for` plus an explicit read imperative.
- Add `tests/test_reference_pointers.sh`, a CI-run guard against dangling pointers, relative mentions in the touched files, orphaned references, and re-inlining — with two negative fixtures proving it goes red.
- Record the two new files in **both** architecture trees (`CLAUDE.md` and `README.md`).
- No plugin version touched — the post-merge workflow owns the bump.

## The number, measured rather than asserted

`measure-skill-length.sh` at base `c2f05216` and at head:

| | `chars_body` | `cap_chars` | `over_cap` | `complexity` |
|---|---|---|---|---|
| base | 21593 | 18000 | **true** | 8 |
| head | **16302** | 18000 | **false** | 8 |

The heading count is unchanged at 8, so `cap_chars` stays `6000 + 1500 × 8` — the headroom is earned by relocation, not by adding a heading to inflate the derived cap.

Exploration established up front that **neither block alone is sufficient**: removing only 77-127 lands at 18671 and only 146-203 at 18265, both still over. Both had to move.

## Scope decisions

- **Split by concern, not lumped.** Two references, one per rendered surface. A single file would re-create the same undifferentiated block one level down.
- **The shared bilingual contract gets one named owner.** `engagement-list-rendering.md` is authoritative for the list table *and* for what both tables share (both languages seeded by verbatim example, day-first dates, identical columns/sort/row-order). The dashboard reference defers to it by absolute pointer. This is what preserves the block's two `as in step 2` cross-references, which would otherwise dangle in files that have no steps — silently costing the dashboard its date contract.
- **Rules relocated, not rewritten.** Every rule, every pinned string and both fenced examples moved byte-for-byte, umlauts and `ß` intact. The only edits are mechanical: deictic phrases ("above", "step 2") became explicit, and the moved bare-relative `references/data-model.md` mention became the absolute house form.
- **Top-level references, not `references/orchestration/`.** That directory's tree caption scopes it to design-thinking extractions; putting resume files there would force rewording an unrelated caption.
- **The guard prevents the next recurrence, not just this one.** It fails on a re-inlined rendering block, so the accretion pattern the issue names is caught by CI.

## Two things worth a reviewer's attention

**1. The guard is deliberately scoped to the absolute pointer form.** Two bare-relative `references/...` mentions pre-exist at base. One is `consult-resume/SKILL.md:114`, which this PR absolutises as it moves. The other is `consult-personas/SKILL.md:189`, left alone as out of scope. A guard demanding the absolute form everywhere would go **red on base** for a reason unrelated to this change. `pointers-absolute` therefore enforces all-absolute only within the three files this PR touched.

**2. The suite's label vocabulary diverges from its siblings on purpose.** It emits `PASS: <case>` / `FAIL: <case> - <detail>` rather than the house `OK   ` / `FAIL <case>:` shape. The shared mutation harness classifies a case by matching `^FAIL: <case>` and `^(ok|PASS): <case>`, each requiring whitespace or end-of-line after the token — so the house shape matches *neither*, and a recipe recorded against it returns `case_not_found` and proves nothing. A colon glued to the case token has the same effect, which is why details use ` - `.

## Test plan

- [x] `python3 scripts/run-plugin-tests.py --filter cogni-consult` exits 0 — 12/12 suites, including the new guard and the unmodified `test_step0_register_block.sh`
- [x] `bash cogni-consult/tests/test_reference_pointers.sh` exits 0, all six cases PASS including both goes-red fixtures
- [x] Skill-length instrument reports `over_cap: false`, `chars_body` 16302 strictly below 18000
- [x] Exactly 8 `##`/`###` headings outside code fences, same titles and order
- [x] Frontmatter lines 1-15 byte-identical
- [x] All 14 pinned strings still present under `cogni-consult/`; no ASCII substitution of ä/ö/ü/ß
- [x] `test_step0_register_block.sh`, `references/orchestration/*`, `consult-design-thinking/SKILL.md` untouched
- [x] No version change in `cogni-consult/.claude-plugin/plugin.json` or the root `.claude-plugin/marketplace.json`

## Mutation recipe

Run from the repo root. Verified before this PR was opened — result `verdict: guard_verified`, `mutated_result: red`, `restored_result: green`.

```bash
bash ~/.claude/plugins/marketplaces/managed-service/cogni-service/scripts/mutation-check.sh --root "$PWD" --file cogni-consult/skills/consult-resume/SKILL.md --expr 's{references/engagement-list-rendering\.md}{references/no-such-reference.md}g' --test 'bash cogni-consult/tests/test_reference_pointers.sh' --case pointers-resolve
```

## Review notes

**Contract anchor drift (recorded at triage, non-blocking).** The issue's ratified acceptance criteria were derived against a slightly earlier base. Two literals had drifted and were re-anchored: the Step-4 heading is at line **144** (the criteria say 146 — there is no heading at 146), and base `chars_body` is **21593** (the criteria say ≈21,800). The heading *count* (8) and the derived cap (18000), which the criteria are actually load-bearing on, are unchanged.

**Pre-existing drift, annotated not fixed** (both flagged `introduced_by_change: false` by the pre-commit skill-quality gate):

- `### 4. Present the Dashboard` owns more than presentation — the visual-dashboard offer, the project-plan pointer, two unconditional filesystem writes (README and assumption-register regeneration) and an output-style blockquote. The clean fix is a separate `### 4b` step, but that would **add a heading and inflate the derived cap**, which this issue's criteria correctly forbid. Left for a dedicated pass.
- Two second-person constructions survive: `you MUST output the full engagement list` (line 69) and `you can regenerate and open it` (line 113). Line 69 sits inside the list-and-stop obligation this PR's criteria pin as verified-unchanged, so rewriting it would break the contract the change is graded against; line 113 is untouched base text. Both predate this diff.

**Possible-duplicate flag.** Triage flagged an overlap with #1205, which covers this same file plus `consult-design-thinking`. Not auto-closed: #1205 carries only a generic `over_cap: false` checkbox for `consult-resume`, while this issue carries the ratified contract. Suggested reconciliation (a maintainer call, not taken here): land this, then narrow #1205 to its remaining half.

<!-- cogni-service:comment v1 -->