### PR TITLE
cogni-trends: fix investment-theme-writer agent registration name

### DIFF
--- a/cogni-trends/agents/trend-report-investment-theme-writer.md
+++ b/cogni-trends/agents/trend-report-investment-theme-writer.md
@@ -1,5 +1,5 @@
 ---
-name: trend-investment-theme-writer
+name: trend-report-investment-theme-writer
 description: Write a single investment theme as a slim 3-beat case (Stake / Move / Cost-of-Inaction) anchored to its dominant Smarter Service dimension. DO NOT USE DIRECTLY — invoked by trend-synthesis Phase 2.
 tools: Read, Write
 model: sonnet

--- a/cogni-trends/tests/test-agent-frontmatter-names.sh
+++ b/cogni-trends/tests/test-agent-frontmatter-names.sh
@@ -1,0 +1,212 @@
+#!/usr/bin/env bash
+# Regression test: every cogni-trends/agents/*.md must declare a frontmatter
+# `name:` equal to its own filename stem. Pins the contract for issue #1388.
+#
+# Why this class needs a guard at all. The host registers a plugin agent under
+# its frontmatter `name`, NOT under its filename. When the two disagree, the
+# agent is addressable only by the declared name, while every dispatch site and
+# doc in the repo naturally reaches for the filename form — so the dispatch
+# resolves to nothing. That is a silent failure: no script is wrong, nothing
+# raises, and the only evidence is the absence of whatever the agent would have
+# produced. It is the same shape the repo CLAUDE.md already calls out for hook
+# matchers. In the case that prompted this suite, one agent's declared name was
+# missing a `report-` segment its filename carried, which cost the canonical
+# TIPS report its per-theme Stake / Move / Cost-of-Inaction cases.
+#
+# No pre-existing gate covers it, which is why the defect survived:
+#   - cogni-workspace/scripts/check-skill-names.sh globs cogni-*/skills/*/SKILL.md
+#     — skills only, never agents.
+#   - cogni-service's check-frontmatter.sh does scan agents/*.md, but its name
+#     regex validates kebab-case SHAPE alone; a well-formed but wrong name passes.
+# Both were green on the broken tree.
+#
+# Case-label shape deviates from the sibling suites on purpose.
+# test-project-status.sh and test-stale-detection.sh print "OK   <label>"; this
+# suite prints "PASS: <label>" / "FAIL: <label>" because the cogni-service
+# mutation harness classifies a case GREEN only on
+# ^[[:space:]]*(ok|PASS):[[:space:]]+<case> and RED on the matching FAIL: form.
+# Neither "OK   " nor "OK:" is in that vocabulary, so a mutation replay against
+# this suite would report case_not_found instead of a verdict. The detail after
+# a case id is separated by a SPACE and never a colon — "FAIL: A5: detail" also
+# reports case_not_found on a genuinely red case. Case ids are A-prefixed and
+# never bare numerals, which keeps the final summary line
+# ("FAIL: <n> agent-frontmatter-name test(s) failed.") from being read as a
+# case's RED line. Do not "fix" these labels back to the house style.
+#
+# This file deliberately never spells the pre-fix bare agent name as one
+# contiguous token: the repo-wide falsifier for issue #1388 is an unfiltered
+# scan for that token expecting zero hits, and naming it here would make the
+# suite's own source the hit.
+#
+# bash-3.2 portable (stock macOS /bin/bash is 3.2.57): no declare -A /
+# typeset -A, no mapfile / readarray, no ${var^^} / ${var,,}.
+#
+# stdlib-only: bash + coreutils. No python3, no pip deps, no network. Writes
+# only under its own mktemp -d.
+#
+# Usage: bash cogni-trends/tests/test-agent-frontmatter-names.sh
+# Exits non-zero on any assertion failure.
+#
+# Mutation recipe (proves case A5 is load-bearing):
+#   bash ~/.claude/plugins/marketplaces/managed-service/cogni-service/scripts/mutation-check.sh \
+#     --root . \
+#     --file cogni-trends/agents/trend-report-investment-theme-writer.md \
+#     --expr 's/^name: trend-report-investment-theme-writer/name: trend-investment-/m' \
+#     --test 'bash cogni-trends/tests/test-agent-frontmatter-names.sh' \
+#     --case A5
+
+set -u
+
+TESTS_DIR="$(cd "$(dirname "$0")" && pwd)"
+PLUGIN_DIR="$(cd "$TESTS_DIR/.." && pwd)"
+AGENTS_DIR="$PLUGIN_DIR/agents"
+
+TMPROOT="$(mktemp -d)"
+trap 'rm -rf "$TMPROOT"' EXIT
+
+failures=0
+pass() { echo "PASS: $1"; }
+fail() { echo "FAIL: $1"; failures=$((failures + 1)); }
+
+# ---------------------------------------------------------------------------
+# The checker. Fixture cases and the real-tree case drive this same function —
+# the matcher is never reimplemented in a case body, so pointing a case at a
+# broken matcher turns that case red rather than silently passing.
+#
+# scan_agents <agents_dir> <count_out_file>
+#   stdout: one line per violation
+#   <count_out_file>: number of *.md files actually scanned (the liveness signal)
+# ---------------------------------------------------------------------------
+scan_agents() {
+  local scan_dir count_file scanned f stem declared
+  scan_dir="$1"
+  count_file="$2"
+  scanned=0
+
+  for f in "$scan_dir"/*.md; do
+    # An unmatched glob expands to the literal pattern; skip it so an empty or
+    # missing directory reports scanned=0 instead of inventing a phantom file.
+    [ -e "$f" ] || continue
+    scanned=$((scanned + 1))
+
+    stem="${f##*/}"
+    stem="${stem%.md}"
+
+    # First `name:` line at column 0 — the frontmatter key. Trailing whitespace
+    # is stripped so a stray space cannot read as a mismatch.
+    declared="$(grep -m1 '^name:' "$f" | sed 's/^name:[[:space:]]*//' | sed 's/[[:space:]]*$//')"
+
+    if [ -z "$declared" ]; then
+      printf '  %s: no frontmatter "name:" key\n' "${f##*/}"
+    elif [ "$declared" != "$stem" ]; then
+      printf '  %s: declared "%s" != filename stem "%s"\n' "${f##*/}" "$declared" "$stem"
+    fi
+  done
+
+  printf '%s' "$scanned" > "$count_file"
+}
+
+# Build a fixture agent file with an arbitrary declared name.
+# write_agent <dir> <stem> <declared-name-or-NONE>
+write_agent() {
+  local wa_dir wa_stem wa_name
+  wa_dir="$1"
+  wa_stem="$2"
+  wa_name="$3"
+  mkdir -p "$wa_dir"
+  {
+    echo "---"
+    if [ "$wa_name" != "NONE" ]; then
+      echo "name: $wa_name"
+    fi
+    echo "description: fixture agent for the frontmatter-name regression suite."
+    echo "tools: Read"
+    echo "model: sonnet"
+    echo "---"
+    echo
+    echo "Fixture body."
+  } > "$wa_dir/$wa_stem.md"
+}
+
+COUNT_FILE="$TMPROOT/scanned"
+
+# --- A1: a fixture whose names all match their stems reports clean -----------
+CLEAN_DIR="$TMPROOT/clean/agents"
+write_agent "$CLEAN_DIR" "alpha-agent" "alpha-agent"
+write_agent "$CLEAN_DIR" "beta-agent" "beta-agent"
+A1_OUT="$(scan_agents "$CLEAN_DIR" "$COUNT_FILE")"
+A1_COUNT="$(cat "$COUNT_FILE")"
+if [ -z "$A1_OUT" ] && [ "$A1_COUNT" = "2" ]; then
+  pass "A1 matching fixture reports no violations (scanned 2)"
+else
+  fail "A1 matching fixture should be clean, got violations: ${A1_OUT:-<none>} (scanned $A1_COUNT)"
+fi
+
+# --- A2: a mismatched fixture is caught, and names both sides ----------------
+# This is the liveness case for the matcher itself: if the checker cannot fire,
+# A2 goes red and the green A5 below is worthless.
+BAD_DIR="$TMPROOT/bad/agents"
+write_agent "$BAD_DIR" "alpha-agent" "alpha-agent"
+write_agent "$BAD_DIR" "gamma-agent" "delta-agent"
+A2_OUT="$(scan_agents "$BAD_DIR" "$COUNT_FILE")"
+A2_LINES="$(printf '%s\n' "$A2_OUT" | grep -c 'gamma-agent')"
+if [ "$A2_LINES" = "1" ] \
+  && printf '%s' "$A2_OUT" | grep -q 'delta-agent' \
+  && printf '%s' "$A2_OUT" | grep -q 'gamma-agent'; then
+  pass "A2 mismatched fixture is reported, naming file, declared and expected"
+else
+  fail "A2 mismatched fixture not reported correctly, got: ${A2_OUT:-<none>}"
+fi
+
+# --- A3: a fixture with no name: key fails rather than being skipped ---------
+NONAME_DIR="$TMPROOT/noname/agents"
+write_agent "$NONAME_DIR" "orphan-agent" "NONE"
+A3_OUT="$(scan_agents "$NONAME_DIR" "$COUNT_FILE")"
+if printf '%s' "$A3_OUT" | grep -q 'no frontmatter'; then
+  pass "A3 agent missing a name: key is reported, not skipped"
+else
+  fail "A3 agent missing a name: key was not reported, got: ${A3_OUT:-<none>}"
+fi
+
+# --- A4: an empty agents dir reports scanned=0 (the vacuity floor) -----------
+# Without this, a glob that silently stops matching would make A5 pass by
+# scanning nothing at all. A4 proves the liveness counter can read zero, which
+# is what gives A6's non-zero assertion its meaning.
+EMPTY_DIR="$TMPROOT/empty/agents"
+mkdir -p "$EMPTY_DIR"
+A4_OUT="$(scan_agents "$EMPTY_DIR" "$COUNT_FILE")"
+A4_COUNT="$(cat "$COUNT_FILE")"
+if [ -z "$A4_OUT" ] && [ "$A4_COUNT" = "0" ]; then
+  pass "A4 empty agents dir scans 0 files (vacuity floor is real)"
+else
+  fail "A4 empty agents dir should scan 0 files, got count $A4_COUNT violations ${A4_OUT:-<none>}"
+fi
+
+# --- A5: the real cogni-trends/agents tree is clean --------------------------
+# The case the mutation recipe in the header targets.
+A5_OUT="$(scan_agents "$AGENTS_DIR" "$COUNT_FILE")"
+REAL_COUNT="$(cat "$COUNT_FILE")"
+if [ -z "$A5_OUT" ]; then
+  pass "A5 every cogni-trends agent declares a name matching its filename stem"
+else
+  fail "A5 agent frontmatter name does not match filename stem"
+  printf '%s\n' "$A5_OUT" >&2
+fi
+
+# --- A6: the real-tree scan actually visited files ---------------------------
+# Deliberately asserts "> 0" and never a fixed count: cogni-trends/agents holds
+# 12 files today while cogni-trends/CLAUDE.md's inventory table still says 11,
+# and pinning a number would couple this suite to that unrelated drift.
+if [ "$REAL_COUNT" -gt 0 ]; then
+  pass "A6 real-tree scan visited $REAL_COUNT agent file(s)"
+else
+  fail "A6 real-tree scan visited no files — the agents glob matched nothing"
+fi
+
+if [ $failures -gt 0 ]; then
+  echo
+  echo "FAIL: $failures agent-frontmatter-name test(s) failed." >&2
+  exit 1
+fi
+echo
+echo "All agent-frontmatter-name assertions passed."


