### PR TITLE
cogni-portfolio: settle the dashboard-handoff path boundary

### DIFF
--- a/cogni-portfolio/CLAUDE.md
+++ b/cogni-portfolio/CLAUDE.md
@@ -92,7 +92,7 @@ scripts/                        14 utility scripts
 
 references/
   data-model.md                   Full entity schema and project structure reference
-  dashboard-handoff.md            End-of-step dashboard handoff contract (dispatch, link, quiet degrade)
+  dashboard-handoff.md            End-of-step dashboard handoff contract (which paths end here, dispatch, link, quiet degrade)
 ```
 
 ## Component Inventory

--- a/cogni-portfolio/references/dashboard-handoff.md
+++ b/cogni-portfolio/references/dashboard-handoff.md
@@ -43,12 +43,22 @@ one — the user is already looking at the entity they just changed, the next ge
 them a fresh dashboard anyway, and a link after every field edit is noise that trains them to
 ignore the link that matters.
 
-**Known coverage gaps.** Some paths qualify under this rule and do not yet carry a pointer:
-`features` Bulk Import, Promote Shadow Candidates and Feature Review; `products` Portfolio Review;
-and `propositions` Quick Fix, whose sibling Deep Dive already has one. These are tracked coverage
-work, not counter-examples to the rule — grade a new path against the rule, not against them. The
-test suite's per-skill pointer counts are floors rather than a census, so closing a gap does not
-break the guard.
+**Where the pointer goes.** Each skill's `## Dashboard handoff` section is terminal for the main
+flow: a path that runs to the end of the steps above it falls through into that section and needs
+nothing added. A qualifying path owes an explicit pointer line back to that section only when it can
+finish *without reaching* it — either because it is documented below that heading, as the
+`propositions` Deep Dive is, or because it exits early or skips forward past the steps leading
+there, as `portfolio-scan`'s research-only and shadow modes do from above it. Position alone does
+not decide it; reachability does — which is why the `features` Research & Improve and Deep Dive
+sections, both above the heading and both falling through, are correctly pointer-free rather than
+coverage gaps.
+
+**Known coverage gaps (2026-08, tracked as follow-up work).** Some paths qualify under this rule and
+do not yet carry a pointer: `features` Bulk Import, Promote Shadow Candidates and Feature Review;
+`products` Portfolio Review; and `propositions` Quick Fix, whose sibling Deep Dive already has one.
+These are tracked coverage work, not counter-examples to the rule — grade a new path against the
+rule, not against them. The test suite's per-skill pointer counts are floors rather than a census,
+so closing a gap does not break the guard.
 
 ## Dispatch the refresher
 

--- a/cogni-portfolio/references/dashboard-handoff.md
+++ b/cogni-portfolio/references/dashboard-handoff.md
@@ -1,13 +1,54 @@
 # End-of-step dashboard handoff
 
-Every skill that writes portfolio entities, and every pipeline or ops skill that changes what
-the dashboard would show, ends its work step the same way: regenerate the dashboard, hand the
-user a link to it, and move on. This file is the only place those steps are
-written. Skills cite it; they never restate it.
+A work step that ends here ends the same way: regenerate the dashboard, hand the user a link to
+it, and move on. This file is the only place those steps are written. Skills cite it; they never
+restate it. Which paths end here is a rule, stated below — not every write qualifies.
 
 The reason it is one file: before this existed, the dispatch was copy-pasted into seven skills as
 near-identical paragraphs, and they had already drifted. A wording change now lands everywhere at
 once.
