### PR TITLE
cogni-consult: imperative register for two consult-resume clauses

### DIFF
--- a/cogni-consult/skills/consult-resume/SKILL.md
+++ b/cogni-consult/skills/consult-resume/SKILL.md
@@ -66,8 +66,8 @@ setup owns scaffolding and the knowledge-base binding.
 - **Multiple, and the user named one** → fuzzy-match the named name or slug
   against discovery and select it directly; confirm only when the match is
   ambiguous.
-- **Multiple, and the user named none** → you MUST output the full engagement
-  list, rendered as the table below, and STOP for the
+- **Multiple, and the user named none** → output the full engagement
+  list, rendered as the table below, and stop for the
   user's explicit choice. Never silently select or infer an engagement in this
   case. The active git branch, working-tree / uncommitted changes, and recent
   commit history are **not** authorized selection signals — they must never
@@ -112,7 +112,7 @@ splitting fields) belongs to `consult-action-fields`, not here.
 themed, browsable HTML view of the same status via `/cogni-consult:consult-dashboard`
 (action-field WBS, deliverable states, design-thinking stages, persona-review
 coverage). When the engagement already has `output/design-variables.json` from a
-prior dashboard run, you can regenerate and open it without a theme prompt by
+prior dashboard run, regenerate and open it without a theme prompt by
 delegating to the `consult-dashboard-refresher` agent with
 `engagement_dir: <engagement-dir>` and `plugin_root: $CLAUDE_PLUGIN_ROOT`. This
 stays read-only — the agent runs the read-only generator; it never edits


### PR DESCRIPTION
Closes #1255.

## Summary

- `skills/consult-resume/SKILL.md` line 69: delete `you MUST ` so the bullet reads `- **Multiple, and the user named none** → output the full engagement`.
- `skills/consult-resume/SKILL.md` line 70: fold `STOP` → `stop`, giving `list, rendered as the table below, and stop for the`.
- `skills/consult-resume/SKILL.md` line 115: delete `you can ` so the sentence reads `prior dashboard run, regenerate and open it without a theme prompt by`.
- Net −17 bytes (`you MUST ` = 9, `you can ` = 8, `STOP`→`stop` length-neutral), 3 added / 3 deleted, 282 lines before and after, one file.

Nothing compensating is added, because nothing is lost: the obligation is already carried by the reasoned sentences that follow it (`Never silently select or infer an engagement in this case.`, `… override the list-and-stop obligation.`), and lowercase `stop` is already the house form — the same paragraph names it the `list-and-stop obligation` two lines down, and `references/engagement-list-rendering.md` uses `list-and-stop` three times with no CAPS token anywhere.

## Scope decisions

- **In:** exactly the two clauses the issue names. A case-sensitive grep of the file for `MUST|STOP|you can|you may` matched only lines 69, 70 and 115 at base, so this is the complete set — no residual CAPS register is left behind and there was nothing else to sweep.
- **Out — the git-signals prohibition (base lines 72–75).** It is the load-bearing half of the same bullet and stays byte-identical, existing line breaks included. No reflow: re-wrapping those lines would preserve the words but change the bytes, which fails the contract even though the prose would read the same. `git diff -U0` contains no `+`/`-` line touching that span.
- **Out — no substituted hedge.** The CAPS is deleted, not downgraded: no `you should`, `you may`, `always`, or `be sure to` is introduced, and clause B is not rewritten into the passive.
- **Out — body trimming.** The issue's "Suggested sequencing" note asked to fold this into "the open `consult-resume` body-trim work" because the file is "~20% over its complexity-scaled character cap". **Both premises are stale**, verified at triage: that trim work is not open (#1263 and #1205 both merged and closed), and `measure-skill-length.sh` reports `chars_body 16302` against `cap_chars 18000` — under cap, not 20% over. There is no trim pass left to ride, so shipping standalone is the correct sequencing rather than a deviation from the issue's advice.
- **Out — versions.** No bump in `cogni-consult/.claude-plugin/plugin.json` or the root `.claude-plugin/marketplace.json`; the post-merge workflow owns the patch bump.
- **Out — new tests.** No existing suite reads the touched lines (`test_step0_register_block.sh` anchors on lines 30–48; `test_reference_pointers.sh` reads pointer tokens, not this prose), and the change is prose in a `SKILL.md`, not executable code, so no behavioral test of a register change is achievable. The bar is the byte/grep assertions below plus the existing CI suites.

