### PR TITLE
cogni-consult: Fortschritt column on the engagement list

### DIFF
--- a/cogni-consult/references/engagement-list-rendering.md
+++ b/cogni-consult/references/engagement-list-rendering.md
@@ -44,8 +44,8 @@ date does. Fill it with one `bash $CLAUDE_PLUGIN_ROOT/scripts/engagement-status.
 <engagement-path>` run per **displayed** row, using the `path` discovery already
 returns; n counts the deliverables at `complete` and m is their flattened total
 across every action field the run reports. This is the one place the list reads
-per-engagement state — the prohibition above is on reading an engagement's
-execution log to resolve a date, not on this rollup. Because the column rides
+per-engagement state — the `last_activity` prohibition below is on reading an
+engagement's execution log to resolve a date, not on this rollup. Because the column rides
 the capped rendering only, a rendering costs at most five runs; that bound is
 what makes the column affordable at all, so never widen it to every registered
 engagement. The runs are one announced step, never one announcement per call.

--- a/cogni-consult/references/engagement-list-rendering.md
+++ b/cogni-consult/references/engagement-list-rendering.md
@@ -35,28 +35,35 @@ engagements render every one and omit the overflow line entirely (never
 `Weitere 0`); above five, render the top five and set `N` to the remainder. On
 an „alle“ reply, re-render every engagement with continuous numbering and no
 overflow line, **omitting `Fortschritt` entirely** — that re-render is the
-two-column table, and the status read below is never run for it. The closing
-line still applies, and the list-and-stop obligation in the skill's step 2 still
-holds.
+two-column table, and the status read below is never run for it. That omission
+is the one place the never-hide guard below yields, and it is an explicit
+exception rather than an instance of the guard: with no status run on that path
+no cell has an unreadable state to hide, and keeping the column would cost one
+status run per registered engagement — the uncapped fan-out the cost bound
+below forbids. The closing line still applies, and the list-and-stop obligation
+in the skill's step 2 still holds.
 
-`Fortschritt` answers "how far did I get", which decides a resume better than the
-date does. Fill it with one `bash $CLAUDE_PLUGIN_ROOT/scripts/engagement-status.sh
-<engagement-path>` run per **displayed** row, using the `path` discovery already
-returns; n counts the deliverables at `complete` and m is their flattened total
-across every action field the run reports. This is the one place the list reads
-per-engagement state — the `last_activity` prohibition below is on reading an
-engagement's execution log to resolve a date, not on this rollup. Because the column rides
+`Fortschritt` answers "how far did I get", which decides a resume better than
+the date does. Fill it with one status run per **displayed** row — `bash
+$CLAUDE_PLUGIN_ROOT/scripts/engagement-status.sh <engagement-path>`, using the
+`path` discovery already returns; n counts the deliverables at
+`state: "complete"` across the run's `data.action_fields[].deliverables[]`, and
+m is their flattened total. This is the one place the list reads per-engagement
+state — the `last_activity` prohibition below is on reading an engagement's
+execution log to resolve a date, not on this rollup. Because the column rides
 the capped rendering only, a rendering costs at most five runs; that bound is
 what makes the column affordable at all, so never widen it to every registered
 engagement. The runs are one announced step, never one announcement per call.
 
-A cell is `—` only when the engagement genuinely has **no planned deliverables**.
-Per rule 8 of the table contract in
+A cell is `—` when the engagement genuinely has **no planned deliverables**,
+and on a suffixed row per the rule below. Per rule 8 of the table contract in
 `$CLAUDE_PLUGIN_ROOT/references/user-facing-output.md`, an action field the run
 reports as `unreadable` — or a run that comes back unsuccessful — is that
 contract's third case, so it renders `nicht lesbar` rather than `—`. Say what
-was unreadable once below the table rather than per row. Drop the column when
-every displayed cell would be `—`, but never to hide a `nicht lesbar` cell.
+was unreadable once below the table rather than per row. On the capped
+rendering, drop the column when every displayed cell would be `—`, but never
+to hide a `nicht lesbar` cell; the „alle“ re-render omits it by the stated
+exception above, not by this rule.
 
 The step-4 engagement dashboard counts the same underlying quantity per action
 field and renders it `2/2 fertig`; this column aggregates engagement-wide and
