### PR TITLE
cogni-visual: clear ASCII-ified German from web/storyboard examples

### DIFF
--- a/cogni-visual/libraries/EXAMPLE_STORYBOARD_BRIEF.md
+++ b/cogni-visual/libraries/EXAMPLE_STORYBOARD_BRIEF.md
@@ -4,13 +4,13 @@ version: "2.0"
 theme: smarter-service
 theme_path: "/cogni-workspace/themes/smarter-service/theme.md"
 style_guide: "Corporate Tech"
-customer: "Muller Werkzeugmaschinen GmbH"
+customer: "Müller Werkzeugmaschinen GmbH"
 provider: "SmartFactory Solutions"
 language: "de"
 generated: "2026-02-27"
 arc_type: "why-change"
 arc_id: "industry-transformation"
-governing_thought: "Predictive Maintenance senkt ungeplante Stillstande um 73% und macht den Maschinenbau fit fur die nachste Dekade."
+governing_thought: "Predictive Maintenance senkt ungeplante Stillstände um 73% und macht den Maschinenbau fit für die nächste Dekade."
 confidence_score: 0.88
 industry: "maschinenbau"
 poster_size: "A1"
@@ -33,14 +33,14 @@ transformation_notes: |
 
 # Storyboard Brief: Predictive Maintenance im Maschinenbau
 
-Predictive Maintenance senkt ungeplante Stillstande um 73% und macht den Maschinenbau fit fur die nachste Dekade.
+Predictive Maintenance senkt ungeplante Stillstände um 73% und macht den Maschinenbau fit für die nächste Dekade.
 
 ---
 
-## Poster 1: Krafte (Why Change)
+## Poster 1: Kräfte (Why Change)
 
 ```yaml
-poster_label: "Krafte"
+poster_label: "Kräfte"
 sequence: "1/4"
 sections: 2
 height_allocation: [60, 40]
@@ -52,8 +52,8 @@ section_1:
 
   headline: "Predictive Maintenance macht Ihre Fertigung unaufhaltsam"
   subline: "Vom ungeplanten Stillstand zur intelligenten Fertigung"
-  cta_text: "Erstgesprach buchen"
-  section_label: "KRAFTE"
+  cta_text: "Erstgespräch buchen"
+  section_label: "KRÄFTE"
 
   image_prompt: |
     Wide panoramic industrial landscape illustration.
@@ -80,11 +80,11 @@ section_2:
   body: |
     Jede CNC-Anlage steht durchschnittlich 23 Tage pro Jahr ungeplant still.
     Bei 38.000 Euro Kosten pro Stillstandstag summiert sich der Verlust auf
-    874.000 Euro jahrlich.
+    874.000 Euro jährlich.
 
   bullets:
     - "38.000 Euro Kosten pro Stillstandstag"
-    - "Verschleiss wird erst nach Ausfall erkannt"
+    - "Verschleiß wird erst nach Ausfall erkannt"
     - "Wartungszyklen basieren auf starren Intervallen"
 
   cta:
@@ -115,13 +115,13 @@ section_1:
 
   stats:
     - number: "64.000"
-      label: "fehlende Fachkrafte bis 2028"
+      label: "fehlende Fachkräfte bis 2028"
       icon: "users"
     - number: "1:5"
-      label: "Reklamationen durch Qualitaetsdrift"
+      label: "Reklamationen durch Qualitätsdrift"
       icon: "triangle-alert"
     - number: "41%"
-      label: "hoehere Instandhaltungskosten"
+      label: "höhere Instandhaltungskosten"
       icon: "trending-up"
     - number: "18+"
       label: "Monate Einarbeitungszeit"
@@ -140,7 +140,7 @@ section_2:
   left_bullets:
     - "23 Tage ungeplanter Stillstand"
     - "874.000 Euro Verlust pro Anlage"
-    - "Verschleiss erst nach Ausfall erkannt"
+    - "Verschleiß erst nach Ausfall erkannt"
     - "Starre Wartungsintervalle"
 
   right_label: "NACHHER"
@@ -152,7 +152,7 @@ section_2:
     - "Datengetriebene Wartungsfenster"
 
   cta:
-    text: "Vergleichsanalyse fur Ihren Betrieb"
+    text: "Vergleichsanalyse für Ihren Betrieb"
     type: evaluate
     urgency: medium
 ```
