### PR TITLE
cogni-consult: one casing rule for design-thinking stage display

### DIFF
--- a/cogni-consult/references/engagement-dashboard-rendering.md
+++ b/cogni-consult/references/engagement-dashboard-rendering.md
@@ -29,8 +29,9 @@ above — stored titles, here English, because stored titles keep their technica
 terms whatever the session language. That carve-out covers those names and
 nothing else; it is not a licence for English elsewhere in the table.
 
-The parenthesised pair's stage is a display label, so it takes proper casing
-(`Empathize`, `Define`, `Ideate`, `Prototype`, `Test`) in either session.
+The parenthesised pair's stage is a display label, so it takes the casing
+`$CLAUDE_PLUGIN_ROOT/references/user-facing-output.md` (c) note 4 mandates
+(`ideate` → `Ideate`), in either session.
 
 An English session renders the same table, seeded by example too: preamble
 labels `Engagement: <name> — last worked on <DD.MM.YYYY>` and

--- a/cogni-consult/references/user-facing-output.md
+++ b/cogni-consult/references/user-facing-output.md
@@ -80,7 +80,13 @@ Four notes travel with the table:
   do not translate them. The casing is what carries the meaning: lower-cased,
   they read as engine values — the consultant sees a stored token rather than
   the name of a method stage, which is exactly the failure proper-casing
-  prevents.
+  prevents. That mandate governs the stage where it appears **as a display
+  label** — a table cell, a badge, prose naming the stage as a stage. Two forms
+  fall outside it and stay lowercase: a code span (`` `ideate` ``), where the
+  token is deliberately being shown as the stored value, and a hyphenated
+  compound built from one (`mid-ideate`), where the stage has become a word
+  inside a phrase rather than a label being displayed. These two are the
+  complete exception set; anywhere else, proper-case.
 
 Where an English display string happens to equal the engine token, that is a
 coincidence of vocabulary, not an exemption — the value still passes through the

--- a/cogni-consult/scripts/generate-engagement-readme.py
+++ b/cogni-consult/scripts/generate-engagement-readme.py
@@ -223,6 +223,26 @@ def load_refresh_order(engagement_dir):
     return data if isinstance(data, dict) else None
 
 