@@ -69,6 +76,14 @@ name or slug the user types. The table carries no slug and no `Scope` column;
 instead, where `scope_state` (the scoping-phase status, not the engagement's
 scope) is not `complete`, append ` · noch nicht geschärft` inside the
 engagement's name cell.
+
+A row carrying that suffix never shows a numeric `n von m fertig` value: it
+renders `—`, unless that row's own status run fails or reports a field at
+`unreadable`, in which case `nicht lesbar` takes precedence. The two conditions
+are orthogonal — the suffix comes from discovery's `scope_state`, `nicht
+lesbar` from the status run — so a row can legitimately carry both, as seed
+row 5 does. Seed row 2 is the plain case: suffixed, so `—`, however many
+deliverables its action fields carry.
 
 `Zuletzt bearbeitet` is the `last_activity` field discovery already returns per
 engagement — the newest transition timestamp from that engagement's execution
@@ -84,8 +99,8 @@ session renders the same table, so it is seeded by example too rather than left
 to improvise: header `# | Engagement | Last worked on | Progress`, row suffix
 ` · not yet scoped`, progress cell `3 of 7 complete` with `—` for no planned
 deliverables and `unreadable` for the state that cannot be read, overflow line
-`N more — say “all” for the full list.`, and
-closing line `A number or a name is enough. Then I'll show you where it stands
-and one next step.` Dates keep the same day-first shape, so a date reads the
-same way in either session. The columns, sort, cap, and the list-and-stop
-obligation are identical in both languages.
+`N more — say “all” for the full list.`, and closing line `A number or a name
+is enough. Then I'll show you where it stands and one next step.` Dates keep
+the same day-first shape, so a date reads the same way in either session. The
+columns, sort, cap, and the list-and-stop obligation are identical in both
+languages.

--- a/cogni-consult/references/engagement-list-rendering.md
+++ b/cogni-consult/references/engagement-list-rendering.md
@@ -2,29 +2,31 @@
 
 How `consult-resume` renders the engagement-selection list in step 2, in either
 interaction language. This document is authoritative for that table's columns,
-sort, cap, re-render and `last_activity` resolution, and for the bilingual
-seeding principle both consult-resume tables share — both languages seeded by
-verbatim example, day-first dates, identical columns and row order. The
-list-and-stop obligation that decides *whether* to render it stays in the skill
-body; everything about *how* it renders is below.
+sort, cap, re-render, `last_activity` resolution, and the `Fortschritt` column
+together with the per-displayed-row status read that fills it, and for the
+bilingual seeding principle both consult-resume tables share — both languages
+seeded by verbatim example, day-first dates, identical columns and row order.
+The list-and-stop obligation that decides *whether* to render it stays in the
+skill body; everything about *how* it renders is below.
 
 Render the engagement list as this table — never as raw field names:
 
 ```
-# | Engagement                                                  | Zuletzt bearbeitet
-1 | Lean-Canvas-Schärfung cogni-work                            | 13.07.2026
-2 | Benchmark Skill- & Agent-Entwicklung · noch nicht geschärft | 11.07.2026
-3 | Marktzugang Mittelstand                                     | 02.07.2026
-4 | Serviceportfolio Nord                                       | 28.06.2026
-5 | Digitalisierung Werk 2 · noch nicht geschärft               | 21.06.2026
+# | Engagement                                                  | Zuletzt bearbeitet | Fortschritt
+1 | Lean-Canvas-Schärfung cogni-work                            | 13.07.2026         | 3 von 7 fertig
+2 | Benchmark Skill- & Agent-Entwicklung · noch nicht geschärft | 11.07.2026         | —
+3 | Marktzugang Mittelstand                                     | 02.07.2026         | 12 von 12 fertig
+4 | Serviceportfolio Nord                                       | 28.06.2026         | 1 von 4 fertig
+5 | Digitalisierung Werk 2 · noch nicht geschärft               | 21.06.2026         | nicht lesbar
 
 Weitere 6 — sag „alle“ für die vollständige Liste.
 
 Nummer oder Name genügt. Danach zeige ich dir den Stand und einen nächsten Schritt.
 ```
 
-Pad the name column to the widest rendered cell so the date column lines up —
-the suffixed rows usually set that width.
+Pad every column but the last to its widest rendered cell, header row included,
+so each following column lines up — the suffixed rows usually set the name
+column's width, and the `Zuletzt bearbeitet` header sets the date column's.
 
 Sort by last activity, newest first, breaking ties on engagement name ascending
 so the numbering is stable across a re-render. Number the rendered rows `1`,