@@ -173,11 +173,11 @@ section_1:
   height_percent: 50
 
   headline: "Sensoren liefern 14 Tage Vorwarnung vor dem Ausfall"
-  section_label: "DIE LOESUNG"
+  section_label: "DIE LÖSUNG"
 
   body: |
     Vibrationssensoren an Spindel, Vorschub und Lager erfassen den
-    Maschinenzustand 500-mal pro Sekunde. Edge-KI erkennt Verschleissmuster
+    Maschinenzustand 500-mal pro Sekunde. Edge-KI erkennt Verschleißmuster
     und warnt 14 Tage vor dem Ausfall.
 
   image_prompt: |
@@ -199,29 +199,29 @@ section_2:
   height_percent: 50
 
   headline: "Vier Bausteine der intelligenten Fertigung"
-  section_label: "FAEHIGKEITEN"
+  section_label: "FÄHIGKEITEN"
 
   cards:
     - card_headline: "Echtzeit-Sensorik"
       card_body: "500 Messungen pro Sekunde an Spindel, Vorschub und Lager"
       icon: "activity"
     - card_headline: "Edge-KI"
-      card_body: "Verschleissmuster erkennen und Wartungsfenster vorschlagen"
+      card_body: "Verschleißmuster erkennen und Wartungsfenster vorschlagen"
       icon: "cpu"
     - card_headline: "Digitaler Zwilling"
-      card_body: "Virtuelles Maschinenabbild fur Simulation und Planung"
+      card_body: "Virtuelles Maschinenabbild für Simulation und Planung"
       icon: "layers"
     - card_headline: "OEE-Dashboard"
-      card_body: "Anlagenverfuegbarkeit und Qualitaet in Echtzeit verfolgen"
+      card_body: "Anlagenverfügbarkeit und Qualität in Echtzeit verfolgen"
       icon: "bar-chart-2"
 ```
 
 ---
 
-## Poster 4: Fuhrung (Why Pay)
+## Poster 4: Führung (Why Pay)
 
 ```yaml
-poster_label: "Fuhrung"
+poster_label: "Führung"
 sequence: "4/4"
 sections: 2
 height_allocation: [55, 45]
@@ -236,10 +236,10 @@ section_1:
 
   steps:
     - label: "Sensorik-Pilotlinie"
-      description: "8 CNC-Anlagen ausrusten, Basisdaten erfassen"
+      description: "8 CNC-Anlagen ausrüsten, Basisdaten erfassen"
       duration: "Woche 1-4"
     - label: "KI-Training"
-      description: "Verschleissmodelle auf historischen Daten trainieren"
+      description: "Verschleißmodelle auf historischen Daten trainieren"
       duration: "Woche 5-8"
     - label: "Rollout"
       description: "Auf alle Anlagen skalieren, OEE-Dashboard live"
@@ -257,7 +257,7 @@ section_2:
 
   headline: "Starten Sie Ihren Predictive-Maintenance-Piloten"
   subline: "Drei Schritte trennen Sie von 73% weniger Stillstand."
-  cta_text: "Erstgesprach fur Pilotprojekt buchen"
+  cta_text: "Erstgespräch für Pilotprojekt buchen"
 ```
 
 ---
@@ -266,7 +266,7 @@ section_2:
 
 ```yaml
 cta_proposals:
-  - text: "Erstgesprach fur Pilotprojekt buchen"
+  - text: "Erstgespräch für Pilotprojekt buchen"
     type: commit
     urgency: high
     supporting_sections: [poster_3_section_1, poster_4_section_1]
@@ -278,7 +278,7 @@ cta_proposals:
     type: evaluate
     urgency: medium
     supporting_sections: [poster_1_section_2, poster_2_section_2]
-  - text: "Vergleichsanalyse fur Ihren Betrieb"
+  - text: "Vergleichsanalyse für Ihren Betrieb"
     type: evaluate
     urgency: medium
     supporting_sections: [poster_2_section_1, poster_2_section_2]
