### PR TITLE
cogni-visual: relocate story-to-infographic tools rationale

### DIFF
--- a/cogni-visual/README.md
+++ b/cogni-visual/README.md
@@ -156,7 +156,7 @@ cogni-visual/                              # 7 skills · 19 agents · 6 commands
 ├── commands/                             6 slash commands (including /render-infographic dispatcher + 2 direct variants)
 ├── hooks/                                1 PreToolUse hook (Excalidraw canvas auto-start)
 ├── scripts/                              Utility scripts (rasterize-sketch.py, cartographic-outline.py, load-theme-component.py)
-├── references/                           Reference data (cartographic-data/, theme-component-loader.md)
+├── references/                           Reference data (cartographic-data/, theme-component-loader.md, agent-tool-declarations.md)
 ├── evals/                                Evaluation harnesses (render-infographic)
 └── libraries/                            17 shared reference files
     ├── arc-taxonomy.md                   arc ID → visual arc type mapping

--- a/cogni-visual/agents/story-to-infographic.md
+++ b/cogni-visual/agents/story-to-infographic.md
@@ -70,9 +70,3 @@ path, where the `render` parameter is `false` and no render ran. Take `out` from
 render dispatch forwards back; never guess it or construct it by path arithmetic from `brief`.
 When a requested render fails, return the error shape with the `render` code — not a success
 shape carrying a fabricated or null `out`. Every other key stays abbreviated.
-
-## Tool declaration
-
-`tools:` mirrors `skills/story-to-infographic/SKILL.md`'s `allowed-tools`: the Skill tool
-runs that skill in this agent's context, so narrowing to `Skill` alone removes capability,
-not privilege.

--- a/cogni-visual/references/agent-tool-declarations.md
+++ b/cogni-visual/references/agent-tool-declarations.md
@@ -1,0 +1,16 @@
+# Agent tool declarations
+
+Why the `tools:` line of a `cogni-visual/agents/*.md` file is shaped the way it is. An agent body is
+a runtime system prompt, loaded on every dispatch — rationale addressed to a future editor spends
+that budget on text the agent cannot act on, so it lives here instead. Cite this file by its
+repo-relative path (`cogni-visual/references/agent-tool-declarations.md`) rather than restating a
+rationale inside the agent it explains.
+
+## story-to-infographic
+
+`tools:` mirrors `skills/story-to-infographic/SKILL.md`'s `allowed-tools`. The Skill tool runs that
+skill in this agent's own context, so the skill's own tool needs are served by the agent's grant —
+which means narrowing `tools:` to `Skill` alone removes capability, not privilege.
+
+An editor who trims the list to what the agent body appears to use directly will break the agent:
+the missing tools are exercised by the skill running inside it, not by the body's own prose.


### PR DESCRIPTION
Closes #1281.

## Summary
- Delete the maintainer-facing `## Tool declaration` section from `cogni-visual/agents/story-to-infographic.md` — base lines 73-78 (blank separator + heading + its blank + the 3-line paragraph). Pure deletion: **zero added lines** in this file; head is exactly 72 lines ending on "Every other key stays abbreviated." with a single trailing newline.
- Preserve the rationale in a non-runtime surface: new `cogni-visual/references/agent-tool-declarations.md`, a short frontmatter-free decision note recording that `agents/story-to-infographic.md`'s `tools:` mirrors `skills/story-to-infographic/SKILL.md`'s `allowed-tools`, and that narrowing to `Skill` alone removes capability, not privilege, because the Skill tool runs that skill in the agent's context.
- Register the new note where its siblings are enumerated: `cogni-visual/README.md`'s architecture tree lists the plugin-root `references/` contents by filename, so the new file is added to that line.

## Scope decisions

**The issue's line range is wrong; the heading anchor is right.** The issue says lines 63-67. On `origin/main` (ab75f0a9) the file is 78 lines and `## Tool declaration` is at line 74; 63-67 currently holds the tail of the `Error codes:` sentence plus the first lines of the `brief`/`out` paragraph. Deleting the stated range would have gutted the output contract (rubric D) and left the offending block in place. The deletion is anchored on the heading, not the numbers — the edit locates `^## Tool declaration`, asserts the preceding line is blank, and truncates there.

**Deletion range 73-78, not 74-78.** Line 73 is the blank separator between the RESPONSE FORMAT tail (line 72) and the heading. Removing only 74-78 would leave line 73 as an orphaned trailing blank before EOF. Removing 73-78 yields exactly 72 lines with a single trailing newline and touches nothing in base 1-72.

**No pointer comment left behind in the agent file.** A one-line "see references/…" breadcrumb would add a line to a file this change keeps as a pure deletion, and would re-spend prompt budget on every dispatch — the exact cost the issue removes. The note is discoverable by path convention, as with the two house precedents.