@@ -32,8 +34,34 @@ so the numbering is stable across a re-render. Number the rendered rows `1`,
 engagements render every one and omit the overflow line entirely (never
 `Weitere 0`); above five, render the top five and set `N` to the remainder. On
 an „alle“ reply, re-render every engagement with continuous numbering and no
-overflow line — the closing line still applies, and the list-and-stop
-obligation in the skill's step 2 still holds.
+overflow line, **omitting `Fortschritt` entirely** — that re-render is the
+two-column table, and the status read below is never run for it. The closing
+line still applies, and the list-and-stop obligation in the skill's step 2 still
+holds.
+
+`Fortschritt` answers "how far did I get", which decides a resume better than the
+date does. Fill it with one `bash $CLAUDE_PLUGIN_ROOT/scripts/engagement-status.sh
+<engagement-path>` run per **displayed** row, using the `path` discovery already
+returns; n counts the deliverables at `complete` and m is their flattened total
+across every action field the run reports. This is the one place the list reads
+per-engagement state — the prohibition above is on reading an engagement's
+execution log to resolve a date, not on this rollup. Because the column rides
+the capped rendering only, a rendering costs at most five runs; that bound is
+what makes the column affordable at all, so never widen it to every registered
+engagement. The runs are one announced step, never one announcement per call.
+
+A cell is `—` only when the engagement genuinely has **no planned deliverables**.
+Per rule 8 of the table contract in
+`$CLAUDE_PLUGIN_ROOT/references/user-facing-output.md`, an action field the run
+reports as `unreadable` — or a run that comes back unsuccessful — is that
+contract's third case, so it renders `nicht lesbar` rather than `—`. Say what
+was unreadable once below the table rather than per row. Drop the column when
+every displayed cell would be `—`, but never to hide a `nicht lesbar` cell.
+
+The step-4 engagement dashboard counts the same underlying quantity per action
+field and renders it `2/2 fertig`; this column aggregates engagement-wide and
+renders `3 von 7 fertig` — the fuller phrasing fits a row carrying one number
+rather than a field's worth.
 
 The number is a reply index into the list as most recently rendered, not a new
 pre-list skip signal — the skill's step-2 matcher is unchanged and still selects on a
@@ -53,8 +81,10 @@ sorts last and renders `—`.
 
 German sessions render the strings above and dates as `TT.MM.JJJJ`. An English
 session renders the same table, so it is seeded by example too rather than left
-to improvise: header `# | Engagement | Last worked on`, row suffix
-` · not yet scoped`, overflow line `N more — say “all” for the full list.`, and
+to improvise: header `# | Engagement | Last worked on | Progress`, row suffix
+` · not yet scoped`, progress cell `3 of 7 complete` with `—` for no planned
+deliverables and `unreadable` for the state that cannot be read, overflow line
+`N more — say “all” for the full list.`, and
 closing line `A number or a name is enough. Then I'll show you where it stands
 and one next step.` Dates keep the same day-first shape, so a date reads the
 same way in either session. The columns, sort, cap, and the list-and-stop

--- a/cogni-consult/references/user-facing-output.md
+++ b/cogni-consult/references/user-facing-output.md
@@ -104,6 +104,14 @@ lexicon rather than being printed because it "already looks like English".
 6. No table under four rows. Below that, prose or a list reads better.
 7. A slug appears only where the reader needs it to *act*, in code form. Never
    as a header, and never as a deliverable's name.
+8. A cell standing in for a missing or unmeasured **quantity or state** renders
+   `—`, never a zero-valued token (`0/0`, `0 von 0`): zero reads as a
+   measurement, the em-dash as "nothing here to measure". A value that could
+   not be read is a third case again — name it rather than flattening it into
+   either of the first two. This does not govern a boolean marker column (a
+   glyph when true, blank when false), which is its own established idiom. And
+   rule 5 never licenses dropping a column to hide a state the reader needs
+   to see.
 
 ## (e) Step announcements and brevity budgets
 

