### PR TITLE
cogni-visual: complete the arc-taxonomy consumers frontmatter

### DIFF
--- a/cogni-visual/libraries/arc-taxonomy.md
+++ b/cogni-visual/libraries/arc-taxonomy.md
@@ -1,11 +1,12 @@
 ---
 type: shared-library
 version: "1.0"
-purpose: "Single source of truth for arc_id → arc_type mapping and arc element names across all cogni-visual skills"
+purpose: "Single source of truth for arc_id → arc_type mapping and arc element names across all cogni-visual skills. The consumers list below is scoped to cogni-visual skills only; the one external, out-of-plugin reader, cogni-website:website-plan, is named here but deliberately not listed."
 consumers:
   - story-to-slides (Step 1)
   - story-to-web (Step 1)
   - story-to-storyboard (Step 1)
+  - story-to-infographic (Step 1)
 ---
 
 # Arc Taxonomy


### PR DESCRIPTION
Closes #1245.

## Summary
- Add `  - story-to-infographic (Step 1)` to the `consumers:` sequence in `cogni-visual/libraries/arc-taxonomy.md` (after the existing story-to-storyboard entry, line 8 at origin/main 7b7a17e8). It is a real runtime reader — `cogni-visual/skills/story-to-infographic/SKILL.md:155` — that the declared contract omitted.
- Reword the `purpose:` value (line 4) so the list's remit is explicit: the `consumers:` list covers cogni-visual skills only, and the one out-of-plugin reader, `cogni-website:website-plan` (`cogni-website/skills/website-plan/SKILL.md:188`), is named as **external** rather than left implicit. The rewritten value stays a single double-quoted YAML scalar and has been round-tripped through a YAML parser; the colon in `cogni-website:website-plan` is legal because it is not followed by a space and sits inside double quotes.
- "Reusable across all four visual skills." is left byte-identical on purpose: with four entries in the list, the numeral now agrees instead of contradicting. The self-contradiction is resolved by completing the list, not by editing prose. Note the sentence is line 217 on base and line 218 after the one-line insert — grade it by grep, not by line number.

## Scope decisions
- **Frontmatter-only, as the issue's third acceptance criterion requires.** The mapping table and its 11 data rows, the Fallback line, the 11 `### <arc-id>` element sections, the Element-to-Label heuristic and its example table, the Arc Resolution pseudocode block, and the Arc Definition File Format are all unchanged — verified by diffing everything below the closing `---` against base: byte-identical.
- **Addition, not rewrite.** The three pre-existing consumer entries survive verbatim in their original order and shape; the new entry is appended last.
- **One mechanism for the scope statement.** The scope sentence lives in the reworded `purpose:` value rather than in a second adjacent key, so the file states its remit once. The value is kept as short as the acceptance bar allows (281 chars) rather than maximally explicit, because it sits on one frontmatter line.
- **Base freshness.** Nothing under `cogni-visual/` or `cogni-narrative/skills/narrative/references/story-arc/` changed between 46a5f60d (where `test-arc-taxonomy-sync.sh` was verified green before the change) and origin/main 7b7a17e8, so the green-on-base result holds for this branch point.
- **Not in this PR:** no CI gate catches `consumers:` drift. The frontmatter is documentation-only — no script or test parses it; `cogni-visual/tests/test-arc-taxonomy-sync.sh` locates its inputs by section heading (mapping table + `### <arc-id>` sections) and reads no line numbers and no frontmatter key, so the one-line insert cannot perturb it. Adding such a guard is a separate change with its own test surface.
- **No version bump** — `plugin.json` and `marketplace.json` are absent from the diff; the post-merge workflow owns the increment.

## Follow-up filed separately
- `cogni-visual/skills/story-to-web/references/02-section-architecture.md:13` still reads: "The shared library is the single source of truth for all three visual skills." Verified stale on base — four cogni-visual skills read the library, so the numeral is already wrong independent of this change. It lives in a different file under a different skill and is outside this issue's acceptance criteria, so it is filed as its own issue rather than widening a frontmatter fix. This is the same convention #1245 itself was created under: #1228 declined to widen its PR for exactly this reason.
- It is deliberately **not** in `deferred[]`: a non-empty `deferred[]` switches this PR to `--partial`/`Refs #1245`, which would strand a fully-satisfied issue open. This diff satisfies every one of #1245's acceptance items, so it ships with `Closes`.

## Test plan
- [x] `bash cogni-visual/tests/test-arc-taxonomy-sync.sh` exits 0 — all 10 cases (V1 V2 V3 V4 S1 S2 T1 E1 D1 M1) reported `ok:`, no line prefixed `FAIL: `.
- [x] `python3 scripts/run-plugin-tests.py --filter cogni-visual` passes (returncode 0).
- [x] Frontmatter parses as YAML with exactly four consumers (`yaml.safe_load` round-trip: `['story-to-slides (Step 1)', 'story-to-web (Step 1)', 'story-to-storyboard (Step 1)', 'story-to-infographic (Step 1)']`).
- [x] `git grep -ln "arc-taxonomy" cogni-visual/skills/ | cut -d/ -f3 | sort -u` returns exactly `story-to-infographic`, `story-to-slides`, `story-to-storyboard`, `story-to-web` — set-equal to the `consumers:` list. Note the raw `git grep -ln` emits **six** paths: the four SKILL.md files plus `story-to-web/references/02-section-architecture.md` and `story-to-storyboard/references/01-poster-architecture.md`, both under already-listed skills — dedupe to the skill directory before comparing against "four".
- [x] `grep -c 'all four visual skills'` returns 1, and the diff shows no change to that line.
- [x] `git diff --name-only origin/main` lists only `cogni-visual/libraries/arc-taxonomy.md` — which also discharges containment, "no version field touched", and "CLAUDE.md / README.md untouched".
- [x] No maintainer breadcrumb: added lines contain no `#[0-9]{3,}` and no version tag.