### PR TITLE
cogni-portfolio: Agent grant for every dashboard-refresher dispatch

### DIFF
--- a/cogni-portfolio/scripts/mutation-check.sh
+++ b/cogni-portfolio/scripts/mutation-check.sh
@@ -17,6 +17,10 @@
 #   4. portfolio-resume dashboard row: delete the Dashboard row from
 #      skills/portfolio-resume/SKILL.md; expect test_resume_shows_dashboard_row
 #      to go RED.
+#   5. dispatch-site Agent grant: strip the Agent token from the allowed-tools
+#      line of skills/products/SKILL.md, a skill that carries a
+#      dashboard-refresher dispatch; expect test_dispatch_sites_grant_agent
+#      to go RED.
 #
 # Kept under scripts/ (NOT tests/) deliberately: run-plugin-tests.py auto-discovers
 # tests/*.sh and would run this as a normal suite; this is a manual meta-check that
@@ -244,10 +248,73 @@ PY
   return "$rc"
 }
 
+# --- Mutation 5: dispatch-site Agent grant ---------------------------------
+# Strips the Agent token from the allowed-tools line of a skill that documents a
+# dashboard-refresher dispatch, then asserts test_dispatch_sites_grant_agent goes
+# RED against the mutant. The target is a SKILL.md — documentation, not a script —
+# for the same reason as mutation 3: the case asserts on frontmatter content, so
+# mutating a script would leave it green and prove nothing. products/SKILL.md is
+# the grant template and is not otherwise touched by this feature, so the mutation
+# stays independent of the skills the fix edits.
+mutation_dispatch_agent_grant() {
+  local target="$PLUGIN_DIR/skills/products/SKILL.md"
+  local suite="$PLUGIN_DIR/tests/test-dashboard-handoff.sh"
+  local test_name="test_dispatch_sites_grant_agent"
+  for f in "$target" "$suite"; do
+    [ -f "$f" ] || { echo "FAIL: missing $f" >&2; return 1; }
+  done
+
+  # Baseline: the target test must be GREEN before we mutate, or a later red
+  # tells us nothing.
+  if ! bash "$suite" "$test_name" >/dev/null 2>&1; then
+    echo "FAIL: baseline $test_name is already red before mutation" >&2
+    return 1
+  fi
+
+  local backup; backup="$(mktemp)"
+  cp "$target" "$backup"
+
+  if ! python3 - "$target" <<'PY'
+import re, sys
+path = sys.argv[1]
+src = open(path, encoding="utf-8").read()
+# Anchored on the frontmatter grant line, dropping ONLY the trailing Agent token.
+# The replacement carries no copy of the searched literal: one that kept `Agent`
+# on the line would leave the grant intact, the case green, and this mutation
+# would survive unnoticed.
+mutated, n = re.subn(
+    r"^(allowed-tools: .*), Agent$",
+    r"\1",
+    src,
+    count=1,
+    flags=re.MULTILINE,
+)
+if n != 1:
+    sys.stderr.write("allowed-tools line with a trailing Agent token not found — cannot mutate.\n")
+    sys.exit(7)
+open(path, "w", encoding="utf-8").write(mutated)
+PY
+  then
+    echo "FAIL: dispatch-site Agent-grant mutation could not be applied" >&2
+    cp "$backup" "$target"; rm -f "$backup"; return 1
+  fi
+
+  local rc=0
+  if bash "$suite" "$test_name" >/dev/null 2>&1; then
+    echo "FALSIFIER: mutation survived — $test_name stayed GREEN with a dispatching skill's Agent grant stripped" >&2
+    rc=1
+  else
+    echo "OK: mutation caught — $test_name goes red when a dispatching skill loses its Agent grant"
+  fi
+  cp "$backup" "$target"; rm -f "$backup"   # always restore
+  return "$rc"
+}
+
 mutation_commercial_consolidation || overall=1
 mutation_solution_candidates || overall=1
 mutation_dashboard_no_skip_path || overall=1
 mutation_resume_dashboard_row || overall=1
+mutation_dispatch_agent_grant || overall=1
 
 if [ "$overall" -eq 0 ]; then
   echo "All mutations caught."

--- a/cogni-portfolio/skills/packages/SKILL.md
+++ b/cogni-portfolio/skills/packages/SKILL.md
@@ -6,7 +6,7 @@ description: |
   combined offering, product bundle, tier design, package pricing, "assemble solutions",
   or wants to group feature-level solutions into market-ready offerings —
   even without saying "package".
-allowed-tools: Read, Write, Edit, Glob, Grep, Bash
+allowed-tools: Read, Write, Edit, Glob, Grep, Bash, Agent
 ---
 
 # Package Design

