### PR TITLE
cogni-visual: report the rendered artifact path from story-to-infographic

### DIFF
--- a/cogni-visual/agents/story-to-infographic.md
+++ b/cogni-visual/agents/story-to-infographic.md
@@ -32,12 +32,18 @@ without re-reading the brief.
 - NO text before or after the JSON
 - NO markdown formatting
 - NO prose, greetings, summaries, or explanations
-- Target: <120 characters total, excluding the `brief` absolute path
+- Target: <120 characters total, excluding the `brief` and `out` absolute paths
 
 **Example valid response:**
 
 ```
-{"ok":true,"brief":"/abs/path/infographic-brief.md","layout":"hero-stat","style":"economist","orient":"portrait","blocks":7,"ratio":0.12}
+{"ok":true,"brief":"/abs/path/infographic-brief.md","out":"/abs/path/infographic.pen","layout":"hero-stat","style":"economist","orient":"portrait","blocks":7,"ratio":0.12}
+```
+
+**Example valid response when `render` is `false` (brief only):**
+
+```
+{"ok":true,"brief":"/abs/path/infographic-brief.md","out":null,"layout":"hero-stat","style":"economist","orient":"portrait","blocks":7,"ratio":0.12}
 ```
 
 **On failure, return the error shape instead:**
@@ -57,8 +63,13 @@ Error codes: `param` (a required parameter is missing or unusable), `skill` (the
 not complete), `files` (source unreadable or output path unwritable), `validation` (the
 brief failed its own schema check), `render` (rendering was requested and failed).
 
-`brief` is the absolute path to the written `infographic-brief.md` — the one field a caller
-stores. Every other key stays abbreviated.
+`brief` and `out` are the two absolute paths a caller stores. `brief` is the written
+`infographic-brief.md`; `out` is the rendered artifact — a `.pen` file for the editorial style
+family, an `.excalidraw` scene for the hand-drawn family. `out` is `null` on the brief-only
+path, where the `render` parameter is `false` and no render ran. Take `out` from the result the
+render dispatch forwards back; never guess it or construct it by path arithmetic from `brief`.
+When a requested render fails, return the error shape with the `render` code — not a success
+shape carrying a fabricated or null `out`. Every other key stays abbreviated.
 
 ## Tool declaration
 

--- a/cogni-visual/skills/story-to-infographic/SKILL.md
+++ b/cogni-visual/skills/story-to-infographic/SKILL.md
@@ -438,6 +438,22 @@ The `/render-infographic` command handles everything from here: brief discovery 
 because we pass the path), style_preset routing, agent dispatch, and the post-render
 interactive edit checkpoint. Do not duplicate any of that logic here.
 
+**Capture the artifact path.** The render command forwards the rendering agent's single-line
+JSON back verbatim. Read the artifact path from whichever key that JSON carries — `pen_path`
+for the editorial family (Pencil backend), `excalidraw_path` for the hand-drawn family — and
+report that absolute path as `out` in the response contract. Check for both keys rather than
+assuming one; the two families genuinely differ. This reads an already-forwarded result; it
+re-implements no routing and no rendering.
+
+If the forwarded JSON reports `ok` false, or carries neither `pen_path` nor `excalidraw_path`,
+do not invent or derive a path: return the `render` error code the response contract already
+defines for a requested render that failed.
+
+That response contract — the `brief` and `out` paths, and the `param` / `skill` / `files` /
+`validation` / `render` error codes — lives in `cogni-visual/agents/story-to-infographic.md`
+under `## RESPONSE FORMAT`. Consult it there when this skill runs outside that agent, so the
+shape stays defined in exactly one place.
+
 **When `render` parameter is `false`:**
 
 Tell the user the brief is ready and how to render it manually:
@@ -446,6 +462,9 @@ Tell the user the brief is ready and how to render it manually:
 > Run **`/render-infographic`** to render, or use the direct commands:
 > `/render-infographic-handdrawn` (sketchnote/whiteboard) or
 > `/render-infographic-editorial` (economist/editorial/data-viz/corporate)."
+
+Report `out` as `null` on this path — no artifact was produced. A `null` marks "render never
+requested", which is why a failed render returns the `render` error code instead.
 
 **Post-render edit checkpoint** (informational note for maintainers): the render commands
 (`/render-infographic`, `/render-infographic-handdrawn`, `/render-infographic-editorial`)


### PR DESCRIPTION
Closes #1278.

## Summary

