### PR TITLE
cogni-portfolio: close the five dashboard-handoff pointer gaps

### DIFF
--- a/cogni-portfolio/references/dashboard-handoff.md
+++ b/cogni-portfolio/references/dashboard-handoff.md
@@ -53,13 +53,6 @@ not decide it; reachability does — which is why the `features` Research & Impr
 sections, both above the heading and both falling through, are correctly pointer-free rather than
 coverage gaps.
 
-**Known coverage gaps (2026-08, tracked as follow-up work).** Some paths qualify under this rule and
-do not yet carry a pointer: `features` Bulk Import, Promote Shadow Candidates and Feature Review;
-`products` Portfolio Review; and `propositions` Quick Fix, whose sibling Deep Dive already has one.
-These are tracked coverage work, not counter-examples to the rule — grade a new path against the
-rule, not against them. The test suite's per-skill pointer counts are floors rather than a census,
-so closing a gap does not break the guard.
-
 ## Dispatch the refresher
 
 Delegate to the `dashboard-refresher` agent with two values:

--- a/cogni-portfolio/skills/features/SKILL.md
+++ b/cogni-portfolio/skills/features/SKILL.md
@@ -539,6 +539,8 @@ When the user provides a product description, website content, or document:
 4. Propose a structured feature set with your reasoning
 5. Let the user confirm, edit, or remove before creating files
 
+This path ends the same way — see the **Dashboard handoff** section in this file.
+
 ### Promote Shadow Candidates
 
 Trigger this operation when the user says "promote shadow candidates", "import scan candidates", or "pull the shadow features in", or after a `portfolio-scan --mode=shadow` run has staged offerings under `research/scan-candidates/{company_slug}/`.
