### PR TITLE
External-dispatch guard: retired prefixes as data, not regex

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,7 +32,10 @@ jobs:
         # Default shallow checkout is sufficient: the guard reads the working
         # tree via `git ls-files`, not git history.
 
-      - name: Assert zero retired-plugin dispatches in live surfaces (set: scripts/retired-plugins.json)
+      # Keep this name free of ": " — an unquoted YAML plain scalar containing a
+      # colon-space makes the whole workflow unparseable, which silently takes
+      # every job in this file offline rather than failing one step.
+      - name: Assert zero retired-plugin dispatches in live surfaces (registry scripts/retired-plugins.json)
         run: |
           set -euo pipefail
           python3 scripts/check-external-dispatch.py

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,7 +32,7 @@ jobs:
         # Default shallow checkout is sufficient: the guard reads the working
         # tree via `git ls-files`, not git history.
 
-      - name: Assert zero cogni-wiki and cogni-research dispatches in live surfaces
+      - name: Assert zero retired-plugin dispatches in live surfaces (set: scripts/retired-plugins.json)
         run: |
           set -euo pipefail
           python3 scripts/check-external-dispatch.py

--- a/scripts/check-external-dispatch.py
+++ b/scripts/check-external-dispatch.py
@@ -13,9 +13,10 @@ file rather than a regex edit here:
 
     {"retired_prefixes": ["cogni-wiki", "cogni-research"]}
 
-Entries are BARE prefixes with no trailing colon — this script appends the colon that
-makes the token dispatch-shaped, and rejects a colon-bearing entry rather than
-compiling a `cogni-wiki::` pattern that would silently match nothing.
+Entries are BARE prefixes with no trailing colon and no surrounding whitespace — this
+script appends the colon that makes the token dispatch-shaped, and rejects both a
+colon-bearing entry (`cogni-wiki::`) and a padded one (`re.escape("  cogni-wiki  ")`)
+rather than compiling a pattern that would silently match nothing.
 
 The registry is **mandatory config, not an optional ratchet**: absent, unreadable,
 malformed, wrongly-typed or empty all exit 2. A guard that quietly loaded nothing and
@@ -149,6 +150,11 @@ def load_registry(path):
             raise RuntimeError(
                 "retired-plugin registry {}: every prefix must be a non-empty "
                 "string, got {!r}".format(path, entry))
