### PR TITLE
cogni-visual: drop stale arc-taxonomy consumer count in story-to-web

### DIFF
--- a/cogni-visual/skills/story-to-web/references/02-section-architecture.md
+++ b/cogni-visual/skills/story-to-web/references/02-section-architecture.md
@@ -10,7 +10,7 @@ Define how narratives decompose into web sections, map arc roles to section type
 
 ## Narrative Arc ID to Visual Arc Type Mapping
 
-**Arc mapping:** See `$CLAUDE_PLUGIN_ROOT/libraries/arc-taxonomy.md` for the complete arc_id → arc_type mapping table, arc element names with EN/DE translations, and the element-to-role assignment heuristic. The shared library is the single source of truth for all three visual skills.
+**Arc mapping:** See `$CLAUDE_PLUGIN_ROOT/libraries/arc-taxonomy.md` for the complete arc_id → arc_type mapping table, arc element names with EN/DE translations, and the element-to-role assignment heuristic. The shared library is the single source of truth for every cogni-visual skill that resolves an arc; its frontmatter `consumers:` list names them.
 
 ### Arc Element Names as Section Labels
 


### PR DESCRIPTION
Closes #1306.

## Summary

- `cogni-visual/skills/story-to-web/references/02-section-architecture.md:13` claimed the shared arc library is the single source of truth for "all three visual skills". Four cogni-visual skills read it — `libraries/arc-taxonomy.md`'s own frontmatter `consumers:` lists story-to-slides, story-to-web, story-to-storyboard, story-to-infographic.
- Rather than re-pinning the numeral to four, the numeral is removed entirely: the line now attributes the count to the library's own `consumers:` list, so this citing file cannot drift again when a fifth skill starts reading the library. Re-pinning would satisfy the issue's AC2 but reinstate the exact drift class the issue exists to end.
- The wording matches what the pointer target actually scopes. `arc-taxonomy.md`'s frontmatter `purpose:` states the `consumers:` list covers cogni-visual skills only (the single external reader, `cogni-website:website-plan`, is deliberately unlisted), so "every cogni-visual skill that resolves an arc" is precisely that list — no numeral, and no new inaccuracy.
- The `$CLAUDE_PLUGIN_ROOT/libraries/arc-taxonomy.md` pointer, the attribution of the mapping table / EN-DE element names / element-to-role heuristic, and the "single source of truth" authority claim are all preserved. Only the numeral changes.

The diff is exactly 1 file, 1 insertion, 1 deletion.

## Scope decisions

- **In:** exactly one line — `02-section-architecture.md:13`. Applied as a surgical single-line replacement, not a whole-file rewrite, because `cogni-visual/tests/test-de-ascii-orthography.sh` scans this file and the German example table around lines 21-23 must keep its diacritics.
- **Out:** `02-section-architecture.md:19` — re-read at `origin/main` and confirmed it carries no consumer numeral, so it is untouched, as is the rest of the file.
- **Out:** `cogni-visual/libraries/arc-taxonomy.md` (its "all four visual skills" line) — correct today. Same drift class one file over, but widening the diff to grab it would break the smallest-blast-radius rule this issue's own provenance rests on.
- **Out:** no registration or index surface needs a co-update. A repo-wide grep at base shows every other citer of arc-taxonomy (`cogni-website/CLAUDE.md`, `cogni-website/libraries/page-templates.md`, `cogni-website/skills/website-plan/SKILL.md`, cogni-portfolio pitch templates, `docs/architecture/er-diagram.md`, `docs/plugin-guide/cogni-visual.md`) cites its authority without stating a consumer count, and no README component table or CLAUDE.md tree enumerates its consumers.
- **Out:** a CI guard that parses the `consumers:` frontmatter. Confirmed nothing parses it today — `git grep -n "consumers:" -- '*.py' '*.sh' '*.yml'` is empty at base. The issue itself files that guard as a separate deliverable with its own test surface, not a rider on this wording fix, so it is neither in this diff nor a deferral of this issue's scope — which is why this PR carries `Closes` rather than `Refs`.
- **Out:** any version bump — the post-merge workflow owns the patch bump per plugin actually touched. Verified: `check-version-bump.py` reports `clean: true`, 0 plugins touched.

## Test plan

All items below were executed on this branch, not just listed.

- [x] `grep -rn "all three visual skills" cogni-visual/` returns nothing (exit 1)
- [x] `sed -n '13p' …/02-section-architecture.md | grep -oE '\b(one|two|three|four|five|six|[0-9]+)\b'` returns nothing — no numeral or number-word survives on the changed line
- [x] `grep -c 'libraries/arc-taxonomy.md' …/02-section-architecture.md` returns 2 — the pointer survives on both line 13 and line 19
- [x] `grep -n 'single source of truth' …/02-section-architecture.md` still returns line 13 — the authority claim survives
- [x] `grep -n "all four visual skills" cogni-visual/libraries/arc-taxonomy.md` still returns its line, untouched
- [x] line 19 diffed byte-for-byte against `origin/main` — identical; `git diff -U0` shows a single hunk
- [x] `git diff --stat` — 1 file changed, 1 insertion(+), 1 deletion(-)
- [x] `bash cogni-visual/tests/test-arc-taxonomy-sync.sh` exits 0, 10 `ok:` lines, 0 `FAIL` (V1 V2 V3 V4 S1 S2 T1 E1 D1 M1)
- [x] `bash cogni-visual/tests/test-de-ascii-orthography.sh` exits 0 — the German example table keeps its diacritics
- [x] `python3 scripts/run-plugin-tests.py --filter cogni-visual` exits 0
- [x] `python3 scripts/check-version-bump.py` — `clean: true`, 0 violations vs `origin/main`

### Note on one test-plan assertion that was corrected

The planned checklist originally carried `grep -nE '\b(one|two|three|four|five|[0-9]+)\b.{0,20}(visual )?skills'` as the no-numeral assertion. That command is **false as written** — it matches pre-existing, unrelated content at line 387 (`Stats: 3 (64k skills gap, 1:5 quality, 41% costs)`), so it would report a red that has nothing to do with this change. It was replaced with the line-13-scoped check listed above, which is what the assertion actually meant and which does hold.

## Guard interactions

- `test-de-ascii-orthography.sh` **does** scan this file (plugin-wide `*.md` walk, no `references/` exclusion) — the reason this is a surgical line replacement. The replacement text carries no diacritics.
- `test-arc-taxonomy-sync.sh` never opens this file; it reads only `libraries/arc-taxonomy.md` and the cogni-narrative story-arc directory. The issue's AC4 is satisfied by not touching `arc-taxonomy.md`.
- `scripts/check-breadcrumbs.py` `DEFAULT_GLOBS` are `*/skills/*/SKILL.md` and `*/agents/*.md`, so this `references/` file is **not** breadcrumb-scanned. A leaked issue reference would ship unflagged; cleanliness here is prose discipline, not a gate. The new sentence carries none.

## Base

Branched from `origin/main` @ `effde435`. The base advanced mid-run (`08d0d4de` → `effde435`) when #1307 merged; that change touched only `cogni-consult` and does not intersect this diff.