- `agents/story-to-infographic.md` success shape gains one optional key, `out` — the absolute path of the rendered artifact (`.pen` for the editorial family, `.excalidraw` for the hand-drawn family). It is `null` on the brief-only path, so a successful render is now as reportable as a failed one (the `render` error code already covered failure).
- A second labelled example demonstrates the `render: false` case with `"out":null`, so the null half of the contract is shown rather than only asserted.
- The gloss states that `out` is taken from the result the render dispatch forwards back and is never guessed or constructed by path arithmetic — without this an agent could synthesize a plausible path that was never written to disk.
- The response character budget is extended to exempt both absolute-path fields, not just `brief`.
- `skills/story-to-infographic/SKILL.md` Step 10b now captures the artifact path from the JSON the render command already forwards, reports `null` on the no-render branch, and falls back to the existing `render` error code when the forwarded JSON reports a failure or carries no path key.

## Scope decisions

**Included all four acceptance criteria in one PR.** The agent-side contract and the skill-side capture are one unit: publishing an `out` key that the dispatch site never populates would ship a contract the agent structurally cannot satisfy. Total diff is 34 insertions / 4 deletions across 2 files.

**Key name is `out`.** The render family returns three divergent shapes — `pen_path` (the Pencil/editorial renderer, and the adjacent storyboard and web agents) versus `excalidraw_path` (the sketchnote and whiteboard renderers) — so no uniform upstream key exists to reuse, and no sibling `story-to-*` agent reports an artifact path at all. `out` is therefore a free design choice; it matches the file's abbreviated-key convention and the issue's own example. Step 10b maps whichever of the two upstream keys is present onto it, and checks for both rather than assuming one.

**A render failure returns the existing error shape, not `out: null`.** The error contract already reserves the `render` code for "rendering was requested and failed", and that shape carries no path keys at all. So `out: null` means exactly one thing — render was never requested — and a failed render keeps returning the untouched error shape. Collapsing both onto `null` would have made the key ambiguous and silently widened the success path to cover failures. This distinction was surfaced by the plan-refine pass, which caught that the first-pass plan's "`out` stays null on a failed render" contradicted an error shape that carries no path keys.

**Repaired two prose claims the acceptance criteria do not name.** The character-budget bullet special-cased exactly one unbounded field, and the gloss asserted `brief` is "the one field a caller stores" with "every other key stays abbreviated". Both become false the instant a second absolute path joins the success line, so they are corrected here rather than left as known-stale text contradicting the line directly above them.

**Backward-safe.** A search across all 14 plugins found no consumer that parses this agent's JSON response keys: the one cross-plugin dispatcher invokes the skill for its filesystem side effect only, and the in-plugin report-enrichment path detects artifacts by direct disk path. Adding an optional key breaks nothing.

**Left alone deliberately.** The agent's `## Tool declaration` block (owned by a separate open change) is byte-identical. The INVALID-response examples, the error shape, and the error-code list are untouched. Step 10a's user summary, Step 10c's preview-copy check, and the post-render edit checkpoint note are untouched. Every other `agents/*.md` file is untouched. Neither version manifest is touched — the post-merge workflow owns the bump.

## Verification

| Check | Result |
|---|---|
| `run-plugin-tests.py --filter cogni-visual` | pass (1 suite, `test-arc-taxonomy-sync.sh`) |
| `check-frontmatter.sh cogni-visual` | `clean: true`, 0 offenders — acceptance criterion 4 |
| Both fenced example lines parse as JSON | pass — `out` a path in one, `null` in the other; all seven original keys retained, `out` inserted directly after `brief` |
| Error shape still carries no path key | pass — 2 keys, `out` absent |
| No version manifest touched | pass |
| No issue/PR/commit reference token in added file lines | pass |

## Review notes

**Pre-existing drift, not introduced by this change — annotated rather than fixed.** The skill-quality gate flagged that this SKILL.md's pre-existing spine leans on CAPS-as-emphasis for its hardest rules (the Workflow preamble's `**CRITICAL:** ... DO NOT ask the user for source_path`, the `Briefs contain ZERO visual fields` line, and the `(YOUR FIRST ACTION)` heading marker) instead of stating the reasoning behind them. The finding is fair, but every one of those lines is outside this diff and untouched by it; folding a whole-skill voice refactor into a two-file contract change would widen the blast radius and collide with other open work on this plugin. Flagging it here for a maintainer instead.

**Breadcrumb guard, for the record.** Run plugin-wide, `check-breadcrumbs.sh cogni-visual` exits 1 with 8 offenders — but that set is **byte-identical on base and on this branch**, this diff introduces none, and none of the 8 sit in either file it touches. All 8 are hex colour values in other `agents/*.md` files (`#06`, `#22`, `#666666`, `#111111`, `#000000`) that the guard's issue-reference pattern matches by coincidence; they are load-bearing values in a rendering plugin and must not be "fixed" by editing them. The handoff preflight is diff-scoped and reported `breadcrumbs: pass` for this branch, and the baselined CI guard (`scripts/check-breadcrumbs.py`) is green on the same tree — so this is context for a maintainer, not a blocker on this PR.