+        if entry != entry.strip():
+            raise RuntimeError(
+                "retired-plugin registry {}: prefix {!r} must not carry surrounding "
+                "whitespace — re.escape would compile it into a pattern that never "
+                "matches".format(path, entry))
         if ":" in entry:
             raise RuntimeError(
                 "retired-plugin registry {}: prefix {!r} must not carry a colon — "

--- a/scripts/check-external-dispatch.py
+++ b/scripts/check-external-dispatch.py
@@ -1,11 +1,44 @@
 #!/usr/bin/env python3
 """check-external-dispatch.py — deterministic external-dispatch guard.
 
-Asserts that **no live-dispatch surface** dispatches the retired engines
-`cogni-wiki:` or `cogni-research:` anywhere in the repo. This is the machine
-proof behind the FMO archival decision: once cogni-research and cogni-wiki are
-archived (source kept, not installable), a live caller dispatching them would
-break at runtime. The guard makes that absence objective and regression-proof.
+Asserts that **no live-dispatch surface** dispatches a retired engine anywhere in
+the repo. This is the machine proof behind the archival decision: once a plugin is
+archived (source kept, not installable) or absorbed into another, a live caller
+dispatching it would break at runtime. The guard makes that absence objective and
+regression-proof.
+
+The retired set is **data, not source** — it lives in `scripts/retired-plugins.json`
+(override with `--registry`), so retiring another plugin is a one-line edit to that
+file rather than a regex edit here:
+
+    {"retired_prefixes": ["cogni-wiki", "cogni-research"]}
+
+Entries are BARE prefixes with no trailing colon — this script appends the colon that
+makes the token dispatch-shaped, and rejects a colon-bearing entry rather than
+compiling a `cogni-wiki::` pattern that would silently match nothing.
+
+The registry is **mandatory config, not an optional ratchet**: absent, unreadable,
+malformed, wrongly-typed or empty all exit 2. A guard that quietly loaded nothing and
+reported a clean zero would be worse than no guard, because CI would stay green while
+the invariant went unprotected.
+
+Two scoping choices, stated because the sibling guard next door made the opposite one:
+
+  - **Enumerated, not derived.** `check-plugin-inventory.py` deliberately avoids a
+    hand-maintained list of retired names, preferring a bijection that works without
+    being told any. That is the right shape *there*, where the live set is the datum.
+    Here the live set is not enough: `\bcogni-[a-z0-9-]+:` minus the installed plugins
+    would also flag every prose mention of a plugin that simply is not installed in
+    the reader's workspace, so the guard would fire on trees it should not. The cost
+    of enumerating is a registry that can go **stale** — a plugin retired without an
+    entry here is silently unguarded — and nothing detects that today. The retiring
+    change is expected to add its own entry; that expectation is the control.
+  - **Plugin-granular.** An entry is a whole plugin prefix, and this script appends
+    the colon. A retired *skill* on a live plugin (`cogni-x:some-skill`) therefore
+    cannot be expressed, and the loader rejects the colon-bearing entry a maintainer
+    would reach for rather than silently compiling `cogni-x::`, which would match
+    nothing. Widening to full dispatch tokens is a ~10-line change to `load_registry`
+    (validate the shape instead of manufacturing it) if that case ever arrives.
 
 Scope — the surfaces a running session actually dispatches FROM:
 
@@ -37,10 +70,10 @@ a lineage mention there ("modeled on the cogni-research verify-report skill") is
 not a caller.
 
 Unlike the breadcrumb guard, this guard targets a HARD clean-zero — there is no
-legitimate live `cogni-wiki:`/`cogni-research:` dispatch after archival, so the
-ratchet/baseline model is the wrong tool. The single escape hatch is a per-line
-marker for a genuine NON-dispatch prose mention that must keep the literal token
-(rare); state the rationale on the same line:
+legitimate live dispatch of a registered retired prefix, so the ratchet/baseline
+model is the wrong tool. The single escape hatch is a per-line marker for a genuine
+NON-dispatch prose mention that must keep the literal token (rare); state the
+rationale on the same line:
 
     ... see cogni-research:verify-report for the lineage  # external-dispatch-guard:allow
 
@@ -77,13 +110,60 @@ EXCLUDE_PREFIXES = ("cogni-knowledge/",)
 EXCLUDE_SEGMENTS = ("/wiki/", "/docs/")
 EXCLUDE_TOPLEVEL = ("wiki/", "docs/")
 
-# The dispatch-shaped token: `cogni-wiki:` / `cogni-research:` — the `plugin:`
-# half of a `plugin:skill` dispatch reference. A bare "cogni-research" (no
-# colon) is a plain noun and is NOT matched.
-DISPATCH_RE = re.compile(r"\bcogni-(wiki|research):")
+# Default registry location, resolved next to THIS script (never under --root, so
+# scanning a foreign tree still reads our own retired set). Override: --registry.
+REGISTRY_BASENAME = "retired-plugins.json"
 
 # Per-line escape hatch for a genuine non-dispatch prose mention.
 ALLOW_MARKER = "external-dispatch-guard:allow"
+
+
+def load_registry(path):
+    """Return the list of bare retired prefixes from the registry at `path`.
+
+    Every degenerate input raises RuntimeError, which main() renders as the exit-2
+    envelope — there is deliberately no empty-list fallback and no hardcoded default
+    set (see the module docstring for why).
+    """
+    if not os.path.exists(path):
+        raise RuntimeError("retired-plugin registry not found: {}".format(path))
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+    except (OSError, ValueError) as exc:
+        raise RuntimeError("bad retired-plugin registry {}: {}".format(path, exc))
+
+    prefixes = data.get("retired_prefixes") if isinstance(data, dict) else None
+
+    # Mutation-recipe invariant: keep the next line exactly as written, on ONE
+    # physical line, and do not repeat its text anywhere else in this file — the
+    # recorded recipe rewrites the FIRST match only (perl -0pi, no /g), so a second
+    # occurrence would mutate the wrong site and report the guard as decorative.
+    if not isinstance(prefixes, list) or not prefixes:
+        raise RuntimeError(
+            "retired-plugin registry {} must carry a non-empty "
+            "'retired_prefixes' list".format(path))
+
+    for entry in prefixes:
+        if not isinstance(entry, str) or not entry.strip():
+            raise RuntimeError(
+                "retired-plugin registry {}: every prefix must be a non-empty "
+                "string, got {!r}".format(path, entry))
+        if ":" in entry:
+            raise RuntimeError(
+                "retired-plugin registry {}: prefix {!r} must not carry a colon — "
+                "this guard appends it".format(path, entry))
+    return prefixes
+
+
+def compile_dispatch_re(prefixes):
+    r"""Compile `\b(?:prefix|…):` — the `plugin:` half of a dispatch reference.
+
+    The trailing colon is MANDATORY, so a bare "cogni-research" is a plain noun and
+    is NOT matched, and a hit's `match` is the full "cogni-research:".
+    """
+    return re.compile(
+        r"\b(?:" + "|".join(re.escape(p) for p in prefixes) + r"):")
 
 
 def discover_files(root):
@@ -109,7 +189,7 @@ def discover_files(root):
     return files
 
 
-def scan_file(abs_path, rel_path):
+def scan_file(abs_path, rel_path, dispatch_re):
     """Yield violation dicts for one file."""
     try:
         with open(abs_path, "r", encoding="utf-8") as fh:
@@ -120,7 +200,7 @@ def scan_file(abs_path, rel_path):
         line = raw.rstrip("\n")
         if ALLOW_MARKER in line:
             continue
-        for m in DISPATCH_RE.finditer(line):
+        for m in dispatch_re.finditer(line):
             yield {
                 "file": rel_path,
                 "line": lineno,
@@ -129,7 +209,7 @@ def scan_file(abs_path, rel_path):
             }
 
 
-def collect(root, explicit_files):
+def collect(root, explicit_files, dispatch_re):
     occ = []
     if explicit_files:
         pairs = []
@@ -143,7 +223,7 @@ def collect(root, explicit_files):
     else:
         pairs = [(os.path.join(root, rel), rel) for rel in discover_files(root)]
     for abs_path, rel in pairs:
-        occ.extend(scan_file(abs_path, rel))
+        occ.extend(scan_file(abs_path, rel, dispatch_re))
     return occ
 
 
@@ -154,13 +234,21 @@ def main(argv):
     ap.add_argument("--root", default=None,
                     help="repo root for discovery + relative paths "
                          "(default: parent of scripts/)")
+    ap.add_argument("--registry", default=None,
+                    help="retired-prefix registry JSON (default: {} next to this "
+                         "script). REPLACES the default file — it is not merged "
+                         "with it.".format(REGISTRY_BASENAME))
     args = ap.parse_args(argv)
 
     script_dir = os.path.dirname(os.path.abspath(__file__))
     root = os.path.abspath(args.root) if args.root else os.path.dirname(script_dir)
+    # Anchored on the script, never on --root: scanning a foreign tree must still
+    # read OUR retired set, not whatever that tree happens to ship.
+    registry_path = args.registry or os.path.join(script_dir, REGISTRY_BASENAME)
 
     try:
-        violations = collect(root, args.files)
+        retired = load_registry(registry_path)
+        violations = collect(root, args.files, compile_dispatch_re(retired))
     except RuntimeError as exc:
         print(json.dumps({"success": False, "data": {}, "error": str(exc)}))
         return 2
@@ -185,8 +273,10 @@ def main(argv):
     print(json.dumps(result, indent=2, ensure_ascii=False))
 
     if violations:
-        print("\nFAIL: {} live cogni-wiki:/cogni-research: dispatch(es) found "
-              "in live-dispatch surfaces:".format(len(violations)), file=sys.stderr)
+        print("\nFAIL: {} live {} dispatch(es) found "
+              "in live-dispatch surfaces:".format(
+                  len(violations), "/".join(p + ":" for p in retired)),
+              file=sys.stderr)
         for o in violations:
             print("  {}:{}: {}  ->  {}".format(
                 o["file"], o["line"], o["match"], o["context"]), file=sys.stderr)

--- a/scripts/retired-plugins.json
+++ b/scripts/retired-plugins.json
@@ -1,0 +1,7 @@
+{
+  "_comment": "Retired-plugin prefixes read by scripts/check-external-dispatch.py. To retire another plugin, add its prefix here — that is the whole change. Entries are bare prefixes with no trailing colon. Format, failure modes, and the scoping rationale: see that script's docstring.",
+  "retired_prefixes": [
+    "cogni-wiki",
+    "cogni-research"
+  ]
+}

--- a/tests/test_check_external_dispatch.sh
+++ b/tests/test_check_external_dispatch.sh
@@ -16,7 +16,7 @@
 #   R1. Missing registry     -> exit 2, never a silent clean-zero.
 #   R2. Malformed JSON       -> exit 2.
 #   R3. Empty prefix list    -> exit 2.
-#   R4. Non-string / blank / colon-bearing entry -> exit 2.
+#   R4. Non-string / blank / padded / colon-bearing entry -> exit 2.
 #   R5. A prefix added to the registry makes a planted dispatch fire -> exit 1.
 #   R6. --registry REPLACES the default file rather than unioning with it.
 #
@@ -269,13 +269,19 @@ run_reg r3 '{"retired_prefixes": []}' "$CLEAN_REL"
 check "R3 empty registry exits 2 and never 0 (base exits 0 here)" \
   "$([ "$CODE" -eq 2 ] && echo 0 || echo 1)"
 
-# --- R4: wrong type / non-string / blank / colon-bearing entry -> exit 2 ----
+# --- R4: wrong type / non-string / blank / padded / colon-bearing -> exit 2 -
+# The padded variant is the subtlest of the set: it survives the non-empty test
+# (it strips to a real prefix) but re.escape would compile the UNSTRIPPED text
+# into `\ \ cogni\-demo\ \ :`, which matches nothing — a clean-zero exit 0 from a
+# registry that looks populated. Rejecting mirrors the colon-bearing entry rather
+# than quietly repairing it.
 R4_FAILED=0
 R4_N=0
 for BAD in \
   '{"retired_prefixes": "cogni-wiki"}' \
   '{"retired_prefixes": ["cogni-wiki", 7]}' \
   '{"retired_prefixes": ["cogni-wiki", "   "]}' \
+  '{"retired_prefixes": ["cogni-wiki", "  cogni-demo  "]}' \
   '{"retired_prefixes": ["cogni-wiki:"]}' \
   '{"nothing_here": true}'
 do

--- a/tests/test_check_external_dispatch.sh
+++ b/tests/test_check_external_dispatch.sh
@@ -3,7 +3,7 @@
 #
 # The guard asserts a HARD clean-zero: no live-dispatch surface
 # (*/skills/*/SKILL.md, */agents/*.md, */commands/*.md, */hooks/**) may carry a
-# `cogni-wiki:` / `cogni-research:` dispatch token. Cases:
+# dispatch token for a prefix listed in scripts/retired-plugins.json. Cases:
 #   1. Negative controls (bare noun "cogni-research" with no colon) -> exit 0.
 #   2. Dispatch-laden fixture (cogni-wiki: + cogni-research:) -> exit 1, naming
 #      the file + line + match.
@@ -11,6 +11,22 @@
 #   4. Path exclusions (cogni-knowledge/ history, */wiki/ mirror) skipped in
 #      discover mode -> exit 0 even though the token is present.
 #   5. Real tree -> exit 0 (clean-zero today).
+#
+# Registry-loading cases (the retired set is data, not source):
+#   R1. Missing registry     -> exit 2, never a silent clean-zero.
+#   R2. Malformed JSON       -> exit 2.
+#   R3. Empty prefix list    -> exit 2.
+#   R4. Non-string / blank / colon-bearing entry -> exit 2.
+#   R5. A prefix added to the registry makes a planted dispatch fire -> exit 1.
+#   R6. --registry REPLACES the default file rather than unioning with it.
+#
+# R1-R4 are the anti-vacuity trio-plus-one: each asserts a NON-ZERO exit on an
+# input where a guard that ignored the registry would exit 0, so none of them can
+# pass against an implementation that does not actually load it. They reach that
+# state by staging a COPY of the guard with (or without) a sibling registry rather
+# than by passing --registry, precisely so the assertion is behavioural — a
+# --registry-based case would go red merely because an older argparse rejects the
+# unknown flag, which proves nothing about the load path.
 #
 # bash 3.2 + stdlib python3 only (+ git for the discover-mode exclusion case).
 
@@ -20,8 +36,14 @@ TESTS_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$TESTS_DIR/.." && pwd)"
 GUARD="$REPO_ROOT/scripts/check-external-dispatch.py"
 
-red()   { printf '\033[31m%s\033[0m\n' "$1"; }
-green() { printf '\033[32m%s\033[0m\n' "$1"; }
+# Plain, uncoloured result lines — unconditionally, matching the harness-parsable
+# suites elsewhere in the repo. A result line must start with the literal `PASS:` /
+# `FAIL:` so a mutation harness can classify it with `^[[:space:]]*FAIL:[[:space:]]+`;
+# an ANSI escape sequence precedes the label and defeats that match. Deciding by
+# `[ -t 1 ]` instead would make parsability environment-dependent — run the suite
+# under a pty and the colour, and the failure, come back.
+red()   { printf '%s\n' "$1"; }
+green() { printf '%s\n' "$1"; }
 
 FAILED=0
 check() {  # check <label> <condition-exit-code>
@@ -156,6 +178,144 @@ python3 "$GUARD" >/dev/null 2>&1
 CODE=$?
 set -e
 check "real tree passes clean-zero" "$([ "$CODE" -eq 0 ] && echo 0 || echo 1)"
+
+# ===========================================================================
+# Registry-loading cases (R1-R6).
+#
+# Case labels below are `<id> <description>` — an id token followed by a SPACE,
+# never a colon abutting the id. The mutation harness matches
+# `^[[:space:]]*FAIL:[[:space:]]+<case>([[:space:]]|$)` (and the ok|PASS twin)
+# whole-token, so `--case R3` matches `FAIL: R3 empty ...` while `--case 'R3:'`
+# would match neither line and return case_not_found instead of a verdict.
+# ===========================================================================
+
+# stage_guard <name> — copy the REAL guard into "$WORK/<name>/" and echo the path.
+# A copy, taken at run time, is what makes these cases meaningful under mutation:
+# a vendored snippet would keep testing a frozen implementation while the actual
+# script drifted. The staged copy's registry default resolves to its own sibling
+# "$WORK/<name>/retired-plugins.json", which the caller writes (or deliberately
+# omits) per case.
+stage_guard() {
+  mkdir -p "$WORK/$1"
+  cp "$GUARD" "$WORK/$1/check-external-dispatch.py"
+  printf '%s' "$WORK/$1/check-external-dispatch.py"
+}
+
+# run_reg <name> <registry-json|NONE> <rel-file> [extra guard args...] — stage a
+# guard copy, give it (or deny it) a sibling registry, run it, and leave the result
+# in $OUT / $CODE. Each case keeps its own check/assert_json label, so the per-case
+# `<id> <description>` targeting above is unaffected.
+run_reg() {
+  local g; g=$(stage_guard "$1")
+  [ "$2" = NONE ] || printf '%s' "$2" > "$WORK/$1/retired-plugins.json"
+  local rel="$3"; shift 3
+  set +e
+  OUT=$(python3 "$g" "$@" --root "$REG_TREE" "$rel" 2>/dev/null)
+  CODE=$?
+  set -e
+}
+
+# A clean live surface plus a planted one, shared by R1-R6. The clean file
+# deliberately carries an ordinary word-colon token (`name: demo` frontmatter):
+# under the empty-registry mutant the compiled alternation degenerates to
+# `\b(?:):`, which matches exactly that shape — so R3 goes red because the mutant
+# demonstrably fires, not incidentally because nothing was scanned.
+REG_TREE="$WORK/regtree"
+mkdir -p "$REG_TREE/cogni-demo/agents"
+cat > "$REG_TREE/cogni-demo/agents/clean.md" <<'EOF'
+---
+name: demo
+---
+Dispatches cogni-knowledge:knowledge-query only.
+EOF
+cat > "$REG_TREE/cogni-demo/agents/planted.md" <<'EOF'
+---
+name: planted
+---
+First the agent dispatches cogni-demo:demo-skill to read the base.
+EOF
+CLEAN_REL="cogni-demo/agents/clean.md"
+PLANTED_REL="cogni-demo/agents/planted.md"
+
+# --- R1: missing registry -> exit 2, never a silent clean-zero -------------
+# Also proves the default registry path follows __file__ and not --root: --root
+# points at REG_TREE, which has no registry, and the staged dir has none either.
+run_reg r1 NONE "$CLEAN_REL"
+check "R1 missing registry exits 2 (base exits 0 here)" \
+  "$([ "$CODE" -eq 2 ] && echo 0 || echo 1)"
+assert_json "R1 missing registry reports success:false and names the path" "$OUT" "
+import json,sys
+d=json.load(sys.stdin)
+assert d['success'] is False, d
+assert d['error'], d
+assert 'retired-plugins.json' in d['error'], d['error']
+"
+
+# --- R2: malformed JSON -> exit 2 ------------------------------------------
+run_reg r2 '{"retired_prefixes": ["cogni-wiki",' "$CLEAN_REL"
+check "R2 malformed registry JSON exits 2 (base exits 0 here)" \
+  "$([ "$CODE" -eq 2 ] && echo 0 || echo 1)"
+assert_json "R2 malformed registry reports success:false with a non-empty error" "$OUT" "
+import json,sys
+d=json.load(sys.stdin)
+assert d['success'] is False, d
+assert d['error'], d
+"
+
+# --- R3: empty prefix list -> exit 2 ---------------------------------------
+# Kept as its own case rather than folded into R4's table: the recorded mutation
+# recipe targets `--case R3`, which needs a separately-labelled line.
+run_reg r3 '{"retired_prefixes": []}' "$CLEAN_REL"
+check "R3 empty registry exits 2 and never 0 (base exits 0 here)" \
+  "$([ "$CODE" -eq 2 ] && echo 0 || echo 1)"
+
+# --- R4: wrong type / non-string / blank / colon-bearing entry -> exit 2 ----
+R4_FAILED=0
+R4_N=0
+for BAD in \
+  '{"retired_prefixes": "cogni-wiki"}' \
+  '{"retired_prefixes": ["cogni-wiki", 7]}' \
+  '{"retired_prefixes": ["cogni-wiki", "   "]}' \
+  '{"retired_prefixes": ["cogni-wiki:"]}' \
+  '{"nothing_here": true}'
+do
+  R4_N=$((R4_N + 1))
+  run_reg "r4_$R4_N" "$BAD" "$CLEAN_REL"
+  [ "$CODE" -eq 2 ] || R4_FAILED=1
+done
+check "R4 degenerate registry entries all exit 2 ($R4_N variants)" "$R4_FAILED"
+
+# --- R5: a prefix added to the registry makes a planted dispatch fire -------
+# The data-driven proof: base's hardcoded regex knows nothing of cogni-demo.
+run_reg r5 '{"retired_prefixes": ["cogni-wiki", "cogni-research", "cogni-demo"]}' \
+  "$PLANTED_REL"
+check "R5 registry-added prefix fires on a planted dispatch (exit 1)" \
+  "$([ "$CODE" -eq 1 ] && echo 0 || echo 1)"
+assert_json "R5 registry-added prefix reports match cogni-demo: with file+line" "$OUT" "
+import json,sys
+d=json.load(sys.stdin)
+v=d['data']['violations']
+assert d['success'] is False, d
+got={(x['match'],x['line'],x['file']) for x in v}
+assert ('cogni-demo:',4,'cogni-demo/agents/planted.md') in got, got
+"
+
+# --- R6: --registry REPLACES the default file, never unions with it ---------
+# The staged copy's sibling registry lists cogni-demo; the override does not.
+# Doubles as the negative control that the compiled alternation is not over-broad.
+mkdir -p "$WORK/r6"
+printf '%s' '{"retired_prefixes": ["cogni-wiki", "cogni-research"]}' \
+  > "$WORK/r6/override.json"
+run_reg r6 '{"retired_prefixes": ["cogni-wiki", "cogni-research", "cogni-demo"]}' \
+  "$PLANTED_REL" --registry "$WORK/r6/override.json"
+check "R6 --registry replaces the default set rather than unioning (exit 0)" \
+  "$([ "$CODE" -eq 0 ] && echo 0 || echo 1)"
+assert_json "R6 override set reports zero violations on the planted file" "$OUT" "
+import json,sys
+d=json.load(sys.stdin)
+assert d['success'] is True, d
+assert d['data']['summary']['total']==0, d['data']['summary']
+"
 
 echo ""
 if [ "$FAILED" -eq 0 ]; then


### PR DESCRIPTION
Closes #1346.

## Summary

`scripts/check-external-dispatch.py` hardcoded the retired set in a single regex
(`DISPATCH_RE = re.compile(r"\bcogni-(wiki|research):")`), so every absorption meant
editing Python in the one place that must not be got wrong. This PR moves the retired
set into `scripts/retired-plugins.json` and compiles the same pattern from it at
runtime — retiring another plugin is now a one-line data edit.

- **The registry is mandatory config, not best-effort.** Missing, malformed, empty, or
  wrongly-typed all raise into the existing `{"success": false, "data": {}, "error": …}`
  envelope and exit **2**. There is no `except: return []`, no hardcoded fallback list,
  and no path on which the guard scans for nothing and exits 0. A guard that passes
  because it loaded nothing is worse than no guard — CI stays green while the invariant
  goes unprotected — so this follows the `check-plugin-inventory.py` mandatory-file
  precedent rather than `check-breadcrumbs.py`'s silent-empty-on-missing baseline load.
  (It does mirror `check-breadcrumbs.py` for the `__file__`-anchored default path and
  the override-flag shape.)
- **Token semantics are identical to base:** leading `\b`, `re.escape`d alternation,
  mandatory trailing colon. A bare `cogni-research` noun still does not match, and a
  hit's `match` is still the full `cogni-wiki:`.
- **Unchanged:** the per-line `# external-dispatch-guard:allow` escape hatch,
  `DEFAULT_GLOBS`, `EXCLUDE_PREFIXES` / `EXCLUDE_SEGMENTS` / `EXCLUDE_TOPLEVEL`, the JSON
  envelope, and the 0/1/2 exit contract.
- **CI behaviour unchanged.** Only the step name at `.github/workflows/lint.yml:35` is
  reworded; the job name (line 27) was already registry-neutral. The run body still uses
  `set -euo pipefail` + `python3 scripts/check-external-dispatch.py` with no `|| true`,
  no `continue-on-error` and no rc capture — so exit 2 still fails the build.
- The stderr FAIL banner is rendered from the loaded registry, so a newly-registered
  prefix names itself in CI output for free.

## Scope decisions

**Four files only:** `scripts/retired-plugins.json` (new), `scripts/check-external-dispatch.py`,
`tests/test_check_external_dispatch.sh`, `.github/workflows/lint.yml`. No `cogni-*/` tree
is touched, no other `lint.yml` job, no other `scripts/*.py`, and no `version` field
anywhere (the post-merge workflow owns the bump).

Repo-root `CLAUDE.md` / `README.md` are deliberately untouched: the guard has zero
mentions in either today, so documenting the registry there would widen the change. The
how-to-add-a-prefix instruction lives in the script docstring and the registry's own
`_comment`, which is where the next absorber already looks.

**Two scoping choices are documented in the docstring** because the sibling guard next
door made the opposite one, and a reader deserves to see that reconciled rather than
discover it:

- *Enumerated, not derived.* `check-plugin-inventory.py` explicitly avoids a
  hand-maintained list of retired names. That is right there, where the live set is the
  datum; here a derived `\bcogni-[a-z0-9-]+:` minus the installed plugins would also
  flag prose mentions of any plugin not installed in the reader's workspace. The cost of
  enumerating is honestly stated: the registry can go **stale**, and nothing detects
  that — the retiring change is expected to add its own entry, and that expectation is
  the control.
- *Plugin-granular.* An entry is a whole plugin prefix and the script appends the colon,
  so a retired *skill* on a live plugin cannot be expressed today. A colon-bearing entry
  is rejected loudly rather than compiling `cogni-wiki::`, which would silently match
  nothing. Widening to full dispatch tokens is a ~10-line change if that case arrives.

**One judgement call worth a reviewer's eye:** the suite's `PASS:`/`FAIL:` emitters
dropped ANSI colour. The base wrapped every result line in escape codes, which no
`^[[:space:]]*FAIL:` matcher can satisfy — so the suite could not have its teeth
verified at all. A `[ -t 1 ]` conditional was considered and rejected: it makes
parsability environment-dependent, and under a pty the colour and the failure both come
back through a channel nothing tests. Plain output matches the harness-parsable suites
already in the repo (`cogni-consult/tests/test_reference_pointers.sh`,
`cogni-visual/tests/test-arc-taxonomy-sync.sh`). Cases 1-5 keep their behaviour and
labels; the `FAILED` flag, `check()`, `assert_json()`, `mktemp -d` and cleanup trap are
all preserved.

## Test plan

`bash tests/test_check_external_dispatch.sh` — cases 1-5 unchanged, plus six registry
cases. Each new case is labelled `<id> <description>` — an id token followed by a space,
never a colon abutting the id — so one `--case` value matches both its `PASS:` and
`FAIL:` line.

R1-R5 stage a **copy** of the guard (`cp` from the suite's `$GUARD` at run time, so a
mutation to the real script reaches them) under `$WORK/<name>/` with an optional sibling
registry, and invoke it **without** `--registry`. That is what makes them honestly red
against the base implementation: base ignores the registry and exits 0 on these
invocations, so an exit-2 assertion fails. Passing `--registry` instead would have made
base argparse exit 2 and the cases *vacuously green*.

| Case | Setup | Expected | Against base |
|---|---|---|---|
| R1 | staged copy, no sibling registry | exit 2, `success:false`, error names the path (also proves the default path follows `__file__`, not `--root`) | RED — base exits 0 |
| R2 | sibling registry is malformed JSON | exit 2 | RED — base exits 0 |
| R3 | sibling registry is `{"retired_prefixes": []}` | exit 2, asserted on the exit code | RED — base exits 0 |
| R4 | 6 degenerate variants: wrong type, non-string entry, blank entry, **whitespace-padded entry**, colon-bearing entry, missing key | exit 2 each | RED — base exits 0 |
| R5 | registry lists `cogni-wiki`, `cogni-research`, `cogni-demo`; input plants a `cogni-demo:` dispatch | exit 1, `match == "cogni-demo:"` | RED — base's hardcoded regex ignores `cogni-demo` |
| R6 | sibling registry lists `cogni-demo`, but `--registry` points at a fixture omitting it | exit 0 — the override **replaces** rather than unions, and doubles as the not-over-broad control | red only because base argparse rejects `--registry`; stated rather than claimed as evidence |

R1-R3 are the anti-vacuity trio the acceptance contract requires red against base, and
all three are red for a behavioural reason. R3's scanned fixture deliberately carries an
ordinary word-colon token (`name: demo`) so that under the empty-registry mutant the
degenerate `\b(?:):` alternation demonstrably fires.

Verified on this branch:

- [x] `python3 scripts/check-external-dispatch.py` → exit 0, `success: true`, `total: 0` on the real tree
- [x] `bash tests/test_check_external_dispatch.sh` → exit 0, all 19 assertions pass (R4 now covers 6 variants)
- [x] `python3 scripts/run-plugin-tests.py` → **all 106 suites pass**
- [x] `check-breadcrumbs.py` and `check-plugin-inventory.py` → exit 0
- [x] Base implementation re-run against the R-case invocations → exit 0 in both, confirming R1-R5 are genuinely red against base
- [x] Mutation recipe below → `verdict: guard_verified`

## Mutation recipe

Proves the empty-registry guard is load-bearing rather than decorative: remove the
empty-registry clause and case **R3** must go red, then green again on restore.

```
bash <YOUR-MARKETPLACE>/cogni-service/scripts/mutation-check.sh \
  --root <ABSOLUTE-PATH-OF-YOUR-CHECKOUT-OF-THIS-BRANCH> \
  --file scripts/check-external-dispatch.py \
  --expr 's/ or not prefixes:/:/' \
  --test 'bash tests/test_check_external_dispatch.sh' \
  --case R3
```

Expected: `data.mutated_result: "red"`, `data.restored_result: "green"`,
`data.verdict: "guard_verified"` — confirmed on this branch.

**What to substitute — two paths, and only two.** `--root` takes the absolute path of
*your* checkout carrying this branch (`gh pr checkout`, then `pwd`); the harness never
infers it and runs `--test` with `cwd=--root`, so `--file` and `--test` are relative to
it and paste unchanged. `<YOUR-MARKETPLACE>` is your installed `cogni-service` path.
Run it on a clean tree — the harness edits in place and restores afterwards.

**Why the expression is safe.** It deletes only the empty-registry clause from the single
line `if not isinstance(prefixes, list) or not prefixes:`, leaving
`if not isinstance(prefixes, list):` — still valid Python, so the mutant imports and
every other case keeps running. (A mutant that failed to import would turn *every* case
red and launder a false "guard verified".) The replacement `:` does not contain the
literal it replaces, so the substitution cannot re-satisfy the guard.

**Two invariants a later edit must not break** — both are pinned as in-line comments at
their sites so this recipe stays executable:

- The literal `" or not prefixes:"` occurs **exactly once** in
  `scripts/check-external-dispatch.py`, on one physical line. `mutation-check.sh` applies
  `perl -0pi` with **no** `/g`, so a second occurrence would mutate the wrong site and
  the case would stay green — reported as "guard not load-bearing" when it is.
- Case ids are `R3`, not `R3:`. The harness classifies with
  `^[[:space:]]*FAIL:[[:space:]]+<case>([[:space:]]|$)` whole-token; since the suite emits
  `FAIL: R3 empty registry …`, passing `--case 'R3:'` matches neither line and returns
  `case_not_found` instead of a verdict.

## Follow-up issues

- #1357 — Repo-root test suites emit ANSI-wrapped `PASS:`/`FAIL:`, defeating
  mutation-harness parsing. The emitters were fixed here for the one suite this change
  needed to be mutation-testable; five other repo-root suites (and ~17 under
  `cogni-knowledge/tests/`) still carry the pattern. Widening that sweep into this PR
  would breach the acceptance contract's scope boundary, so it is tracked separately.

- #1366 — CI gate jobs can vanish silently: no suite parses the workflow YAML, and a
  workflow-load failure never reaches the PR check surface. Raised as a waived advisory
  on this PR's review; filed separately rather than swept in, since a real fix needs a
  stdlib-vs-PyYAML decision and the surfacing half is a config question, not a test.

Nothing in #1346's own acceptance criteria is deferred — this PR ships full scope.

---

## Review-fix pass (commit `85f66987`)

Two findings from the BLOCK verdict, both closed. Same four files — no scope widening.

**Critical — `.github/workflows/lint.yml:35` took all four gate jobs offline.** The step
name was an unquoted YAML plain scalar carrying a colon-space, so `yaml.safe_load` raised
`ScannerError` at line 35 col 74 and Actions could not load the workflow at all. Reworded
to `(registry scripts/retired-plugins.json)` rather than quoted, so a later edit cannot
re-break it, with a comment at the site explaining why. Confirmed on the new head: the
`Lint` run now materialises **all four jobs** where the previous run died in 0s.

This is also what re-grades review-contract item 6. The `run:` body was always correct —
`set -euo pipefail`, no `|| true`, no rc capture — but the job never executed, so the
build-failure guarantee was never exercised. It is now satisfied *on execution*, not on
reading.

**Minor — padded registry entries compiled to a pattern that never matches.**
`load_registry` tested emptiness with `entry.strip()` but fed the unstripped entry into
`re.escape`, so `{"retired_prefixes": ["  cogni-demo  "]}` returned `success:true`,
`total: 0`, exit 0 against a real `cogni-demo:` dispatch — the exact silent vacuity the
module docstring promises the registry prevents. Now rejected loudly, mirroring the
colon-bearing rejection rather than quietly repairing the entry, and pinned as R4's sixth
variant. The reviewer's reproduction returns exit 2.

Re-verified on the new head: guard clean-zero on the real tree · suite 19/19 with R4 at 6
variants · **all 106 plugin suites pass** · `check-breadcrumbs.py` and
`check-plugin-inventory.py` exit 0 · `mutation-check.sh --case R3` still returns
`guard_verified`. The mutation-recipe invariant holds — `" or not prefixes:"` still occurs
exactly once, on one physical line.
