### PR TITLE
cogni-consult: Step 3 dashboard cosmetics + framework offload

### DIFF
--- a/cogni-consult/README.md
+++ b/cogni-consult/README.md
@@ -183,6 +183,7 @@ cogni-consult/
 │   ├── engagement-dashboard-rendering.md  Step-4 action-field dashboard rendering contract
 │   ├── engagement-list-rendering.md  Step-2 engagement-list rendering + the shared bilingual contract
 │   ├── evaluation-criteria.md     Six criteria from the dogfood replacement evaluation
+│   ├── framework-selection.md     Step-4 chosen_framework selection + idempotency guard
 │   ├── frameworks-registry.md     Consulting-framework catalog backing the Define/
 │   │                              Prototype framework lens
 │   ├── interaction-language.md    Interaction language vs. deliverable language rule

--- a/cogni-consult/references/framework-selection.md
+++ b/cogni-consult/references/framework-selection.md
@@ -1,0 +1,67 @@
+# Framework Selection
+
+How `consult-action-fields` chooses each deliverable's `chosen_framework` when it
+plans a field's deliverable set in step 4. This document is authoritative for the
+top-5 shortlist, the consulting-partner recommendation and consultant
+confirmation, the `combo:<slugA>+<slugB>` storage form, the `framework-selection`
+decision-log entry, and the write-once idempotency guard. Deciding *when* to plan
+a field's deliverable set, and the manifest entry the choice is written into,
+stay in the skill body.
+
+**Select the structuring framework for each deliverable.** Before writing each
+entry, choose its `chosen_framework` — the shape the deliverable's argument will
+take. Read `$CLAUDE_PLUGIN_ROOT/references/frameworks-registry.md` (once per
+session — it covers every deliverable), then for each deliverable being planned:
+
+1. **Shortlist the top-5.** For each deliverable being planned, rank the
+   applicable frameworks and take the five strongest — this top-5 is per
+   deliverable, not the `1-3 deliverables` count from the start of this step.
+   Rank by combining the registry's deliverable-type and field-type
+   **affinity** columns with your own judgment of the field's `framing` and the
+   engagement's key question (from `scope/` / `consult-project.json`).
+2. **Present each candidate** with its one-line structure signature from the
+   registry's `Structure signature` column, so the consultant sees what each
+   shape commits the deliverable to.
+3. **Recommend in the consulting-partner's voice.** Act as the
+   `consulting-partner` persona
+   (`$CLAUDE_PLUGIN_ROOT/references/personas/consulting-partner.json`) — the
+   advisor who knows which frameworks fit which problem shape — and recommend one
+   framework, or a combination of two, **with an explicit rationale** tying the
+   choice to the field's so-what. A combination is stored as
+   `combo:<slugA>+<slugB>`.
+4. **Confirm with the consultant** before storing — the recommendation is a
+   starting point, not a constraint; the consultant may pick any registry slug,
+   or name a new structure (give it a clear kebab-case slug like any other).
+5. **Store the choice.** Set `chosen_framework` on the deliverable's `field.json`
+   entry to the chosen registry slug, the `combo:<slugA>+<slugB>` string, or
+   `null` if the consultant defers, and append a `framework-selection` entry to
+   the engagement's `.metadata/decision-log.json` `decisions[]` array (the same
+   array that already holds gap-check entries), discriminated by
+   `"kind": "framework-selection"`:
+
+```json
+{
+  "id": "<next decision id>",
+  "kind": "framework-selection",
+  "action_field": "<field-slug>",
+  "deliverable": "<deliverable-slug>",
+  "candidates_presented": ["pyramid-principle", "scqa", "..."],
+  "chosen": "pyramid-principle",
+  "is_combination": false,
+  "rationale": "<why this framework fits the field's so-what>",
+  "timestamp": "<ISO timestamp>"
+}
+```
+
+`candidates_presented[]` is the top-5 slugs you shortlisted, `chosen` mirrors the
+value written to `chosen_framework`, and `is_combination` is `true` only when
+`chosen` is a `combo:` string.
+
+**Idempotency — never silently overwrite a chosen framework.** `chosen_framework`
+is written once at creation and read-only thereafter. On a re-run over a
+deliverable whose entry already carries a non-null `chosen_framework`, surface the
+existing choice and require explicit reconfirmation from the consultant before
+changing it — never overwrite it silently, and append no new decision-log entry
+unless the consultant explicitly chooses to change it. When the consultant does
+change it, append a fresh `framework-selection` entry (the decision-log is
+append-only) so both the prior choice and the change stay on the trail.

