### PR TITLE
cogni-consult: lowercase CAPS emphatic in consult-resume description

### DIFF
--- a/cogni-consult/skills/consult-resume/SKILL.md
+++ b/cogni-consult/skills/consult-resume/SKILL.md
@@ -5,7 +5,7 @@ description: |
   the status of a cogni-consult engagement across sessions. Trigger on:
   "continue the engagement", "resume the engagement", "engagement status",
   "where was I with the engagement", "what's next for the engagement", "show
-  engagement progress", "consult resume", or ANY session start that references
+  engagement progress", "consult resume", or any session start that references
   an existing cogni-consult engagement — even if the user doesn't say "resume"
   explicitly. Double Diamond phrasing ("resume diamond", "diamond status",
   phase talk like "continue discover") refers to a legacy engagement model no


### PR DESCRIPTION
Closes #1285.

## Summary

- Lowercases the CAPS emphatic `ANY` to `any` on line 8 of `cogni-consult/skills/consult-resume/SKILL.md`, inside the `description: |` block scalar. The line reads identically to the trigger classifier afterwards; skill-creator's Writing Style section treats CAPS emphatics as a yellow flag and prefers reasoned phrasing.
- Exactly one line changes: `git diff --numstat` reads `1	1`. The substitution is length-preserving, so the file is byte-identical in size (17224 bytes both sides) — no reflow, no rewrap.
- Completes the register cleanup on this file. The earlier body pass was pinned by its acceptance contract to three body lines and could not reach the frontmatter above them, leaving the description carrying an emphatic on an axis the body had already dropped.

## Scope decisions

- **One file, one line.** Verified against `origin/main`: `ANY` is the only case-sensitive occurrence in the whole file (frontmatter and body) and the only repo-wide hit for `ANY session start`, so there is no second site to fix.
- **No registration or help-text site to update.** The frontmatter description is not mirrored in `cogni-consult/README.md`, `docs/plugin-guide/cogni-consult.md`, `.claude-plugin/marketplace.json`, or any command file (this plugin ships no `commands/` directory).
- **No new test.** `cogni-consult/tests/test_step0_register_block.sh` anchors on body paragraphs (`^The `description` of a Bash tool call`, `^The register that output follows`, `^Before any user-facing output, resolve the`) and never reads the frontmatter, so this edit is structurally outside its reach and the nine-way byte-identity guard stays green unchanged. A frontmatter-orthography guard would be new capability, out of scope here.
- **No version bump.** The post-merge workflow patch-bumps each touched plugin on push to `main`; a branch-side bump would reintroduce the version-line conflict class.
- **No breadcrumbs** in the edited file. Provenance lives in this PR body and the commit message only.

## Review notes

- **Skill length, annotate-only.** `chars_body` is 16285 against an 18000 cap — 90.5%, inside the approach zone. This diff's net growth is exactly **0** (base and head both measure 16285; the file is byte-identical in size), so the net-growth budget is satisfied without a coupled rewrite. The approach-zone reading is pre-existing and is **not** introduced by this change. A whole-file prose-simplify pass was deliberately not run: it would breach this PR's own acceptance-contract SCOPE item, which requires `git diff --numstat` to read exactly `1	1`.
- **Out of scope, and deliberately not deferred here:** `cogni-consult/skills/consult-project-plan/SKILL.md` line 11 carries `This is an INTERNAL engagement-management` — the only other CAPS emphatic across the nine `consult-*` skill descriptions. It is a distinct instance on the same axis, tracked separately, and is **not** a remainder of this issue. This PR delivers 100% of #1285, which is why it carries `Closes` rather than `Refs`.

## Test plan

- [x] `git diff --numstat` reads `1	1` for `cogni-consult/skills/consult-resume/SKILL.md` and lists no other path
- [x] Line 8 reads exactly `  engagement progress", "consult resume", or any session start that references` — two-space continuation indent, both quote pairs, and every other byte preserved
- [x] `grep -c 'ANY' cogni-consult/skills/consult-resume/SKILL.md` prints `0`. Note it also **exits 1** (grep's no-match status) — that is the passing result, not a failure, so do not run it bare under `set -e`
- [x] `bash cogni-consult/tests/test_step0_register_block.sh` exits 0 (all 8 assertion groups, including the two `goes-red` mutation checks)
- [x] `python3 scripts/run-plugin-tests.py --filter cogni-consult` exits 0 — 12/12 suites
- [x] `python3 scripts/check-version-bump.py` clean: 14 plugins scanned, 0 touched, 0 violations vs `origin/main`
- [x] `python3 scripts/check-breadcrumbs.py` exits 0 with 0 new offenders
- [x] Baseline confirmed green **before** the edit, so the change inherits no red base

Branch cut from `origin/main` @ `d4fa5144`; anchors re-validated after the base advanced mid-run (the drift was PR #1291 merging — cogni-visual only, no cogni-consult files).