### PR TITLE
cogni-knowledge: plain PASS:/FAIL: emitters in tests and shared helper

### DIFF
--- a/cogni-knowledge/tests/README.md
+++ b/cogni-knowledge/tests/README.md
@@ -39,7 +39,10 @@ via `trap rm -rf "$WORK" EXIT`.
 
 - bash 3.2 + python3 stdlib only (no pytest, no pip).
 - `set -eu` at the top; exit non-zero on any failure.
-- Color helpers `red`/`green` for human-readable output.
+- Source `fixtures/test_helpers.sh` for `red`/`green` rather than inlining
+  them, so a `PASS:`/`FAIL:` label stays machine-parsable — plain, never
+  wrapped in an escape sequence and never chosen by an environment probe.
+  `test_plain_result_emitters.sh` holds this shape.
 - `assert_grep <pattern> <description>` for contract-level SKILL.md checks.
 - Real Python harness (inline `python3 - <<PY ... PY` heredoc) for
   script-level assertions.

--- a/cogni-knowledge/tests/fixtures/test_helpers.sh
+++ b/cogni-knowledge/tests/fixtures/test_helpers.sh
@@ -12,8 +12,8 @@
 #
 # Bash 3.2 compatible.
 
-red()   { printf '\033[31m%s\033[0m\n' "$1"; }
-green() { printf '\033[32m%s\033[0m\n' "$1"; }
+red()   { printf '%s\n' "$1"; }
+green() { printf '%s\n' "$1"; }
 
 # assert_grep PATTERN FILE DESCRIPTION
 #   Increments the caller's `errors` variable on failure.

--- a/cogni-knowledge/tests/test_binding_project_path.sh
+++ b/cogni-knowledge/tests/test_binding_project_path.sh
@@ -22,8 +22,8 @@ set -eu
 PLUGIN_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 SCRIPT="$PLUGIN_ROOT/scripts/knowledge-binding.py"
 
-red()   { printf '\033[31m%s\033[0m\n' "$1"; }
-green() { printf '\033[32m%s\033[0m\n' "$1"; }
+red()   { printf '%s\n' "$1"; }
+green() { printf '%s\n' "$1"; }
 
 if [ ! -f "$SCRIPT" ]; then
   red "FAIL: knowledge-binding.py not found at $SCRIPT"

--- a/cogni-knowledge/tests/test_cycle_guard_clear.sh
+++ b/cogni-knowledge/tests/test_cycle_guard_clear.sh
@@ -17,8 +17,8 @@ SCRIPT="$PLUGIN_ROOT/scripts/cycle-guard.py"
 
 . "$TESTS_DIR/fixtures/_cycle_guard_lib.sh"
 
-red()   { printf '\033[31m%s\033[0m\n' "$1"; }
-green() { printf '\033[32m%s\033[0m\n' "$1"; }
+red()   { printf '%s\n' "$1"; }
+green() { printf '%s\n' "$1"; }
 
 WORK=$(mktemp -d)
 trap 'rm -rf "$WORK"' EXIT

--- a/cogni-knowledge/tests/test_cycle_guard_depth_bound.sh
+++ b/cogni-knowledge/tests/test_cycle_guard_depth_bound.sh
@@ -17,8 +17,8 @@ SCRIPT="$PLUGIN_ROOT/scripts/cycle-guard.py"
 
 . "$TESTS_DIR/fixtures/_cycle_guard_lib.sh"
 
-red()   { printf '\033[31m%s\033[0m\n' "$1"; }
-green() { printf '\033[32m%s\033[0m\n' "$1"; }
+red()   { printf '%s\n' "$1"; }
+green() { printf '%s\n' "$1"; }
 
 WORK=$(mktemp -d)
 trap 'rm -rf "$WORK"' EXIT

--- a/cogni-knowledge/tests/test_cycle_guard_direct.sh
+++ b/cogni-knowledge/tests/test_cycle_guard_direct.sh
@@ -19,8 +19,8 @@ SCRIPT="$PLUGIN_ROOT/scripts/cycle-guard.py"
 # shellcheck source=fixtures/_cycle_guard_lib.sh
 . "$TESTS_DIR/fixtures/_cycle_guard_lib.sh"
 
-red()   { printf '\033[31m%s\033[0m\n' "$1"; }
-green() { printf '\033[32m%s\033[0m\n' "$1"; }
+red()   { printf '%s\n' "$1"; }
+green() { printf '%s\n' "$1"; }
 
 WORK=$(mktemp -d)
 trap 'rm -rf "$WORK"' EXIT