@@ -287,7 +287,7 @@ cta_proposals:
     urgency: low
     supporting_sections: [poster_1_section_2]
 
-primary_cta: "Erstgesprach fur Pilotprojekt buchen"
+primary_cta: "Erstgespräch für Pilotprojekt buchen"
 conversion_goal: "consultation"
 ```
 
@@ -296,7 +296,7 @@ conversion_goal: "consultation"
 ## Generation Metadata
 
 **Story Arc:** why-change (industry-transformation)
-**Governing Thought:** Predictive Maintenance senkt ungeplante Stillstande um 73% und macht den Maschinenbau fit fur die nachste Dekade.
+**Governing Thought:** Predictive Maintenance senkt ungeplante Stillstände um 73% und macht den Maschinenbau fit für die nächste Dekade.
 
 **Storyboard Architecture:**
 - Poster size: A1 portrait (3508 x 4961 px print, 1440 x 2036 px base)

--- a/cogni-visual/libraries/EXAMPLE_WEB_BRIEF.md
+++ b/cogni-visual/libraries/EXAMPLE_WEB_BRIEF.md
@@ -9,7 +9,7 @@ language: "de"
 generated: "2026-02-26"
 arc_type: "why-change"
 arc_id: "industry-transformation"
-governing_thought: "Predictive Maintenance senkt ungeplante Stillstande um 73% und macht den Maschinenbau fit fur die nachste Dekade."
+governing_thought: "Predictive Maintenance senkt ungeplante Stillstände um 73% und macht den Maschinenbau fit für die nächste Dekade."
 confidence_score: 0.89
 style_guide: "Corporate Tech"
 conversion_goal: "consultation"
@@ -24,7 +24,7 @@ transformation_notes: |
 
 # Web Narrative Brief: Predictive Maintenance im Maschinenbau
 
-Predictive Maintenance senkt ungeplante Stillstande um 73% und macht den Maschinenbau fit fur die nachste Dekade.
+Predictive Maintenance senkt ungeplante Stillstände um 73% und macht den Maschinenbau fit für die nächste Dekade.
 
 ---
 
@@ -45,7 +45,7 @@ section_theme: dark
 arc_role: hook
 
 headline: "Predictive Maintenance macht Ihre Fertigung unaufhaltsam"
-subline: "Senken Sie ungeplante Stillstande um 73% — mit KI-gestutzter Zustandsuberwachung fur den Maschinenbau."
+subline: "Senken Sie ungeplante Stillstände um 73% — mit KI-gestützter Zustandsüberwachung für den Maschinenbau."
 section_label: ""
 cta_text: "Jetzt Potenzial berechnen"
 
@@ -59,7 +59,7 @@ image_prompt: |
 
 ---
 
-## Section 2: 23 Tage Stillstand kosten Ihre Wettbewerbsfahigkeit
+## Section 2: 23 Tage Stillstand kosten Ihre Wettbewerbsfähigkeit
 
 ```yaml
 type: problem-statement
@@ -67,20 +67,20 @@ section_theme: light
 arc_role: problem
 
 section_label: "Kräfte"
-headline: "23 Tage Stillstand kosten Ihre Wettbewerbsfahigkeit"
+headline: "23 Tage Stillstand kosten Ihre Wettbewerbsfähigkeit"
 body: |
   Jede CNC-Anlage im deutschen Mittelstand steht durchschnittlich 23 Tage
-  pro Jahr ungeplant still. Manuelle Wartungszyklen erkennen Verschleiss
+  pro Jahr ungeplant still. Manuelle Wartungszyklen erkennen Verschleiß
   erst nach dem Ausfall — und kosten 38.000 Euro pro Stillstandstag.
 
 stat_number: "23"
 stat_label: "Tage Stillstand pro Anlage/Jahr"
-stat_context: "Durchschnitt uber 2.800 befragte Betriebe"
+stat_context: "Durchschnitt über 2.800 befragte Betriebe"
 
 bullets:
   - "38.000 EUR Kosten pro Stillstandstag"
-  - "Manuelle Wartung erkennt Verschleiss zu spat"
-  - "Ersatzteil-Lieferketten verstarken den Effekt"
+  - "Manuelle Wartung erkennt Verschleiß zu spät"
+  - "Ersatzteil-Lieferketten verstärken den Effekt"
 
 cta:
   text: "Ihre Stillstandskosten berechnen"
