### PR TITLE
cogni-consult: lowercase CAPS emphatic in project-plan description

### DIFF
--- a/cogni-consult/skills/consult-project-plan/SKILL.md
+++ b/cogni-consult/skills/consult-project-plan/SKILL.md
@@ -8,7 +8,7 @@ description: |
   roadmap", "gantt", "gantt chart", "schedule the engagement", "when does the
   engagement finish", "plan the timeline", "render the project plan", or when a
   WBS/dashboard view hands off a request for the sequenced plan — even if the user
-  doesn't say "project plan" explicitly. This is an INTERNAL engagement-management
+  doesn't say "project plan" explicitly. This is an internal engagement-management
   view (a read-mostly sibling of consult-dashboard and consult-resume), not a
   client-facing content producer. Double Diamond phase phrasing ("discover phase",
   "deliver phase timeline") refers to a legacy engagement model no longer in the


### PR DESCRIPTION
Closes #1294.

## Summary
- `cogni-consult/skills/consult-project-plan/SKILL.md` line 11: `This is an INTERNAL engagement-management` -> `This is an internal engagement-management`.
- The sentence already carries its own contrast (`not a client-facing content producer.` on lines 12-13), so the CAPS emphasis was redundant; skill-creator §Writing Style treats CAPS emphatics as a yellow flag and prefers reasoned phrasing.
- Length-preserving substitution (`INTERNAL` -> `internal`, 8 chars either way) — the `description: |` block scalar needs no reflow and the contrast clause on lines 12-13 is unchanged byte-for-byte.

## Scope decisions
- **In scope:** exactly one line in one file. `git diff --numstat origin/main...HEAD` reads `1	1` on `cogni-consult/skills/consult-project-plan/SKILL.md` and `--name-only` lists that path alone. Both verified post-commit.
- **Out of scope (already correct):** `docs/plugin-guide/cogni-consult.md:93` already reads `This is an *internal* engagement-management view`; `cogni-consult/README.md:152` already reads `Internal engagement roadmap/timeline: ...` (sentence-initial capital in a table cell, not an emphatic). Neither is touched.
- **Out of scope (already shipped):** the sibling `ANY` emphatic in `cogni-consult/skills/consult-resume/SKILL.md` was fixed by a separate merged PR — zero matches remain on `origin/main`, nothing to fold in.
- **Not touched:** no version bump in the branch (the post-merge workflow owns it), and no `cogni-consult/tests/**` change — `test_step0_register_block.sh` is body-anchored and structurally cannot reach frontmatter, so it stays green unchanged.
- **Blast radius:** the other 26 repo-wide `INTERNAL` hits live in cogni-portfolio dashboard labels and cogni-visual slide banners; none reference this description, and no guard (`check-breadcrumbs.py`, `check-skill-names.sh`) or reference doc asserts on this string.

## Review notes — deliberate deviation at the prose-simplify pass
The prose-simplify gate fires (a `*/skills/*/SKILL.md` is touched), but no whole-file `skill-simplifier` rewrite was dispatched. Rationale, so the choice is auditable rather than silent:

- **Net-growth budget imposes no obligation.** Measured base vs head with `measure-skill-length.sh`: `chars_body` is **12009 on both** (the substitution is length-preserving), against a `cap_chars` of 19500. 12009 < 0.9 x 19500 = 17550, so the unit is **below the approach zone** and `over_cap` is false on both sides.
- **A rewrite would violate the acceptance contract** posted on issue #1294 *before* this branch was cut, which the merger grades against: SCOPE items 1-2 pin the diff to one path at exactly `1	1`; item 10 requires the rest of the description byte-identical; item 11 requires the body at/below line 19 untouched. The contract's own risk watchlist names that sprawl as a defect.
- **The bloat class is pre-existing, not introduced here** — the class annotated rather than acted on. `service-simplify`'s standing corpus-wide sweep is the documented backstop for sub-zone accretion.

## Test plan
All run in the isolated worktree at `origin/main` (ab75f0a9), and all green:

- [x] `grep -c 'INTERNAL' cogni-consult/skills/consult-project-plan/SKILL.md` returns **0**
- [x] `grep -c 'internal engagement-management' ...` returns **1**; line 11 verified byte-exact via `cat -e` (two leading spaces of block-scalar indent, no trailing whitespace, no tab)
- [x] `git diff --numstat origin/main...HEAD` reads exactly `1	1	cogni-consult/skills/consult-project-plan/SKILL.md`; `--name-only` lists only that path
- [x] Frontmatter parses as valid YAML — keys `name`, `description`, `allowed-tools`; `description` is 1022 chars; `allowed-tools:` still line 17, closing `---` still line 18
- [x] `bash cogni-consult/tests/test_step0_register_block.sh` exits 0 (unmodified)
- [x] `python3 scripts/run-plugin-tests.py --filter cogni-consult` exits 0 — **12 suites, 12 passed, 0 failed**
- [x] `check-frontmatter.sh cogni-consult` clean (0 offenders); `check-breadcrumbs.sh cogni-consult` clean (0 offenders)
- [x] `bash cogni-workspace/scripts/check-skill-names.sh` exits 0

Baselines for all of the above were captured on `origin/main` **before** the edit and were already green, so any of them going red would be attributable to this change.