--- a/cogni-knowledge/tests/test_cycle_guard_distilled.sh
+++ b/cogni-knowledge/tests/test_cycle_guard_distilled.sh
@@ -26,8 +26,8 @@ SCRIPT="$PLUGIN_ROOT/scripts/cycle-guard.py"
 
 . "$TESTS_DIR/fixtures/_cycle_guard_lib.sh"
 
-red()   { printf '\033[31m%s\033[0m\n' "$1"; }
-green() { printf '\033[32m%s\033[0m\n' "$1"; }
+red()   { printf '%s\n' "$1"; }
+green() { printf '%s\n' "$1"; }
 
 errors=0
 

--- a/cogni-knowledge/tests/test_cycle_guard_dry_run.sh
+++ b/cogni-knowledge/tests/test_cycle_guard_dry_run.sh
@@ -17,8 +17,8 @@ SCRIPT="$PLUGIN_ROOT/scripts/cycle-guard.py"
 
 . "$TESTS_DIR/fixtures/_cycle_guard_lib.sh"
 
-red()   { printf '\033[31m%s\033[0m\n' "$1"; }
-green() { printf '\033[32m%s\033[0m\n' "$1"; }
+red()   { printf '%s\n' "$1"; }
+green() { printf '%s\n' "$1"; }
 
 WORK=$(mktemp -d)
 trap 'rm -rf "$WORK"' EXIT

--- a/cogni-knowledge/tests/test_cycle_guard_not_applicable.sh
+++ b/cogni-knowledge/tests/test_cycle_guard_not_applicable.sh
@@ -17,8 +17,8 @@ SCRIPT="$PLUGIN_ROOT/scripts/cycle-guard.py"
 
 . "$TESTS_DIR/fixtures/_cycle_guard_lib.sh"
 
-red()   { printf '\033[31m%s\033[0m\n' "$1"; }
-green() { printf '\033[32m%s\033[0m\n' "$1"; }
+red()   { printf '%s\n' "$1"; }
+green() { printf '%s\n' "$1"; }
 
 WORK=$(mktemp -d)
 trap 'rm -rf "$WORK"' EXIT

--- a/cogni-knowledge/tests/test_cycle_guard_question.sh
+++ b/cogni-knowledge/tests/test_cycle_guard_question.sh
@@ -25,8 +25,8 @@ SCRIPT="$PLUGIN_ROOT/scripts/cycle-guard.py"
 
 . "$TESTS_DIR/fixtures/_cycle_guard_lib.sh"
 
-red()   { printf '\033[31m%s\033[0m\n' "$1"; }
-green() { printf '\033[32m%s\033[0m\n' "$1"; }
+red()   { printf '%s\n' "$1"; }
+green() { printf '%s\n' "$1"; }
 
 errors=0
 

--- a/cogni-knowledge/tests/test_cycle_guard_transitive.sh
+++ b/cogni-knowledge/tests/test_cycle_guard_transitive.sh
@@ -18,8 +18,8 @@ SCRIPT="$PLUGIN_ROOT/scripts/cycle-guard.py"
 
 . "$TESTS_DIR/fixtures/_cycle_guard_lib.sh"
 
-red()   { printf '\033[31m%s\033[0m\n' "$1"; }
-green() { printf '\033[32m%s\033[0m\n' "$1"; }
+red()   { printf '%s\n' "$1"; }
+green() { printf '%s\n' "$1"; }
 
 WORK=$(mktemp -d)
 trap 'rm -rf "$WORK"' EXIT

--- a/cogni-knowledge/tests/test_fetch_cache.sh
+++ b/cogni-knowledge/tests/test_fetch_cache.sh
@@ -23,8 +23,8 @@ set -eu
 PLUGIN_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 SCRIPT="$PLUGIN_ROOT/scripts/fetch-cache.py"
 
-red()   { printf '\033[31m%s\033[0m\n' "$1"; }
-green() { printf '\033[32m%s\033[0m\n' "$1"; }
+red()   { printf '%s\n' "$1"; }
+green() { printf '%s\n' "$1"; }
 
 if [ ! -f "$SCRIPT" ]; then
   red "FAIL: fetch-cache.py not found at $SCRIPT"