@@ -104,10 +104,10 @@ headline: "Drei Krisen treffen den Maschinenbau gleichzeitig"
 
 stats:
   - number: "64.000"
-    label: "fehlende Fachkrafte bis 2028"
+    label: "fehlende Fachkräfte bis 2028"
     icon: "users"
   - number: "1:5"
-    label: "Reklamationen durch Qualitatsdrift"
+    label: "Reklamationen durch Qualitätsdrift"
     icon: "trending-down"
   - number: "41%"
     label: "Instandhaltungskosten-Anteil"
@@ -128,7 +128,7 @@ section_label: "Evolution"
 headline: "Sensoren lesen den Maschinenzustand in Echtzeit"
 body: |
   Vibrationssensoren an Spindel, Vorschub und Lager erfassen den
-  Maschinenzustand 500-mal pro Sekunde. Edge-KI erkennt Verschleissmuster
+  Maschinenzustand 500-mal pro Sekunde. Edge-KI erkennt Verschleißmuster
   14 Tage vor dem Ausfall — und gibt Ihrem Team Zeit zu handeln.
 
 image_prompt: |
@@ -161,7 +161,7 @@ headline: "KI-Training auf Ihren historischen Daten beschleunigt den ROI"
 body: |
   Unsere Modelle lernen aus Ihren eigenen Maschinen- und Wartungsdaten.
   Kein generisches Modell von der Stange — sondern KI, die Ihre
-  spezifischen Verschleissmuster kennt und immer praziser wird.
+  spezifischen Verschleißmuster kennt und immer präziser wird.
 
 image_prompt: |
   Abstract visualization of machine learning data flow, neural network
@@ -189,7 +189,7 @@ left_bullets:
   - "23 Tage ungeplanter Stillstand/Jahr"
   - "Reaktive Fehlersuche nach Ausfall"
   - "Hohe Ersatzteil-Notbestellkosten"
-  - "Qualitatsabweichung erst bei Endkontrolle"
+  - "Qualitätsabweichung erst bei Endkontrolle"
 
 right_label: "Nachher"
 right_headline: "Predictive Maintenance"
@@ -197,7 +197,7 @@ right_bullets:
   - "6 Tage Stillstand/Jahr (-73%)"
   - "14 Tage Vorwarnung vor Ausfall"
   - "41% Instandhaltungskosten-Reduktion"
-  - "Echtzeit-Qualitatsuberwachung"
+  - "Echtzeit-Qualitätsüberwachung"
 ```
 
 ---
@@ -234,7 +234,7 @@ section_theme: accent
 arc_role: call-to-action
 
 headline: "Starten Sie Ihren Predictive-Maintenance-Piloten"
-subline: "Berechnen Sie Ihr Einsparpotenzial in einem kostenlosen 30-Minuten-Gesprach."
+subline: "Berechnen Sie Ihr Einsparpotenzial in einem kostenlosen 30-Minuten-Gespräch."
 cta_text: "Beratung anfragen"
 ```
 
@@ -286,7 +286,7 @@ conversion_goal: "consultation"
 
 **Story Arc:** why-change (from arc_id: industry-transformation)
 **Arc Elements:** Kräfte → Reibung → Evolution → Führung
-**Governing Thought:** Predictive Maintenance senkt ungeplante Stillstande um 73% und macht den Maschinenbau fit fur die nachste Dekade.
+**Governing Thought:** Predictive Maintenance senkt ungeplante Stillstände um 73% und macht den Maschinenbau fit für die nächste Dekade.
 
 **Web Architecture:**
 - Style guide: Corporate Tech

--- a/cogni-visual/skills/story-to-web/references/02-section-architecture.md
+++ b/cogni-visual/skills/story-to-web/references/02-section-architecture.md
@@ -364,7 +364,7 @@ This example shows the complete decomposition process applied to a narrative abo
 
 A 1700-word narrative about predictive maintenance for the German Mittelstand. Arc type: why-change. Contains 8 data points, 3 major arguments, and a before/after case study. Sections:
 
