### PR TITLE
cogni-visual: story-to-* description-budget sweep

### DIFF
--- a/cogni-visual/skills/story-to-infographic/SKILL.md
+++ b/cogni-visual/skills/story-to-infographic/SKILL.md
@@ -2,13 +2,14 @@
 name: story-to-infographic
 description: >
   Transform any narrative into a single-page infographic brief. Use this skill whenever
-  the user mentions "infographic", "Infografik", "data poster", "visual one-pager", "stat sheet",
-  "KPI poster", "single-page overview", "visual summary", "visuelle Zusammenfassung", "Dateninfografik",
-  "Einseiter mit Zahlen", or wants a narrative distilled into a scannable visual.
-  Also on named styles — "Economist data page", "Tufte data-ink", "FT visual journalism",
+  the user mentions "infographic", "Infografik", "data poster", "dashboard poster",
+  "visual one-pager", "stat sheet", "KPI poster", "single-page overview", "visual summary",
+  "visuelle Zusammenfassung", "Dateninfografik", "Einseiter mit Zahlen", "make this visual",
+  or wants a narrative distilled visually.
+  Named styles — "Economist data page", "Tufte data-ink", "FT visual journalism",
   "Mike Rohde sketchnote", "graphic recording", "visual facilitation",
   "RSA Animate whiteboard", "Back of the Napkin". Creates and renders an infographic-brief.md:
-  hand-drawn (sketchnote, whiteboard) via /render-infographic-handdrawn, or editorial (economist,
+  hand-drawn (sketchnote, whiteboard) via /render-infographic-handdrawn, editorial (economist,
   editorial, data-viz, corporate) via /render-infographic-editorial.
   It does NOT render an existing brief (use /render-infographic), create slides
   (story-to-slides), a scrollable web page (story-to-web), a storyboard

--- a/cogni-visual/skills/story-to-slides/SKILL.md
+++ b/cogni-visual/skills/story-to-slides/SKILL.md
@@ -11,7 +11,7 @@ description: >
   and both English and German output. Produces a presentation-brief.md (v4.0) that the
   PPTX agent renders. Important: this skill CREATES the brief from a narrative source —
   it does NOT render an existing brief (use PPTX skill for that), does NOT create a web page
-  (use story-to-web), and does NOT enhance prose (use Copywriter skill).
+  (use story-to-web), and does NOT enhance prose (use cogni-copywriting:copywriter).
 allowed-tools: Read, Write, Edit, Bash, Grep, Glob, AskUserQuestion, Agent, Skill
 ---
 

--- a/cogni-visual/skills/story-to-storyboard/SKILL.md
+++ b/cogni-visual/skills/story-to-storyboard/SKILL.md
@@ -12,7 +12,8 @@ description: >
   that the storyboard agent renders via Pencil MCP. Important: this skill CREATES the brief
   from a narrative source — it does NOT render an existing brief (use storyboard agent for
   that), does NOT create slides (use story-to-slides), does NOT create a web page (use story-to-web),
-  and does NOT polish prose (use Copywriter skill).
+  does NOT create a single-page infographic (use story-to-infographic), and does NOT polish prose
+  (use cogni-copywriting:copywriter).
 allowed-tools: Read, Write, Edit, Bash, Grep, Glob, TodoWrite, AskUserQuestion, Agent
 ---
 

--- a/cogni-visual/skills/story-to-web/SKILL.md
+++ b/cogni-visual/skills/story-to-web/SKILL.md
@@ -12,7 +12,7 @@ description: >
   Produces a web-brief.md. Important: this skill CREATES the brief from a narrative
   source — it does NOT render an existing brief (use web agent for that), does NOT
   create slides (use story-to-slides), does NOT create print storyboard posters
-  (use story-to-storyboard), and does NOT polish prose (use Copywriter skill).
+  (use story-to-storyboard), and does NOT polish prose (use cogni-copywriting:copywriter).
 allowed-tools: Read, Write, Edit, Bash, Grep, Glob, AskUserQuestion, Agent, Skill
 ---
 


### PR DESCRIPTION
Closes #1277.

Frontmatter `description:` values only, across the four `cogni-visual/skills/story-to-*/SKILL.md` files. No body edits, no `allowed-tools` edits, no allowlist file, no version bump. All four bodies are byte-identical to base (verified via `measure-skill-length.sh`: +0 body chars on every file).

## Summary

- **story-to-infographic** — restores `"dashboard poster"` and `"make this visual"`, dropped by an earlier description-cap compression and absent plugin-wide since. Paid for by in-block compression, never appended.
- **story-to-slides / story-to-web / story-to-storyboard** — the prose label `use Copywriter skill` becomes the plugin-qualified, dispatchable `use cogni-copywriting:copywriter`, applied in one sweep so no cross-file variant is created.
- **story-to-storyboard** — its anti-trigger block now names story-to-infographic, closing the asymmetry (story-to-infographic already named story-to-storyboard; the two share the token "poster").

## Scope decisions

### Item 2 — the open question is resolved from base evidence, not escalated

The issue flags `cogni-copywriting:copywrite` vs `cogni-copywriting:copywriter` as ambiguous. They are different component *types*, not two names for one thing:

- `cogni-copywriting/skills/copywriter/SKILL.md:2` → `name: copywriter` — **the skill**
- `cogni-copywriting/commands/copywrite.md:2` → `name: copywrite` — a slash command wrapping it
- `cogni-copywriting/agents/copywriter.md:2` → `name: copywriter` — a separate agent

An anti-trigger clause points a reader at a skill, so the token is **`cogni-copywriting:copywriter`**, byte-identical in all three files. Not `copywrite` (a command), not bare `copywriter` (ambiguous between skill and agent).

`story-to-storyboard`'s `allowed-tools` omits `Skill`, but no change is needed there: the gate's `undeclared-tool-dispatch` check scans `lines[fm_end + 1:]` — body only, verified at `check-frontmatter.sh:578-582` — and every edit here stays inside frontmatter. These clauses are anti-triggers pointing a reader elsewhere, not dispatches.

### Item 1 — the issue's budget figure was stale; re-measured before planning

The issue quotes **1017/1024, 7 chars headroom**. That figure predates PRs #1291 / #1292 / #1298. Re-measured on the gate's own resolved-folded value: **1004/1024, headroom 20**.

The cap counts **characters, not bytes** (`len(resolved)` on a Python `str`, `check-frontmatter.sh:563`). Worth stating because the description carries an em-dash: the final value is 1018 chars / 1020 bytes, so it clears either way.

Funding — three removals, then two additions (removals first, so the value never transiently exceeds the cap mid-edit):

| Span | Before | After | Δ |
|---|---|---|---|
| lead-in | `Also on named styles — ` | `Named styles — ` | −8 |
| tail of trigger sentence | `distilled into a scannable visual` | `distilled visually` | −15 |
| render route | `…handdrawn, or editorial (` | `…handdrawn, editorial (` | −3 |
| addition | — | `, "dashboard poster"` | +20 |
| addition | — | `, "make this visual"` | +20 |

1004 − 26 + 40 = **1018 / 1024**.

**All 19 pre-existing quoted triggers survive byte-identically** (19 → 21). Listed so the removed-set can be computed explicitly rather than inferred: `"infographic"`, `"Infografik"`, `"data poster"`, `"visual one-pager"`, `"stat sheet"`, `"KPI poster"`, `"single-page overview"`, `"visual summary"`, `"visuelle Zusammenfassung"`, `"Dateninfografik"`, `"Einseiter mit Zahlen"`, `"Economist data page"`, `"Tufte data-ink"`, `"FT visual journalism"`, `"Mike Rohde sketchnote"`, `"graphic recording"`, `"visual facilitation"`, `"RSA Animate whiteboard"`, `"Back of the Napkin"`. Nothing was traded away to fund the additions.

The four `style_preset` values in `(economist, editorial, data-viz, corporate)` are all kept — `editorial` there is a distinct preset, not a redundant word. The anti-trigger block was left untouched: it is the forward half of the symmetry item 3 restores.

### A defect this PR introduced and then fixed

The first pass compressed `Creates and renders an infographic-brief.md:` → `Creates an infographic-brief.md:` to buy 12 chars. The pre-commit skill-quality review caught that this deletes the verb governing the render-route list that immediately follows, so the sentence read as though the *brief* were produced "via /render-infographic-handdrawn" — and, worse, understated a default-on capability in always-loaded metadata: the body states the skill auto-dispatches `/render-infographic` by default (line 39), `render` defaults to `true` (line 76), with the dispatch at line 435.

`and renders` is restored, funded instead from `distilled into a scannable visual` → `distilled visually`. The reviewer's own suggested funding — `Use this skill whenever` → `Use whenever` — was **declined**: all four story-to-* siblings open with `Use this skill whenever`, so taking it would have introduced exactly the cross-file inconsistency item 2 exists to remove.

### Item 3 — taken, not declined

The reviewer had marked it optional; the budget fits, so it ships. `story-to-storyboard` gains `, does NOT create a single-page infographic (use story-to-infographic)` (+70): 930 + 12 + 70 = **1012 / 1024**.

## Post-change budgets

| File | Before | After | Headroom |
|---|---|---|---|
| story-to-infographic/SKILL.md | 1004 | 1018 | 6 |
| story-to-storyboard/SKILL.md | 930 | 1012 | 12 |
| story-to-web/SKILL.md | 938 | 950 | 74 |
| story-to-slides/SKILL.md | 934 | 946 | 78 |

## Out of scope

- `cogni-visual/agents/story-to-infographic.md` — a concurrent instance owns that file under #1281. Untouched here.
- `cogni-visual/scripts/frontmatter-allowlist.txt` — deliberately **not** created. The cap is met by compression; an exemption file would defeat the acceptance criterion.
- No version bump in `cogni-visual/.claude-plugin/plugin.json` or the root marketplace manifest — the post-merge workflow owns it.
- `story-to-slides`' verb `enhance` was **not** normalized to `polish`; only the label changed.

## Verification

| Check | Result |
|---|---|
| `check-frontmatter.sh cogni-visual` | `clean: true`, `count: 0`, 26 files scanned, exit 0 |
| `run-plugin-tests.py --filter cogni-visual` | exit 0 (`tests/test-arc-taxonomy-sync.sh`) |
| `check-breadcrumbs.py` | exit 0, `files_affected: 0` |
| `grep -rn "Copywriter skill" cogni-visual/` | 0 hits |
| `grep -rn "cogni-copywriting:copywriter" cogni-visual/skills/` | exactly 3 |
| base↔head quoted-trigger set-difference, all four files | removed set **empty** |
| `measure-skill-length.sh`, all four | body delta +0; 48–63% of cap, none over |

## Suggested follow-up (not filed)

The same anti-trigger sentences still carry two sibling prose labels of the identical defect class — `(use web agent for that)` in story-to-web and `(use PPTX skill for that)` in story-to-slides. Both are pre-existing and outside this issue's acceptance criteria, and each needs its own base-evidence token resolution (a cogni-visual agent vs. `anthropic-skills:pptx`), so resolving them here would have widened a description-scoped PR into unresolved token work.