### PR DESCRIPTION
Closes #1388.

## Summary
- `cogni-trends/agents/trend-report-investment-theme-writer.md:2` declared a frontmatter `name` missing the `report-` segment its filename carries, so the host registered the agent under a name **no dispatch site uses**. The trend-synthesis Phase 2.1 dispatch could not resolve, and the canonical TIPS report silently lost its Stake / Move / Cost-of-Inaction theme-cases.
- Renames the frontmatter to match the filename stem. One line; the diff on that file is a single `-`/`+` pair.
- Adds `cogni-trends/tests/test-agent-frontmatter-names.sh`, a regression suite asserting every `cogni-trends/agents/*.md` frontmatter `name` equals its filename stem, so the class cannot silently return.

## Verification

| Check | Result |
|---|---|
| Bare-token scan repo-wide (the falsifier) | 1 hit on base → **0** on this branch |
| New suite | 6/6 `PASS:` (A1–A6), exit 0 |
| `run-plugin-tests.py --filter cogni-trends` | 3/3 suites pass |
| Mutation replay of case A5 | `mutated: red`, `restored: green`, **`verdict: guard_verified`** |
| `check-breadcrumbs.py` | clean (rc=0) |
| `check-version-bump.py` | `0 touched, 0 violation(s)` |
| `check-plugin-inventory.py` / `check-external-dispatch.py` | clean (rc=0) |
| Agent length | description 197/3600, system prompt 22391/28000 — both under cap, unchanged by this diff |