+
+## Which paths end here
+
+A path ends at the handoff when it is a **generation run**: a multi-step workflow that produces or
+regenerates a body of entity content and then finishes the user's work step. It usually dispatches
+an agent to do that work. The table below carries the shapes that qualify.
+
+A path does **not** end here when it is a **management operation**: applying a change the user
+already named to one entity in front of them, or only reading. The plugin already uses this split
+elsewhere — `portfolio-taxonomy` calls its two mode families *creation modes* and *management
+modes*, and this is the same line drawn through every skill.
+
+Grade a path with one question: **when it finishes, is there a body of newly written entity content
+the user has not yet seen rendered?** If yes, it ends here.
+
+| Path shape | Ends here |
+|---|---|
+| A skill's main phase workflow | yes |
+| Create or generate a set — batch generation, co-development | yes |
+| Import, scan, ingest, or promote candidates | yes |
+| Regenerate or research-and-rewrite existing entities — repricing, a deep dive | yes |
+| A branch that skips forward past the steps leading here, or exits early | yes |
+| Edit or delete one named entity | no |
+| List, view, or a read-only review pass | no |
+
+The fourth row is why "only paths that create new entities end here" is the wrong rule: repricing a
+solution and deep-diving a proposition both rewrite entities that already exist, and both end here.
+The sixth and seventh rows are why "every path that writes entity data ends here" is also wrong:
+editing and deleting write, across six skills, and correctly do not. Both simpler rules have been
+proposed and both are contradicted by the code; neither should be re-proposed.
+
+Excluding management operations is deliberate. An edit is a step inside a session, not the end of
+one — the user is already looking at the entity they just changed, the next generation run hands
+them a fresh dashboard anyway, and a link after every field edit is noise that trains them to
+ignore the link that matters.
+
+**Known coverage gaps.** Some paths qualify under this rule and do not yet carry a pointer:
+`features` Bulk Import, Promote Shadow Candidates and Feature Review; `products` Portfolio Review;
+and `propositions` Quick Fix, whose sibling Deep Dive already has one. These are tracked coverage
+work, not counter-examples to the rule — grade a new path against the rule, not against them. The
+test suite's per-skill pointer counts are floors rather than a census, so closing a gap does not
+break the guard.
 
 ## Dispatch the refresher
 

--- a/cogni-portfolio/scripts/mutation-check.sh
+++ b/cogni-portfolio/scripts/mutation-check.sh
@@ -319,7 +319,7 @@ PY
   return "$rc"
 }
 
-# --- Mutation 5: dispatch-site Agent grant ---------------------------------
+# --- Mutation 6: dispatch-site Agent grant ---------------------------------
 # Strips the Agent token from the allowed-tools line of a skill that documents a
 # dashboard-refresher dispatch, then asserts test_dispatch_sites_grant_agent goes
 # RED against the mutant. The target is a SKILL.md — documentation, not a script —

--- a/cogni-portfolio/tests/test-dashboard-handoff.sh
+++ b/cogni-portfolio/tests/test-dashboard-handoff.sh
@@ -21,7 +21,8 @@
 #   test_pipeline_skills_cite_handoff
 #                                    the six pipeline and ops skills each cite it exactly once
 #   test_secondary_paths_reach_handoff
-#                                    alternate write paths point back to that terminal section
+#                                    rostered alternate write paths keep their pointer back to
+#                                    that terminal section (per-skill floors, not a census)
 #   test_handoff_not_duplicated      the handoff is authored once, and no skill restates it
 #   test_entity_handoff_does_not_open
 #                                    the end-of-step path opens nothing on its own
@@ -148,8 +149,10 @@
 #   works because the harness feeds the expr to `perl -0pi`, which slurps the file.
 #   The replacement is deliberately DISJOINT from the searched string: one that still
 #   contained the pointer sentence would hold the count at 3 and the mutation would
-#   survive. No in-repo equivalent is registered — the exact-count assertion is itself
-#   the gate, and it is what this recipe proves has teeth.
+#   survive. No in-repo equivalent is registered — the floor assertion is itself the
+#   gate, and it is what this recipe proves has teeth: a REMOVED pointer still drops the
+#   count below want, which is the failure the case exists to catch. The floor only
+#   stops rejecting the opposite change, extending coverage to a path the rule covers.
 
 # `set -u` only — `set -e` would abort on the first failing assertion and defeat
 # the failure counter below, which exists so one run reports every offender.