--- a/cogni-consult/skills/consult-resume/SKILL.md
+++ b/cogni-consult/skills/consult-resume/SKILL.md
@@ -20,7 +20,8 @@ Re-enter a cogni-consult engagement: discover what exists, show progress
 against the action-fields WBS (fields × deliverables × status), and route to
 the most valuable next action. This skill is a read-only orienter — it never
 edits engagement state; the only files it writes are the derived front-door
-artifacts (`README.md`, `assumptions.md`) regenerated from that state.
+artifacts (`README.md`, `assumptions.md`) regenerated from that state, and every
+other write belongs to the skill it routes to.
 
 ## Workflow
 
@@ -116,7 +117,8 @@ coverage). When the engagement already has `output/design-variables.json` from a
 prior dashboard run, regenerate and open it without a theme prompt by
 delegating to the `consult-dashboard-refresher` agent with
 `engagement_dir: <engagement-dir>` and `plugin_root: $CLAUDE_PLUGIN_ROOT`. This
-stays read-only: the agent runs the read-only generator.
+stays read-only — the agent runs the read-only generator; it never edits
+engagement state.
 
 **Point at the project plan (only when scheduling data exists).** When the engagement
 carries a schedule, surface it here as a one-line read-only pointer. Detect it cheaply:
@@ -140,8 +142,10 @@ unconditional (unlike the theme-gated dashboard offer above, no
 continue. An engagement that predates the README front door gains one here on
 its next re-entry — no migration step needed; a hand-authored root `README.md`
 is never overwritten (the generator refuses when its marker footer is absent —
-that refusal is the same non-fatal warning case). The README is a derived
-front-door artifact, not engagement state, so the read-only contract holds.
+that refusal is the same non-fatal warning case). The README is a derived front-door
+artifact regenerated from engagement state, not engagement state itself, so the
+read-only contract over `consult-project.json`, `field.json`, personas, and logs
+holds.
 
 **Assumption register refresh.** On every re-entry, also run
 `python3 $CLAUDE_PLUGIN_ROOT/scripts/register-generator.py "<engagement-dir>"`
@@ -153,16 +157,17 @@ missing, empty, or malformed registry degrades to an empty register, never an
 error), and on any failure, warn and continue. Back-fill and no-overwrite
 behave as for the README above: a populated `assumptions.json` gains a register
 on its next re-entry, and a hand-authored `assumptions.md` is never overwritten.
-Like the README it is a derived read model, so the read-only contract holds.
+Like the README it is a derived read model, not engagement state itself, so the
+read-only contract above holds.
 
 **Point at the register (only when it is non-empty).** When the generator returns
 `success: true` with `data.assumptions_count > 0`, surface a one-line read-only