--- a/cogni-knowledge/tests/test_knowledge_binding.sh
+++ b/cogni-knowledge/tests/test_knowledge_binding.sh
@@ -29,8 +29,8 @@ set -eu
 PLUGIN_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 SCRIPT="$PLUGIN_ROOT/scripts/knowledge-binding.py"
 
-red()   { printf '\033[31m%s\033[0m\n' "$1"; }
-green() { printf '\033[32m%s\033[0m\n' "$1"; }
+red()   { printf '%s\n' "$1"; }
+green() { printf '%s\n' "$1"; }
 
 if [ ! -f "$SCRIPT" ]; then
   red "FAIL: knowledge-binding.py not found at $SCRIPT"

--- a/cogni-knowledge/tests/test_knowledge_setup_probe.sh
+++ b/cogni-knowledge/tests/test_knowledge_setup_probe.sh
@@ -25,8 +25,8 @@ set -eu
 PLUGIN_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 SETUP="$PLUGIN_ROOT/skills/knowledge-setup/SKILL.md"
 
-red()   { printf '\033[31m%s\033[0m\n' "$1"; }
-green() { printf '\033[32m%s\033[0m\n' "$1"; }
+red()   { printf '%s\n' "$1"; }
+green() { printf '%s\n' "$1"; }
 
 errors=0
 

