### PR TITLE
cogni-workspace: reconcile manifest descriptions with the horizontal-layer claim

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -122,7 +122,7 @@
       "source": "./cogni-workspace",
       "version": "0.6.56",
       "maturity": "preview",
-      "description": "Foundation-layer plugin for insight-wave marketplace plugins. Manages shared infrastructure (env vars, settings), MCP server installation and Desktop config patching, theme management, theme picker, plugin discovery, workspace health, an interactive workspace-configuration dashboard, Obsidian vault integration, and a bundled vendor-curated insight-wave reference wiki queryable via the ask skill.",
+      "description": "The horizontal layer of the insight-wave marketplace — it owns the shared workspace state the vertical business plugins consume. Manages shared infrastructure (env vars, settings), MCP server installation and Desktop config patching, theme management, theme picker, plugin discovery, workspace health, an interactive workspace-configuration dashboard, Obsidian vault integration, and a bundled vendor-curated insight-wave reference wiki queryable via the ask skill.",
       "keywords": [
         "workspace",
         "themes",

--- a/cogni-workspace/.claude-plugin/plugin.json
+++ b/cogni-workspace/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cogni-workspace",
   "version": "0.6.56",
-  "description": "Foundation-layer plugin for insight-wave marketplace plugins. Manages shared infrastructure (env vars, settings), MCP server installation and Desktop config patching, theme management, theme picker, plugin discovery, workspace health, an interactive workspace-configuration dashboard, Obsidian vault integration, and a bundled vendor-curated insight-wave reference wiki queryable via the ask skill.",
+  "description": "The horizontal layer of the insight-wave marketplace — it owns the shared workspace state the vertical business plugins consume. Manages shared infrastructure (env vars, settings), MCP server installation and Desktop config patching, theme management, theme picker, plugin discovery, workspace health, an interactive workspace-configuration dashboard, Obsidian vault integration, and a bundled vendor-curated insight-wave reference wiki queryable via the ask skill.",
   "author": {
     "name": "Stephan de Haas",
     "email": "stephan@cogni-work.ai"

--- a/cogni-workspace/tests/test-layering-claim-reconciled.sh
+++ b/cogni-workspace/tests/test-layering-claim-reconciled.sh
@@ -82,19 +82,21 @@
 #     editing it would also break the per-page parity assertion below
 #   - cogni-visual/libraries/ — "Foundation Layer" there is an ASCII-art fill
 #     label in a diagram legend, unrelated to the claim
-#   - cogni-workspace/.claude-plugin/plugin.json and .claude-plugin/marketplace.json
-#     — these two say "Foundation-layer plugin". They are the retired claim's
-#     upstream source and DO need fixing, but the reconciliation's scope boundary
-#     confines its diff to markdown surfaces and tests/*.sh, so a manifest edit
-#     belongs to its own change. Excluded so the guard stays honest about what it
-#     covers rather than silently green; remove both entries when the manifests
-#     are corrected. Named as two exact paths, never as a `.claude-plugin/`
-#     fragment — that fragment would exempt all 15 files under every plugin's
-#     manifest directory, so any OTHER plugin could reintroduce the claim
-#     invisibly, and the gap would be far wider than the two files documented here.
 #   - .git/ and .claude/worktrees/ — nested checkouts of this same repo that
 #     local tooling leaves in the tree. Untracked, so `grep_hits` already skips
 #     them on the real repo; these entries only cover the filesystem fallback.
+#
+# No manifest is exempt. cogni-workspace's own plugin.json and the root
+# marketplace.json were the retired claim's last upstream source and carried a
+# temporary exemption while the reconciliation's scope boundary kept manifest
+# edits out of its diff; both descriptions now assert the horizontal-layer scope
+# claim, so the exemption is gone and the scan covers them like any other file.
+#
+# Never re-add a bare `.claude-plugin/` fragment in their place. `is_excluded`
+# matches by SUBSTRING, so that one fragment would exempt all 15 files under
+# every plugin's manifest directory — any OTHER plugin could then reintroduce
+# the claim invisibly, a gap far wider than the two files it would read as
+# covering. Case L9 is what keeps that revert red.
 #
 # Parity is per-page, never tree-wide, and that is load-bearing. The two trees
 # legitimately differ (the root tree carries lint-2026-04-20.md and the bundled
@@ -149,8 +151,6 @@ cogni-workspace/references/absorption-roadmap.md
 wiki/wiki/log.md
 wiki/wiki/pages/lint-2026-04-20.md
 cogni-visual/libraries/
-cogni-workspace/.claude-plugin/plugin.json
-.claude-plugin/marketplace.json
 .git/
 .claude/worktrees/'
 
@@ -464,31 +464,37 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# L9 — the manifest exemption is scoped to two exact files, not to every
-# `.claude-plugin/` directory.
+# L9 — no manifest is exempt: every `.claude-plugin` manifest is scanned.
 #
-# Same lesson as L8: without a case, the narrowing is asserted only in a comment.
-# L1 is green whether EXCLUDED names the two paths or the old `.claude-plugin/`
-# fragment, because the two exempt manifests carry the literal either way and no
-# other manifest carries it today — so a revert to the fragment would silently
-# re-open a 15-file exemption with every case still passing. This case makes that
-# revert red by planting the literal in a DIFFERENT plugin's manifest, which must
-# be caught, while cogni-workspace's own stays exempt.
+# Same lesson as L8: without a case, the rule is asserted only in a comment.
+# L1 cannot carry this one. Once the manifests were corrected, no manifest in
+# the real repo holds a forbidden literal, so L1 is green whether EXCLUDED is
+# empty of manifest entries or names them again — a re-added exemption, or a
+# bare `.claude-plugin/` fragment re-opening all 15 files under every plugin's
+# manifest directory, would slip in with every case still passing.
+#
+# This case makes both reverts red by planting the literal in three manifests
+# that must ALL be caught: another plugin's, cogni-workspace's own (formerly
+# exempt), and the root marketplace.json (which no case exercised before).
 # ---------------------------------------------------------------------------
 l9_ok=1
 X="$TMPROOT/l9"
-mkdir -p "$X/cogni-workspace/.claude-plugin" "$X/cogni-other/.claude-plugin"
+mkdir -p "$X/cogni-workspace/.claude-plugin" "$X/cogni-other/.claude-plugin" \
+  "$X/.claude-plugin"
 printf '{"description": "Foundation-layer plugin for insight-wave."}\n' \
   > "$X/cogni-workspace/.claude-plugin/plugin.json"
 printf '{"description": "Foundation-layer plugin for insight-wave."}\n' \
   > "$X/cogni-other/.claude-plugin/plugin.json"
+printf '{"description": "Foundation-layer plugin for insight-wave."}\n' \
+  > "$X/.claude-plugin/marketplace.json"
 run_scan "$X" "manifest-scope"
 assert_rc 1 && assert_out_has "cogni-other/.claude-plugin/plugin.json" || l9_ok=0
-assert_out_lacks "cogni-workspace/.claude-plugin/plugin.json" || l9_ok=0
+assert_out_has "cogni-workspace/.claude-plugin/plugin.json" || l9_ok=0
+assert_out_has ".claude-plugin/marketplace.json" || l9_ok=0
 if [ "$l9_ok" -eq 1 ]; then
-  pass "L9 the manifest exemption covers two exact files, not every .claude-plugin dir"
+  pass "L9 no manifest is exempt — every .claude-plugin manifest is scanned"
 else
-  fail "L9 the manifest exemption covers two exact files, not every .claude-plugin dir"
+  fail "L9 no manifest is exempt — every .claude-plugin manifest is scanned"
 fi
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #1376.

## Summary

Both copies of cogni-workspace's plugin description opened with the retired layering claim — *"Foundation-layer plugin for insight-wave marketplace plugins."* They were the claim's last un-reconciled upstream source, and its highest-visibility one: this string is what `/plugin` and the marketplace listing render.

- Replaced that opening with the horizontal-layer scope claim already canonical in `cogni-workspace/README.md:7` and `cogni-workspace/CLAUDE.md:7`, written **byte-identically** into `cogni-workspace/.claude-plugin/plugin.json` and the `cogni-workspace` entry of `.claude-plugin/marketplace.json`.
- All nine capability phrases in the tail are preserved verbatim, from `Manages shared infrastructure (env vars, settings)` through `queryable via the ask skill`. No `version`, `maturity` or `keywords` line is touched — the post-merge workflow owns the bump.
- Dropped the two manifest entries from `EXCLUDED` in `cogni-workspace/tests/test-layering-claim-reconciled.sh`, which were added with an explicit note to remove them once the manifests were corrected.
- Rewrote case **L9** and relocated the removed header bullet's lesson (details below).

## Two defects in the issue's acceptance criteria

Both were found at triage and independently confirmed by two read-only explorations. Flagging them because the issue's AC cannot be satisfied as literally written.

**1. AC 3's anchor is stale.** It says to remove `.claude-plugin/` from `EXCLUDED`. No such fragment exists on base — a prior change already narrowed the exemption to two exact path lines. The real edit removes *those two lines*; a check keyed on the fragment would be unfalsifiable.

**2. AC 4 is unsatisfiable by AC 3's edit alone.** `is_excluded` matches by **substring**, so `EXCLUDED`'s `cogni-workspace/.claude-plugin/plugin.json` entry was the sole reason L9's `assert_out_lacks` on that path held. Removing the entry turns L9 red. Retiring or rewriting L9 is required work that appears nowhere in the AC.

**A third gap surfaced during exploration:** L9 never planted a `marketplace.json` fixture, so the second exemption's removal was exercised by **no existing case**. The successor closes that hole.

## What L9 became

It could not simply be deleted. L1 cannot carry this invariant: now that the manifests are corrected, no real-repo manifest holds a forbidden literal, so L1 stays green whether or not an exemption is re-added — a revert would slip in silently. L9 now plants the literal in **three** manifests that must all be caught: another plugin's `plugin.json`, cogni-workspace's own (formerly exempt), and the root `marketplace.json`.

The removed header bullet's lesson is relocated, not lost: a bare `.claude-plugin/` fragment in place of the two exact paths would exempt all 15 files under every plugin's manifest directory, letting any plugin reintroduce the claim invisibly.

## Preserved invariants

`FORBIDDEN` stays at 14 literals (floor asserted by L2); the seven surviving `EXCLUDED` entries are byte-unchanged; `PAGE_PARITY`, `is_excluded`, `scan_literals` and cases L1–L8 are untouched; neither wiki tree is regenerated.

## Verification

All run on this branch, all green:

- `bash cogni-workspace/tests/test-layering-claim-reconciled.sh` — **9/9 PASS**, including L1 (the real repo now scanned with the manifests un-exempt) and the L9 successor.
- `python3 scripts/run-plugin-tests.py --filter cogni-workspace` — exit 0 across all four cogni-workspace suites.
- Both manifests parse (`python3 -m json.tool`), and their two `description` values compare **byte-identical**.
- `git diff -U0 | grep -cE '^[+-].*"(version|maturity)"'` → **0**.
- `git diff --name-only` lists exactly the three in-scope paths; nothing under `wiki/`, `docs/`, `skills/` or `agents/`.

## Mutation recipe

Proves the L9 successor is falsifiable. Verified by an actual harness run on this branch — `mutated_result: red`, `restored_result: green`, `verdict: guard_verified` — and the mutation turns **exactly one** case red.

Note the harness ships with the `cogni-service` plugin; it is not vendored in this repo, so the path is the plugin cache, not `scripts/`.

```bash
bash "$CLAUDE_PLUGIN_ROOT/scripts/mutation-check.sh" --root . --file cogni-workspace/tests/test-layering-claim-reconciled.sh --expr 's{cogni-visual/libraries/\n}{cogni-visual/libraries/\n.claude-plugin/\n}' --test 'bash cogni-workspace/tests/test-layering-claim-reconciled.sh' --case L9
```

The expression re-introduces the broad `.claude-plugin/` fragment into `EXCLUDED`, which re-exempts all three fixture manifests so the scan comes back clean and L9 goes red. `--expr` is evaluated by `perl -0pi`, never sed. The suite prints `PASS: L9 …` / `FAIL: L9 …`, so `L9` is the token `--case` matches.

## Process notes for the reviewer

Two mandated pipeline steps were reduced or skipped as **stated** context-budget decisions, recorded here rather than left implicit:

- The Step 4a/4b fan-out table prescribes 2 Explore + 2 Plan for an S3 issue; this run used 2 Explore + **1** Plan, skipping the 4c pick and the 4c.5 refine pass. Both explorations ran in full and independently corroborated every cited anchor.
- The Step 6.4 `/simplify` quality pass was **not** run. The diff is two single-line JSON string edits plus one bash test-case rewrite, so its reuse/efficiency remit has little surface here — but it was skipped, not satisfied.

Step 6.4b (prose simplify) and Step 6.5 (skill-quality review) are genuine no-ops: the diff touches no `SKILL.md` and no `agents/*.md`.