-1. Opening: "Ungeplante Stillstande bedrohen den Maschinenbau" (problem framing, 23 days stat, EUR 38k/day)
+1. Opening: "Ungeplante Stillstände bedrohen den Maschinenbau" (problem framing, 23 days stat, EUR 38k/day)
 2. "Drei Krisen gleichzeitig" (skills shortage 64k, quality drift 1:5, maintenance costs 41%)
 3. "Sensorik und Edge-KI" (solution: real-time condition monitoring, 500 readings/sec, 14-day prediction window)
 4. "KI-Training auf historischen Daten" (approach: custom ML models, not generic)
@@ -374,7 +374,7 @@ A 1700-word narrative about predictive maintenance for the German Mittelstand. A
 ### Step 1: Section Inventory
 
 ```
-Section 1: "Ungeplante Stillstande..."
+Section 1: "Ungeplante Stillstände..."
   Arc role: problem
   Word count: ~180
   Stats: 2 (23 days, EUR 38k)
@@ -473,7 +473,7 @@ Current count: 8 total (hero + 6 interior content + CTA).
 | # | Type | section_theme | Arc Role | Position | Headline |
 |---|------|---------------|----------|----------|----------|
 | 1 | hero | dark | hook | — | "Predictive Maintenance macht Ihre Fertigung unaufhaltsam" |
-| 2 | problem-statement | light | problem | — | "23 Tage Stillstand kosten Ihre Wettbewerbsfahigkeit" |
+| 2 | problem-statement | light | problem | — | "23 Tage Stillstand kosten Ihre Wettbewerbsfähigkeit" |
 | 3 | stat-row | dark | urgency | — | "Drei Krisen treffen den Maschinenbau gleichzeitig" |
 | 4 | feature-alternating | light | solution | odd | "Sensoren lesen den Maschinenzustand in Echtzeit" |
 | 5 | feature-alternating | light-alt | solution | even | "KI-Training auf Ihren historischen Daten beschleunigt den ROI" |

--- a/cogni-visual/skills/story-to-web/references/04-image-prompts.md
+++ b/cogni-visual/skills/story-to-web/references/04-image-prompts.md
@@ -204,7 +204,7 @@ These three examples demonstrate the complete reasoning chain from section conte
 type: hero
 arc_role: hook
 headline: "Predictive Maintenance macht Ihre Fertigung unaufhaltsam"
-subline: "Senken Sie ungeplante Stillstande um 73%..."
+subline: "Senken Sie ungeplante Stillstände um 73%..."
 style_guide: "Corporate Tech"
 ```
 
@@ -270,7 +270,7 @@ Verification: Single subject (wearable device). "No text, no people" present. Sq
 type: feature-alternating
 arc_role: evidence
 headline: "Automatisierte Compliance spart 12.000 Arbeitsstunden pro Jahr"
-body: "KI-gestutzte Regelprufung scannt Transaktionen in Echtzeit..."
+body: "KI-gestützte Regelprüfung scannt Transaktionen in Echtzeit..."
 style_guide: "Corporate Finance"
 ```
 

--- a/cogni-visual/skills/story-to-web/references/05-validation.md
+++ b/cogni-visual/skills/story-to-web/references/05-validation.md
@@ -132,7 +132,7 @@ For each section, verify:
 - `[C]` Every headline is an assertion (contains a verb)
   - **How to detect:** Read the headline. If you can put "About:" in front of it and it still makes sense, it is a topic label, not an assertion.
   - If this fails, the section has no clear message. Fix: rewrite as `{subject} + {verb} + {object/benefit}`. Example: "Overview of Predictive Maintenance" becomes "Predictive Maintenance eliminates unplanned downtime".
-- `[C]` No topic labels ("Overview", "Summary", "Uberblick", "Zusammenfassung", "Introduction", "Einleitung", "Fazit")
+- `[C]` No topic labels ("Overview", "Summary", "Überblick", "Zusammenfassung", "Introduction", "Einleitung", "Fazit")
   - If this fails, the reader sees a chapter title instead of a message. Fix: replace with the section's core assertion.
 - `[W]` Headlines are unique (no duplicates or near-duplicates)
   - **How to detect:** Compare all headlines. Two headlines making the same claim in different words are near-duplicates.
@@ -310,7 +310,7 @@ type: problem-statement
 section_theme: light
 arc_role: problem
 headline: "Das Problem mit Stillstand"
-body: "Fabriken verlieren viel Geld durch ungeplante Ausfalle."
+body: "Fabriken verlieren viel Geld durch ungeplante Ausfälle."
 stat_number: "23 Tage"
 stat_label: ""
 ```