@@ -550,6 +552,8 @@ The full workflow lives in [`references/promote-shadow.md`](references/promote-s
 4. Dispatch `feature-deduplication-detector` in candidate mode against the affected product so new features compete with existing ones on equal footing
 
 The helper handles the mechanical bits (`_shadow_candidate` / `_source_offering` field strip, move to `features/{slug}.json`, delete or archive the source).
+
+This path ends the same way — see the **Dashboard handoff** section in this file.
 
 ### Feature Review
 
@@ -576,6 +580,8 @@ When the user asks to review or improve their feature set (or when you notice is
 Present your assessment as a consulting memo — lead with "here's what I'd change and why" backed by specific analysis. Don't list observations and ask "what do you think?" — state your recommended changes and let the user push back.
 
 For features with quality issues that need company-specific information to fix (mechanism clarity, differentiation), offer to research and improve them via the `quality-enricher` agent — see Research & Improve above.
+
+This path ends the same way — see the **Dashboard handoff** section in this file.
 
 ## Important Notes
 

--- a/cogni-portfolio/skills/products/SKILL.md
+++ b/cogni-portfolio/skills/products/SKILL.md
@@ -268,6 +268,8 @@ When the user asks to review or improve their portfolio (or when you notice issu
 
 The key difference from define mode: in review mode you have data to audit, so Phase 1 is analysis not interview, and Phase 2 should challenge the existing structure rather than the user's verbal framing.
 
+This path ends the same way — see the **Dashboard handoff** section in this file.
+
 ## Important Notes
 
 - Products are the first entity to define after portfolio setup — features, markets, and all downstream entities build on them

--- a/cogni-portfolio/skills/propositions/SKILL.md
+++ b/cogni-portfolio/skills/propositions/SKILL.md
@@ -288,6 +288,8 @@ Pick the right repair path by the assessor's verdict:
 
 Offer Quick Fix after the post-check shows any `warn` or `fail`, when the user explicitly asks to "improve" / "fix" / "strengthen" / "sharpen", or during Proposition Review when you spot generic messaging. The full Quick Fix workflow (agent dispatch contract, regional URL derivation, before/after presentation, "not all dimensions need research") lives in `$CLAUDE_PLUGIN_ROOT/skills/propositions/references/research-and-enrich.md`.
 
+This path ends the same way — see the **Dashboard handoff** section in this file.
+
 ## Deep Dive (Single-Proposition Intensive)
 
 For propositions needing more than reactive quality repair — buyer language validation, competitive messaging analysis, evidence enrichment, or co-creation dialogue. One proposition at a time. The deep dive produces messaging intelligence that informs not just this proposition but downstream competitor positioning, solution design, and sales enablement.

--- a/cogni-portfolio/tests/test-dashboard-handoff.sh
+++ b/cogni-portfolio/tests/test-dashboard-handoff.sh
@@ -477,13 +477,13 @@ test_pipeline_skills_cite_handoff() {
 
 # --- test_secondary_paths_reach_handoff ------------------------------------
 # The acceptance bar is falsified by any file "whose end-of-step path can complete
-# without reaching the handoff". Six skills carry alternate write paths that do not
-# flow into the terminal section — nine pointers rostered below, solutions holding three
-# and portfolio-scan two — so each such path needs an explicit pointer back. The counts
-# are floors rather than a census: which paths owe a pointer is decided by the rule in
-# references/dashboard-handoff.md, and that rule currently covers paths this roster does
-# not yet list. Adding one of those must not turn this case red; losing a rostered one
-# must.
+# without reaching the handoff". Eight skills carry alternate write paths that do not
+# flow into the terminal section — fourteen pointers rostered below, solutions and
+# features holding three each, propositions and portfolio-scan two each — so each such
+# path needs an explicit pointer back. The counts are floors rather than a census: which
+# paths owe a pointer is decided by the rule in references/dashboard-handoff.md, so a
+# path that rule covers but this roster has not caught up with must not turn this case
+# red; losing a rostered one must.
 # Three of them are early exits ABOVE the section rather than paths below it: portfolio-scan's
 # research-only and shadow modes stop before Step 7.7, and portfolio-verify's
 # no-propagable-resolutions branch jumps back to its communicate gate. All three have
@@ -493,7 +493,7 @@ test_secondary_paths_reach_handoff() {
   pipeline_surface_ok test_secondary_paths_reach_handoff || return
 
   local offenders="" spec skill want got strays
-  for spec in solutions:3 packages:1 propositions:1 portfolio-communicate:1 portfolio-scan:2 portfolio-verify:1; do
+  for spec in solutions:3 packages:1 propositions:2 portfolio-communicate:1 portfolio-scan:2 portfolio-verify:1 features:3 products:1; do
     skill="${spec%%:*}"
     want="${spec##*:}"
     got="$(grep -cF "$PTR_LINE" "$PLUGIN_DIR/skills/$skill/SKILL.md")"


### PR DESCRIPTION
Closes #1342.

## Summary

Five generation paths qualify under the reachability rule recorded in `cogni-portfolio/references/dashboard-handoff.md` — each sits **below** its skill's terminal `## Dashboard handoff` heading (features:493, products:227, propositions:242), so each can finish *without falling through into it* — but carried no pointer back:

| Skill | Section | Pointer count |
|---|---|---|
| `features` | Bulk Import, Promote Shadow Candidates, Feature Review | 0 → 3 |
| `products` | Portfolio Review | 0 → 1 |
| `propositions` | Research & Improve (Quick Fix) | 1 → 2 |

- Appends the canonical pointer literal to all five, byte-identical to the suite's `PTR_LINE`.
- Raises `test_secondary_paths_reach_handoff`'s roster from nine pointers across six skills to fourteen across eight, so every new pointer is asserted by something, and refreshes the case's header comment — it claimed the rule covered paths the roster did not list, which is no longer true.
- Deletes the **Known coverage gaps** paragraph from the reference, which enumerated exactly these five paths as outstanding work.

## Why this could start now

The issue's `## Depends on` says "do not start until the boundary work has merged", naming branch `docs/issue-1324-dashboard-handoff-boundary`. That branch is PR #1343, **merged 2026-08-13T00:50:25Z**, with no open PR remaining on it — the gate is satisfied. The three acceptance criteria the triage recorded as unsatisfiable against `main` were each re-verified as satisfiable at `59142eca` before this branch was cut.

Note #1324 itself stays **open by design**: its PR linked with `Refs`, not `Closes`, and it is recorded as staying open until this follow-up lands. It is not a reap candidate.

## Scope decisions

- **A blank line precedes each new pointer.** All six pre-existing standalone occurrences have one, and without it the Bulk Import pointer renders as a *lazy continuation of numbered item 5* rather than as the section-closing step. This was caught by the pre-commit quality gate and fixed before commit.
- **`features` Research & Improve and Deep Dive get no pointer.** Both sit above the terminal heading and fall through into it, so the rule leaves them pointer-free. The reference sentence saying so is kept.
- **No new handoff citation anywhere.** All three skills keep exactly one `references/dashboard-handoff.md` citation, which `test_entity_skills_cite_handoff` pins; a pointer that restates the dispatch is what the `strays` regex exists to catch.
- **The `>=` floor comparison is unchanged** — it is the guard the parent change installed so a future correct coverage extension cannot turn the case red. Raising the roster does not convert it back to a census.
- **No version bump.** The post-merge workflow owns the patch increment; neither manifest is touched.
- **Advisory:** `skills/features/SKILL.md` is at 53977/60000 chars (89.96% of cap), up from 89.55%. Still below the 90% approach zone, so no trim is bundled here — a length pass would be a separate, unrelated diff.

## Test plan

- `bash cogni-portfolio/tests/test-dashboard-handoff.sh` — **green**, all 13 cases
- `bash cogni-portfolio/scripts/mutation-check.sh` — **all nine mutations caught**
- `python3 scripts/run-plugin-tests.py --filter cogni-portfolio` — **6/6 suites pass**
- `python3 scripts/check-breadcrumbs.py` — clean (46 occurrences scanned against a 43-entry baseline)
- `python3 scripts/check-version-bump.py` — 13 plugins scanned, 0 touched, 0 violations

## Mutation recipe

The diff touches a guard file, so here is the replayable proof the raised roster has teeth. Both cases were executed against this branch and returned `verdict: guard_verified` (`mutated_result: red`, `restored_result: green`). Run from the repo root.

Case 1 — the new `products:1` roster entry:

```bash
bash ~/.claude/plugins/cache/managed-service/cogni-service/0.0.384/scripts/mutation-check.sh \
  --root . \
  --file cogni-portfolio/skills/products/SKILL.md \
  --expr 's#verbal framing\.\n\nThis path ends the same way#verbal framing.\n\nPortfolio review is complete#' \
  --test 'bash cogni-portfolio/tests/test-dashboard-handoff.sh test_secondary_paths_reach_handoff' \
  --case test_secondary_paths_reach_handoff
```

Case 2 — the new `features:3` entry, proving the *count* and not merely presence:

```bash
bash ~/.claude/plugins/cache/managed-service/cogni-service/0.0.384/scripts/mutation-check.sh \
  --root . \
  --file cogni-portfolio/skills/features/SKILL.md \
  --expr 's#remove before creating files\n\nThis path ends the same way#remove before creating files\n\nBulk import is complete#' \
  --test 'bash cogni-portfolio/tests/test-dashboard-handoff.sh test_secondary_paths_reach_handoff' \
  --case test_secondary_paths_reach_handoff
```

Each expr strips one newly-rostered pointer, so that skill reports `got < want` and the case goes RED on the mutant, green on HEAD. Both replacements are deliberately **disjoint** from the searched literal — one still containing `This path ends the same way` would hold the count and let the mutation survive. Each anchor occurs exactly once in its file. If version directory `0.0.384` is gone, use the newest under the same parent; everything after the path is version-independent.

## Open questions

None.