### PR TITLE
cogni-portfolio: Agent-grant check counts handoff citations

### DIFF
--- a/cogni-portfolio/scripts/mutation-check.sh
+++ b/cogni-portfolio/scripts/mutation-check.sh
@@ -31,6 +31,10 @@
 #      allowed-tools line of skills/portfolio-canvas/SKILL.md, a skill that
 #      documents script invocations; expect test_invocation_sites_grant_bash
 #      to go RED.
+#   9. citation-only dispatch Agent grant: strip the mid-list Agent token from
+#      the allowed-tools line of skills/portfolio-ingest/SKILL.md, a skill whose
+#      only documented dispatch is the canonical handoff citation (it never
+#      names the agent); expect test_dispatch_sites_grant_agent to go RED.
 #
 # Kept under scripts/ (NOT tests/) deliberately: run-plugin-tests.py auto-discovers
 # tests/*.sh and would run this as a normal suite; this is a manual meta-check that
@@ -498,6 +502,72 @@ PY
 }
 
 
+# --- Mutation 9: citation-only dispatch Agent grant ------------------------
+# The citation-only counterpart of mutation_dispatch_agent_grant, which targets
+# products/SKILL.md and so exercises only the arm the case could already see.
+# portfolio-ingest reaches the scan surface solely by citing the canonical handoff
+# reference, and is not otherwise mutated here, so the two stay independent.
+mutation_citation_only_agent_grant() {
+  local target="$PLUGIN_DIR/skills/portfolio-ingest/SKILL.md"
+  local suite="$PLUGIN_DIR/tests/test-dashboard-handoff.sh"
+  local test_name="test_dispatch_sites_grant_agent"
+  for f in "$target" "$suite"; do
+    [ -f "$f" ] || { echo "FAIL: missing $f" >&2; return 1; }
+  done
+
+  # Baseline: the target test must be GREEN before we mutate, or a later red
+  # tells us nothing.
+  if ! bash "$suite" "$test_name" >/dev/null 2>&1; then
+    echo "FAIL: baseline $test_name is already red before mutation" >&2
+    return 1
+  fi
+
+  local backup; backup="$(mktemp)"
+  cp "$target" "$backup"
+
+  if ! python3 - "$target" <<'PY'
+import re, sys
+path = sys.argv[1]
+src = open(path, encoding="utf-8").read()
+# MID-LIST, deliberately not the trailing `, Agent$` anchor mutation 6 uses: none
+# of the citation-only skills ends its grant line with Agent, so that anchor would
+# match nothing here and the mutation could never run.
+mutated, n = re.subn(
+    r"^(allowed-tools: .*), Agent,(.*)$",
+    r"\1,\2",
+    src,
+    count=1,
+    flags=re.MULTILINE,
+)
+if n != 1:
+    sys.stderr.write("allowed-tools line with a mid-list Agent token not found — cannot mutate.\n")
+    sys.exit(10)
+# Disjointness is the whole point, so assert it rather than trusting the regex: a
+# replacement that left any whole Agent token would keep the grant, keep the case
+# green, and let this mutation survive unnoticed.
+line = next(l for l in mutated.splitlines() if l.startswith("allowed-tools:"))
+if "Agent" in [t.strip() for t in line.split(":", 1)[1].split(",")]:
+    sys.stderr.write("mutant still grants Agent — mutation is not disjoint.\n")
+    sys.exit(11)
+open(path, "w", encoding="utf-8").write(mutated)
+PY
+  then
+    echo "FAIL: citation-only Agent-grant mutation could not be applied" >&2
+    cp "$backup" "$target"; rm -f "$backup"; return 1
+  fi
+
+  local rc=0
+  if bash "$suite" "$test_name" >/dev/null 2>&1; then
+    echo "FALSIFIER: mutation survived — $test_name stayed GREEN with a citation-only skill's Agent grant stripped" >&2
+    rc=1
+  else
+    echo "OK: mutation caught — $test_name goes red when a skill whose only dispatch is the canonical citation loses its Agent grant"
+  fi
+  cp "$backup" "$target"; rm -f "$backup"   # always restore
+  return "$rc"
+}
+
+
 mutation_commercial_consolidation || overall=1
 mutation_solution_candidates || overall=1
 mutation_dashboard_no_skip_path || overall=1