-pointer to the regenerated `assumptions.md` (e.g. *"Assumption register:
-`assumptions.md` (N registered) — value, provenance, and `used_by[]` backlinks"*),
-so the refresh is visible rather than silent. When the count is `0` or the
-generator warned, say nothing — the pointer degrades silently. Like the
-project-plan pointer it is informational only: never a branch in the Step-5
-next-action ladder.
+pointer to the regenerated `assumptions.md` — mirroring the project-plan pointer
+above so the refresh is visible rather than silent (e.g. *"Assumption register:
+`assumptions.md` (N registered) — value, provenance, and `used_by[]` backlinks"*).
+When the count is `0` (no registered assumptions) or the generator warned, say
+nothing — the pointer degrades silently. It is informational only: like the
+project-plan pointer, do not add it as a branch in the Step-5 next-action ladder.
 
 > **Strategy Advisor voice** — this plugin ships one advisory output style: **Strategy Advisor** (answer-first, MECE options), language-neutral, so it renders in the resolved interaction language. Enable it from the `/config` output-style picker; it's opt-in and fixed at session start, so set it now or `/clear` after.
 
@@ -230,15 +235,16 @@ state calls for them — not as standing menu items:
   `rework-intent` entry. That intent capture, like the reopen write itself —
   the `complete` → `in-progress` Edit and the up-front cascade-stale of its
   downstream dependents — is owned by `consult-design-thinking`'s Open-the-Loop
-  step; resume routes, it does not ask and does not write.
+  step, so resume stays read-only; it routes, it does not ask and does not write.
 - **A deliverable's stored `chosen_framework` is `null`** (a legacy deliverable
   created before a framework was chosen) and the consultant wants to assign one
   → offer to set it inline rather than sending them on a separate
   `consult-action-fields` round-trip. "Inline" means the offer surfaces here in
   the recommendation flow; the actual `field.json` write is delegated to
-  `consult-action-fields`, which owns the deliverable manifest. Surface this
-  only when the framework gap is relevant to the next action — never as
-  blanket nagging across every legacy deliverable.
+  `consult-action-fields` (which owns the deliverable manifest), so resume's
+  read-only contract holds. Surface this only when the framework gap is
+  relevant to the next action — never as blanket nagging across every legacy
+  deliverable.
 - **A deliverable is `complete` with a non-`null` `chosen_framework` whose
   conformance hasn't been verified** → offer a **framework-adherence review**:
   dispatch the `consult-framework-adherence-reviewer` agent
@@ -247,11 +253,11 @@ state calls for them — not as standing menu items:
   the finished artifact against its stored framework's structure signature and
   report drift with concrete findings. This is a structural-conformance axis
   distinct from the persona-challenge (Test) pass, so it complements rather
-  than duplicates `consult-personas`. The reviewer reports drift and never
-  rewrites the artifact; acting on a finding is a separate
-  `consult-design-thinking` rework. Surface this only when the conformance
-  question is relevant to the next action, not as a standing audit of every
-  complete deliverable.
+  than duplicates `consult-personas`. The reviewer is read-only — it reports
+  drift, it never rewrites the artifact — so resume stays read-only too;
+  acting on a finding is a separate `consult-design-thinking` rework. Surface
+  this only when the conformance question is relevant to the next action, not
+  as a standing audit of every complete deliverable.
 - **A `complete` deliverable (its `persona_review` closed) is unpublished, or
   published but not yet rendered** → offer the publish / render next step from
   its `publish[]` lineage, even before the whole engagement is complete: an

--- a/cogni-consult/skills/consult-resume/SKILL.md
+++ b/cogni-consult/skills/consult-resume/SKILL.md
@@ -82,7 +82,8 @@ cap and overflow line, the „alle“ re-render, the reply-index rule, the
 `Fortschritt` column and the per-displayed-row status read that fills it, and
 both language seeds. Read it before rendering. The list-and-stop obligation
 above still holds. Step 3's status read for the picked engagement is separate
-from that column's per-row read and unaffected by it.
+from that column's per-row read and unaffected by it — Step 3 re-runs it fresh,
+per **Derived, not stored** below.
 
 ### 3. Read the Engagement Status
 

--- a/cogni-consult/skills/consult-resume/SKILL.md
+++ b/cogni-consult/skills/consult-resume/SKILL.md
@@ -20,8 +20,7 @@ Re-enter a cogni-consult engagement: discover what exists, show progress
 against the action-fields WBS (fields × deliverables × status), and route to
 the most valuable next action. This skill is a read-only orienter — it never
 edits engagement state; the only files it writes are the derived front-door
-artifacts (`README.md`, `assumptions.md`) regenerated from that state, and every
-other write belongs to the skill it routes to.
+artifacts (`README.md`, `assumptions.md`) regenerated from that state.
 
 ## Workflow
 
@@ -78,9 +77,11 @@ Render that list as the table defined in
 `$CLAUDE_PLUGIN_ROOT/references/engagement-list-rendering.md` — never as raw
 field names — which is authoritative for its columns, padding, sort, five-row
 cap and overflow line, the „alle“ re-render, the reply-index rule, the
-`scope_state` name-cell suffix, the `last_activity` resolution, and both
-language seeds. Read it before rendering. The list-and-stop obligation above
-still holds.
+`scope_state` name-cell suffix, the `last_activity` resolution, the
+`Fortschritt` column and the per-displayed-row status read that fills it, and
+both language seeds. Read it before rendering. The list-and-stop obligation
+above still holds. Step 3's status read for the picked engagement is separate
+from that column's per-row read and unaffected by it.
 
 ### 3. Read the Engagement Status
 
@@ -115,8 +116,7 @@ coverage). When the engagement already has `output/design-variables.json` from a
 prior dashboard run, regenerate and open it without a theme prompt by
 delegating to the `consult-dashboard-refresher` agent with
 `engagement_dir: <engagement-dir>` and `plugin_root: $CLAUDE_PLUGIN_ROOT`. This
-stays read-only — the agent runs the read-only generator; it never edits
-engagement state.
+stays read-only: the agent runs the read-only generator.
 
 **Point at the project plan (only when scheduling data exists).** When the engagement
 carries a schedule, surface it here as a one-line read-only pointer. Detect it cheaply:
@@ -140,10 +140,8 @@ unconditional (unlike the theme-gated dashboard offer above, no
 continue. An engagement that predates the README front door gains one here on
 its next re-entry — no migration step needed; a hand-authored root `README.md`
 is never overwritten (the generator refuses when its marker footer is absent —
-that refusal is the same non-fatal warning case). The README is a derived front-door
-artifact regenerated from engagement state, not engagement state itself, so the
-read-only contract over `consult-project.json`, `field.json`, personas, and logs
-holds.
+that refusal is the same non-fatal warning case). The README is a derived
+front-door artifact, not engagement state, so the read-only contract holds.
 
 **Assumption register refresh.** On every re-entry, also run
 `python3 $CLAUDE_PLUGIN_ROOT/scripts/register-generator.py "<engagement-dir>"`
@@ -155,17 +153,16 @@ missing, empty, or malformed registry degrades to an empty register, never an
 error), and on any failure, warn and continue. Back-fill and no-overwrite
 behave as for the README above: a populated `assumptions.json` gains a register
 on its next re-entry, and a hand-authored `assumptions.md` is never overwritten.
-Like the README it is a derived read model, not engagement state itself, so the
-read-only contract above holds.
+Like the README it is a derived read model, so the read-only contract holds.
 
 **Point at the register (only when it is non-empty).** When the generator returns
 `success: true` with `data.assumptions_count > 0`, surface a one-line read-only