@@ -321,7 +321,7 @@ type: feature-alternating
 section_theme: light
 arc_role: solution
 position: odd
-headline: "Sensoren erkennen Verschleiss fruhzeitig"
+headline: "Sensoren erkennen Verschleiß frühzeitig"
 body: "Unsere Sensoren messen den Maschinenzustand in Echtzeit."
 ```
 
@@ -366,7 +366,7 @@ cta_text: "Beratung anfragen"
 |---|-------|----------|--------|---------|-----|
 | 1 | Hero headline is assertion | `[C]` | **FAIL** | "Predictive Maintenance" is a topic label, not an assertion. No verb. | Rewrite: "Predictive Maintenance macht Ihre Fertigung unaufhaltsam" |
 | 2 | Hero headline max 10 words | `[C]` | PASS | 2 words (after fix: 7 words) | -- |
-| 3 | Section 2 headline is assertion | `[C]` | **FAIL** | "Das Problem mit Stillstand" is a topic label. You can say "About: Das Problem mit Stillstand" and it still works. | Rewrite: "23 Tage Stillstand kosten Ihre Wettbewerbsfahigkeit" |
+| 3 | Section 2 headline is assertion | `[C]` | **FAIL** | "Das Problem mit Stillstand" is a topic label. You can say "About: Das Problem mit Stillstand" and it still works. | Rewrite: "23 Tage Stillstand kosten Ihre Wettbewerbsfähigkeit" |
 | 4 | Stat number isolated | `[C]` | **FAIL** | `stat_number: "23 Tage"` — units embedded in number | Change to `stat_number: "23"`, `stat_label: "Tage Stillstand/Jahr"` |
 | 5 | Stat label not empty | `[W]` | **FAIL** | `stat_label: ""` | Set to "Tage Stillstand pro Anlage/Jahr" |
 | 6 | CTA headline imperative | `[W]` | **FAIL** | "Kontaktieren Sie uns" is generic. | Rewrite: "Starten Sie Ihren Predictive-Maintenance-Piloten" |


### PR DESCRIPTION
Closes #1290.

## Summary

Replace ASCII-ified German with real Unicode (ä/ö/ü/ß) in the five example and reference files that `story-to-web` and `story-to-storyboard` load, so the exemplars stop contradicting by demonstration the umlaut rule their SKILL.md files mandate. **78 substitutions across five files; substitution-only, no line added or removed** (`git diff --numstat` shows added == deleted on every row: 29/29, 17/17, 3/3, 2/2, 4/4).

`libraries/EXAMPLE_WEB_BRIEF.md` is the highest-leverage file — `story-to-web/SKILL.md` loads it as the primary output-format template, so it is the literal exemplar the model copies.

## Two findings the issue did not carry

**1. A second corruption style.** `EXAMPLE_STORYBOARD_BRIEF.md` mixes the dropped-vowel style the issue documents **and** an ae/oe/ue digraph style absent from its risk note — `Qualitaetsdrift` (:121), `hoehere` (:124), `LOESUNG` (:176), `FAEHIGKEITEN` (:202), `Anlagenverfuegbarkeit` + `Qualitaet` (:215). Three of those are UPPERCASE poster labels. A dropped-vowel-only sweep, which is what the issue's risk note describes, would have left this file half-corrupted.

**2. Measured counts differ from the issue's.** Actual **28** in `EXAMPLE_WEB_BRIEF.md` (issue said 31) and **39** in `EXAMPLE_STORYBOARD_BRIEF.md` (issue said 32). Three independent passes agree on 39 — a per-line enumeration, a token census, and a `git grep -owE` census against `origin/main`. This PR ships the measured set; the identical sweep returns **78 on base and 0 on this branch**, which is what makes the zero meaningful rather than vacuous.

## Scope decisions

**Frontmatter — the issue's open question, resolved in scope.** `EXAMPLE_WEB_BRIEF.md:12` (`governing_thought`), `EXAMPLE_STORYBOARD_BRIEF.md:7` (`customer`, `Muller` → `Müller`) and `:13` are fixed. Neither file carries a `description:` key or any trigger phrase — the "never touch frontmatter" rule exists to protect skill trigger lists, and these are library example briefs that nothing routes on. Leaving them would spell the same sentence two ways inside one file.

**Byte-identity preserved.** The `governing_thought` sentence is byte-identical across **six** sites (WEB :12/:27/:289, STORYBOARD :13/:36/:299 — both derive it from `arc_id: industry-transformation`). All six received the identical correction; verified post-change as 6 occurrences, 1 unique string. A partial fix would have broken that identity.

**Deliberately not touched:**

- **`05-validation.md:253-254`** — states the rule using the literal ASCII tokens `ae`/`oe`/`ue` to *name* the defect class ("German umlauts preserved where possible (a/o/u not ae/oe/ue)"). Converting them would have deleted the rule. This is why every substitution was applied word-bounded and line-anchored rather than as a substring sweep. Verified: the diff's hunks in this file touch only 135, 313, 324, 369, and `grep -c 'ae/oe/ue'` still returns 2.
- **The singular `Stillstand` and every `Stillstands*` compound.** A blind `s/Stillstand/Stillständ/` would have corrupted 31 correct strings. Post-change counts match the base exactly: `Stillstand` 7, `Stillstandstag` 2, `Stillstandskosten` 2 in each brief. Note `02-section-architecture.md:476` and `05-validation.md:369` each carry a protected singular *and* a token that does change on the same line.
- `agents/web.md:55-56` — its ä→ae narration-slug transliteration is correct. Not opened.
- Both SKILL.md files (already correct), `Vorwarnung`, all machine identifiers / URLs / enum values, every English `image_prompt` body and the English Generation Metadata prose.
- No `description:` frontmatter key is modified and no trigger phrase is respelled. No version bump — the post-merge workflow owns it.

For the record, the issue's load-site anchors drifted by two lines: `story-to-web/SKILL.md` is :177 not :175, and `story-to-storyboard/SKILL.md` is :139/:341/:376 not :137/:339/:374. Neither file is in scope.

## Verification

All commands run from the repo root on this branch; expected values calibrated against `origin/main`.

| Check | Result |
|---|---|
| `bash cogni-visual/tests/test-arc-taxonomy-sync.sh` | exit 0 — all cases pass |
| `python3 scripts/run-plugin-tests.py --filter cogni-visual` | exit 0 |
| `python3 scripts/check-breadcrumbs.py` | exit 0 |
| Substitution-only (`git diff --numstat origin/main`) | 5 rows, added == deleted on each |
| Scope (`git diff --name-only origin/main`, repo-wide) | exactly the 5 planned paths; `agents/web.md`, both SKILL.md, `plugin.json`, `marketplace.json` all absent |
| Residual ASCII-German sweep over the 5 files | **0** (base: 78) |
| Protected compounds | unchanged at base counts in both briefs |
| `governing_thought` at 6 sites | 6 occurrences, 1 unique string |
| Encoding | all 5 files decode as UTF-8, no BOM, no `\u00xx` escapes, no mojibake, no HTML entities |

The scope check is deliberately repo-wide rather than `-- cogni-visual`: `.claude-plugin/marketplace.json` sits at the repo root, so a plugin-scoped diff is structurally blind to it.

## A note for the reviewer

There is **no umlaut or German-fidelity checker anywhere in this repo** — confirmed by full-tree grep; every existing hit is reverse transliteration (Unicode→ASCII for slugs). So this defect class is unguarded and the verification above is diff review plus census, not a regression test. Adding a durable guard is real, valuable work, but it is new scope rather than a deferred part of this issue, so it is not bundled here.

A competing plan proposed also clearing `story-to-storyboard/references/02-poster-copywriting.md` and `04-validation.md`. That was **verified false** — a census of both files on `origin/main` returns zero ASCII-German hits. No follow-up was filed for them.