### PR TITLE
Fix vacuously-passing test assertions and wire the theme harness into CI

### DIFF
--- a/cogni-knowledge/tests/test_contradictor_contract.sh
+++ b/cogni-knowledge/tests/test_contradictor_contract.sh
@@ -161,6 +161,11 @@ assert_grep 'write_failed' "$CTR" "wiki-contradictor: documents write_failed fai
 assert_not_grep 'Skill("cogni-research:' "$CTR" "wiki-contradictor: no Skill('cogni-research:') dispatch (clean break)"
 assert_not_grep 'Skill("cogni-claims:' "$CTR" "wiki-contradictor: no Skill('cogni-claims:') dispatch (clean break)"
 assert_not_grep 'Skill("cogni-wiki:' "$CTR" "wiki-contradictor: no Skill('cogni-wiki:') dispatch (clean break)"
+# Positive control, per tests/README.md: the absence assertions above also pass on a
+# gutted file, so pair them with the mechanism that replaced the dispatch. The colon
+# form is deliberate — the maintainer comment block's mention is the non-colon
+# "::pre_extracted_claims;", so this literal matches body prose only.
+assert_grep 'pre_extracted_claims:' "$CTR" "wiki-contradictor: cogni-claims replacement present — scores the synthesis against on-disk pre_extracted_claims: frontmatter (zero-network)"
 
 if [ $errors -eq 0 ]; then
   green ""

--- a/cogni-knowledge/tests/test_finalize_contract.sh
+++ b/cogni-knowledge/tests/test_finalize_contract.sh
@@ -102,6 +102,9 @@ assert_grep 'citation-manifest' "$FIN" "knowledge-finalize: notes citation-manif
 assert_not_grep 'Skill("cogni-research:' "$FIN" "knowledge-finalize: no Skill('cogni-research:') dispatch (clean break)"
 assert_not_grep 'Skill("cogni-claims:' "$FIN" "knowledge-finalize: no Skill('cogni-claims:') dispatch (clean break)"
 assert_not_grep 'Skill("cogni-wiki:' "$FIN" "knowledge-finalize: no Skill('cogni-wiki:') dispatch (M6 contract: call helpers at script level)"
+# Positive control, per tests/README.md: the absence assertions above also pass on a
+# gutted file, so pair them with the mechanism that replaced the dispatch.
+assert_grep 'pre_extracted_claims:' "$FIN" "knowledge-finalize: cogni-claims replacement present — the contradiction pass reads on-disk pre_extracted_claims: frontmatter (zero-network)"
 # Post-review hardening (v0.0.24, all 15 review findings).
 # E1: wiki:// shape must be bare slug, not path-prefixed (cogni-wiki health.py:206).
 assert_grep 'wiki://" + slug' "$FINREF" "knowledge-finalize: emits bare 'wiki://<slug>' (not 'wiki://<wiki_slug>/<slug>') per cogni-wiki contract"

--- a/cogni-knowledge/tests/test_reviewer_contract.sh
+++ b/cogni-knowledge/tests/test_reviewer_contract.sh
@@ -148,6 +148,12 @@ assert_grep 'write_failed' "$REV" "wiki-reviewer: documents write_failed failure
 assert_not_grep 'Skill("cogni-research:' "$REV" "wiki-reviewer: no Skill('cogni-research:') dispatch (clean break)"
 assert_not_grep 'Skill("cogni-claims:' "$REV" "wiki-reviewer: no Skill('cogni-claims:') dispatch (clean break)"
 assert_not_grep 'Skill("cogni-wiki:' "$REV" "wiki-reviewer: no Skill('cogni-wiki:') dispatch (clean break)"
+# Positive control, per tests/README.md: an absence assertion alone also passes on a
+# gutted file, so pair it with the mechanism that replaced the dispatch.
+# Anchored on structural_scores, not the pre_extracted_claims: literal the four sibling
+# suites use: this agent's single mention of that literal describes knowledge-verify's
+# job, not its own, so it would not track this agent losing its mechanism.
+assert_grep 'structural_scores' "$REV" "wiki-reviewer: cogni-claims replacement present — emits its own structural_scores verdict instead of a claims-verification multiplier"
 
 if [ $errors -eq 0 ]; then
   green ""