-pointer to the regenerated `assumptions.md` — mirroring the project-plan pointer
-above so the refresh is visible rather than silent (e.g. *"Assumption register:
-`assumptions.md` (N registered) — value, provenance, and `used_by[]` backlinks"*).
-When the count is `0` (no registered assumptions) or the generator warned, say
-nothing — the pointer degrades silently. It is informational only: like the
-project-plan pointer, do not add it as a branch in the Step-5 next-action ladder.
+pointer to the regenerated `assumptions.md` (e.g. *"Assumption register:
+`assumptions.md` (N registered) — value, provenance, and `used_by[]` backlinks"*),
+so the refresh is visible rather than silent. When the count is `0` or the
+generator warned, say nothing — the pointer degrades silently. Like the
+project-plan pointer it is informational only: never a branch in the Step-5
+next-action ladder.
 
 > **Strategy Advisor voice** — this plugin ships one advisory output style: **Strategy Advisor** (answer-first, MECE options), language-neutral, so it renders in the resolved interaction language. Enable it from the `/config` output-style picker; it's opt-in and fixed at session start, so set it now or `/clear` after.
 
@@ -233,16 +230,15 @@ state calls for them — not as standing menu items:
   `rework-intent` entry. That intent capture, like the reopen write itself —
   the `complete` → `in-progress` Edit and the up-front cascade-stale of its
   downstream dependents — is owned by `consult-design-thinking`'s Open-the-Loop
-  step, so resume stays read-only; it routes, it does not ask and does not write.
+  step; resume routes, it does not ask and does not write.
 - **A deliverable's stored `chosen_framework` is `null`** (a legacy deliverable
   created before a framework was chosen) and the consultant wants to assign one
   → offer to set it inline rather than sending them on a separate
   `consult-action-fields` round-trip. "Inline" means the offer surfaces here in
   the recommendation flow; the actual `field.json` write is delegated to
-  `consult-action-fields` (which owns the deliverable manifest), so resume's
-  read-only contract holds. Surface this only when the framework gap is
-  relevant to the next action — never as blanket nagging across every legacy
-  deliverable.
+  `consult-action-fields`, which owns the deliverable manifest. Surface this
+  only when the framework gap is relevant to the next action — never as
+  blanket nagging across every legacy deliverable.
 - **A deliverable is `complete` with a non-`null` `chosen_framework` whose
   conformance hasn't been verified** → offer a **framework-adherence review**:
   dispatch the `consult-framework-adherence-reviewer` agent
@@ -251,11 +247,11 @@ state calls for them — not as standing menu items:
   the finished artifact against its stored framework's structure signature and
   report drift with concrete findings. This is a structural-conformance axis
   distinct from the persona-challenge (Test) pass, so it complements rather
-  than duplicates `consult-personas`. The reviewer is read-only — it reports
-  drift, it never rewrites the artifact — so resume stays read-only too;
-  acting on a finding is a separate `consult-design-thinking` rework. Surface
-  this only when the conformance question is relevant to the next action, not
-  as a standing audit of every complete deliverable.
+  than duplicates `consult-personas`. The reviewer reports drift and never
+  rewrites the artifact; acting on a finding is a separate
+  `consult-design-thinking` rework. Surface this only when the conformance
+  question is relevant to the next action, not as a standing audit of every
+  complete deliverable.
 - **A `complete` deliverable (its `persona_review` closed) is unpublished, or
   published but not yet rendered** → offer the publish / render next step from
   its `publish[]` lineage, even before the whole engagement is complete: an

--- a/cogni-consult/tests/test_reference_pointers.sh
+++ b/cogni-consult/tests/test_reference_pointers.sh
@@ -110,7 +110,7 @@ for rel in "$LIST_REF" "$DASH_REF"; do
 done
 # Explicit presence half, which the derived check above cannot make: grep -F pins
 # the umlauts, so an ASCII-folded copy of a relocated rule fails to match.
-for tok in 'Weitere' 'TT.MM.JJJJ' 'Nächstes Deliverable' 'Schlüsselfrage:'; do
+for tok in 'Weitere' 'TT.MM.JJJJ' 'Nächstes Deliverable' 'Schlüsselfrage:' 'Fortschritt'; do
   grep -qF -- "$tok" "$PLUGIN_DIR/$LIST_REF" "$PLUGIN_DIR/$DASH_REF" 2>/dev/null ||
     fail "contract-relocated" "token absent from both reference files: $tok"
 done


### PR DESCRIPTION
Closes #1149.

## Summary

- `references/engagement-list-rendering.md` — adds `Fortschritt` as the third column of the authoritative step-2 table: a new column in the fenced German example, a stated derivation rule (deliverables at `complete` over the flattened total across every action field, from one `engagement-status.sh` run), and an explicit English seed (`Progress`, cell `3 of 7 complete`) so the bilingual-by-verbatim-example principle still holds.
- **Bounds the cost.** The column rides the capped rendering only, so a rendering costs at most five runs. The „alle" re-render **omits the column entirely** and keeps the two-column table — stated in the „alle" paragraph itself, not only as a rationale aside, because "one run per displayed row" alone is satisfied by running it for every row.
- **Separates the empty cell from the broken one.** `—` renders only when the engagement genuinely has no planned deliverables. An action field the run reports as `unreadable`, or an unsuccessful run, renders `nicht lesbar` — never `—` and never `0 von 0`.
- Generalizes the padding rule from the two columns it named to every column but the last, header row included.
- `references/user-facing-output.md` — adds table-contract item (d).8 codifying the `—` empty-cell convention the rendering references already use, so AC 3 follows from the contract AC 4 cites instead of from precedent alone.
- `skills/consult-resume/SKILL.md` — extends the step-2 pointer enumeration to name the column and its per-row status read, and records that step 3's own read is separate and unaffected.
- `tests/test_reference_pointers.sh` — pins `Fortschritt` in the case-4 presence token list.

No version bump: `plugin.json` / `marketplace.json` are untouched, per the post-merge bump workflow.

## Scope decisions

**No script change.** `engagement-status.sh` already emits every field's full `deliverables[]`, so n and m are a render-time reduction of data already on the wire — the same one the step-4 dashboard performs per field.

**`n von m fertig`, not `n/m fertig` — and the sibling dashboard stays untouched.** `references/engagement-dashboard-rendering.md` already renders the same semantic quantity per action field as `2/2 fertig`, so this ships two shapes for one concept in one skill. The `von` form is kept anyway: AC 1 literally mandates it, and `user-facing-output.md` (h) uses `14/14 Deliverables complete` as its *negative* example, so the slash form is the one the register disfavours. The two cells also aggregate at different levels. Harmonizing the dashboard is deliberately **not** in this PR — no acceptance criterion asks for it. The new prose names the relationship instead, so a reader sees a documented distinction rather than drift.

**(d).8 is scoped, not blanket.** An earlier draft said an empty cell is "never a blank". That would have put two working tables in violation — `consult-project-plan/SKILL.md:196-197` renders `◆`/`●` on true and blank on false, and `consult-action-fields` renders genuinely blank cells on placeholder rows. The rule is therefore scoped to a missing or unmeasured *quantity or state* and explicitly does not govern a boolean marker column.

**Guard invariants respected.** Every `references/` mention in the three files case 2 watches stays in the `$CLAUDE_PLUGIN_ROOT/references/` absolute form (list 2/2, dashboard 4/4, skill 6/6 — each equal). `user-facing-output.md` is deliberately *not* in that guarded set (7 bare / 0 absolute), so (d).8 keeps that file's own bare-relative style.

**The fenced overflow line is a test fixture.** `tests/test_reference_pointers.sh` case 5 (`mutate_reinline`) appends the overflow line verbatim into the skill and asserts the guard goes red. The fenced example therefore gains a column on its value rows only; the overflow and closing lines are byte-identical to base (verified with `cmp`), and the example stays at exactly five value rows — the cap this same document sets.

## Verification

All run on the PR branch:

- `bash cogni-consult/tests/test_reference_pointers.sh` — 6/6 pass (`pointers-resolve`, `pointers-absolute`, `reference-anchored`, `contract-relocated`, `goes-red`, `goes-red-reinline`).
- `python3 scripts/run-plugin-tests.py --filter cogni-consult` — 12 suites, 0 failed.
- `check-breadcrumbs.py` — `files_affected: 0`.
- `check-frontmatter.sh cogni-consult` — `clean: true`, 0 offenders.
- `check-skill-names.sh` — OK.
- Pointer-count equality re-checked per file with `grep -o | wc -l` (occurrences, not lines).
- Overflow and closing lines `cmp`-identical to base.
- No `.claude-plugin/plugin.json` or `marketplace.json` change in the diff.

## Mutation recipe

Replay against a checkout of this branch:

```
bash "$HOME/.claude/plugins/marketplaces/managed-service/cogni-service/scripts/mutation-check.sh" --root <your-checkout> --file cogni-consult/references/engagement-list-rendering.md --expr 's/Fortschritt/Restspalte/g' --test 'bash cogni-consult/tests/test_reference_pointers.sh' --case contract-relocated
```

**Already executed on this branch, not merely written down** — result: `mutated_result: red`, `restored_result: green`, `verdict: guard_verified`. The suite labels cases `PASS: <case>` / `FAIL: <case> - <detail>` with a space-separated detail, so `contract-relocated` is the whole case token the classifier matches.

## Review notes

- **Size budget paid in-section.** `consult-resume/SKILL.md` was already at 90.5% of its 18000-char cap on base (16285). The change initially took it to 16570, so a simplifier pass folded six restatements of the skill's read-only contract into its two canonical statements, ending at **16051 — below base**. Every removed base line was audited: all prohibitions and qualifiers survive, and the `Important Notes` Read-only bullet still carries the full file enumeration (`consult-project.json`, `field.json`, personas, logs) plus the "state writes belong to the routed skills" rule.
- **Annotated, not fixed (pre-existing).** The step-2 pointer's "authoritative for ..." enumeration now lists eleven items and mirrors the reference's own opening paragraph, so each new reference rule has to be mirrored here or the list silently under-claims. This is a pre-existing idiom the step-4 dashboard pointer shares (`introduced_by_change: false`), so trimming it is a convention change across both pointers rather than something this PR should carry.
- **Deliberately skipped.** A review pass suggested changing "rendered as the table below" to "...the table defined below" on a base line this diff never touched (category: preference). Skipped as unrelated churn.
- **Not deduplicated.** When the user picks an engagement that was one of the displayed rows, `engagement-status.sh` runs once for the row and again in step 3. Reusing the step-2 result would save one invocation, but that changes step 3's contract and no acceptance criterion asks for it — noted here rather than silently folded in.

## Open questions

- **The „alle" re-render path** *(avoidable — resolved from the issue's own reasoning, recorded for a human to confirm)*. AC 2 reads "exactly one `engagement-status.sh` run per **displayed** row"; on the „alle" path every registered engagement is displayed, so a literal reading reinstates the per-engagement invocation cost the issue's own *Alternatives considered* section rejects. This PR resolves the tension toward that stated rationale — the column rides the capped rendering only, bounding every rendering at five runs — which means the „alle" table renders two columns, not three. If you would rather the column be filled on „alle" too and accept the unbounded cost, that is a one-paragraph change to the same reference.