+DT_STAGES = ["empathize", "define", "ideate", "prototype", "test"]
+
+
+def dt_stage_label(stage):
+    """The display form of a stored dt_stage, per references/user-facing-output.md
+    (c) note 4: stage names are method terms and are proper-cased wherever they
+    are displayed, so an engine value is never surfaced raw. Every display site
+    in this script routes through here. The stored tokens stay lowercase.
+    An unrecognised value passes through unchanged rather than being capitalised
+    on a guess, so a stage this script does not know surfaces visibly as
+    unmapped instead of silently posing as a known one.
+
+    Deliberately duplicated from the consult-dashboard generator rather than
+    shared: no cogni-consult script imports another, and the two live in
+    different directories with no package path between them. Kept
+    line-for-line identical to that copy so a future edit to one is visibly
+    absent from the other."""
+    return stage.capitalize() if stage in DT_STAGES else stage
+
+
 def next_action(eng, summary, personas_gate, engagement_dir):
     """The single recommendation as (rung, text). Precedence: scope-incomplete,
     then the stale set upstream-first, then the personas gate, then in-progress,
@@ -258,7 +278,7 @@ def next_action(eng, summary, personas_gate, engagement_dir):
         for d in f["deliverables"]:
             if d.get("state", "pending") == "in-progress":
                 stage = d.get("dt_stage") or "empathize"
-                return "continue", f"Continue “{d.get('title', d.get('slug'))}” in {f['title']} (design thinking, {stage} stage)."
+                return "continue", f"Continue “{d.get('title', d.get('slug'))}” in {f['title']} (design thinking, {dt_stage_label(stage)} stage)."
     for f in eng["action_fields"]:
         for d in f["deliverables"]:
             if d.get("state", "pending") == "pending":

--- a/cogni-consult/skills/consult-action-fields/SKILL.md
+++ b/cogni-consult/skills/consult-action-fields/SKILL.md
@@ -116,7 +116,7 @@ deliverables in manifest order:
 ```
 
 `Stand` merges the stored `state` and `dt_stage` into one value, the stage
-proper-cased for display (`ideate` → `Ideate`). A `complete` or `pending`
+cased per the register's (c) note 4. A `complete` or `pending`
 deliverable renders no stage — a **render-time** suppression only, so
 `dt_stage` stays stored in `field.json`.
 

--- a/cogni-consult/skills/consult-action-fields/SKILL.md
+++ b/cogni-consult/skills/consult-action-fields/SKILL.md
@@ -116,9 +116,9 @@ deliverables in manifest order:
 ```
 
 `Stand` merges the stored `state` and `dt_stage` into one value, the stage
-cased per the register's (c) note 4. A `complete` or `pending`
-deliverable renders no stage — a **render-time** suppression only, so
-`dt_stage` stays stored in `field.json`.
+cased per `references/user-facing-output.md` (c) note 4. A `complete` or
+`pending` deliverable renders no stage — a **render-time** suppression, so
+`dt_stage` stays in `field.json`.
 
 `Route` is not a column: when a deliverable's `producing_route` differs from
 the default `consult-design-thinking`, note it beneath the table, never a

--- a/cogni-consult/skills/consult-dashboard/scripts/generate-dashboard.py
+++ b/cogni-consult/skills/consult-dashboard/scripts/generate-dashboard.py
@@ -25,6 +25,19 @@ from datetime import datetime, timezone
 
 DT_STAGES = ["empathize", "define", "ideate", "prototype", "test"]
 
+
+def dt_stage_label(stage):
+    """The display form of a stored dt_stage, per references/user-facing-output.md
+    (c) note 4: stage names are method terms and are proper-cased wherever they
+    are displayed, so an engine value is never surfaced raw. Every display site
+    in this script routes through here — including the dt-label span, whose CSS
+    deliberately carries no text-transform, so this function is the single
+    casing authority rather than one of two. The stored tokens stay lowercase.
+    An unrecognised value passes through unchanged rather than being capitalised
+    on a guess, so a stage this script does not know surfaces visibly as
+    unmapped instead of silently posing as a known one."""
+    return stage.capitalize() if stage in DT_STAGES else stage
+
 # ---------------------------------------------------------------------------
 # Theme — design-variables JSON is the contract; --theme parses a theme.md as a
 # legacy/CI fallback; DEFAULT_THEME is the last resort. Precedence:
@@ -312,7 +325,7 @@ def next_action(eng, summary, refresh=None, deliv_index=None):
         for d in f["deliverables"]:
             if d.get("state") == "in-progress":
                 stage = d.get("dt_stage") or "empathize"
-                return f"Continue “{d.get('title', d.get('slug'))}” in {f['title']} (design thinking, {stage} stage)."
+                return f"Continue “{d.get('title', d.get('slug'))}” in {f['title']} (design thinking, {dt_stage_label(stage)} stage)."
     for f in eng["action_fields"]:
         for d in f["deliverables"]:
             if d.get("state") == "pending":
@@ -366,8 +379,8 @@ def dt_indicator(stage):
             cls += " dt-done"
         elif idx >= 0 and i == idx:
             cls += " dt-current"
-        dots.append(f'<span class="{cls}" title="{esc(name)}"></span>')
-    label = esc(stage) if stage else "—"
+        dots.append(f'<span class="{cls}" title="{esc(dt_stage_label(name))}"></span>')
+    label = esc(dt_stage_label(stage)) if stage else "—"
     return f'<span class="dt-track">{"".join(dots)}</span><span class="dt-label">{label}</span>'
 
 
@@ -639,7 +652,7 @@ header.hero .hero-meta {{ margin-top: 1rem; display: flex; flex-wrap: wrap; gap:
 .dt-dot {{ width: 9px; height: 9px; border-radius: 50%; background: var(--border); display: inline-block; }}
 .dt-dot.dt-done {{ background: var(--accent-muted); }}
 .dt-dot.dt-current {{ background: var(--accent-dark); box-shadow: 0 0 0 2px var(--surface2); }}
-.dt-label {{ font-size: .72rem; color: var(--text-muted); margin-left: .4rem; text-transform: capitalize; }}
+.dt-label {{ font-size: .72rem; color: var(--text-muted); margin-left: .4rem; }}
 .badge {{ display: inline-block; font-size: .72rem; font-weight: 600; padding: .12rem .5rem; border-radius: 999px; text-transform: capitalize; }}
 .badge-success {{ background: color-mix(in srgb, var(--green) 16%, transparent); color: var(--green); }}
 .badge-warning {{ background: color-mix(in srgb, var(--yellow) 18%, transparent); color: var(--yellow); }}

--- a/cogni-consult/tests/test_generate_dashboard.sh
+++ b/cogni-consult/tests/test_generate_dashboard.sh
@@ -43,8 +43,16 @@ TMPROOT="$(mktemp -d)"
 trap 'rm -rf "$TMPROOT"' EXIT
 
 failures=0
-pass() { printf 'OK   %s\n' "$1"; }
-fail() { printf 'FAIL %s: %s\n' "$1" "$2" >&2; failures=$((failures + 1)); }
+# Case labels use the `PASS: <case>` / `FAIL: <case>` shape. cogni-service's
+# mutation-check.sh --case classifies a run by scanning suite output for
+# `FAIL: <case>` (red) or `ok:`/`PASS: <case>` (green); anything else is
+# case_not_found. The `OK   `/`FAIL ` shape this suite used before matched
+# neither, so a mutation recipe naming one of these cases could not return a
+# verdict at all. (The plugin-local scripts/mutation-check.sh is a different
+# instrument — it takes no --case and reads only exit status.) Suites here are
+# mixed on this today; test_reference_pointers.sh already uses this shape.
+pass() { printf 'PASS: %s\n' "$1"; }
+fail() { printf 'FAIL: %s - %s\n' "$1" "$2" >&2; failures=$((failures + 1)); }
 
 run() { python3 "$SCRIPT" "$@"; }
 
@@ -182,6 +190,14 @@ assert_html_has "4b slug chip rendered"   "$HTML4" '<span class="fw-chip" title=
 assert_html_has "4c combo split rendered" "$HTML4" '<span class="fw-chip" title="Structuring framework">scqa + pyramid-principle</span>'
 # The legacy deliverable with no chosen_framework renders the empty-cell dash.
 assert_html_has "4d absent renders dash"  "$HTML4" '<span class="deliv-fw-empty" title="No framework chosen">'
+# The in-progress options-brief carries dt_stage "ideate". Every site that
+# *displays* that stage is proper-cased per references/user-facing-output.md (c)
+# note 4 — the dt-indicator label and the next-action line alike, so one rendered
+# artifact cannot disagree with itself. Nothing pinned a stage token before, so
+# neither raw-token render would have been caught.
+assert_html_has "4e dt label proper-cased" "$HTML4" '<span class="dt-label">Ideate</span>'
+assert_html_has "4f next-action stage"     "$HTML4" "(design thinking, Ideate stage)"
+assert_html_lacks "4g raw token absent"    "$HTML4" '<span class="dt-label">ideate</span>'
 
 # --- Fixture 5: optional scheduling fields surfaced read-only ----------------------
 # A deliverable carrying scheduling fields (start_date/due_date/duration/owner/milestone)

--- a/cogni-consult/tests/test_generate_engagement_readme.sh
+++ b/cogni-consult/tests/test_generate_engagement_readme.sh
@@ -48,8 +48,16 @@ TMPROOT="$(mktemp -d)"
 trap 'rm -rf "$TMPROOT"' EXIT
 
 failures=0
-pass() { printf 'OK   %s\n' "$1"; }
-fail() { printf 'FAIL %s: %s\n' "$1" "$2" >&2; failures=$((failures + 1)); }
+# Case labels use the `PASS: <case>` / `FAIL: <case>` shape. cogni-service's
+# mutation-check.sh --case classifies a run by scanning suite output for
+# `FAIL: <case>` (red) or `ok:`/`PASS: <case>` (green); anything else is
+# case_not_found. The `OK   `/`FAIL ` shape this suite used before matched
+# neither, so a mutation recipe naming one of these cases could not return a
+# verdict at all. (The plugin-local scripts/mutation-check.sh is a different
+# instrument — it takes no --case and reads only exit status.) Suites here are
+# mixed on this today; test_reference_pointers.sh already uses this shape.
+pass() { printf 'PASS: %s\n' "$1"; }
+fail() { printf 'FAIL: %s - %s\n' "$1" "$2" >&2; failures=$((failures + 1)); }
 
 run() { python3 "$SCRIPT" "$@"; }
 
@@ -354,6 +362,22 @@ assert_md_has "8c bound slug + count"   "$MD8" 'Bound knowledge base: `eu-ai-act
 assert_md_has "8d scope research link"  "$MD8" "(scope/research)"
 assert_md_has "8e field research link"  "$MD8" "(action-fields/market-evidence/research)"
 assert_links_resolve "8f links resolve" "$D8"
+
+# --- Fixture 9: in-progress deliverable — the next-action line displays the
+# design-thinking stage, and it must be proper-cased per
+# references/user-facing-output.md (c) note 4 rather than surfacing the stored
+# token raw. The suite pinned only next_action_rung before, never the display
+# text, which is how a raw `ideate` shipped in user-facing prose unnoticed.
+D9="$TMPROOT/dt-stage-display"
+seed_scoped "$D9" '[
+  {"slug": "competitor-map", "title": "Competitor map", "state": "in-progress", "dt_stage": "ideate"}
+]'
+echo '{"source": "scope-seeded", "name": "CFO"}' > "$D9/personas/cfo.json"
+OUT9="$(run "$D9")"
+MD9="$D9/README.md"
+assert_json "9a rung continue"          "$OUT9" "d['data']['next_action_rung'] == 'continue'"
+assert_md_has "9b stage proper-cased"   "$MD9" "(design thinking, Ideate stage)"
+assert_md_lacks "9c raw token absent"   "$MD9" "(design thinking, ideate stage)"
 
 # --- Summary ----------------------------------------------------------------------
 if [ "$failures" -eq 0 ]; then


### PR DESCRIPTION
Closes #1179.

Design-thinking stage names are method terms: proper-cased where they are displayed, left lowercase where the stored token is deliberately the thing being shown. That rule lived in one canonical place and was then restated — inconsistently, and in one case only half-stated — on four prose surfaces, while two Python renderers ignored it entirely and interpolated the stored token straight into user-facing text.

## Summary

- **Amend the canonical rule in place.** `references/user-facing-output.md` `## (c)` note 4 already mandated proper-casing for display. It now names the complete exception set too: a code span (`` `ideate` ``), where the token is deliberately shown as the stored value, and a hyphenated compound built from one (`mid-ideate`), where the stage has become a word inside a phrase rather than a label. Nothing in `consult-resume/SKILL.md` changes — its Step-5 `mid-ideate` and `` `define` ``/`` `ideate` `` become *covered* by the amended clause rather than edited.
- **Replace the restatements with pointers.** `skills/consult-action-fields/SKILL.md` (the `Stand` column) and `references/engagement-dashboard-rendering.md` (which independently enumerated `Empathize, Define, Ideate, Prototype, Test`) now defer to (c) note 4. `references/interaction-language.md` already cited it correctly and is untouched — it is the model the other two now follow, including keeping one worked example beside the pointer.
- **Fix both renderers through a display helper.** `scripts/generate-engagement-readme.py` and `skills/consult-dashboard/scripts/generate-dashboard.py` interpolated the raw `dt_stage` into the next-action line. In the dashboard the same token also fed the dt-indicator label and its per-dot tooltips, so a single generated `dashboard.html` could read "Ideate stage" in one place and "ideate" in another for the same deliverable. Every display site in a given script now routes through that script's `dt_stage_label()`.
- **Remove the competing CSS authority.** `.dt-label` carried `text-transform: capitalize`, so the rendered label was already capitalized before this change — by a second mechanism that disagrees with the Python one (CSS uppercases every word; `str.capitalize()` lowercases the tail) and that silently overrides the code-span carve-out the amended note just added. Dropping it makes the helper the single authority. Its only other use is the publish date, where the rule was a no-op.
- **Pin the rendered string, not just the rung.** Neither suite asserted on display text before — `test_generate_engagement_readme.sh` pinned only `next_action_rung`, and `test_generate_dashboard.sh` pinned no stage token at all — so nothing would have caught either defect.

The stored enum is unchanged everywhere: `CLAUDE.md`, `references/data-model.md`, `references/dependency-model.md`, `references/project-plan-model.md`, `consult-action-fields/SKILL.md`'s `field.json` template, `scripts/dt-stage-advance.sh`'s `STAGES` and `generate-dashboard.py`'s `DT_STAGES` all keep their five lowercase members. No version bump — the post-merge workflow owns it.

## The issue's own "Current behavior" table is stale — read the files, not the table

This issue was filed on 2026-08-03. It claims `consult-action-fields` renders lowercase `ideate`. **It does not, and has not for some time** — the base is already proper-cased at both the German (`in Arbeit · Ideate`) and English (`in progress · Ideate`) example cells. A diff that "fixed" them from lowercase would be wrong. Those lines, and the equivalent cells in `engagement-dashboard-rendering.md`, are deliberately byte-identical here.

Separately, the surface map moved after this issue's acceptance criteria were groomed. The refactor that folded `consult-resume`'s table and dashboard-rendering blocks into `references/engagement-dashboard-rendering.md` for body-cap headroom (21,800 → 16,302 chars) took the Step-4 casing example with it. So:

- the AC's Step-4 item ("the rule sentence is deleted in favour of a pointer, or matches (c)") was **already discharged by that merge** — this PR does not recreate the deleted example cells, and `test_reference_pointers.sh` case `contract-relocated` would go red if it did;
- the same merge created a **fourth restatement** the original issue text never mentions. Fixing the three named surfaces and leaving that one would have re-seeded the drift, so it is fixed here.

Full re-anchoring of every AC line number against the current base is recorded in the triage comment on the issue.

## Scope decisions

**In scope**

- Both Python renderers. The stage they print is a display surface, and (c)'s "an engine value is never displayed raw" applies to generated artifacts exactly as it does to chat output.
- `references/engagement-dashboard-rendering.md` — the fourth surface described above.
- The dt-indicator's per-dot `title=` tooltips. They render inside the same dt-track whose label is fixed, and `text-transform` does not reach attribute values, so they genuinely needed the helper.
- The `.dt-label` CSS rule, for the double-authority reason above.

**Deliberately not in scope**

- `consult-resume/SKILL.md` — zero edits. Its Step-5 lowercase usages are correct under the amended rule; editing them would have inverted the fix.
- A single cross-script display helper. No cogni-consult script imports another, and the two live in different directories with no package path between them, so the helper is duplicated by necessity. The two copies are kept line-for-line identical, and each says so, precisely so a future edit to one is visibly absent from the other.
- Any version or `marketplace.json` change.

## Test plan

- [x] `python3 scripts/run-plugin-tests.py --filter cogni-consult` — exit 0.
- [x] `bash cogni-consult/tests/test_generate_engagement_readme.sh` — new Fixture 9 (in-progress deliverable, `dt_stage: "ideate"`) asserts the README next-action line reads `(design thinking, Ideate stage)` and that the raw lowercase form is absent.
- [x] `bash cogni-consult/tests/test_generate_dashboard.sh` — new cases `4e`/`4f`/`4g` on Fixture 4 (which already seeded an in-progress `"dt_stage": "ideate"`) assert `<span class="dt-label">Ideate</span>` and `(design thinking, Ideate stage)`, with the lowercase label asserted absent.
- [x] `bash cogni-consult/tests/test_reference_pointers.sh` — exit 0: the new pointer uses the absolute `$CLAUDE_PLUGIN_ROOT/references/...` form (case `pointers-absolute`) and nothing was re-inlined into `consult-resume/SKILL.md` (case `contract-relocated`).
- [x] `bash cogni-consult/tests/test_dt_stage_advance.sh`, `bash cogni-consult/tests/test_step0_register_block.sh` — exit 0.
- [x] `check-frontmatter.sh` and `check-breadcrumbs.sh` clean for cogni-consult; repo CI `scripts/check-breadcrumbs.py` exit 0.
- [x] `consult-action-fields/SKILL.md` did not grow: 21,663 → 21,652 body chars. It remains over its 21,000 cap — a **pre-existing** condition this diff reduces rather than introduces.

## Mutation recipe

Run and verified, not merely recorded — `verdict: guard_verified` (mutated `red`, restored `green`):

```bash
bash ~/.claude/plugins/cache/managed-service/cogni-service/0.0.383/scripts/mutation-check.sh \
  --root . \
  --file cogni-consult/skills/consult-dashboard/scripts/generate-dashboard.py \
  --expr 's/esc\(dt_stage_label\(stage\)\)/esc(stage)/' \
  --test 'bash cogni-consult/tests/test_generate_dashboard.sh' \
  --case 4e
```

That harness classifies a run by scanning suite output for `FAIL: <case>` / `ok:`/`PASS: <case>`, so the two extended suites' `pass()`/`fail()` printers are canonicalised from the `OK   `/`FAIL ` shape (which matches neither, and returns `case_not_found`) to the shape `test_reference_pointers.sh` already uses. Note this is a different instrument from the plugin-local `cogni-consult/scripts/mutation-check.sh`, which takes no `--case` and reads only exit status.

**Known limitation, flagged rather than papered over:** `cogni-consult/tests/` is now mixed — 4 suites on the canonical shape, 8 on the old one. Converting the rest, or teaching the classifier both shapes, is a repo-wide change a casing fix should not carry; the same applies to the shared `cogni-projects/tests/fixtures/test_helpers.sh` that 67 files source.

## Open questions

Neither blocks review; both are recorded because they surfaced during the change and a human, not this PR, should settle them.

1. **The code-span carve-out may belong to all of (c), not just note 4.** "Inside a code span the lowercase token is the point" is equally true of `` `pending` ``, `` `complete` ``, `` `stale` `` — every row under a section that opens "An engine value is **never** displayed raw." The carve-out is written into note 4 here because the ratified acceptance criteria put it there. Generalising it to (c)'s post-notes paragraph would be the deeper fix.
2. **`user-facing-output.md`'s closing boundary declares the generated HTML dashboard "outside this contract"**, which sits awkwardly with bringing `generate-dashboard.py`'s render under (c) — the next-action string *is* rendered into that document. The AC settled that the renderers are in scope; whether that sentence should be narrowed to the language axis is a judgment call no gate can adjudicate.