@@ -506,6 +576,7 @@ mutation_resume_dashboard_row || overall=1
 mutation_dispatch_agent_grant || overall=1
 mutation_pipeline_handoff_citation || overall=1
 mutation_invocation_bash_grant || overall=1
+mutation_citation_only_agent_grant || overall=1
 
 if [ "$overall" -eq 0 ]; then
   echo "All mutations caught."

--- a/cogni-portfolio/tests/test-dashboard-handoff.sh
+++ b/cogni-portfolio/tests/test-dashboard-handoff.sh
@@ -19,7 +19,7 @@
 #   test_refresher_returns_url       a successful result carries a clickable url
 #   test_entity_skills_cite_handoff  all eight entity skills end by citing the canonical handoff
 #   test_pipeline_skills_cite_handoff
-#                                    the six pipeline and ops skills cite it and grant Agent
+#                                    the six pipeline and ops skills each cite it exactly once
 #   test_secondary_paths_reach_handoff
 #                                    alternate write paths point back to that terminal section
 #   test_handoff_not_duplicated      the handoff is authored once, and no skill restates it
@@ -28,7 +28,7 @@
 #   test_midflow_offers_survive      the pre-existing review offers still open on request
 #   test_resume_shows_dashboard_row  portfolio-resume surfaces a flag-driven dashboard row
 #   test_handoff_does_not_open       the resume generation offer dispatches without opening a browser
-#   test_dispatch_sites_grant_agent  every skill documenting a dispatch grants Agent in allowed-tools
+#   test_dispatch_sites_grant_agent  every skill dispatching by name or citation grants Agent
 #
 # Usage: bash cogni-portfolio/tests/test-dashboard-handoff.sh [test_name ...]
 #   No args -> run every test (the CI path). One or more names -> run only those
@@ -106,6 +106,31 @@
 #   `Agent` would leave the grant intact, the case green, and the mutation would
 #   survive unnoticed. A documentation file again, for the reason above.
 #   The in-repo equivalent is registered as mutation_dispatch_agent_grant in
+#   cogni-portfolio/scripts/mutation-check.sh.
+#
+# Mutation recipe — test_dispatch_sites_grant_agent (citation-only arm). Same
+#   SHARED harness, same classify-on-labels contract, replayable as written from
+#   the repo root.
+#   bash ~/.claude/plugins/cache/managed-service/cogni-service/0.0.383/scripts/mutation-check.sh \
+#     --root . \
+#     --file cogni-portfolio/skills/portfolio-ingest/SKILL.md \
+#     --expr 's#Grep, Bash, Agent, Skill#Grep, Bash, Skill#' \
+#     --test 'bash cogni-portfolio/tests/test-dashboard-handoff.sh test_dispatch_sites_grant_agent' \
+#     --case test_dispatch_sites_grant_agent
+#   The recipe above covers the OTHER arm of the same case. Its sibling recipe
+#   mutates products/SKILL.md, which names the agent outright; portfolio-ingest
+#   names it nowhere — neither its SKILL.md nor any of its references/*.md carries
+#   the literal — so it enters the surface only through the canonical citation.
+#   Before this case derived both forms, the mutant here survived: the skill was
+#   invisible to the scan, so stripping its grant changed nothing.
+#   `Grep, Bash, Agent, Skill` occurs exactly once in that file and is
+#   metacharacter-free, which matters because the harness feeds the expr to
+#   perl -0pi. The replacement is deliberately DISJOINT from the searched string
+#   and retains no whole Agent token — one that still granted Agent would leave
+#   the case green and the mutation would survive unnoticed. portfolio-verify
+#   carries a byte-identical allowed-tools tail, which is harmless because --file
+#   scopes the harness to one file.
+#   The in-repo equivalent is registered as mutation_citation_only_agent_grant in
 #   cogni-portfolio/scripts/mutation-check.sh.
 #
 # Mutation recipe — test_secondary_paths_reach_handoff. Same SHARED harness, same