--- a/cogni-knowledge/tests/test_source_contradictor_contract.sh
+++ b/cogni-knowledge/tests/test_source_contradictor_contract.sh
@@ -107,6 +107,11 @@ assert_grep 'never gates ingest\|never gate ingest\|gate ingest\|roll back\|roll
 assert_not_grep 'Skill("cogni-research:' "$SC" "source-contradictor: no Skill('cogni-research:') dispatch (clean break)"
 assert_not_grep 'Skill("cogni-claims:' "$SC" "source-contradictor: no Skill('cogni-claims:') dispatch (clean break)"
 assert_not_grep 'Skill("cogni-wiki:' "$SC" "source-contradictor: no Skill('cogni-wiki:') dispatch (clean break)"
+# Positive control, per tests/README.md: the absence assertions above also pass on a
+# gutted file, so pair them with the mechanism that replaced the dispatch. The colon
+# form is deliberate — the maintainer comment block's mention is the non-colon
+# "::pre_extracted_claims;", so this literal matches body prose only.
+assert_grep 'pre_extracted_claims:' "$SC" "source-contradictor: cogni-claims replacement present — scores NEW vs PEER claims from on-disk pre_extracted_claims: frontmatter (zero-network)"
 
 # Recency survivor annotation (the resolution{} producer contract, #874).
 assert_grep 'resolution' "$SC" "source-contradictor: documents the resolution annotation"

--- a/cogni-knowledge/tests/test_verify_contract.sh
+++ b/cogni-knowledge/tests/test_verify_contract.sh
@@ -115,6 +115,9 @@ assert_not_grep 'Skill("cogni-knowledge:revisor' "$VERIFY" "knowledge-verify: no
 assert_not_grep '01-contexts/data' "$VERIFY" "knowledge-verify: does NOT reference cogni-research's 01-contexts/data"
 assert_not_grep '02-sources/data' "$VERIFY" "knowledge-verify: does NOT reference cogni-research's 02-sources/data"
 assert_not_grep 'cogni-claims:' "$VERIFY" "knowledge-verify: does NOT dispatch any cogni-claims skill"
+# Positive control, per tests/README.md: an absence assertion alone also passes on a
+# gutted file, so pair it with the mechanism that replaced the dispatch.
+assert_grep 'pre_extracted_claims:' "$VERIFY" "knowledge-verify: cogni-claims replacement present — scores citations against the cited page's on-disk pre_extracted_claims: frontmatter (zero-network)"
 # allowed-tools must include Task (we dispatch the verifier and revisor).
 VERIFY_TOOLS_LINE=$(grep '^allowed-tools:' "$VERIFY" || true)
 if echo "$VERIFY_TOOLS_LINE" | grep -q Task; then

--- a/cogni-workspace/CLAUDE.md
+++ b/cogni-workspace/CLAUDE.md
@@ -41,8 +41,13 @@ The harness complements the per-skill validators
 local violations; this catches integration drift across plugins.
 
 `--help` prints a failure-mode triage table mapping each failure to the