--- a/cogni-consult/skills/consult-action-fields/SKILL.md
+++ b/cogni-consult/skills/consult-action-fields/SKILL.md
@@ -113,7 +113,12 @@ deliverables in manifest order:
 | market-evidence | competitor-landscape | in Arbeit · Ideate | — | offen |
 | portfolio-fit | — (keine Deliverables geplant) | | | |
 | go-to-market | ⚠ field.json nicht lesbar (siehe Warnungen) | | | |
+
+Route: gtm-onepager · cogni-visual
 ```
+
+That is a German session. `Deliverable` and `Framework` are the same token in
+both header rows.
 
 `Stand` merges the stored `state` and `dt_stage` into one value, the stage
 cased per `references/user-facing-output.md` (c) note 4. A `complete` or
@@ -193,69 +198,19 @@ consultant names one (e.g. a direct `cogni-visual` export of an existing
 artifact). `persona_review` tracks the acting-persona challenge pass:
 `pending` → `in-progress` → `complete`. Both fields are manifest metadata —
 recommend the route, never dispatch it from here. `chosen_framework` records
-the deliverable's structuring framework and is selected per the sub-step below
-(default `null` until chosen). `evidence_class` records the provenance class of
+the deliverable's structuring framework and is selected per
+`$CLAUDE_PLUGIN_ROOT/references/framework-selection.md` (default `null` until
+chosen). `evidence_class` records the provenance class of
 the deliverable's evidence base — left `null` at planning and set during the
 deliverable's design-thinking loop (the completion gate requires a provenance
 record naming it); see `$CLAUDE_PLUGIN_ROOT/references/data-model.md`.
 
 **Select the structuring framework for each deliverable.** Before writing each
 entry, choose its `chosen_framework` — the shape the deliverable's argument will
-take. Read `$CLAUDE_PLUGIN_ROOT/references/frameworks-registry.md` (once per
-session — it covers every deliverable), then for each deliverable being planned:
-
-1. **Shortlist the top-5.** For each deliverable being planned, rank the
-   applicable frameworks and take the five strongest — this top-5 is per
-   deliverable, not the `1-3 deliverables` count from the start of this step.
-   Rank by combining the registry's deliverable-type and field-type
-   **affinity** columns with your own judgment of the field's `framing` and the
-   engagement's key question (from `scope/` / `consult-project.json`).
-2. **Present each candidate** with its one-line structure signature from the
-   registry's `Structure signature` column, so the consultant sees what each
-   shape commits the deliverable to.
-3. **Recommend in the consulting-partner's voice.** Act as the
-   `consulting-partner` persona
-   (`$CLAUDE_PLUGIN_ROOT/references/personas/consulting-partner.json`) — the
-   advisor who knows which frameworks fit which problem shape — and recommend one
-   framework, or a combination of two, **with an explicit rationale** tying the
-   choice to the field's so-what. A combination is stored as
-   `combo:<slugA>+<slugB>`.
-4. **Confirm with the consultant** before storing — the recommendation is a
-   starting point, not a constraint; the consultant may pick any registry slug,
-   or name a new structure (give it a clear kebab-case slug like any other).
-5. **Store the choice.** Set `chosen_framework` on the deliverable's `field.json`
-   entry to the chosen registry slug, the `combo:<slugA>+<slugB>` string, or
-   `null` if the consultant defers, and append a `framework-selection` entry to
-   the engagement's `.metadata/decision-log.json` `decisions[]` array (the same
-   array that already holds gap-check entries), discriminated by
-   `"kind": "framework-selection"`:
-
-```json
-{
-  "id": "<next decision id>",
-  "kind": "framework-selection",
-  "action_field": "<field-slug>",
-  "deliverable": "<deliverable-slug>",
-  "candidates_presented": ["pyramid-principle", "scqa", "..."],
-  "chosen": "pyramid-principle",
-  "is_combination": false,
-  "rationale": "<why this framework fits the field's so-what>",
-  "timestamp": "<ISO timestamp>"
-}
-```
-
-`candidates_presented[]` is the top-5 slugs you shortlisted, `chosen` mirrors the
-value written to `chosen_framework`, and `is_combination` is `true` only when
-`chosen` is a `combo:` string.
-
-**Idempotency — never silently overwrite a chosen framework.** `chosen_framework`
-is written once at creation and read-only thereafter. On a re-run over a
-deliverable whose entry already carries a non-null `chosen_framework`, surface the
-existing choice and require explicit reconfirmation from the consultant before
-changing it — never overwrite it silently, and append no new decision-log entry
-unless the consultant explicitly chooses to change it. When the consultant does
-change it, append a fresh `framework-selection` entry (the decision-log is
-append-only) so both the prior choice and the change stay on the trail.
+take — per `$CLAUDE_PLUGIN_ROOT/references/framework-selection.md`, which is
+authoritative for the top-5 shortlist, the consulting-partner recommendation and
+consultant confirmation, the `combo:<slugA>+<slugB>` storage form, the
+`framework-selection` decision-log entry, and its write-once idempotency guard.
 
 **Auto-wire solution-field deliverables to the diagnostic field-0 gate.** A
 mandated diagnostic field-0 is only load-bearing if solution work actually


### PR DESCRIPTION
Closes #1196.

## Summary

Relocates the **framework-selection sub-steps** — the block opening `**Select the structuring framework for each deliverable.**` (base `SKILL.md` lines 202-258) — verbatim into a new `cogni-consult/references/framework-selection.md`, leaving a six-line absolute-form pointer at the offload site. That buys the character headroom the issue named as the blocker, and it is spent on the two outstanding Step 3 cosmetics.

- **Item 1** — the `Route: gtm-onepager · cogni-visual` deviation-note example now renders **inside** the Step 3 fence, one blank line below the last data row (U+00B7 middle dot preserved).
- **Item 2** — the fenced example is labelled `That is a German session.`, immediately after the closing fence marker.
- **Item 3** — **no code change.** All four placeholder strings are already byte-exact at base; this PR freezes them as a regression guard.
- The forward reference at base line 196 (`selected per the sub-step below`) is repointed at the new reference file — once the block moves, "the sub-step below" is a false claim.
- `cogni-consult/README.md` gains one alphabetical entry in the architecture tree.

## Character budget

| | `chars_body` | `over_cap` |
|---|---|---|
| Base (`origin/main` @ `544cee2b`) | **21,660** | `true` |
| Head | **19,079** | `false` |

Offloaded block: the framework-selection sub-steps, 57 lines / 3,236 bytes. Net **−2,581 chars**, so the file clears the 21,000 cap with 1,921 to spare and `over_cap` flips **true → false**. The contract grades the delta only (head ≤ base), which this meets with wide margin.

## Scope decisions

- **This PR pays its own way** and the offload target is the framework-selection sub-steps **only** — both settled by the ratified contract, not re-litigated. The diagnostic auto-wire block stays inline and unmodified.
- **Line-196 repoint is in scope though neither the issue nor the contract names it.** It is the leading edge of the same relocation and lives in an already-in-scope file; leaving it would ship a dangling forward reference. A base-ref sweep confirmed it is the *only* forward reference into lines 202-258 anywhere in the plugin.
- **Item 2 placement.** The contract allows anywhere between the closing fence marker and the `An English session renders the same table` sentence. Chosen: immediately after the fence, mirroring the house precedent at `references/engagement-dashboard-rendering.md:25`, where the label sits directly beneath the fence rather than after two intervening paragraphs of rendering prose.
- **Item 3 deliberately not re-implemented.** The issue's quoted English string `⚠ unreadable field.json (see warnings)` does **not** match base — base carries `⚠ field.json not readable (see warnings)`. Implementing the quoted form would be a regression dressed as compliance, so base wins.
- **The Route prose paragraph is left intact.** A rejected alternative plan proposed deleting its trailing `, e.g. ...` clause on the reasoning that the example "moves rather than doubles". Rejected: the contract's item-1 guard requires that paragraph to keep stating the rule, removing base prose is the higher-risk direction, and with ~1,900 chars of headroom the ~45 saved bytes are not needed. The doubling is intentional — the prose states the rule, the fence demonstrates it.
- **Absolute pointer form is mandatory.** `tests/test_reference_pointers.sh` case `pointers-resolve` greps only `$CLAUDE_PLUGIN_ROOT/references/...`; a bare-relative pointer is invisible to the guard by explicit design.
- **Not touched, deliberately:** `cogni-consult/CLAUDE.md`'s second reference tree (already non-alphabetical at base — pre-existing drift) and `test_reference_pointers.sh`'s hardcoded `contract-relocated` case. Both are outside the ratified changed-file set. These are settled exclusions, **not** deferred work — no follow-up issue is filed and this PR fully closes #1196.
- **No version bump** in the branch; the post-merge workflow owns it (`check-version-bump.py` clean, 0 violations).

## Review notes

- **Pre-existing, not introduced here:** `SKILL.md` line ~124 cites `references/user-facing-output.md` in bare-relative rather than absolute `$CLAUDE_PLUGIN_ROOT/...` form, so it is invisible to the pointer guard. `skill-quality-reviewer` flagged it with `introduced_by_change: false` and `opt_out: true`, and explicitly said not to fix it here — it predates the change and sits inside a contract-protected region of §3. Reasonable follow-up candidate; left for a maintainer to call rather than widened into this diff.
- **`SKILL.md` sits in the length "approach zone"** at 19,079 / 21,000 (90.9%) — under cap, and this PR shrank it. Per the net-growth rule that is annotate-only, no coupled rewrite. The prose-simplify pass ran and returned **no edits** with `load_bearing_preserved: true`.

## Test plan

All checks below were run on the branch head and passed.

- [x] `bash cogni-consult/tests/test_reference_pointers.sh` — **6/6 cases pass** (`pointers-resolve`, `pointers-absolute`, `reference-anchored`, `contract-relocated`, `goes-red`, `goes-red-reinline`), exit 0. `pointers-resolve` scans `references/` too, so the new file's own two absolute tokens (`.../frameworks-registry.md`, `.../personas/consulting-partner.json`) are covered as must-resolve.
- [x] `python3 scripts/run-plugin-tests.py --filter cogni-consult` — exit 0, all 12 suites green.
- [x] `check-breadcrumbs.sh` and `check-frontmatter.sh` on `cogni-consult` — both clean, 0 offenders across 13 files.
- [x] `python3 scripts/check-version-bump.py` — 0 violations vs `origin/main`.
- [x] **Item 3 regression guard** — all four strings present byte-exact, and the issue's incorrect English wording confirmed *absent*:
  ```
  grep -Fq -- '— (keine Deliverables geplant)'                 SKILL.md
  grep -Fq -- '⚠ field.json nicht lesbar (siehe Warnungen)'    SKILL.md
  grep -Fq -- '— (no deliverables planned)'                    SKILL.md
  grep -Fq -- '⚠ field.json not readable (see warnings)'       SKILL.md
  ! grep -Fq -- '⚠ unreadable field.json (see warnings)'       SKILL.md
  ```
- [x] **Verbatim survival** in `references/framework-selection.md` — `diff` against the extracted block confirms lines 11-67 are **byte-identical** to base `SKILL.md` 202-258. All nine decision-log keys present in order; `"kind": "framework-selection"`, `combo:<slugA>+<slugB>`, sub-step 1 and the idempotency guard all present.

  > **Note for the grader:** the top-5 disambiguation is line-wrapped as `this top-5 is per\n   deliverable`, so a newline-only collapse (`tr '\n' ' '`) returns **0 on correct content** — the three-space continuation indent survives it. Use whitespace-collapsing normalisation:
  > ```
  > tr -s '[:space:]' ' ' < cogni-consult/references/framework-selection.md | grep -Fq 'this top-5 is per deliverable, not the'
  > ```
- [x] **No re-inline / no dangle** — `Shortlist the top-5` and `the sub-step below` are both absent from `SKILL.md`; `$CLAUDE_PLUGIN_ROOT/references/framework-selection.md` is present (twice, both absolute).
- [x] **Fence integrity** — bare ``` markers, exactly five columns in the header and every data row, `Route:` line inside the fence one blank line below the last row and not parseable as a sixth row.
- [x] Frontmatter unchanged — `allowed-tools: Read, Write, Edit, Bash, Skill` byte-identical.

Per the settled test bar, all three items are mechanisms carried in **prose** inside a SKILL.md, so no behavioural test is demanded; the achievable bar is the code-shape-anchored checks above plus the existing `test_reference_pointers.sh` structural guard.