--- a/cogni-knowledge/tests/test_plain_result_emitters.sh
+++ b/cogni-knowledge/tests/test_plain_result_emitters.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+# test_plain_result_emitters.sh — the result-line shape every suite here relies on.
+#
+# The `red`/`green` emitters must write their argument verbatim, with no escape
+# sequence wrapping it. A mutation harness matches result lines by their
+# `PASS: <case>` / `FAIL: <case>` label; an escape sequence sitting in front of
+# the label makes that match miss and the harness reports `case_not_found`
+# instead of a real verdict — a red case reads as a missing one.
+#
+# Contract under test:
+#   1. The shared helper emits exactly the text it was handed, one line per
+#      call, on stdout.
+#   2. No file under the scanned tree carries an escape literal at all.
+#   3. Any file defining an emitter defines BOTH, and both bodies are the plain
+#      form — catching a half-conversion, and a definition deleted while its
+#      call sites live on.
+#
+# Two properties this suite deliberately does NOT assert, because asserting
+# them would work against the conventions it exists to protect:
+#
+#   - It never requires a file to define the emitters INLINE. The liveness
+#     floor counts files that *exercise* the contract — defining the emitters
+#     or sourcing the shared helper — so consolidating a suite onto
+#     fixtures/test_helpers.sh keeps this suite green. A floor keyed on inline
+#     definitions would turn the shared helper's own purpose into a failure.
+#   - It never spells the escape literal itself: case 2 assembles the pattern
+#     at run time, so the file cannot trip its own sweep and needs no exclusion
+#     marker to pass.
+#
+# The scan root defaults to this file's directory and can be overridden by the
+# first argument, so a wider guard can reuse this file rather than fork it.
+# A wider guard must re-home the liveness floor below — that count is scoped to
+# this plugin.
+#
+# bash 3.2 + python3 stdlib only (no pytest, no pip). Matches tests/README.md.
+
+set -eu
+
+TESTS_DIR="$(cd "$(dirname "$0")" && pwd)"
+HELPER="$TESTS_DIR/fixtures/test_helpers.sh"
+SCAN_ROOT="${1:-$TESTS_DIR}"
+
+. "$HELPER"
+
+errors=0
+
+# --- Case 1: the helper emits its argument verbatim -------------------------
+# `cat -v` renders an escape byte as `^[`, so an exact string comparison proves
+# plain-ness, one line per call, and stdout delivery in a single assertion —
+# without this file needing to contain an escape byte to compare against.
+# Whole-string equality is the point: a substring match would still succeed
+# against a colour-wrapped label, so it could not falsify what is under test.
+
+CAPTURED="$(bash -c '. "$1"; green "PASS: probe-green"; red "FAIL: probe-red"' _ "$HELPER" | cat -v)"
+EXPECTED='PASS: probe-green
+FAIL: probe-red'
+
+if [ "$CAPTURED" = "$EXPECTED" ]; then
+  green "PASS: helper emits plain result lines on stdout"
+else
+  red "FAIL: helper did not emit the expected plain result lines"
+  red "  expected: $EXPECTED"
+  red "  actual:   $CAPTURED"
+  errors=$((errors + 1))
+fi
+
+# --- Case 2: no escape literal anywhere under the scanned tree --------------
+# Assembled at run time from a lone backslash so the 4-character literal never
+# appears contiguously in this file's own source.
+
+BSL='\'
+ESC_PAT="${BSL}033"
+
+CARRIERS="$(grep -rlF -- "$ESC_PAT" "$SCAN_ROOT" || true)"
+
+if [ -z "$CARRIERS" ]; then
+  green "PASS: no file under the scanned tree carries an escape literal"
+else
+  red "FAIL: escape literal still present under the scanned tree"
+  echo "$CARRIERS" | sed 's/^/  /'
+  errors=$((errors + 1))
+fi
+
+# --- Case 3: emitter definitions are paired and plain -----------------------
+# Keyed on definition lines only. Call-site labels are deliberately not
+# inspected: some suites emit bare labels with no PASS:/FAIL: prefix, and a
+# fixture that defines neither emitter must pass rather than fail.
+#
+# One grep per file: the emitters are one-liners, so the definition line
+# carries its own body and feeds every check below from a single read.
+
+definers=0
+exercisers=0
+shape_errors=0
+
+for f in "$SCAN_ROOT"/*.sh "$SCAN_ROOT"/fixtures/*.sh; do
+  [ -f "$f" ] || continue
+
+  defs="$(grep -E '^(red|green)\(\)' "$f" || true)"
+
+  if [ -z "$defs" ]; then
+    # Sourcing the shared helper exercises the same contract without defining
+    # anything — that is the preferred shape, so it must count toward liveness.
+    if grep -qF 'test_helpers.sh' "$f"; then
+      exercisers=$((exercisers + 1))
+    fi
+    continue
+  fi
+
+  definers=$((definers + 1))
+  exercisers=$((exercisers + 1))
+
+  n_red=0
+  n_green=0
+  n_plain=0
+  while IFS= read -r line; do
+    case "$line" in
+      red\(\)*) n_red=$((n_red + 1)) ;;
+      green\(\)*) n_green=$((n_green + 1)) ;;
+    esac
+    case "$line" in
+      *"printf '%s"*) n_plain=$((n_plain + 1)) ;;
+    esac
+  done <<<"$defs"
+
+  if [ "$n_red" -ne 1 ] || [ "$n_green" -ne 1 ]; then
+    red "FAIL: $(basename "$f") defines red=$n_red green=$n_green (expected 1 each)"
+    shape_errors=$((shape_errors + 1))
+  elif [ "$n_plain" -ne 2 ]; then
+    red "FAIL: $(basename "$f") emitter bodies are not both the plain printf form"
+    printf '%s\n' "$defs" | sed 's/^/  /'
+    shape_errors=$((shape_errors + 1))
+  fi
+done
+
+errors=$((errors + shape_errors))
+
+# Liveness floor — a broken glob must fail loudly rather than pass vacuously.
+# 78 files exercise the contract today (16 define the emitters, 62 source the
+# helper). The floor sits at 50 so either direction of drift has room, and
+# consolidating definers onto the helper cannot trip it.
+if [ "$exercisers" -lt 50 ]; then
+  red "FAIL: only $exercisers file(s) exercising the emitter contract were found (expected at least 50) — the scan is not reaching them"
+  errors=$((errors + 1))
+elif [ "$shape_errors" -eq 0 ]; then
+  green "PASS: $definers emitter-defining file(s) are paired and plain, of $exercisers exercising the contract"
+fi
+
+echo
+if [ "$errors" -eq 0 ]; then
+  green "plain result-emitter contract all pass."
+else
+  red "plain result-emitter contract: $errors failure(s)."
+  exit 1
+fi

--- a/cogni-knowledge/tests/test_portal_store.sh
+++ b/cogni-knowledge/tests/test_portal_store.sh
@@ -32,8 +32,8 @@ OVERVIEW="$WIKI/wiki/overview.md"
 cleanup() { rm -rf "$WORKDIR"; }
 trap cleanup EXIT
 
-red() { printf '\033[31m%s\033[0m\n' "$1"; }
-green() { printf '\033[32m%s\033[0m\n' "$1"; }
+red() { printf '%s\n' "$1"; }
+green() { printf '%s\n' "$1"; }
 fail() { red "FAIL: $1"; printf -- '----- index.md -----\n'; cat "$INDEX" 2>/dev/null; exit 1; }
 
 if [ ! -f "$UPDATE" ]; then

--- a/cogni-knowledge/tests/test_resolve_wiki_scripts.sh
+++ b/cogni-knowledge/tests/test_resolve_wiki_scripts.sh
@@ -36,8 +36,8 @@ RESOLVER_SNIPPET="$PLUGIN_ROOT/scripts/resolve-wiki-scripts.sh"
 # instead of carrying an inline copy. These are the flows expected to source it.
 SOURCING_SKILLS="knowledge-ingest knowledge-finalize knowledge-dashboard knowledge-health knowledge-lint knowledge-resume knowledge-ingest-source knowledge-query"
 
-red()   { printf '\033[31m%s\033[0m\n' "$1"; }
-green() { printf '\033[32m%s\033[0m\n' "$1"; }
+red()   { printf '%s\n' "$1"; }
+green() { printf '%s\n' "$1"; }
 
 errors=0
 

--- a/cogni-knowledge/tests/test_synthesis_impact.sh
+++ b/cogni-knowledge/tests/test_synthesis_impact.sh
@@ -28,8 +28,8 @@ set -eu
 PLUGIN_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 SCRIPT="$PLUGIN_ROOT/scripts/synthesis-impact.py"
 
-red()   { printf '\033[31m%s\033[0m\n' "$1"; }
-green() { printf '\033[32m%s\033[0m\n' "$1"; }
+red()   { printf '%s\n' "$1"; }
+green() { printf '%s\n' "$1"; }
 
 if [ ! -f "$SCRIPT" ]; then
   red "FAIL: synthesis-impact.py not found at $SCRIPT"


### PR DESCRIPTION
Refs #1359.

Step 1 of the issue only. Step 2 (the CI guard) is deliberately **not** in this PR — see Scope decisions.

## Summary

- Rewrite the `red()` / `green()` bodies in `cogni-knowledge/tests/fixtures/test_helpers.sh` and the 15 suites that inline their own copies to `printf '%s\n' "$1"` — 32 definition lines across 16 files. No escape sequence remains under `cogni-knowledge/tests/`.
- Function bodies are **rewritten, not deleted**. Seven of these suites call the emitters from an end-of-run summary block *after* the last per-case check, so deleting the definitions would kill the suite under `set -eu` once every case line had already printed — normal-looking text, wrong exit code. Every file that defined both emitters still defines both.
- Both spacing variants are covered: the three-space `red()   {` in 15 files, and the lone one-space `red() {` in `test_portal_store.sh`. A substitution keyed on one variant would have silently half-converted.
- No environment probe is introduced. The emitters are unconditional, so parsability never depends on where a suite runs.
- Correct `cogni-knowledge/tests/README.md`, whose convention bullet described the emitters as colour helpers.
- Add `cogni-knowledge/tests/test_plain_result_emitters.sh` holding the shape. CI already discovers `*/tests/*.sh`, so the property is falsifiable in the build rather than only at review time.

**Diff shape:** of the 64 changed lines in the 16 converted files, all 64 are emitter definition lines. No call site changes, and no line containing a `PASS:` or `FAIL:` label changes — those labels are the machine contract this whole change exists to protect.

## Scope decisions

**Deferred — the CI guard (issue step 2), filed as #1362.** The issue's own `## Dependencies` section gates it: #1358 owns `tests/test_check_external_dispatch.sh`, and all six repo-root `tests/*.sh` suites still carry the escape pair on `main`, so a repo-wide guard would be red from this diff by construction. No exclusion, allowlist, or skip marker is added for the external-dispatch file either — an exclusion someone must remember to delete is the bandaid the guard exists to replace. #1362 carries its entry condition as a runnable check rather than a claim about which PRs have landed, so it stays correct however the in-flight PRs resolve.

**Deferred — consolidating the inlined emitters onto the shared helper, filed as #1364.** The pre-commit cleanup review raised this as the deeper fix, and it is a fair point: `fixtures/test_helpers.sh` exists to end exactly this duplication, and consolidation is a *smaller* diff than what shipped here (−2/+1 per suite instead of −2/+2). It is deferred because it answers a different question than this issue asks — this issue's falsifier is "no escape sequence in a result line"; who owns the definition is a separate property with a separate falsifier. #1364 records the supporting evidence and tells the next author to re-verify rather than trust it.

**Untouched.** `cogni-knowledge/_archive/tests/test_read_project_config_bare.sh` carries the same pair but sits one directory level below both of `scripts/run-plugin-tests.py`'s discovery globs (`tests/*.sh`, `*/tests/*.sh`), so it is outside CI by design. The six repo-root `tests/*.sh` suites are byte-untouched — #1358 / #1360 own them. No version bump; the post-merge workflow owns that.

## One defect found and fixed before commit

Worth flagging because it changed the shipped code, and because it is the kind of thing a guard review is for.

`test_plain_result_emitters.sh` originally keyed its liveness floor on files that **inline** the emitter definitions. That made the guard depth-negative: consolidating a suite onto the shared helper — the deeper fix, and one this issue's acceptance contract explicitly permits — would have turned the guard **red**. A guard that fails when duplication is removed argues against the helper whose stated purpose is ending that duplication, and whoever tried #1364 later would have had to edit this guard to do it.

The floor now counts files that **exercise** the contract — defining the emitters *or* sourcing the helper. Verified both ways, below.

## Mutation recipe

Every case in the new suite was driven red before it was trusted. Each mutation was applied to a clean tree, the suite run, and the mutation reverted. From the repo root:

| # | Mutation | Expected | Observed |
|---|---|---|---|
| M1 | Revert `red()` in `test_portal_store.sh` (the one-space variant) to the escape form | red | **red** — caught by case 2 and case 3, exit 1 |
| M2 | Delete the `green()` definition from `test_fetch_cache.sh`, leaving its call sites | red | **red** — `defines red=1 green=0 (expected 1 each)` |
| M3 | Revert both emitters in `fixtures/test_helpers.sh` to the escape form | red | **red** — case 1 exact-match fails, case 2 fails |
| M4 | Point the suite at a scan root containing only the helper (simulates a broken glob) | red | **red** — `only 1 file(s) exercising the emitter contract were found (expected at least 50)` |

M1 is the half-conversion case, M2 the orphaned-summary-call case the issue warns about, M3 the straight revert, M4 the anti-vacuity floor.

Consolidation-neutrality was verified separately: converting all 15 inlining suites to source the helper in a scratch tree drops the definer count 16 → 1, and the suite **stays green**. Under the original floor that same tree failed — which is how the defect above was caught.

```bash
# M1 — half-conversion of the one-space variant
python3 - <<'PY'
import pathlib
p = pathlib.Path("cogni-knowledge/tests/test_portal_store.sh")
t = p.read_text()
old = "red() { printf '%s\\n' \"$1\"; }"
new = "red() { printf '\\033[31m%s\\033[0m\\n' \"$1\"; }"
assert old in t, "MUTATION TARGET NOT FOUND"
p.write_text(t.replace(old, new))
PY
bash cogni-knowledge/tests/test_plain_result_emitters.sh; echo "exit=$?"   # expect non-zero
git checkout -- cogni-knowledge/tests/test_portal_store.sh
```

```bash
# M2 — orphan a summary call by deleting one definition
cp cogni-knowledge/tests/test_fetch_cache.sh /tmp/fc.bak
grep -v "^green() { printf '%s" /tmp/fc.bak > cogni-knowledge/tests/test_fetch_cache.sh
bash cogni-knowledge/tests/test_plain_result_emitters.sh; echo "exit=$?"   # expect non-zero
git checkout -- cogni-knowledge/tests/test_fetch_cache.sh
```

Note the suite never spells the escape literal in its own source — case 2 assembles the pattern at run time — so it cannot trip its own sweep and needs no exclusion marker to pass. Confirmed: `grep -cF '\033'` on the new file returns 0.

## Test plan

- [x] `grep -rn '\033' cogni-knowledge/tests/` returns nothing (32 hits on `main`)
- [x] `bash -c '. cogni-knowledge/tests/fixtures/test_helpers.sh; green "PASS: x"; red "FAIL: y"' | cat -v` prints exactly two plain lines, zero `^[`
- [x] `bash cogni-knowledge/tests/test_plain_result_emitters.sh` exits 0 (3/3 cases; 16 definers of 78 exercising the contract)
- [x] `python3 scripts/run-plugin-tests.py --filter cogni-knowledge` green — 77/77
- [x] `python3 scripts/run-plugin-tests.py` full sweep green — 108/108
- [x] `python3 scripts/check-breadcrumbs.py` — no violations
- [x] Every `PASS:` / `FAIL:` label byte-identical to base — `git diff -U0` shows only emitter definition lines changing (64 of 64)
- [x] No repo-root `tests/` file and no version manifest in the changed-file list