### PR TITLE
cogni-visual: restore umlauts in story-to-web example body

### DIFF
--- a/cogni-visual/skills/story-to-web/references/04-image-prompts.md
+++ b/cogni-visual/skills/story-to-web/references/04-image-prompts.md
@@ -237,7 +237,7 @@ Verification: Single subject (factory floor). "No text, no people" present. Wide
 type: feature-alternating
 arc_role: solution
 headline: "Remote Patient Monitoring reduziert Klinikbesuche um 40%"
-body: "Wearable-Sensoren ubermitteln Vitalwerte in Echtzeit an das Arzteteam..."
+body: "Wearable-Sensoren übermitteln Vitalwerte in Echtzeit an das Ärzteteam..."
 style_guide: "Clean Medical"
 ```
 

--- a/cogni-visual/tests/test-de-ascii-orthography.sh
+++ b/cogni-visual/tests/test-de-ascii-orthography.sh
@@ -16,18 +16,21 @@
 #
 # WHAT A GREEN RUN DOES AND DOES NOT MEAN
 #   Green means NO ENUMERATED TOKEN APPEARED. It does NOT mean the corpus is
-#   orthographically correct. This distinction is not hedging — at the time this suite
-#   was written the corpus ALREADY contained ASCII-ified German outside this vocabulary,
-#   in a story-to-web image-prompt worked example. That defect is tracked separately and
-#   this suite is deliberately green on it.
+#   orthographically correct. This distinction is not hedging — the vocabulary is a
+#   curated list, so a corruption whose token is not on it passes unseen, and has done.
+#   Read a green run as "no enumerated token regressed", never as proof the German in
+#   the corpus is clean.
 #
 # WHY A CURATED VOCABULARY RATHER THAN A GENERAL ORTHOGRAPHY PATTERN
 #   Forced, not stylistic. A general pattern that infers "this looks like a de-umlauted
-#   German word" is red on the base tree, because of the out-of-vocabulary defect noted
-#   above. The requirement this suite was written against is that it exit 0 on a clean
-#   base. Only an enumerated vocabulary can satisfy both at once. The cost is that the
-#   guard catches exactly what it lists, which is why extending it is a first-class,
-#   test-enforced operation (see below) rather than an afterthought.
+#   German word" is red on the base tree: the scanned corpus deliberately documents the
+#   umlaut-to-ASCII transliteration used for slugs and filenames, and carries English
+#   prose and brand words, none of which such an inference separates from real
+#   corruption — which is why the EXEMPT table and the de-context guard column exist.
+#   So the suite has to do two things at once: flag genuine ASCII-ified German, and exit
+#   0 on a clean base. Only an enumerated vocabulary can satisfy both at once. The cost
+#   is that the guard catches exactly what it lists, which is why extending it is a
+#   first-class, test-enforced operation (see below) rather than an afterthought.
 #
 # HOW TO EXTEND THE VOCABULARY
 #   1. Add a row to VOCABULARY: ascii_token|correct_form|style|guard


### PR DESCRIPTION
Closes #1309.

## Summary

- Repair `cogni-visual/skills/story-to-web/references/04-image-prompts.md:240`: `ubermitteln` → `übermitteln`, `Arzteteam` → `Ärzteteam`. Precomposed NFC only (U+00FC / U+00C4), matching the same file's line 273 (`KI-gestützte Regelprüfung`). Only those two characters change — key, quotes, word order and the trailing three-dot ellipsis stay byte-identical, and the diff is exactly 1 line removed / 1 line added.
- Comment-only refresh of the header prose in `cogni-visual/tests/test-de-ascii-orthography.sh`. Two of its rationale paragraphs asserted that the corpus already contains ASCII-ified German outside the vocabulary, in a story-to-web image-prompt worked example, and that the suite is deliberately green on it. **This PR is what makes that false.** Behaviour is untouched: the VOCABULARY heredoc, the EXEMPT heredoc and `ALL_CASES` are unchanged, and every changed line is a comment.

## Scope decisions

- **In — the content repair only.** Two characters on one line. No reflow, no surrounding-example rewrite.
- **In — the guard-header refresh** (the judgment call the triage contract deliberately left open). Three reasons. (1) This PR is the sole cause of the falsehood; shipping it and leaving the sentence is knowingly landing a false claim. (2) It is not cosmetic — the `WHY A CURATED VOCABULARY` paragraph grounds the whole design decision in that specific defect, so a stale version tells the next maintainer either to re-file this issue or that the curated-vocabulary constraint has lifted and the scanner can be generalised. (3) It is the one file in the plugin whose stated premise is "Prose did not hold. A suite does" — stale self-documentation there is exactly the failure it warns about. The cost is bounded and mechanically checkable: comment-only, asserted below.
- **Out — extending the guard VOCABULARY.** Case `W2` set-differences the vocabulary against the `P1`/`P2` fixtures in both directions, so a bare row addition turns the suite red and pulls fixture authoring into a two-character content repair. Both tokens stay out of vocabulary by design; the guard's job here is to stay green and keep its teeth, which the mutation recipe below proves it does.
- **Out — the deliberate umlaut→ASCII transliteration documentation** in `agents/web.md`, the four `story-to-*/SKILL.md` slug rules and `story-to-infographic/references/05-validation-checklist.md`. Those ASCII forms are correct content, and two of them are content-anchored in the guard's EXEMPT table. Not touched.
- **Out — any version change.** `cogni-visual/.claude-plugin/plugin.json` and the root `.claude-plugin/marketplace.json` are untouched; the post-merge workflow owns the patch bump.

## Test plan

All of the following were **executed** on this branch, not inferred:

- [x] `git diff --numstat origin/main -- cogni-visual/skills/story-to-web/references/04-image-prompts.md` reports exactly `1	1`.
- [x] Line 240 reads exactly `body: "Wearable-Sensoren übermitteln Vitalwerte in Echtzeit an das Ärzteteam..."`.
- [x] NFC form confirmed — line 240 and the whole file equal their NFC normalisation; `ü` is U+00FC and `Ä` is U+00C4, with no combining U+0308 anywhere on the line.
- [x] `grep -rn 'ubermitteln\|Arzteteam'` returns **0** hits repo-wide (base had exactly 1).
- [x] `grep -rn 'uebermitteln\|Aerzteteam'` returns **0** hits — no digraph substituted for the umlaut.
- [x] Guard-file diff is comment-only: every added/removed line in `test-de-ascii-orthography.sh` begins with `#` (0 non-comment changed lines).
- [x] `python3 scripts/run-plugin-tests.py --filter cogni-visual` exits 0 — both cogni-visual suites pass, including `test-de-ascii-orthography.sh`.
- [x] `python3 scripts/check-version-bump.py` — 14 plugins scanned, 0 touched, 0 violations.
- [x] `python3 scripts/check-breadcrumbs.py` — 0 files affected, no new breadcrumb against the baseline.

## Mutation recipe

Proves the orthography guard still has teeth on the exact line this PR repairs — a green suite over a repaired line is otherwise indistinguishable from a guard that stopped looking. `Wearable-Sensoren` is a repo-unique string on line 240; substituting the enumerated `Qualitaet` token for it must turn case `C1` red, and restoring must return it to green.

```bash
bash ~/.claude/plugins/marketplaces/managed-service/cogni-service/scripts/mutation-check.sh --root . --file cogni-visual/skills/story-to-web/references/04-image-prompts.md --expr 's/Wearable-Sensoren/Qualitaet/' --test 'bash cogni-visual/tests/test-de-ascii-orthography.sh' --case C1
```

**Run on this branch, result:** exit 0, `verdict: guard_verified`, `mutated_result: red`, `restored_result: green`, tree restored clean.

## Note for the reviewer

The guard was green over this defect for its entire life, and is green again now — that is the designed behaviour of a curated vocabulary, not a regression, and neither token was ever on the list. What changed is that the guard no longer *claims* the defect is still out there. If you want the recurrence closed rather than documented, that is a vocabulary extension with its own `P1`/`P2` fixture work, and it belongs in its own issue — deliberately not smuggled into a two-character repair.