--- a/cogni-portfolio/skills/portfolio-architecture/SKILL.md
+++ b/cogni-portfolio/skills/portfolio-architecture/SKILL.md
@@ -7,7 +7,7 @@ description: |
   "visualize the portfolio", portfolio architecture, feature map, product tree,
   "how do the products relate", or wants a visual overview of how products and
   features fit together — even if they don't say "architecture" explicitly.
-allowed-tools: Read, Write, Glob, Grep, Bash, mcp__excalidraw__clear_canvas, mcp__excalidraw__create_element, mcp__excalidraw__batch_create_elements, mcp__excalidraw__group_elements, mcp__excalidraw__describe_scene, mcp__excalidraw__get_canvas_screenshot, mcp__excalidraw__snapshot_scene, mcp__excalidraw__export_scene, mcp__excalidraw__export_to_excalidraw_url, mcp__excalidraw__import_scene, mcp__excalidraw__query_elements, mcp__excalidraw__update_element, mcp__excalidraw__delete_element
+allowed-tools: Read, Write, Glob, Grep, Bash, Agent, mcp__excalidraw__clear_canvas, mcp__excalidraw__create_element, mcp__excalidraw__batch_create_elements, mcp__excalidraw__group_elements, mcp__excalidraw__describe_scene, mcp__excalidraw__get_canvas_screenshot, mcp__excalidraw__snapshot_scene, mcp__excalidraw__export_scene, mcp__excalidraw__export_to_excalidraw_url, mcp__excalidraw__import_scene, mcp__excalidraw__query_elements, mcp__excalidraw__update_element, mcp__excalidraw__delete_element
 ---
 
 # Portfolio Architecture Diagram

--- a/cogni-portfolio/skills/portfolio-dashboard/SKILL.md
+++ b/cogni-portfolio/skills/portfolio-dashboard/SKILL.md
@@ -5,7 +5,7 @@ description: |
   Use whenever the user mentions dashboard, portfolio dashboard, portfolio view,
   "show me the portfolio", "visualize portfolio", status overview, or wants to
   see all portfolio data in a browser — even if they don't say "dashboard".
-allowed-tools: Read, Write, Edit, Glob, Grep, Bash, Skill
+allowed-tools: Read, Write, Edit, Glob, Grep, Bash, Agent, Skill
 ---
 
 # Portfolio Dashboard

--- a/cogni-portfolio/tests/test-dashboard-handoff.sh
+++ b/cogni-portfolio/tests/test-dashboard-handoff.sh
@@ -19,6 +19,7 @@
 #   test_refresher_returns_url       a successful result carries a clickable url
 #   test_resume_shows_dashboard_row  portfolio-resume surfaces a flag-driven dashboard row
 #   test_handoff_does_not_open       the resume generation offer dispatches without opening a browser
+#   test_dispatch_sites_grant_agent  every skill documenting a dispatch grants Agent in allowed-tools
 #
 # Usage: bash cogni-portfolio/tests/test-dashboard-handoff.sh [test_name ...]
 #   No args -> run every test (the CI path). One or more names -> run only those
@@ -49,6 +50,23 @@
 #   There is no in-repo copy of the SHARED harness; if that version directory is gone,
 #   use the newest under the same parent — everything after the path is version-independent.
 #   The in-repo equivalent is registered as mutation_dashboard_no_skip_path in
+#   cogni-portfolio/scripts/mutation-check.sh.
+#
+# Mutation recipe — test_dispatch_sites_grant_agent. Same SHARED harness, same
+#   classify-on-labels contract, replayable as written from the repo root.
+#   bash ~/.claude/plugins/cache/managed-service/cogni-service/0.0.383/scripts/mutation-check.sh \
+#     --root . \
+#     --file cogni-portfolio/skills/products/SKILL.md \
+#     --expr 's#Grep, Bash, Agent#Grep, Bash#' \
+#     --test 'bash cogni-portfolio/tests/test-dashboard-handoff.sh test_dispatch_sites_grant_agent' \
+#     --case test_dispatch_sites_grant_agent
+#   The expr strips the Agent token from a skill that carries a dispatch line, so
+#   the case goes red on the mutant and green on HEAD. `Grep, Bash, Agent` occurs
+#   exactly once in that file and is metacharacter-free. The replacement is
+#   deliberately DISJOINT from the searched string — one that still contained
+#   `Agent` would leave the grant intact, the case green, and the mutation would
+#   survive unnoticed. A documentation file again, for the reason above.
+#   The in-repo equivalent is registered as mutation_dispatch_agent_grant in
 #   cogni-portfolio/scripts/mutation-check.sh.
 
 # `set -u` only — `set -e` would abort on the first failing assertion and defeat
