### PR TITLE
repo-root tests: emit plain PASS:/FAIL: result lines

### DIFF
--- a/tests/test_apply_version_bump.sh
+++ b/tests/test_apply_version_bump.sh
@@ -29,8 +29,10 @@ TESTS_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$TESTS_DIR/.." && pwd)"
 BUMPER="$REPO_ROOT/scripts/apply-version-bump.py"
 
-red()   { printf '\033[31m%s\033[0m\n' "$1"; }
-green() { printf '\033[32m%s\033[0m\n' "$1"; }
+# Plain text on purpose — result lines are machine-read; tooling anchors a
+# literal PASS:/FAIL: prefix. Emit unconditionally, never probe the environment.
+red()   { printf '%s\n' "$1"; }
+green() { printf '%s\n' "$1"; }
 
 FAILED=0
 check() {  # check <label> <condition-exit-code>

--- a/tests/test_check_breadcrumbs.sh
+++ b/tests/test_check_breadcrumbs.sh
@@ -19,8 +19,10 @@ TESTS_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$TESTS_DIR/.." && pwd)"
 GUARD="$REPO_ROOT/scripts/check-breadcrumbs.py"
 
-red()   { printf '\033[31m%s\033[0m\n' "$1"; }
-green() { printf '\033[32m%s\033[0m\n' "$1"; }
+# Plain text on purpose — result lines are machine-read; tooling anchors a
+# literal PASS:/FAIL: prefix. Emit unconditionally, never probe the environment.
+red()   { printf '%s\n' "$1"; }
+green() { printf '%s\n' "$1"; }
 
 FAILED=0
 check() {  # check <label> <condition-exit-code>

--- a/tests/test_check_plugin_inventory.sh
+++ b/tests/test_check_plugin_inventory.sh
@@ -21,8 +21,10 @@ TESTS_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$TESTS_DIR/.." && pwd)"
 GUARD="$REPO_ROOT/scripts/check-plugin-inventory.py"
 
-red()   { printf '\033[31m%s\033[0m\n' "$1"; }
-green() { printf '\033[32m%s\033[0m\n' "$1"; }
+# Plain text on purpose — result lines are machine-read; tooling anchors a
+# literal PASS:/FAIL: prefix. Emit unconditionally, never probe the environment.
+red()   { printf '%s\n' "$1"; }
+green() { printf '%s\n' "$1"; }
 
 FAILED=0
 check() {  # check <label> <condition-exit-code>

--- a/tests/test_check_version_bump.sh
+++ b/tests/test_check_version_bump.sh
@@ -37,8 +37,10 @@ TESTS_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$TESTS_DIR/.." && pwd)"
 GATE="$REPO_ROOT/scripts/check-version-bump.py"
 
-red()   { printf '\033[31m%s\033[0m\n' "$1"; }
-green() { printf '\033[32m%s\033[0m\n' "$1"; }
+# Plain text on purpose — result lines are machine-read; tooling anchors a
+# literal PASS:/FAIL: prefix. Emit unconditionally, never probe the environment.
+red()   { printf '%s\n' "$1"; }
+green() { printf '%s\n' "$1"; }
 
 FAILED=0
 check() {  # check <label> <condition-exit-code>

--- a/tests/test_run_plugin_tests.sh
+++ b/tests/test_run_plugin_tests.sh
@@ -32,8 +32,10 @@ TESTS_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$TESTS_DIR/.." && pwd)"
 RUNNER="$REPO_ROOT/scripts/run-plugin-tests.py"
 
-red()   { printf '\033[31m%s\033[0m\n' "$1"; }
-green() { printf '\033[32m%s\033[0m\n' "$1"; }
+# Plain text on purpose — result lines are machine-read; tooling anchors a
+# literal PASS:/FAIL: prefix. Emit unconditionally, never probe the environment.
+red()   { printf '%s\n' "$1"; }
+green() { printf '%s\n' "$1"; }
 
 FAILED=0
 check() {  # check <label> <condition-exit-code>


### PR DESCRIPTION
Closes #1357.

## Summary

The five repo-root suites defined their result emitters as `printf '\033[31m%s\033[0m\n'`, so an emitted line was `\033[31mFAIL: <case>\033[0m` rather than `FAIL: <case>`. A harness anchoring `^[[:space:]]*FAIL:[[:space:]]+<case>` matched neither the red nor the green arm and reported `case_not_found` instead of a verdict — meaning these suites could not have their teeth verified at all.

This rewrites the two function bodies to `printf '%s\n'` in each of the five suites, and adds a two-line comment recording why the format is plain and unconditional.

**The helper names and signatures are kept deliberately.** Each helper has **four** call sites per suite, not two: `check()` uses both, and the end-of-run summary calls both again (measured: every suite reports 4). Deleting the helpers and inlining `printf` at the `check()` sites would orphan the summary calls and abort each suite under `set -eu` — *after* every case line had already printed, so the output would still read as normal at a glance.

No output-format branching is introduced. The emitters print identical bytes to a pipe, a file, and a pty. A TTY-conditional emitter was rejected upstream because it makes parsability environment-dependent — the colour returns under `script(1)` through a channel nothing tests.

No `plugin.json` / `marketplace.json` version change; the post-merge workflow owns the bump.

## Sequencing against open PR #1358 — please read before grading AC1

Issue #1357's Scope says `tests/test_check_external_dispatch.sh` "was fixed in passing while resolving #1346, and is the reference shape". **That is not true of `main`.** It is true only on the unmerged branch of **PR #1358**, which contains exactly the two-line hunk converting it. On `main` all **six** repo-root suites carried the ANSI pair, not five — the issue was authored from #1358's branch and describes that branch's post-merge world.

That file is therefore **intentionally untouched here**: editing the same two lines a concurrent open PR already owns would guarantee a conflict between two open PRs.

Consequence for **AC1** ("*every* repo-root `tests/*.sh` suite"): it is satisfied for everything this PR owns, and becomes literally true repo-wide the moment #1358 merges. The review contract committed on the issue rules the untouched sixth file compliant and states this explicitly.

## Scope decisions

**In:** the five suites that still emitted ANSI-wrapped result lines — `tests/test_apply_version_bump.sh`, `tests/test_check_breadcrumbs.sh`, `tests/test_check_plugin_inventory.sh`, `tests/test_check_version_bump.sh`, `tests/test_run_plugin_tests.sh`.

**Out, with reasons:**

- `tests/test_check_external_dispatch.sh` — owned by open PR #1358; see above.
- The 16 `cogni-knowledge/tests/` suites and `cogni-knowledge/tests/fixtures/test_helpers.sh` — same defect, but the ACs scope to repo-root. Filed as #1359.
- A repo-wide guard forbidding escapes before `PASS:`/`FAIL:` — it would be red against the sixth suite for as long as #1358 sits unmerged, turning a green change red for reasons outside this diff. Deferred into #1359, which records the dependency rather than adding an exclusion marker someone must remember to delete.
- A shared repo-root emitter helper — rejected: the five suites' `check()` bodies diverge in failure accounting (`FAILED=$((FAILED + 1))` in two, `FAILED=1` in three), so a shared helper would have to change failure-count semantics in some of them — a behavioural change inside a purely mechanical fix.

## Verification

All run on the PR head.

| Check | Result |
|---|---|
| `bash tests/<suite>` × 5 | exit 0 each, summary line printed (proves the summary call sites still resolve) |
| `python3 scripts/run-plugin-tests.py` (AC3) | exit 0 — **all 107 suites passed** |
| `grep -c '033\[' tests/*.sh` (AC1) | `0` for all five converted suites; `2` only in the #1358-owned file |
| `grep -rEn 'tput\|NO_COLOR\|CLICOLOR\|-t 1' tests/` (AC2) | no matches |
| `cat -v` raw-byte proof | result lines begin `PASS: ` at column 0, no `^[` anywhere on the line — **literal captured output below** |

A note on that AC2 grep, because it caught a real trap during authoring: the ordinary word **"output" contains the substring `tput`**, so the added comment deliberately says "result lines" instead. Worth knowing before editing these files.

### Raw-byte evidence — literal `cat -v` capture

Recorded because a summary assertion is not the evidence: this is the actual byte-level
output, not a restatement of it.

`bash tests/test_check_breadcrumbs.sh | cat -v` on the PR head (`e0145b33`), verbatim:

```
PASS: negative controls exit 0
PASS: negative controls report zero violations
PASS: breadcrumb fixture exits 1
PASS: breadcrumb fixture names every token with correct file+line
PASS: inline-allow line exits 0
PASS: inline-allow suppresses the M2 match
PASS: real tree passes against committed baseline

All breadcrumb-guard tests passed.
```

Every result line starts `PASS: ` at column 0; `cat -v` renders no `^[` anywhere.

**The same capture on the base tree (`19e6c1a7`), as a control** — so the check above is
demonstrably non-vacuous rather than a probe that would pass either way:

```
^[[32mPASS: negative controls exit 0^[[0m
^[[32mPASS: negative controls report zero violations^[[0m
^[[32mPASS: breadcrumb fixture exits 1^[[0m
```

All five converted suites, counted from the same `cat -v` rendering:

| Suite | exit | result lines at column 0 (head) | lines containing `^[` (head) | lines containing `^[` (base) |
|---|---|---|---|---|
| `tests/test_apply_version_bump.sh` | 0 | 18 | 0 | 19 |
| `tests/test_check_breadcrumbs.sh` | 0 | 7 | 0 | 8 |
| `tests/test_check_plugin_inventory.sh` | 0 | 12 | 0 | 13 |
| `tests/test_check_version_bump.sh` | 0 | 12 | 0 | 13 |
| `tests/test_run_plugin_tests.sh` | 0 | 13 | 0 | 14 |

Base shows **0** column-0 result lines across all five suites, head shows **0** escape
sequences across all five — the two columns invert exactly, which is the change this PR makes.

## Mutation recipe (AC4)

Harness is the plugin-shipped `scripts/mutation-check.sh` under `${CLAUDE_PLUGIN_ROOT}` — not a repo file, and a same-named harness with a different argument contract exists elsewhere, so this is the five-flag form.

```bash
bash "${CLAUDE_PLUGIN_ROOT}/scripts/mutation-check.sh" \
  --root . \
  --file scripts/check-breadcrumbs.py \
  --expr 's/breadcrumb-guard:allow/mutation-marker-disabled/g' \
  --test 'bash tests/test_check_breadcrumbs.sh' \
  --case 'inline-allow line exits 0'
```

**Result on this branch:** `"verdict": "guard_verified"` — `mutated_result: red`, `restored_result: green`.

**The counterfactual is the real evidence.** The identical recipe, same `--case`, same `--expr`, run against an unconverted tree:

```
error: case_not_found: no 'FAIL: inline-allow line exits 0' and no
'ok:/PASS: inline-allow line exits 0' line in the mutated test output.
```

Same guard, same case, same expression — the only difference is the emitter format. That is the defect this PR fixes, reproduced and then closed.

Why the recipe is shaped this way: `--expr` is a single-quoted `perl -0pi` substitution (never a `sed`-style `/.../d`, which hard-errors as `expr_no_op`); the replacement `mutation-marker-disabled` is disjoint from the matched literal `breadcrumb-guard:allow`, so the mutated tree genuinely diverges rather than staying green; and `--case 'inline-allow line exits 0'` reproduces verbatim the label printed at `tests/test_check_breadcrumbs.sh:129`. Both literals were confirmed present on `origin/main` before the recipe was written.

## Follow-up issues

- #1359 — `cogni-knowledge` test suites and their shared helper still emit ANSI-wrapped `PASS:`/`FAIL:`; no guard prevents regression. Carries the larger share of the same defect (~17 files vs the 5 here) plus the regression guard, with its dependency on #1358 recorded.