## Scope decisions

- **In:** the frontmatter rename plus the regression suite — the two acceptance criteria that change files. Deferring the suite would close the issue on a fix nothing guards.
- **Out — dispatch sites and docs.** All were checked and already use the filename form, so they need no change and are untouched: `skills/trend-synthesis/SKILL.md:337,341`, `skills/trend-synthesis/references/synthesis-skeleton.md:10,137,147`, `agents/trend-report-composer.md:15,122`, `references/json-quote-discipline.md:77`, `README.md:141,167,236`, `CLAUDE.md:49,87`, plus the two generated wiki mirrors (which key on the filename and stay correct — no regeneration).
- **Out — `cogni-trends/CLAUDE.md:87`** says 11 agents where `agents/` holds 12. The absent row is `br-pre-scorer`, unrelated to agent registration; pre-existing drift, deliberately not swept in. The new suite pins **no** agent count for exactly this reason.
- **Out — a repo-wide guard.** The defect class spans 101 agents across all plugins with exactly one offender (this file). Promoting the check to a shared `scripts/` gate wired into `lint.yml` is a separate change with a different blast radius; this PR's edits stay inside `cogni-trends/`. Flagged for a maintainer under Open questions.
- **No version bump** — the post-merge workflow owns it.

## ⚠ Acceptance criterion 2 was corrected, not copied