@@ -313,7 +331,99 @@ test_handoff_does_not_open() {
   fi
 }
 
-ALL_TESTS="test_refresher_has_no_skip_path test_open_browser_optin test_refresher_returns_url test_resume_shows_dashboard_row test_handoff_does_not_open"
+# --- test_dispatch_sites_grant_agent ---------------------------------------
+# A documented dispatch is only reachable at runtime if the frontmatter GOVERNING
+# that file grants the dispatch tool. Both halves are derived, never enumerated:
+# the surface is the same three-glob scan test_open_browser_optin computes, and
+# the governing file comes from the path — a dispatch in
+# skills/<x>/references/*.md is governed by skills/<x>/SKILL.md, the only file in
+# that skill carrying frontmatter. A skill that starts dispatching tomorrow is
+# covered with no edit here. agents/*.md declare their tools under a different
+# key, so they stay in the scan surface but outside this rule.
+test_dispatch_sites_grant_agent() {
+  local surface scanned
+  surface="$(
+    find "$PLUGIN_DIR/agents" -name '*.md' -type f 2>/dev/null
+    find "$PLUGIN_DIR/skills" -mindepth 2 -maxdepth 2 -name 'SKILL.md' -type f 2>/dev/null
+    find "$PLUGIN_DIR/skills" -mindepth 3 -maxdepth 3 -path '*/references/*.md' -type f 2>/dev/null
+  )"
+  scanned="$(printf '%s\n' "$surface" | grep -c . )"
+  if [ "$scanned" -eq 0 ]; then
+    fail test_dispatch_sites_grant_agent "scanned no files; scan surface is broken"
+    return
+  fi
+
+  local dispatch_lines dispatch_count
+  dispatch_lines="$(
+    printf '%s\n' "$surface" | while IFS= read -r f; do
+      [ -n "$f" ] || continue
+      [ "$f" = "$AGENT" ] && continue
+      grep -nF 'dashboard-refresher' "$f" 2>/dev/null | while IFS= read -r hit; do
+        printf '%s:%s\n' "$f" "$hit"
+      done
+    done
+  )"
+  dispatch_count="$(printf '%s\n' "$dispatch_lines" | grep -c . )"
+  if [ "$dispatch_count" -eq 0 ]; then
+    fail test_dispatch_sites_grant_agent "found no dashboard-refresher dispatch lines; scan surface is broken"
+    return
+  fi
+
+  # One pass, no early exit: every offender lands in $offenders and the single
+  # fail() below names them all. $seen collapses a skill that dispatches from more
+  # than one file so it is reported once. The heredoc — not a pipe — is what keeps
+  # both accumulators in this shell.
+  local offenders="" seen="" governed=0
+  while IFS= read -r entry; do
+    local file governing rel grant
+    file="${entry%%:*}"
+    governing=""
+    case "$file" in
+      "$PLUGIN_DIR"/skills/*/references/*) governing="${file%/references/*}/SKILL.md" ;;
+      "$PLUGIN_DIR"/skills/*/SKILL.md)     governing="$file" ;;
+    esac
+    if [ -n "$governing" ]; then
+      rel="${governing#"$PLUGIN_DIR/"}"
+      case " $seen " in
+        *" $rel "*) : ;;
+        *)
+          seen="$seen $rel"
+          governed=$((governed + 1))
+          if [ ! -s "$governing" ]; then
+            # Distinct from a missing grant on purpose: a broken surface must never
+            # read as a skill that simply forgot the token.
+            offenders="$offenders $rel:governing-SKILL.md-missing"
+          else
+            grant="$(grep -m1 '^allowed-tools:' "$governing")"
+            if [ -z "$grant" ]; then
+              offenders="$offenders $rel:no-allowed-tools-line"
+            else
+              # The grant LINE only, whole-token. Every dispatching skill's prose
+              # says "dashboard-refresher agent", so a body-wide grep for Agent
+              # would be vacuously green; and matching a substring would let
+              # Skill, AskUserQuestion or an mcp__* token pass as the grant.
+              grant="${grant#allowed-tools:}"
+              case ",${grant//[[:space:]]/}," in
+                *,Agent,*) : ;;
+                *) offenders="$offenders $rel:missing-Agent" ;;
+              esac
+            fi
+          fi
+          ;;
+      esac
+    fi
+  done <<EOF
+$dispatch_lines
+EOF
+
+  if [ -n "$offenders" ]; then
+    fail test_dispatch_sites_grant_agent "dispatching skills whose allowed-tools omits Agent:$offenders"
+  else
+    pass test_dispatch_sites_grant_agent "all $governed dispatching skills grant Agent ($dispatch_count dispatch lines scanned)"
+  fi
+}
+
+ALL_TESTS="test_refresher_has_no_skip_path test_open_browser_optin test_refresher_returns_url test_resume_shows_dashboard_row test_handoff_does_not_open test_dispatch_sites_grant_agent"
 
 # Reject an unknown case name instead of letting bash's "command not found" pass
 # through: with no `set -e` and no failures increment, an unrecognised name would