@@ -419,15 +444,17 @@ test_entity_skills_cite_handoff() {
 # do. Same exactly-one-citation discipline as the entity case, for the same reason:
 # the single-occurrence count keeps the registered mutation's anchor unambiguous.
 #
-# This case also carries the Agent-grant assertion for its roster, which looks like
-# it belongs in test_dispatch_sites_grant_agent and cannot live there. That case
-# derives its surface from files containing the literal `dashboard-refresher`, and
-# the canonical citation deliberately never names the agent — so these six are
-# invisible to it while still depending on the grant to execute the handoff at all.
+# The Agent grant is NOT asserted here. test_dispatch_sites_grant_agent derives its
+# dispatch lines from either form — naming the agent, or citing the canonical
+# reference — so these six sit inside that case's surface and it covers their grant
+# without a roster. Keeping a rostered copy too would mean the rostered one fails
+# first, and only ever for the skills someone remembered to list.
+# (test_resume_shows_dashboard_row still checks portfolio-resume's own grant as part
+# of its row assertion; that is a narrower claim about one skill, not this roster.)
 test_pipeline_skills_cite_handoff() {
   pipeline_surface_ok test_pipeline_skills_cite_handoff || return
 
-  local offenders="" skill f count grant
+  local offenders="" skill f count
   for skill in $PIPELINE_SKILLS; do
     f="$PLUGIN_DIR/skills/$skill/SKILL.md"
     count="$(grep -cF "$HANDOFF_PATH_LITERAL" "$f")"
@@ -436,26 +463,12 @@ test_pipeline_skills_cite_handoff() {
     elif [ -z "$(handoff_section "$f")" ]; then
       offenders="$offenders $skill(no-section)"
     fi
-
-    # The grant LINE only, whole-token — the same idiom test_dispatch_sites_grant_agent
-    # uses. A body-wide grep would be vacuously green (the prose says "agent"), and a
-    # substring match would let Skill or AskUserQuestion pass as the grant.
-    grant="$(grep -m1 '^allowed-tools:' "$f")"
-    if [ -z "$grant" ]; then
-      offenders="$offenders $skill:no-allowed-tools-line"
-    else
-      grant="${grant#allowed-tools:}"
-      case ",${grant//[[:space:]]/}," in
-        *,Agent,*) : ;;
-        *) offenders="$offenders $skill:missing-Agent" ;;
-      esac
-    fi
   done
 
   if [ -n "$offenders" ]; then
-    fail test_pipeline_skills_cite_handoff "pipeline skills without exactly one handoff citation and an Agent grant:$offenders"
+    fail test_pipeline_skills_cite_handoff "pipeline skills without exactly one handoff citation:$offenders"
   else
-    pass test_pipeline_skills_cite_handoff "all 6 pipeline and ops skills cite the canonical handoff and grant Agent"
+    pass test_pipeline_skills_cite_handoff "all 6 pipeline and ops skills cite the canonical handoff"
   fi
 }
 