The issue's AC-2 reads:

> A grep for `trend-investment-theme-writer` not preceded by `report-` returns no hits under `cogni-trends/`.

Run literally, that recipe returns **zero hits on the unfixed tree** and exits 1:

```
$ grep -rn "trend-investment-theme-writer" cogni-trends/ | grep -v "report-"
$ echo $?
1
```

Grep prefixes each hit with its file path, and that path (`.../trend-report-investment-theme-writer.md`) contains `report-` — so the `-v` filter discards the very line the criterion targets. It passes identically before and after the fix and gates nothing.

The correct falsifier is the **same scan with no filter**: the bare form is not a substring of the corrected form (the fix inserts `report-` mid-string), so it returns exactly 1 hit on base and 0 here. That is the check used above and pinned by the suite.

Consequently the new suite deliberately **never spells the pre-fix bare token as one contiguous string** — doing so would make the suite's own source the hit and re-break the falsifier.

## Notes on the test suite

- Sits directly at `cogni-trends/tests/` — `scripts/run-plugin-tests.py` discovers via the **non-recursive** globs `tests/*.sh` and `*/tests/*.sh`, so a subdirectory would be invisible to CI.
- **Cannot pass vacuously.** A2 is a negative fixture proving the checker can fire; A3 covers a missing `name:` key; A4 pins that an empty directory scans zero files, which is what gives A6's non-zero floor its meaning. Fixture and real-tree cases drive the *same* checker function, so a broken matcher turns cases red rather than silently green.
- **Label-shape deviation, on purpose.** The two sibling suites print `OK   <label>`; this one prints `PASS: <case>` / `FAIL: <case> <detail>` because the mutation harness classifies GREEN only on `^[[:space:]]*(ok|PASS):[[:space:]]+<case>` and RED on the matching `FAIL:` form. The detail is space-separated, never `FAIL: A5: detail`, which would report `case_not_found` on a genuinely red case. Case ids are letter-prefixed so the summary line is never read as a case result. Same documented deviation as `cogni-workspace/tests/test-wiki-namespace-sync.sh`.
- bash-3.2 portable (no `declare -A`), stdlib-only, no network, writes only under its own `mktemp -d`.

## Mutation recipe

Proves case A5 is load-bearing by re-introducing the defect. Replayable as written, from the repo root.

```bash
bash ~/.claude/plugins/marketplaces/managed-service/cogni-service/scripts/mutation-check.sh \
  --root . \
  --file cogni-trends/agents/trend-report-investment-theme-writer.md \
  --expr 's/^name: trend-report-investment-theme-writer/name: trend-investment-/m' \
  --test 'bash cogni-trends/tests/test-agent-frontmatter-names.sh' \
  --case A5
```

Verified on this branch: `mutated_result: red`, `restored_result: green`, `verdict: guard_verified`.

Two notes on the expression. `--expr` is a `perl -0pi -e` expression, so the `/m` flag is **required**: `-0` slurps the file into one string, and without `/m` the `^` would anchor only at byte zero, never at line 2. And the replacement is deliberately truncated to `name: trend-investment-` rather than the full pre-fix name — it is still disjoint from the matched literal and still un-fixes the file (declared ≠ stem, so A5 goes red), while keeping the contiguous bare token out of every in-repo file so the falsifier above stays valid.

## Base note

`origin/main` advanced mid-run (a `bump(multi)` landing cogni-trends v0.6.11 among others). This branch is cut from the **post-bump** base `48cad95c`, and every plan anchor was re-validated against it — which is how the `SKILL.md` dispatch citations above read 337/341 rather than the pre-bump 341/345.

## Open questions

- **Guard placement (judgment, no gate can decide).** The suite is plugin-scoped to `cogni-trends/agents/` as the acceptance criterion asks, but the defect class is repo-wide: 101 agents, one offender. A maintainer may prefer this promoted to a shared `scripts/check-*.py` guard wired into `lint.yml`. The suite is written so a repo-wide superset would be a drop-in widening.
- **Live registration is unprovable in CI.** No check can confirm the host now registers `cogni-trends:trend-report-investment-theme-writer`; the frontmatter assertion is a proxy, and confirming the live registry needs a session that reloads the plugin.