### PR DESCRIPTION
Closes #1320.

## Summary

Three cogni-portfolio skills documented a `dashboard-refresher` dispatch without declaring `Agent` in `allowed-tools`, so the documented branch was inert — the instruction reads fine and never runs. This grants the tool in all three and adds the rule that keeps the next one from being silent too.

- **`skills/packages/SKILL.md`**, **`skills/portfolio-architecture/SKILL.md`**, **`skills/portfolio-dashboard/SKILL.md`** each gain `Agent`. Frontmatter line only — no body change in any of the three. All 13 `mcp__excalidraw__*` tokens survive verbatim on portfolio-architecture; `Skill` is retained on portfolio-dashboard (`Skill` and `Agent` are different tools, and line 32 genuinely dispatches `cogni-workspace:pick-theme` via `Skill`).
- **`tests/test-dashboard-handoff.sh`** gains `test_dispatch_sites_grant_agent`, registered in `ALL_TESTS`.
- **`scripts/mutation-check.sh`** gains `mutation_dispatch_agent_grant`, invoked in the driver chain.

## The rule the new case encodes

Both halves are **derived, never enumerated**, so a skill that starts dispatching tomorrow is covered with no edit to the case:

- **Dispatch surface** — the same three-glob scan `test_open_browser_optin` already computes (`agents/*.md`, `skills/*/SKILL.md`, `skills/*/references/*.md`), with the agent's own contract file excluded.
- **Governing frontmatter** — derived from the path: a dispatch under `skills/<x>/references/` is governed by `skills/<x>/SKILL.md`. This is *attribution, not narrowing*. Restricting the scan to `SKILL.md` paths was the easier way to avoid attributing a frontmatter-less references file, and it would have re-opened the blind spot that scan exists to close: `propositions` dispatches **only** from `references/quality-gates.md` and would have dropped out of coverage entirely.
- **Grant check** — the governing `^allowed-tools:` line alone, whole-token. Every dispatching skill's prose contains the words "`dashboard-refresher` agent", so a body-wide grep would be vacuously green; and a substring match would let `Skill`, `AskUserQuestion` or an `mcp__*` token pass as the grant.
- **One run, every offender** — offenders accumulate into a single string with one `fail()` after the loop; no `return`/`exit`/`break` inside it. Three distinct labels (`missing-Agent`, `no-allowed-tools-line`, `governing-SKILL.md-missing`) so a broken surface never reads as a skill that merely forgot the token. Both broken-surface guards from the existing case are mirrored ahead of the loop.

On this head it reports `all 11 dispatching skills grant Agent (12 dispatch lines scanned)`.

## Scope decisions

- **Least privilege in both directions.** Exactly three `allowed-tools:` lines change. None of the eleven cogni-portfolio skills that do not dispatch the agent gains a grant.
- **`agents/dashboard-refresher.md` is unmodified** — it is the definition surface the existing cases assert on.
- **`test_resume_shows_dashboard_row` is left intact.** It already carries a per-skill Agent assertion that this case generalizes, but the two are not equivalent: that one uses the substring form `'^allowed-tools:.*Agent'`, while the new case matches `Agent` as a whole comma-separated token. The redundancy is asymmetric in rigor, so removing the per-skill copy would weaken coverage rather than dedupe it.
- **No version bump** — neither `plugin.json` nor `marketplace.json` is in the diff; the post-merge workflow owns the patch bump.
- **Not fixed here (same bug class, different agents).** `portfolio-communicate` (`… Bash, AskUserQuestion, Skill`) dispatches `communicate-review-assessor` and `customer-narrative-writer`, and `portfolio-taxonomy` (`… Bash, AskUserQuestion`) dispatches `portfolio-web-researcher` — neither grants `Agent`. Verified against this head. No acceptance criterion here covers them and widening would break the least-privilege claim, so they are left for their own issue; nothing in this change blocks that generalisation.

## Concurrency