**Home is plugin-root `cogni-visual/references/`, not `skills/story-to-infographic/references/`.** The skill-scoped path is a `check-frontmatter.sh` pass-2 companion, body-scanned against that SKILL.md's `allowed-tools`; prose that names the Skill tool sits close to that check's shape and a later light edit could trip it under the wrong governing frontmatter. Plugin root is scanned by neither guard (`check-breadcrumbs.py`'s globs are `*/skills/*/SKILL.md` and `*/agents/*.md`; `check-frontmatter.sh` bounds its companion walk at `<root>/skills`) and matches `cogni-workspace/references/agent-model-cost.md` and `cogni-consult/references/subagent-output-contract.md`.

**README registration is in scope; the CLAUDE.md tree is not.** `cogni-visual/README.md`'s architecture tree enumerates plugin-root `references/` *by filename* and is accurate at base — adding a file to that directory without touching the line would newly falsify it, so the one-parenthetical update ships here. By contrast `cogni-visual/CLAUDE.md`'s tree omits plugin-root `references/` altogether (it lists neither `theme-component-loader.md` nor `cartographic-data/`) — pre-existing drift this change neither creates nor worsens, left alone rather than fixed opportunistically.

**Frontmatter byte-identical** (`name`, `model`, `color`, `description`, `tools`); no line of base 1-11 appears in the diff. Capability (rubric E) and output contract (rubric D) are untouched.

**Siblings spot-checked, not swept.** `grep -rn '^## Tool declaration' --include='*.md'` returns a single hit repo-wide — this file. The issue's spot-check ask is satisfied with no further edits, and the plugin-wide prose sweep it rules out is also unnecessary.

**No version bump** — the post-merge workflow owns `plugin.json` / `marketplace.json`. **No breadcrumbs** in the new note; provenance stays in git history.

## Note for the reviewer — one deliberate divergence from the issue-time contract

The acceptance contract derived at triage scopes the changed-file set to `cogni-visual/agents/story-to-infographic.md` plus **at most one** non-runtime home file under `cogni-visual/references/`. This PR ships a **third** path, `cogni-visual/README.md`. The divergence is intentional and narrow: the contract was derived without reading README, whose line 159 enumerates the plugin-root `references/` directory by filename and is accurate at base — so landing the AC2 note without that one-parenthetical edit would newly falsify a currently-true documentation line, trading one prose defect for another. The edit is a single line, adds no new surface, and touches neither `agents/*.md` nor `skills/**/SKILL.md` (the two exclusions that same contract item names explicitly). Flagged here so the grade is a judgment, not a surprise.

## Root-cause note

The issue's Origin section describes the recurrence mechanism, and it is worth stating what the durable fix is *not*. **Detection was never the gap** — `plugin-dev:plugin-validator` already catches this class and did catch this instance, classifying it correctly as minor and auto-fixable. The finding was then waived at ship time because a new commit would have invalidated a completed multi-perspective review, and re-filed as this issue. So a new static guard here would be redundant with a detector that already fires, and a heading-denylist arm on `scripts/check-breadcrumbs.py` would carry near-zero recall for rationale prose with no giveaway heading, at the cost of a ratcheted baseline across 14 plugins. The actual lever is the waive-and-refile policy for auto-fixable findings on an already-reviewed PR, which lives in the review pipeline rather than in this repo. Nothing is deferred on that basis. What does ride along at zero extra scope is the in-plugin mitigation: the new reference note states the standing rule, so the next tool-shape rationale has somewhere to go that is not an agent body.

## Test plan

All executed against the branch before push:

- [x] `wc -l cogni-visual/agents/story-to-infographic.md` → **72**; last line is ``shape carrying a fabricated or null `out`. Every other key stays abbreviated.`` with a single trailing newline (last byte `0a`), no orphaned blank
- [x] `grep -n '^##' cogni-visual/agents/story-to-infographic.md` → exactly one hit: `27:## RESPONSE FORMAT (MANDATORY)`
- [x] `grep -rn '^## Tool declaration' --include='*.md' .` → **0** hits repo-wide (was exactly 1 at base)
- [x] `git diff origin/main -- cogni-visual/agents/story-to-infographic.md | grep -c '^+[^+]'` → **0** (pure deletion)
- [x] No frontmatter line in the diff (grep for `^[-+](---|name:|model:|color:|description:|tools:)` → empty)
- [x] Output contract intact: `Error codes:`, `"ok":true,"brief"`, `{"ok":false,"e":"validation"}`, `## RESPONSE FORMAT (MANDATORY)`, and all five codes `param`/`skill`/`files`/`validation`/`render` still present
- [x] AC2 — rationale absent from every runtime prompt surface, **newline-normalised** (the phrase wraps across base lines 77-78, so a naive `grep` returns 0 even on `main` and proves nothing): `for f in */agents/*.md */skills/*/SKILL.md; do tr '\n' ' ' < "$f"; echo; done | grep -c 'capability, not privilege'` → **0**
- [x] AC2 — greppable at its new home: `tr '\n' ' ' < cogni-visual/references/agent-tool-declarations.md | grep -c 'capability, not privilege'` → **1**
- [x] README registration true: `grep -c 'agent-tool-declarations.md' cogni-visual/README.md` → **1**
- [x] AC4 — `check-frontmatter.sh cogni-visual` → `clean: true`, `count: 0`, 26 files scanned (unchanged from base)
- [x] `python3 scripts/check-breadcrumbs.py` → exit 0
- [x] `python3 scripts/run-plugin-tests.py --filter cogni-visual` → exit 0
- [x] No version bump: `git diff origin/main --name-only | grep -E 'plugin\.json|marketplace\.json'` → empty
- [x] Changed-file set is exactly three paths

No `## Mutation recipe` section: the diff touches no `*/tests/test-*.sh` and no `*/scripts/check-*.sh`.