## Verification

All run on the branch head:

| Check | Result |
|---|---|
| `git diff --numstat` | `3	3	cogni-consult/skills/consult-resume/SKILL.md` — line-neutral |
| `git diff --name-only` | exactly one path |
| `git diff -U0` | two hunks only (`@@ -69,2 +69,2 @@`, `@@ -115 +115 @@`); base lines 72–75 absent |
| Byte delta vs `origin/main` | `17241 → 17224` = exactly −17 |
| Line count | 282 → 282 |
| `grep -cE` for `MUST` / `STOP` / `you can` / `you may` / `you should` / `be sure to` | `0` for all six |
| `grep -c 'list-and-stop obligation'` | `2` (lines 74 and 82) — the cross-file anchor in `references/engagement-list-rendering.md` still resolves |
| `bash cogni-consult/tests/test_step0_register_block.sh` | exit 0 |
| `bash cogni-consult/tests/test_reference_pointers.sh` | exit 0 |
| `python3 scripts/run-plugin-tests.py --filter cogni-consult` | exit 0 — 12/12 suites pass |
| `check-breadcrumbs.sh cogni-consult` | `clean: true`, 0 offenders |
| `check-frontmatter.sh cogni-consult` | `clean: true`, 0 offenders |

## Review notes

**1. Modality change on line 115 — flagged by the skill-quality review as introduced by this change, and deliberately not acted on. A human should make the call.**

Deleting `you can ` removes the only permissive marker from that sentence. Base read as a capability ("you can regenerate and open it"); head reads as an instruction ("regenerate and open it"). The reviewer's concern is that the model may now regenerate and open an HTML view in the consultant's browser without the consultant electing it — a Principle-of-Lack-of-Surprise violation for a read-only skill.

This was not fixed here for two reasons, both stated rather than assumed:

- **Every available remedy is foreclosed by the acceptance contract.** That contract was derived at triage from the issue, before this branch existed, and it pins clause B's exact surviving text while explicitly forbidding `you may`, `it can be regenerated`, any passive rewrite, and any added clause. A re-plan could only produce a contract-violating diff.
- **The offer framing survives outside the edited sentence.** The paragraph's own header is **`Offer the visual dashboard.`**; its lead sentence is `After the text table, offer the consultant a themed, browsable HTML view…`; the `When the engagement already has output/design-variables.json…` conditional is preserved verbatim, keeping the imperative applicability-gated; and the next paragraph still contrasts the README refresh as `unconditional (unlike the theme-gated dashboard offer above…)`. So the surrounding text continues to mark this as an offer.

If a reviewer judges the sentence-level marker load-bearing anyway, the fix belongs in a follow-up that can amend the contract, not in this PR.

**2. Near-cap annotation (no action required).** After the change the unit sits at `chars_body 16285` against `cap_chars 18000` — inside the ≥90% approach zone (16200) but under cap, and *shrunk* by this diff (16302 → 16285). The prose-simplify pass's net-growth budget is therefore satisfied. Its ordinary bloat pass was **skipped deliberately**: an Edit-capable prose rewrite here would fail the contract's "no rider edits", "exactly −17 bytes", and "trimming is out of scope" items to chase an advisory cap the file is already under. Recorded as a stated deviation rather than done silently.

**3. Pre-existing, out of scope — filed as #1285.** The frontmatter `description` (line 8) still carries a CAPS emphatic: `or ANY session start that references an existing cogni-consult engagement`. Same axis as this issue, but the contract scopes this PR to lines 69/70/115, so it is tracked separately rather than folded in. Filed as an independent issue, not as deferred scope from this plan — this PR remains full-scope and keeps `Closes #1255`.