@@ -475,9 +478,13 @@ test_pipeline_skills_cite_handoff() {
 # --- test_secondary_paths_reach_handoff ------------------------------------
 # The acceptance bar is falsified by any file "whose end-of-step path can complete
 # without reaching the handoff". Six skills carry alternate write paths that do not
-# flow into the terminal section — nine in total, solutions holding three and
-# portfolio-scan two — so each such path needs an explicit pointer back. Three of them
-# are early exits ABOVE the section rather than paths below it: portfolio-scan's
+# flow into the terminal section — nine pointers rostered below, solutions holding three
+# and portfolio-scan two — so each such path needs an explicit pointer back. The counts
+# are floors rather than a census: which paths owe a pointer is decided by the rule in
+# references/dashboard-handoff.md, and that rule currently covers paths this roster does
+# not yet list. Adding one of those must not turn this case red; losing a rostered one
+# must.
+# Three of them are early exits ABOVE the section rather than paths below it: portfolio-scan's
 # research-only and shadow modes stop before Step 7.7, and portfolio-verify's
 # no-propagable-resolutions branch jumps back to its communicate gate. All three have
 # already written data the dashboard renders, so all three owe the same pointer.
@@ -490,13 +497,19 @@ test_secondary_paths_reach_handoff() {
     skill="${spec%%:*}"
     want="${spec##*:}"
     got="$(grep -cF "$PTR_LINE" "$PLUGIN_DIR/skills/$skill/SKILL.md")"
-    if [ "$got" -ne "$want" ]; then
-      offenders="$offenders $skill(want=$want,got=$got)"
+    # >= so extending coverage to a path the rule already covers cannot break the case.
+    if [ "$got" -lt "$want" ]; then
+      offenders="$offenders $skill(want>=$want,got=$got)"
     fi
   done
 
   # A pointer names the section only. If one ever restates the dispatch it becomes a
-  # second source of truth, and if it re-cites the path it breaks the count above.
+  # second source of truth, and this check still catches that.
+  # What the floor gives up, deliberately: a SURPLUS bare pointer. PTR_LINE names neither
+  # the canonical path nor the agent, so a pointer added to a section the rule excludes is
+  # invisible here, to the strays regex below, and to the citation counts. The exact count
+  # used to catch it, at the price of rejecting correct coverage extensions too. Nothing
+  # replaces that signal today; a ceiling keyed on the rule's excluded shapes would.
   strays="$(grep -lE "$(printf '%s' "$PTR_LINE" | sed 's/[][\.*^$]/\\&/g').*(dashboard-refresher|open_browser|references/dashboard-handoff)" \
             "$PLUGIN_DIR"/skills/*/SKILL.md 2>/dev/null | tr '\n' ' ')"
   if [ -n "$strays" ]; then
@@ -506,7 +519,7 @@ test_secondary_paths_reach_handoff() {
   if [ -n "$offenders" ]; then
     fail test_secondary_paths_reach_handoff "secondary write paths do not reach the handoff:$offenders"
   else
-    pass test_secondary_paths_reach_handoff "every alternate write path points back to the handoff"
+    pass test_secondary_paths_reach_handoff "every rostered alternate write path carries at least its expected pointer count"
   fi
 }
 


### PR DESCRIPTION
Refs #1324.

## Summary

`references/dashboard-handoff.md` now states which paths end at the handoff, as a rule a reviewer can grade a path against without opening a skill:

> A path ends at the handoff when it is a **generation run** — a multi-step workflow that produces or regenerates a body of entity content and then finishes the user's work step. It does not when it is a **management operation** applying a change the user already named to one entity, or when it only reads.

Grading question: *when it finishes, is there a body of newly written entity content the user has not yet seen rendered?* The section carries a path-shape table, and reuses the **creation modes / management modes** split `portfolio-taxonomy` already draws rather than inventing vocabulary.

The file's opening sentence asserted the any-write rule and was the one line directly contradicting the shipped wiring. It is rewritten; that contradiction is why three review perspectives read the maintenance-path gap as an accidental miss — they were reading the document correctly.

## Why neither rule the issue proposed

Both are falsified by the merged code, so the PR records the discriminator that actually explains all **nine** shipped pointer occurrences:

| Proposed rule | Falsified by |
|---|---|
| creation-only | `solutions` Repricing Workflow and `propositions` Deep Dive — both rewrite *existing* entities, both carry pointers |
| any-write | Editing/Deleting across six skills — they write entity JSON and correctly carry none |

The reference says this explicitly so neither gets re-proposed. **This is a third rule, not one of the two the issue offered** — the issue said "pick one, do not mix", and this substitutes rather than mixes. Flagging it as the most contestable call in the PR: a maintainer who prefers one of the named candidates should say so, and the reference is the only file that would change.

## Also in

- `test_secondary_paths_reach_handoff`: `-ne` exact counts → `-lt` floor with a `want>=` offender form, mirroring the sibling `test_midflow_offers_survive`. Three further assertions that still claimed a census — the pass message, the strays rationale, the named-test index — are reworded, so the file is not self-contradictory.
- `scripts/mutation-check.sh:322`: the in-body banner read `Mutation 5`, duplicating the resume-dashboard-row banner. Now `Mutation 6`, matching the header entry that was already correct. In-body banners now read 1–9 with no repeat.
- `CLAUDE.md:95`: the reference's one-line paraphrase gains the scope behavior the file now carries.

## What the floor gives up

Honest trade, stated at the assertion: the exact count caught a **surplus** pointer — one added to a section the rule excludes. `PTR_LINE` names neither the canonical path nor the agent, so a surplus bare pointer is invisible to this case, to the `strays` regex, and to the citation counts. **Nothing replaces that signal today.** A ceiling keyed on the rule's excluded shapes would; that belongs with the rewiring follow-up, not in a diff whose purpose is to remove a brittleness rather than add a new heuristic.

## Scope

**Out, deferred to #1342:** wiring the five paths that qualify under the rule and carry no pointer — `features` Bulk Import / Promote Shadow Candidates / Feature Review, `products` Portfolio Review, `propositions` Quick Fix. The reference names them as known coverage gaps so the file does not silently contradict the code. That work is *unblocked* by this PR: the exact-count assertion replaced here is what would have turned red on it.

**Deliberately untouched:** the Editing/Deleting/Listing/Viewing quartet and read-only Review sections (they are what the rule excludes); the `-ne 1` citation counts in `test_entity_skills_cite_handoff` / `test_pipeline_skills_cite_handoff` (deliberate single-occurrence mutation anchors); the `strays` check; the mutation-check header block, function names and driver order.

No version bump — the post-merge workflow owns it.

## Test plan

All run on this branch, not asserted:

- [x] `bash cogni-portfolio/tests/test-dashboard-handoff.sh` → `All tests passed.`
- [x] `bash cogni-portfolio/scripts/mutation-check.sh` → `All mutations caught.`
- [x] `python3 scripts/run-plugin-tests.py --filter cogni-portfolio` → exit 0
- [x] `python3 scripts/check-breadcrumbs.py` → exit 0
- [x] `python3 scripts/check-version-bump.py` → `0 touched, 0 violation(s)`
- [x] Handoff still authored once: `grep -rlF '# End-of-step dashboard handoff' cogni-portfolio --include='*.md' --exclude-dir=tests | wc -l` → `1`
- [x] All seven literals the suite pins in the reference survive; `open_browser: true` still absent
- [x] `grep -n '^# --- Mutation' cogni-portfolio/scripts/mutation-check.sh` → 1,2,3,4,5,6,7,8,9, no repeat

Base was green on `359e513f` before any edit, so the green above is not inherited noise.

## Mutation recipe

Proves the loosened assertion still has teeth. Strips the repricing pointer specifically, so `solutions` drops to 2 against a floor of 3 — red on the mutant, green restored. The replacement is deliberately disjoint from the searched literal; one still containing the pointer sentence would hold the count at 3 and the mutation would survive.

```
bash ~/.claude/plugins/cache/managed-service/cogni-service/0.0.384/scripts/mutation-check.sh \
  --root . \
  --file cogni-portfolio/skills/solutions/SKILL.md \
  --expr 's#deal size data for the relevant segment.\n\nThis path ends the same way#deal size data for the relevant segment.\n\nRepricing is complete#' \
  --test 'bash cogni-portfolio/tests/test-dashboard-handoff.sh test_secondary_paths_reach_handoff' \
  --case test_secondary_paths_reach_handoff
```

Run from the repo root. **Executed on this branch, not just quoted** — returned `"mutated_result": "red"`, `"restored_result": "green"`, `"verdict": "guard_verified"`.

The harness path is pinned to `0.0.384`, the loaded version. The five in-file recipe stanzas in the suite header still cite `0.0.383`; refreshing them is out of scope, and the header already declares the path version-independent ("use the newest under the same parent").

## Follow-up issues

- #1342 — wire the five generation paths the rule covers but that carry no pointer, raise the per-skill floors, and drop the known-coverage-gaps paragraph.