-likely upstream child issue (#126–#130). CI integration is intentionally
-out of scope; manual invocation before PRs is the contract.
+likely upstream child issue (#126–#130). The harness runs in CI through the
+wrapper suite `cogni-workspace/tests/test-theme-backcompat.sh`, which
+`scripts/run-plugin-tests.py` discovers and the "Plugin test suites" job in
+`.github/workflows/lint.yml` runs; invoking it manually before a PR still
+gives the faster signal. A listed visual consumer whose `SKILL.md` is missing
+is a hard failure, not a skip — the check has to fire precisely when the file
+it guards has disappeared.
 
 ## Language
 

--- a/cogni-workspace/scripts/verify-theme-backcompat.sh
+++ b/cogni-workspace/scripts/verify-theme-backcompat.sh
@@ -14,6 +14,10 @@
 # Exit code 0 on success, 1 on the first failure encountered. Failures print a
 # triage line indicating which child of the v2 epic likely broke. Run
 # `--help` for the full triage table.
+#
+# This harness also runs in CI, via the thin wrapper suite
+# cogni-workspace/tests/test-theme-backcompat.sh that run-plugin-tests.py
+# discovers. Keep it runnable with no arguments and no network access.
 
 set -uo pipefail
 
@@ -347,8 +351,7 @@ for entry in "${VISUAL_CONSUMERS[@]}"; do
   skill="${entry#*:}"
   skill_md="$REPO_ROOT/$plugin/skills/$skill/SKILL.md"
   if [[ ! -f "$skill_md" ]]; then
-    c_skip "$entry — SKILL.md not present at expected path"
-    continue
+    fail "$entry SKILL.md not present at expected path" "$skill_md is missing. A listed visual consumer lost its SKILL.md — either the skill was renamed or removed (update VISUAL_CONSUMERS) or a regeneration dropped the file."
   fi
   if grep -qE 'theme\.md|theme_slug|pick-theme|themes/' "$skill_md"; then
     c_pass "$entry references the theme contract"

--- a/cogni-workspace/tests/test-theme-backcompat.sh
+++ b/cogni-workspace/tests/test-theme-backcompat.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# CI seam for scripts/verify-theme-backcompat.sh — the theme back-compat harness.
+#
+# scripts/run-plugin-tests.py discovers suites with two non-recursive globs,
+# `tests/*.sh` and `*/tests/*.sh`. The harness lives one directory over, under
+# `scripts/`, so nothing discovers it and it has never run in CI however loudly it
+# fails. This file sits where the runner already looks and hands its exit status
+# straight back.
+#
+# This is a per-harness wrapper, not a settled pattern to copy. The underlying gap
+# is in discovery: every `*/scripts/verify-*.sh` harness is invisible to CI for the
+# same reason, and cogni-workspace/scripts/verify-claude-design-importer.sh is in
+# the identical blind spot today. Widening the runner's globs would fix the class
+# in one line; that belongs in its own change against run-plugin-tests.py and its
+# suite, not here. Prefer it to a second wrapper.
+#
+# Contract: no arguments, no network, no cwd assumptions, and the harness's exit
+# status reaches the runner unchanged — a wrapper that swallowed a failure would
+# reproduce exactly the vacuous-pass class this suite exists to prevent.
+
+set -uo pipefail
+
+TESTS_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# exec replaces this shell with the harness, so its exit status IS this suite's
+# status — no capture, and no branch that could drop a non-zero code on the floor.
+exec bash "$TESTS_DIR/../scripts/verify-theme-backcompat.sh"


### PR DESCRIPTION
Closes #1345.

## Summary

Five cogni-knowledge contract suites asserted only the **absence** of the retired `cogni-claims` dispatch. An absence assertion is satisfied by the guarded surface ceasing to exist, so each passed just as happily on a gutted file as on a correct one. Each now carries a paired **presence** assertion for the mechanism that replaced the dispatch, following the existing precedent at `test_refresh_resweep_contract.sh:47-51` (absence first, replacement second, same comment-delimited block).

`verify-theme-backcompat.sh` had the same defect in script form: Phase C **skipped** when a listed visual consumer's `SKILL.md` was missing — precisely when the check most needed to fire. That branch now fails. And the harness ran nowhere at all: `run-plugin-tests.py` discovers `tests/*.sh` and `*/tests/*.sh`, and the harness sits under `scripts/`, so a thin wrapper suite gives it discovery.

## The presence literal is chosen per file, not templated

This is the part worth reviewing closely, because a positive control that a maintainer comment block can satisfy is *itself* vacuous — the same bug one level up. Counts verified against `origin/main`:

| Suite | Guarded file | Literal | Body matches | In-comment-block matches |
|---|---|---|---|---|
| `test_verify_contract.sh` | `knowledge-verify/SKILL.md` | `pre_extracted_claims:` | 2 (L9, L13) | 0 — file has no comment block |
| `test_finalize_contract.sh` | `knowledge-finalize/SKILL.md` | `pre_extracted_claims:` | 2 (L824, L1101) | 0 — file has no comment block |
| `test_contradictor_contract.sh` | `agents/wiki-contradictor.md` | `pre_extracted_claims:` | 10 | 0 — the in-block mention is the non-colon `::pre_extracted_claims;` |
| `test_source_contradictor_contract.sh` | `agents/source-contradictor.md` | `pre_extracted_claims:` | 4 | 0 — same non-colon form in-block |
| `test_reviewer_contract.sh` | `agents/wiki-reviewer.md` | **`structural_scores`** | 5 (L225, L271, L273, L286, L335) | 0 — block spans L9-68 |

The colon form is deliberate: it is what excludes the two agents' in-block mentions.

`test_reviewer_contract.sh` diverges on purpose. `wiki-reviewer.md` mentions `pre_extracted_claims:` exactly once (L76), and that sentence describes **`knowledge-verify`'s** job, not wiki-reviewer's own — so it would not track this agent losing its mechanism. `structural_scores` is wiki-reviewer's actual replacement (it scores a weighted structural average instead of running claim verification), and it occurs five times in the body.

## Scope decisions

- **Full scope.** All four acceptance criteria are addressed here; nothing is deferred and no follow-up issues were filed.
- **CI wiring by wrapper, not by moving the harness.** The harness derives `PLUGIN_ROOT`, `REPO_ROOT` and `TIER0_BASELINE` from `$SCRIPT_DIR` (L20-25), so relocating it silently re-roots the tier-0 baseline it diffs against; sixteen references across nine files also name its current path.
- **Deliberately unchanged:** Phase D's `c_skip` at L388 (missing plugin *directory*) fires today because `cogni-research` is genuinely absent — converting it would red CI immediately. Phase E's `c_info` calls stay informational (`document-skills:*` is an external collection). `c_skip` therefore remains defined and still has a live caller.
- **No version bump** — the post-merge workflow owns it. No `.claude-plugin/*.json` path is in the diff.

## Known limitation — please read before merging

The wrapper is a **per-harness bandaid, and its header says so**. The real defect is in discovery: `run-plugin-tests.py`'s two non-recursive globs make *every* `*/scripts/verify-*.sh` harness invisible to CI. `cogni-workspace/scripts/verify-claude-design-importer.sh` is in the identical blind spot today, runs clean with no args and no network, and gets **zero** coverage from this PR. Widening the runner's globs would fix the whole class in about one line, but it changes repo-wide discovery semantics and would require updating `tests/test_run_plugin_tests.sh`, so it is out of scope here and belongs in its own change. The wrapper header tells the next maintainer to prefer that over writing wrapper #2.

Also out of scope, and worth a follow-up: `test_refresh_push_chain.sh:88-98` has the same unpaired-absence shape for the `cogni-research` guard class. This issue enumerated the five `cogni-claims` sites, and each pairing needs its own verified anchor — the wiki-reviewer case above is exactly why they are not a mechanical sweep.

## Test plan

- [x] All five edited suites exit 0
- [x] `bash cogni-workspace/scripts/verify-theme-backcompat.sh` exits 0, Phase C prints nine PASS lines and no SKIP
- [x] `bash cogni-workspace/tests/test-theme-backcompat.sh` exits 0
- [x] `python3 scripts/run-plugin-tests.py` green — **107 passed, 0 failed** (base was 106; the new suite is the +1, and it is listed in `--list`)

## Mutation recipe

Run from the repo root. Verified against this branch: `mutated_result: red`, `restored_result: green`, `verdict: guard_verified`, working tree clean afterwards.

```
bash cogni-service/scripts/mutation-check.sh --root . --file cogni-knowledge/skills/knowledge-verify/SKILL.md --expr 's/pre_extracted_claims:/MUTANT_CLAIM_FRONTMATTER_ABSENT:/g' --test 'bash cogni-knowledge/tests/test_verify_contract.sh | sed s/.\[[0-9]*m//g' --case 'knowledge-verify:'
```

Two notes on the shape, both learned by running it rather than reasoning about it:

- **The `sed` in `--test` is load-bearing.** `assert_grep`/`assert_not_grep` print through `red()`/`green()`, which wrap the label in ANSI colour codes. The classifier anchors on `^[[:space:]]*FAIL:`, so without stripping the escape the run returns `case_not_found` on a genuinely red case. The strip uses `[0-9]*` rather than `[0-9;]*` deliberately — a `;` is a shell metacharacter the recipe gate rejects, and these labels only ever carry single-number codes.
- **The replacement token is disjoint from the asserted literal.** A replacement still containing `pre_extracted_claims:` would leave the mutant green and prove nothing.

## Mutation evidence

Beyond the recipe above, both mutations were run by hand and reverted; the exit codes below are observed, not predicted.

**A — the guarded mechanism is deleted; the paired assertion must go red.**

```bash
cd "$(git rev-parse --show-toplevel)"
S=cogni-knowledge/tests/test_verify_contract.sh
T=cogni-knowledge/skills/knowledge-verify/SKILL.md
bash "$S" >/dev/null 2>&1; echo "baseline exit=$?"
cp "$T" /tmp/kv.bak
perl -pi -e 's/pre_extracted_claims:/MUTANT_TOKEN_ABSENT:/g' "$T"
bash "$S" >/dev/null 2>&1; echo "mutant exit=$?"
cp /tmp/kv.bak "$T"
bash "$S" >/dev/null 2>&1; echo "restored exit=$?"
```

Observed: baseline `0`, mutant `1`, restored `0`. The failing line was exactly the new assertion, by name. The replacement token is uppercase and so disjoint from the asserted literal — a replacement containing the literal would leave the mutant green and prove nothing.

**B — a listed visual consumer loses its SKILL.md; the harness must go red.**

```bash
mv cogni-website/skills/website-setup/SKILL.md /tmp/ws.bak
bash cogni-workspace/scripts/verify-theme-backcompat.sh >/dev/null 2>&1; echo "harness exit=$?"
bash cogni-workspace/tests/test-theme-backcompat.sh >/dev/null 2>&1; echo "wrapper exit=$?"
mv /tmp/ws.bak cogni-website/skills/website-setup/SKILL.md
```

Observed: harness `1` (printing `FAIL  cogni-website:website-setup SKILL.md not present at expected path`), wrapper `1`, restored `0`. On `main` this same mutation exits **0** with a SKIP line — which is the bug.

Mutation B has no `mutation-check.sh` form: the harness prints through `c_pass`/`c_fail` and carries no `ok()`/`bad()` case labels for the classifier to key on, so its falsification is recorded as the replayable block above rather than as a second recipe.

## Note for the reviewer on two preflight results

Both were run down rather than worked around, and both are recorded here because the next person to touch this branch will hit them again:

- **`version-bump` reported a violation that is not this branch's.** It flagged `cogni-projects/.claude-plugin/plugin.json` 0.0.7→0.0.8. This branch touches no `plugin.json` at all — the three-dot diff against `origin/main` is the eight files listed above. `check-version-bump.sh` takes only a positional repo root and never receives the preflight's `--head-ref`, so run against a shared clone that is checked out on another branch it grades *that* branch. Re-run against a checkout of this branch it is clean: 13 plugins scanned, 2 touched (`cogni-knowledge`, `cogni-workspace`), **0 violations**.
- **`mutation-recipe` initially reported a missing section.** That was correct and is now fixed — the section above is present and verified. Worth noting for anyone reading the plan record: the planning pass concluded no harness accepted the five-flag contract, having searched only the repo. The canonical harness ships with the installed `cogni-service` plugin, not in this tree.