@@ -712,6 +725,21 @@ test_handoff_does_not_open() {
 # that skill carrying frontmatter. A skill that starts dispatching tomorrow is
 # covered with no edit here. agents/*.md declare their tools under a different
 # key, so they stay in the scan surface but outside this rule.
+#
+# A documented dispatch is EITHER form: naming the agent, or citing the canonical
+# references/dashboard-handoff.md contract that dispatches it. The canonical
+# end-of-step handoff deliberately never names the agent — that omission is what
+# keeps it clear of test_handoff_not_duplicated and of test_open_browser_optin's
+# offender window — so a name-only surface was blind to exactly the skills using
+# the shared contract, and their grant had to be rostered elsewhere. Deriving both
+# forms here is what lets the grant be asserted in one place. The dot is escaped
+# in the alternation, so a near-miss path like references/dashboard-handoffXmd
+# cannot pass.
+#
+# What this case still shares with test_open_browser_optin is the three-glob FILE
+# surface below, not the dispatch-line derivation: that is deliberately wider here,
+# because promising to open a browser is a different claim from documenting a
+# dispatch, and only the latter is satisfied by citing the contract.
 test_dispatch_sites_grant_agent() {
   local surface scanned
   surface="$(
@@ -730,14 +758,33 @@ test_dispatch_sites_grant_agent() {
     printf '%s\n' "$surface" | while IFS= read -r f; do
       [ -n "$f" ] || continue
       [ "$f" = "$AGENT" ] && continue
-      grep -nF 'dashboard-refresher' "$f" 2>/dev/null | while IFS= read -r hit; do
+      grep -nE 'dashboard-refresher|references/dashboard-handoff\.md' "$f" 2>/dev/null | while IFS= read -r hit; do
         printf '%s:%s\n' "$f" "$hit"
       done
     done
   )"
   dispatch_count="$(printf '%s\n' "$dispatch_lines" | grep -c . )"
   if [ "$dispatch_count" -eq 0 ]; then
-    fail test_dispatch_sites_grant_agent "found no dashboard-refresher dispatch lines; scan surface is broken"
+    fail test_dispatch_sites_grant_agent "found no documented dispatch lines (agent name or canonical citation); scan surface is broken"
+    return
+  fi
+
+  # PARTIAL decay is what the zero-check above structurally cannot catch, and a
+  # two-form derivation is exactly where it bites: the name arm satisfies that
+  # check on its own forever, so the citation arm could die — a renamed reference,
+  # a lost escape — and this case would stay green with the citation-only skills
+  # silently ungoverned again. That is the defect this widening exists to remove,
+  # and the rostered assertion that used to cover those skills is gone, so each arm
+  # carries its own floor. Same discipline as test_invocation_surface_intact in
+  # test-bash-grant.sh. The citation floor is built from HANDOFF_PATH_LITERAL, so a
+  # rename that leaves the alternation behind fails LOUDLY here instead of quietly
+  # narrowing the surface. Floors, never exact counts, so honest churn cannot trip
+  # them.
+  local name_arm citation_arm
+  name_arm="$(printf '%s\n' "$dispatch_lines" | grep -cF 'dashboard-refresher')"
+  citation_arm="$(printf '%s\n' "$dispatch_lines" | grep -cF "$HANDOFF_PATH_LITERAL")"
+  if [ "$name_arm" -eq 0 ] || [ "$citation_arm" -eq 0 ]; then
+    fail test_dispatch_sites_grant_agent "a derivation arm went dead: name hits=$name_arm citation hits=$citation_arm (both must be non-zero)"
     return
   fi
 


### PR DESCRIPTION
Closes #1333.

## Summary

- `test_dispatch_sites_grant_agent` derives its dispatch lines with an ERE alternation (`dashboard-refresher|references/dashboard-handoff\.md`) instead of a fixed-string grep for the agent name, so a skill whose only documented dispatch is the canonical citation is now governed by the grant rule. Governed skills move **11 → 17** — the 11 name-the-agent skills plus exactly the six pipeline/ops skills. `propositions` matches via both its `SKILL.md` and its `references/quality-gates.md` and is collapsed by the existing `$seen` dedupe, so the total is 17, not 18. The pass message renders `$governed`, so there was no hardcoded count to edit.
- Everything downstream of the grep is untouched: the three `find` globs, the `[ "$f" = "$AGENT" ]` skip, the governing-`SKILL.md` `case`, the `$seen` dedupe, `grep -m1 '^allowed-tools:'`, and the whole-token match on the grant line.
- `test_pipeline_skills_cite_handoff` drops its grant arm and asserts only the citation and the handoff section. The rationale that claimed the grant "cannot live there" and both result messages are corrected in the same commit.
- `mutation-check.sh` gains `mutation_citation_only_agent_grant` (mutation 9) plus its registration line and header entry. It strips the **mid-list** `Agent` token from `portfolio-ingest/SKILL.md` — the existing mutation 6 targets `products/SKILL.md`, which names the agent, and its `, Agent$` anchor would match nothing on any of the six citation-only skills.

## Not in the issue, added deliberately: per-arm liveness

Widening a detector to two forms introduces a failure mode the issue does not mention, and this diff would otherwise make it worse rather than better.

The existing `dispatch_count -eq 0` check is a **whole-detector** floor. The name arm satisfies it forever on its own, so the citation arm can die — a renamed reference, a lost escape, a careless regex edit — and the case stays green while the six citation-only skills silently revert to ungoverned. That is the exact defect this PR exists to remove. And because the same diff deletes the rostered assertion that used to cover those six, the net trade without a floor is *a CI-enforced assertion for one that can fail silently* (`mutation-check.sh` is deliberately outside CI, per its own header).

So each arm now carries its own non-zero floor, matching `test_invocation_surface_intact` in `tests/test-bash-grant.sh`, whose header states the same rationale for the same reason. Verified both directions:

- Killing the citation arm → `FAIL: … a derivation arm went dead: name hits=12 citation hits=0`.
- On the pre-floor version of this branch the same edit left the **full suite exiting 0**.

The citation floor is built from `HANDOFF_PATH_LITERAL`, so a rename of the reference now fails loudly here instead of quietly narrowing the surface. Floors, never exact counts, so honest churn cannot trip them.

## Scope decisions

- **In:** `cogni-portfolio/tests/test-dashboard-handoff.sh` and `cogni-portfolio/scripts/mutation-check.sh` only. No `SKILL.md` or agent content changes, so `scripts/check-breadcrumbs.py` (which scans `*/skills/*/SKILL.md` and `*/agents/*.md`) is structurally unaffected and no new maintainer breadcrumb is introduced.
- **Deliberately not done — the DRY refactor.** `test_open_browser_optin`'s derivation block stays byte-identical to base. Hoisting both onto a shared helper would drag citation-only skills into the browser-opt-in scan, a different rule with a different surface.
- **Deliberately not done — widening the `find` globs.** The reference file itself has no governing `SKILL.md`, so admitting it to the surface is silently skipped: noise instead of a red case. The grep is the correct lever.
- **Considered and skipped — building the ERE from `HANDOFF_PATH_LITERAL`.** A review pass proposed `grep -nF -e 'dashboard-refresher' -e "$HANDOFF_PATH_LITERAL"`, which reuses the constant and makes the dot literal by construction. It was skipped because the issue and the acceptance contract both specify an ERE alternation with an escaped dot, and substituting the raw constant into an ERE would turn its `.` into a wildcard (`references/dashboard-handoffXmd` would start matching), falsifying the comment's own claim. The rename-fragility that motivated the proposal is instead covered by the liveness floor above, which *is* keyed on the constant. Flagging it so the choice is visible rather than accidental.
- **Left alone —** `test_resume_shows_dashboard_row` keeps its own `^allowed-tools:.*Agent` check on `portfolio-resume`. It is a narrower per-skill claim inside a row assertion, not a second roster; the new comment is worded to say so rather than to claim sole ownership.
- **Version pin in the recipe block.** The new suite-header recipe reuses the `cogni-service/0.0.383` path the five sibling recipes already use (verified present in the local cache, so the recipe replays as written). The installed cogni-service is newer, so that pin is already mildly stale for all six blocks; refreshing it repo-wide is a separate change, and introducing a third value here would be worse than matching the sibling convention.
- No version field touched in `cogni-portfolio/.claude-plugin/plugin.json` or the repo-root `.claude-plugin/marketplace.json` — the post-merge workflow owns the bump.

## Test plan

All run on this branch, against `origin/main` @ `2445fd1b`.

- [x] `bash cogni-portfolio/tests/test-dashboard-handoff.sh` exits 0, no `FAIL:`, and the grant case reads `all 17 dispatching skills grant Agent (26 dispatch lines scanned)`.
- [x] `bash cogni-portfolio/scripts/mutation-check.sh` exits 0, prints `All mutations caught.`, exactly nine `OK: mutation caught` lines and zero `FALSIFIER:`.
- [x] `python3 scripts/run-plugin-tests.py --filter cogni-portfolio` exits 0 — 6 suites, none failed.
- [x] **Red-proof, both directions.** Strip the mid-list `Agent` token from `portfolio-ingest/SKILL.md`, then run the single case: against the **base** suite it exits 0 (`all 11 dispatching skills grant Agent` — the mutant is invisible, which is the bug), and against **this** suite it exits 1 naming `skills/portfolio-ingest/SKILL.md:missing-Agent`. This is what proves the new mutation exercises the new arm rather than the pre-existing one.
- [x] **Arm-liveness proof.** Deleting the citation alternative makes the case exit 1 (`citation hits=0`); on the pre-floor version of this branch the same edit left the suite green.
- [x] Shape checks: `grep -cF "grep -nF 'dashboard-refresher'"` → 1 (2 on base); `grep -cF ',Agent,'` → 1 (2 on base, at 449 and 779; the survivor is the one inside `test_dispatch_sites_grant_agent`); `grep -c '|| overall=1'` → 9 (8 on base).

**One correction to the acceptance contract, not a deviation.** Contract item 14 asserts the suite prints "12 `ok:` lines". Both base and head print **13** — the number was wrong when the contract was derived. The case count is unchanged by this diff (`ALL_TESTS` untouched), no `FAIL:` is printed, and the grant case reads 17, so the substance of the item holds.

## Mutation recipe

Proves the newly added citation-only arm has teeth. Replayable as written from the repo root; the target names the agent nowhere, so it is invisible to the base-ref derivation and red only after this change.

```
bash ~/.claude/plugins/cache/managed-service/cogni-service/0.0.383/scripts/mutation-check.sh --root . --file cogni-portfolio/skills/portfolio-ingest/SKILL.md --expr 's#Grep, Bash, Agent, Skill#Grep, Bash, Skill#' --test 'bash cogni-portfolio/tests/test-dashboard-handoff.sh test_dispatch_sites_grant_agent' --case test_dispatch_sites_grant_agent
```

The searched literal occurs exactly once in the target (the frontmatter grant line) and is metacharacter-free, which matters because the harness feeds the expr to `perl -0pi`. The replacement is deliberately **disjoint**: it carries no `Agent` token, so the grant is genuinely gone — a replacement that still contained it would leave the case green and the mutation would survive unnoticed. `portfolio-verify` carries a byte-identical `allowed-tools` tail, which is harmless because `--file` scopes the harness to one file. The in-repo equivalent is registered as `mutation_citation_only_agent_grant`.

## Noted, not filed — the same class one level up

Surfaced by the review pass, verified as **latent, not live**, and left out of this diff: both derived guards (`test_dispatch_sites_grant_agent` here and `test_invocation_sites_grant_bash` in `test-bash-grant.sh`) scan `skills/*/references/*.md` but **exclude plugin-level `cogni-portfolio/references/*.md`**. That directory holds the shared contracts — `references/data-model.md` names `scripts/register-solution-candidates.py`, and ten skills cite that file. A skill whose only documented invocation were "via the path described in `references/data-model.md`" would be ungoverned by the Bash-grant guard: the identical indirection class this PR fixes for the Agent grant.

Nothing is falsely green today — `portfolio-canvas`, `portfolio-ingest` and `portfolio-setup` each name the script path directly — so this is a follow-up, not a blocker. Recording it here rather than filing an issue from a single review pass; a maintainer may want it filed against both suites.

Also observed and left alone as pre-existing drift: `mutation-check.sh`'s in-file section banners are mis-numbered — line 267 and line 322 both read `Mutation 5`. The new block is banner-numbered 9 and refers to its sibling by function name rather than ordinal to avoid compounding the ambiguity.