### PR TITLE
cogni-workspace: refresh stale rationale in relocated-skill hygiene suite

### DIFF
--- a/cogni-workspace/tests/test-relocated-skill-hygiene.sh
+++ b/cogni-workspace/tests/test-relocated-skill-hygiene.sh
@@ -6,11 +6,11 @@
 # else in the repo enforces either one:
 #
 #   - No `cogni-help:` dispatch token may survive in the adopted copies. The
-#     obvious candidate guard, scripts/check-external-dispatch.py, structurally
-#     cannot catch this: it compiles its pattern from the retired-prefix registry
-#     at scripts/retired-plugins.json, and cogni-help is deliberately absent from
-#     that registry because cogni-help still ships. A verbatim `cogni-help:teach`
-#     leaves that guard green.
+#     obvious candidate guard, scripts/check-external-dispatch.py, reaches only
+#     part of that surface: its globs cover SKILL.md, agents, commands, hooks,
+#     while a skill's own scripts/, evals/ and references/ files match none of
+#     them. P1 below walks every file in both trees instead — the gap is one of
+#     file-type coverage, not of what scripts/retired-plugins.json carries.
 #   - Every `${CLAUDE_PLUGIN_ROOT}`-relative path documented in those trees must
 #     resolve under cogni-workspace. Most such paths are skill-relative and
 #     survive relocation untouched, but a plugin-root-relative one silently
@@ -19,15 +19,15 @@
 #     exist and will not, because that script belongs to the course-delivery
 #     system being retired. Nothing would have reported it.
 #
-# Scope. Every assertion reads the cogni-workspace tree ONLY. cogni-help keeps
-# its own copies during the retirement transition and is legitimately allowed
-# both the dispatch token and the plugin-root-relative path, so scanning it would
-# be red on arrival. Scoping here also means this suite keeps passing unchanged
-# once cogni-help is deleted — it asserts nothing about the source.
+# Scope. Every assertion reads the cogni-workspace tree ONLY. The properties
+# under test belong to the destination copies, so no source tree is an input to
+# any of them: this suite reads the same and passes the same whether or not a
+# cogni-help tree exists anywhere in the repo. That independence is the point —
+# relocation hygiene is checked where the relocated files actually live.
 #
-# Deliberately NOT asserted: counterpart-completeness against cogni-help. That
-# assertion would start failing the moment cogni-help is removed, shipping a
-# guard a later change must remember to rewrite.
+# Deliberately NOT asserted: counterpart-completeness against cogni-help. An
+# assertion reading a tree this plugin does not own breaks whenever that tree
+# changes or disappears — a guard a later change must remember to rewrite.
 #
 # Case-label shape is "PASS: <case>" / "FAIL: <case>", matching
 # test-layering-claim-reconciled.sh and test-wiki-namespace-sync.sh, because the


### PR DESCRIPTION
Closes #1385.

## Summary

The header rationale of `cogni-workspace/tests/test-relocated-skill-hygiene.sh` was written while cogni-help still shipped, and both of its premises inverted when the retirement landed. Comment-only refresh: 13 lines replaced across three header regions, each line-count neutral, nothing at or after `set -u` (line 42).

What was false on `main` before this change:

| Header claim | Reality at base |
|---|---|
| cogni-help is "deliberately absent from that registry" | `scripts/retired-plugins.json` lists `cogni-help` in `retired_prefixes[]` |
| "because cogni-help still ships" | the `cogni-help/` tree no longer exists in the repo |
| "keeps its own copies during the retirement transition" | there is no source tree left to keep copies |
| "once cogni-help is deleted" / "the moment cogni-help is removed" | already deleted — a future tense describing the past |

## The justification survives, for a more durable reason

The suite is still correct; the header just explained it wrongly. Verified against base:

- `scripts/check-external-dispatch.py` `DEFAULT_GLOBS` is exactly `*/skills/*/SKILL.md`, `*/agents/*.md`, `*/commands/*.md`, `*/hooks/*`, `*/hooks/*/*`, and its docstring holds `references/` out of scope on purpose.
- The two adopted trees hold **9 files**. Exactly **2** match a glob (`cogni-issues/SKILL.md`, `troubleshoot/SKILL.md`). The other **7** — 3× `cogni-issues/scripts/*.sh`, 2× `evals/evals.json`, 2× `references/*.md` — match none and are never discovered.
- Case P1 walks `find "$tree" -type f` over all 9.

So the gap is **file-type coverage**, which is registry-independent — not registry membership, which has now changed. That phrasing stays true if another plugin is retired later or if cogni-help's registry entry changes again, which is what makes it durable rather than merely current.

**Deliberately not claimed:** that the guard is blind to a `cogni-help:` token in general. Now that the prefix is registered, the guard *would* flag one in the two `SKILL.md` files. The replacement narrows the claim to the files outside its scanned surfaces.

## Preserved

The case-label-shape paragraph (documenting that the cogni-service mutation harness classifies green only on the `PASS: <case>` form, with P-prefixed ids) and the `# Contract:` paragraph survive verbatim — both load-bearing. Every assertion, case id, PASS/FAIL label, both liveness floors and every fixture are byte-identical. No `plugin.json` / `marketplace.json` version touched — the post-merge workflow owns the bump.

## Verification

- [x] `bash cogni-workspace/tests/test-relocated-skill-hygiene.sh` exits 0 — `PASS: P1 ... (9 files scanned)`, `PASS: P2 all 4 ${CLAUDE_PLUGIN_ROOT} references ...`. **Both counts identical to base**, so assertion strength is unchanged.
- [x] `bash -n` clean.
- [x] `git diff --name-only origin/main...HEAD` → exactly one file.
- [x] Comment-only: every changed line matches `^[+-]\s*#` (0 non-comment lines in the diff).
- [x] `set -u` still at line 42; file still 148 lines.
- [x] `python3 scripts/run-plugin-tests.py --filter cogni-workspace` → exit 0.
- [x] `python3 scripts/check-breadcrumbs.py` → `success: true`; no `#NNNN` introduced in any added line.
- [x] `python3 scripts/check-external-dispatch.py` → `success: true`.
- [x] `python3 scripts/check-version-bump.py` → exit 0; zero version files touched.

## Mutation recipe

Run from the PR worktree root. This mutates a `references/` file — deliberately the exact file class the refreshed header says the dispatch guard cannot see — so the recipe exercises the documented gap:

```bash
bash ~/.claude/plugins/cache/managed-service/cogni-service/0.0.395/scripts/mutation-check.sh --root . --file cogni-workspace/skills/troubleshoot/references/known-issues.md --expr 's/cogni-teacher/cogni-help:teach/' --test 'bash cogni-workspace/tests/test-relocated-skill-hygiene.sh' --case P1
```

- `cogni-teacher` occurs in that file (the progress-file rename note), so the expr is not a no-op.
- The replacement `cogni-help:teach` is disjoint from the searched string, so the mutant cannot silently stay green or be re-applied into a no-op.
- `/` is safe as the delimiter — neither side contains one.
- The case token is the bare `P1`: this suite prints `PASS: P1 …` / `FAIL: P1 adopted trees must contain no 'cogni-help:' dispatch token`, never `P1:`. The trailing summary line leads with a bare numeral and is therefore not read as a case's red line.

## Review notes

This is a prose-accuracy change with no behavioural component, so the achievable bar is the grep-anchored checks above plus the unchanged green suite. Whether the new wording actually reads more clearly to the next maintainer is a judgment call no grep decides — worth a human eye on the three replaced paragraphs.