This branch was cut from `f17f7c87`, after #1321 merged. #1322 is still open and also appends to `tests/test-dashboard-handoff.sh` and `scripts/mutation-check.sh`, and edits `packages/SKILL.md`'s **body** (a `## Dashboard handoff` section) without touching `allowed-tools` — so the two changes are orthogonal in content. The new case and mutation are self-contained: they introduce and depend on no shared helper, so this lands in any merge order. The residual conflict is a mechanical append in the header block, the `ALL_TESTS` line, and the driver chain.

## Test plan

- [x] `bash cogni-portfolio/tests/test-dashboard-handoff.sh` → six `ok:` lines, `All tests passed.`, exit 0.
- [x] `bash cogni-portfolio/tests/test-dashboard-handoff.sh test_dispatch_sites_grant_agent` → exit 0, `ok: test_dispatch_sites_grant_agent all 11 dispatching skills grant Agent (12 dispatch lines scanned)`. (An exit 2 would mean it was never registered in `ALL_TESTS`.)
- [x] `bash cogni-portfolio/scripts/mutation-check.sh` → five `OK: mutation caught` lines, `All mutations caught.`, exit 0; `products/SKILL.md` clean afterwards (backup restored).
- [x] `python3 scripts/run-plugin-tests.py --filter cogni-portfolio` → `success: true`, 0 failed.
- [x] `python3 scripts/check-breadcrumbs.py` → `success: true`, 0 violations.
- [x] `python3 scripts/check-version-bump.py` → 14 plugins scanned, 0 touched, 0 violations.
- [x] Reproduce loop from the issue prints zero `NO-Agent` rows.

## Mutation recipe

```bash
bash ~/.claude/plugins/cache/managed-service/cogni-service/0.0.383/scripts/mutation-check.sh \
  --root . \
  --file cogni-portfolio/skills/products/SKILL.md \
  --expr 's#Grep, Bash, Agent#Grep, Bash#' \
  --test 'bash cogni-portfolio/tests/test-dashboard-handoff.sh test_dispatch_sites_grant_agent' \
  --case test_dispatch_sites_grant_agent
```

Replayed on this head: `"mutated_result": "red"`, `"restored_result": "green"`, `"verdict": "guard_verified"`, exit 0.

The mutant is a documentation file, for the same reason as mutation 3 — the case asserts on frontmatter content, so mutating a script would leave it green and prove nothing. `Grep, Bash, Agent` occurs exactly once in that file and is metacharacter-free (the harness feeds the expr to `perl -0pi`). The replacement is deliberately **disjoint** from the searched literal: one that still carried `Agent` would leave the grant intact, the case green, and the mutation would survive unnoticed. `products/SKILL.md` is the grant template and is not otherwise touched by this change, so the mutation stays independent of the three skills being fixed.

## Review notes

Carried from the pre-commit skill-quality pass. All three are **pre-existing** (`introduced_by_change: false`) in body prose this frontmatter-only diff never edits, so they are annotated rather than fixed here.

1. **`packages/SKILL.md:311` — `plugin_root: $CLAUDE_PLUGIN_ROOT` in its bare form.** Line 18 of the same skill warns the harness may not inject that variable and mandates the inline-fallback form, and `agents/dashboard-refresher.md` declares `plugin_root` **required**. This change does not cause it — but by making the dispatch reachable for the first time, it is what turns a dormant inconsistency into a live code path. It plausibly recurs across every dispatching skill, so if real it wants a plugin-wide follow-up rather than a patch to this file. Worth a human eye.
2. **`portfolio-architecture/SKILL.md:85 vs :90`** — the product-height formula hardcodes a 40px feature height while the next subsection instructs 56px whenever any feature carries a `purpose` field, so product rectangles compute ~16px per feature too short and nested features overflow. Pre-existing layout math, unrelated to this diff.
3. **`packages/SKILL.md:18`** — the "Plugin root resolution" convention paragraph sits as the first paragraph under `## Why Packages Exist`, splitting that section's argument. Placement preference, not content.

The `Agent` vs `Task` token spelling was independently verified against plugin convention by all three reviewers: cogni-portfolio uses `Agent`, and a `Task`-spelled grant would have left the dispatch exactly as inert.

## Simplify pass

One finding applied: the whitespace-stripping `printf | tr` subshell folded into bash parameter expansion (one fork per dispatching skill removed), semantics verified identical across six token shapes including `AgentX` and `AskUserQuestion` rejection.

Four skipped, with reasons: extracting the mutation scaffold (now on its fifth copy) needs all four existing mutations migrated — outside this diff and directly in #1322's conflict path; flattening the offender loop with `continue` trades a graded invariant (zero early-exit keywords in that loop) for indentation; extracting the scan preamble requires editing a frozen pre-existing case; and the duplicated disjointness rationale across the two files is deliberate documentation of a subtle trap.