### PR TITLE
cogni-knowledge: consolidate test emitters onto the shared helper

### DIFF
--- a/cogni-knowledge/tests/test_binding_project_path.sh
+++ b/cogni-knowledge/tests/test_binding_project_path.sh
@@ -22,8 +22,7 @@ set -eu
 PLUGIN_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 SCRIPT="$PLUGIN_ROOT/scripts/knowledge-binding.py"
 
-red()   { printf '%s\n' "$1"; }
-green() { printf '%s\n' "$1"; }
+. "$(dirname "$0")/fixtures/test_helpers.sh"
 
 if [ ! -f "$SCRIPT" ]; then
   red "FAIL: knowledge-binding.py not found at $SCRIPT"

--- a/cogni-knowledge/tests/test_cycle_guard_clear.sh
+++ b/cogni-knowledge/tests/test_cycle_guard_clear.sh
@@ -15,10 +15,8 @@ PLUGIN_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 TESTS_DIR="$(cd "$(dirname "$0")" && pwd)"
 SCRIPT="$PLUGIN_ROOT/scripts/cycle-guard.py"
 
+. "$(dirname "$0")/fixtures/test_helpers.sh"
 . "$TESTS_DIR/fixtures/_cycle_guard_lib.sh"
-
-red()   { printf '%s\n' "$1"; }
-green() { printf '%s\n' "$1"; }
 
 WORK=$(mktemp -d)
 trap 'rm -rf "$WORK"' EXIT

--- a/cogni-knowledge/tests/test_cycle_guard_depth_bound.sh
+++ b/cogni-knowledge/tests/test_cycle_guard_depth_bound.sh
@@ -15,10 +15,8 @@ PLUGIN_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 TESTS_DIR="$(cd "$(dirname "$0")" && pwd)"
 SCRIPT="$PLUGIN_ROOT/scripts/cycle-guard.py"
 
+. "$(dirname "$0")/fixtures/test_helpers.sh"
 . "$TESTS_DIR/fixtures/_cycle_guard_lib.sh"
-
-red()   { printf '%s\n' "$1"; }
-green() { printf '%s\n' "$1"; }
 
 WORK=$(mktemp -d)
 trap 'rm -rf "$WORK"' EXIT

--- a/cogni-knowledge/tests/test_cycle_guard_direct.sh
+++ b/cogni-knowledge/tests/test_cycle_guard_direct.sh
@@ -16,11 +16,10 @@ PLUGIN_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 TESTS_DIR="$(cd "$(dirname "$0")" && pwd)"
 SCRIPT="$PLUGIN_ROOT/scripts/cycle-guard.py"
 
+. "$(dirname "$0")/fixtures/test_helpers.sh"
+
 # shellcheck source=fixtures/_cycle_guard_lib.sh
 . "$TESTS_DIR/fixtures/_cycle_guard_lib.sh"
-
-red()   { printf '%s\n' "$1"; }
-green() { printf '%s\n' "$1"; }
 
 WORK=$(mktemp -d)
 trap 'rm -rf "$WORK"' EXIT

--- a/cogni-knowledge/tests/test_cycle_guard_distilled.sh
+++ b/cogni-knowledge/tests/test_cycle_guard_distilled.sh
@@ -24,10 +24,8 @@ PLUGIN_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 TESTS_DIR="$(cd "$(dirname "$0")" && pwd)"
 SCRIPT="$PLUGIN_ROOT/scripts/cycle-guard.py"
 
+. "$(dirname "$0")/fixtures/test_helpers.sh"
 . "$TESTS_DIR/fixtures/_cycle_guard_lib.sh"
-
-red()   { printf '%s\n' "$1"; }
-green() { printf '%s\n' "$1"; }
 
 errors=0
 

--- a/cogni-knowledge/tests/test_cycle_guard_dry_run.sh
+++ b/cogni-knowledge/tests/test_cycle_guard_dry_run.sh
@@ -15,10 +15,8 @@ PLUGIN_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 TESTS_DIR="$(cd "$(dirname "$0")" && pwd)"
 SCRIPT="$PLUGIN_ROOT/scripts/cycle-guard.py"
 
+. "$(dirname "$0")/fixtures/test_helpers.sh"
 . "$TESTS_DIR/fixtures/_cycle_guard_lib.sh"
-
-red()   { printf '%s\n' "$1"; }
-green() { printf '%s\n' "$1"; }
 
 WORK=$(mktemp -d)
 trap 'rm -rf "$WORK"' EXIT

--- a/cogni-knowledge/tests/test_cycle_guard_not_applicable.sh
+++ b/cogni-knowledge/tests/test_cycle_guard_not_applicable.sh
@@ -15,10 +15,8 @@ PLUGIN_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 TESTS_DIR="$(cd "$(dirname "$0")" && pwd)"
 SCRIPT="$PLUGIN_ROOT/scripts/cycle-guard.py"
 
+. "$(dirname "$0")/fixtures/test_helpers.sh"
 . "$TESTS_DIR/fixtures/_cycle_guard_lib.sh"
-
-red()   { printf '%s\n' "$1"; }
-green() { printf '%s\n' "$1"; }
 
 WORK=$(mktemp -d)
 trap 'rm -rf "$WORK"' EXIT

--- a/cogni-knowledge/tests/test_cycle_guard_question.sh
+++ b/cogni-knowledge/tests/test_cycle_guard_question.sh
@@ -23,10 +23,8 @@ PLUGIN_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 TESTS_DIR="$(cd "$(dirname "$0")" && pwd)"
 SCRIPT="$PLUGIN_ROOT/scripts/cycle-guard.py"
 
+. "$(dirname "$0")/fixtures/test_helpers.sh"
 . "$TESTS_DIR/fixtures/_cycle_guard_lib.sh"
-
-red()   { printf '%s\n' "$1"; }
-green() { printf '%s\n' "$1"; }
 
 errors=0
 

--- a/cogni-knowledge/tests/test_cycle_guard_transitive.sh
+++ b/cogni-knowledge/tests/test_cycle_guard_transitive.sh
@@ -16,10 +16,8 @@ PLUGIN_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 TESTS_DIR="$(cd "$(dirname "$0")" && pwd)"
 SCRIPT="$PLUGIN_ROOT/scripts/cycle-guard.py"
 
+. "$(dirname "$0")/fixtures/test_helpers.sh"
 . "$TESTS_DIR/fixtures/_cycle_guard_lib.sh"
-
-red()   { printf '%s\n' "$1"; }
-green() { printf '%s\n' "$1"; }
 
 WORK=$(mktemp -d)
 trap 'rm -rf "$WORK"' EXIT

--- a/cogni-knowledge/tests/test_fetch_cache.sh
+++ b/cogni-knowledge/tests/test_fetch_cache.sh
@@ -23,8 +23,7 @@ set -eu
 PLUGIN_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 SCRIPT="$PLUGIN_ROOT/scripts/fetch-cache.py"
 
-red()   { printf '%s\n' "$1"; }
-green() { printf '%s\n' "$1"; }
+. "$(dirname "$0")/fixtures/test_helpers.sh"
 
 if [ ! -f "$SCRIPT" ]; then
   red "FAIL: fetch-cache.py not found at $SCRIPT"

--- a/cogni-knowledge/tests/test_knowledge_binding.sh
+++ b/cogni-knowledge/tests/test_knowledge_binding.sh
@@ -29,8 +29,7 @@ set -eu
 PLUGIN_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 SCRIPT="$PLUGIN_ROOT/scripts/knowledge-binding.py"
 
-red()   { printf '%s\n' "$1"; }
-green() { printf '%s\n' "$1"; }
+. "$(dirname "$0")/fixtures/test_helpers.sh"
 
 if [ ! -f "$SCRIPT" ]; then
   red "FAIL: knowledge-binding.py not found at $SCRIPT"

--- a/cogni-knowledge/tests/test_knowledge_setup_probe.sh
+++ b/cogni-knowledge/tests/test_knowledge_setup_probe.sh
@@ -25,8 +25,7 @@ set -eu
 PLUGIN_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 SETUP="$PLUGIN_ROOT/skills/knowledge-setup/SKILL.md"
 
-red()   { printf '%s\n' "$1"; }
-green() { printf '%s\n' "$1"; }
+. "$(dirname "$0")/fixtures/test_helpers.sh"
 
 errors=0
 

--- a/cogni-knowledge/tests/test_plain_result_emitters.sh
+++ b/cogni-knowledge/tests/test_plain_result_emitters.sh
@@ -136,9 +136,9 @@ done
 errors=$((errors + shape_errors))
 
 # Liveness floor — a broken glob must fail loudly rather than pass vacuously.
-# 78 files exercise the contract today (16 define the emitters, 62 source the
-# helper). The floor sits at 50 so either direction of drift has room, and
-# consolidating definers onto the helper cannot trip it.
+# 78 files exercise the contract today (1 defines the emitters — the shared
+# helper — and 77 source it). The floor sits at 50 so either direction of drift
+# has room, and consolidating definers onto the helper cannot trip it.
 if [ "$exercisers" -lt 50 ]; then
   red "FAIL: only $exercisers file(s) exercising the emitter contract were found (expected at least 50) — the scan is not reaching them"
   errors=$((errors + 1))

--- a/cogni-knowledge/tests/test_portal_store.sh
+++ b/cogni-knowledge/tests/test_portal_store.sh
@@ -32,8 +32,7 @@ OVERVIEW="$WIKI/wiki/overview.md"
 cleanup() { rm -rf "$WORKDIR"; }
 trap cleanup EXIT
 
-red() { printf '%s\n' "$1"; }
-green() { printf '%s\n' "$1"; }
+. "$(dirname "$0")/fixtures/test_helpers.sh"
 fail() { red "FAIL: $1"; printf -- '----- index.md -----\n'; cat "$INDEX" 2>/dev/null; exit 1; }
 
 if [ ! -f "$UPDATE" ]; then

--- a/cogni-knowledge/tests/test_resolve_wiki_scripts.sh
+++ b/cogni-knowledge/tests/test_resolve_wiki_scripts.sh
@@ -36,8 +36,7 @@ RESOLVER_SNIPPET="$PLUGIN_ROOT/scripts/resolve-wiki-scripts.sh"
 # instead of carrying an inline copy. These are the flows expected to source it.
 SOURCING_SKILLS="knowledge-ingest knowledge-finalize knowledge-dashboard knowledge-health knowledge-lint knowledge-resume knowledge-ingest-source knowledge-query"
 
-red()   { printf '%s\n' "$1"; }
-green() { printf '%s\n' "$1"; }
+. "$(dirname "$0")/fixtures/test_helpers.sh"
 
 errors=0
 

--- a/cogni-knowledge/tests/test_synthesis_impact.sh
+++ b/cogni-knowledge/tests/test_synthesis_impact.sh
@@ -28,8 +28,7 @@ set -eu
 PLUGIN_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 SCRIPT="$PLUGIN_ROOT/scripts/synthesis-impact.py"
 
-red()   { printf '%s\n' "$1"; }
-green() { printf '%s\n' "$1"; }
+. "$(dirname "$0")/fixtures/test_helpers.sh"
 
 if [ ! -f "$SCRIPT" ]; then
   red "FAIL: synthesis-impact.py not found at $SCRIPT"


### PR DESCRIPTION
Closes #1364.

## Summary

`cogni-knowledge/tests/fixtures/test_helpers.sh` exists to be the single definition of the
`red()` / `green()` result emitters, but 15 suites still carried byte-identical inlined
copies. This deletes those copies and sources the helper instead, so the helper is now the
only definition under `cogni-knowledge/tests/`.

Net: **16 files changed, 20 insertions, 47 deletions.**

Two edit shapes, both matching existing house style:

- **7 plain suites** — the source line takes the slot the two definitions vacated
  (precedent `test_candidate_store.sh:27-32`).
- **8 cycle-guard-family suites** — the source line goes *above* their existing
  `. "$TESTS_DIR/fixtures/_cycle_guard_lib.sh"` line, matching the sole multi-source
  precedent, `test_finalize_contract.sh:21-22`, which sources `test_helpers.sh` first.

No call site changed: the helper's bodies are byte-identical to the copies they replace,
so this is a pure de-duplication with no behavioral surface.

## The one non-obvious deliverable

`test_plain_result_emitters.sh:139-141` carried a count this change falsifies —
"78 files exercise the contract today (16 define the emitters, 62 source the helper)".
It is restated to the post-change split (1 defining, 77 sourcing, total still 78).

The floor logic one line below is deliberately **untouched**:

```sh
if [ "$exercisers" -lt 50 ]; then
```

It is keyed on *exercisers* (define **or** source), not definers, precisely so
consolidation cannot trip it — #1359 re-homed it for exactly this reason. Re-keying it to
`$definers` would false-fail the guard at 1.

## Why a line per suite, and not the "deeper" fix

The obvious objection is that the 8 cycle-guard suites already source
`fixtures/_cycle_guard_lib.sh`, so sourcing the helper from *inside* that lib would fix 8
files with one line instead of 8. That alternative was measured and rejected, because it
would quietly blind the guard.

`test_plain_result_emitters.sh:104` counts an exerciser with a per-file literal match:

```sh
grep -qF 'test_helpers.sh' "$f"
```

That is a text match, not a resolved source graph. Route the emitters transitively and none
of the 8 suites carries the literal any more — only the lib does. The exerciser count falls
**78 → 71** (−8 suites, +1 lib) against a floor of 50, so the guard stays **green while
going blind to 8 files that genuinely depend on the contract**. Nothing else would flag it:
the escape-literal sweep and the definition-shape loop are both unaffected. That is exactly
the vacuous pass the liveness floor exists to prevent.

Two smaller reasons the per-suite line is right: `test_finalize_contract.sh` — the lib's 9th
consumer — already carries its own explicit helper source line, so these 8 additions match a
sibling rather than inventing a convention; and `_cycle_guard_lib.sh` is a fixture *builder*
that uses neither emitter, so making it a helper conduit would invert the dependency and make
emitter availability implicit and source-order-dependent for every future consumer.

## Verification

| Check | Result |
|---|---|
| `bash cogni-knowledge/tests/test_plain_result_emitters.sh` | exit 0 |
| Guard's case-3 line | `PASS: 1 emitter-defining file(s) are paired and plain, of 78 exercising the contract` (base: `16 … of 78`) |
| `grep -lE '^(red\|green)\(\)' cogni-knowledge/tests/*.sh` | 0 files (base: 15) |
| Each of the 15 suites run standalone from repo root | all exit 0 |
| `python3 scripts/run-plugin-tests.py --filter cogni-knowledge` | 77/77 passed (base: 77/77) |
| `python3 scripts/run-plugin-tests.py` (full repo sweep) | 115/115 passed |
| Call-site counts per file, base vs head | identical in all 15 |
| `fixtures/test_helpers.sh` in diff | no |
| `cogni-knowledge/tests/README.md` in diff | no |

The `16 → 1` flip with exercisers steady at `78` is the observable proof the consolidation
happened; a no-op diff would leave it at 16.

### A counting note for whoever grades this

Two different greps give two different (both correct) sourcer counts, so please don't read
one as a shortfall against the other:

- files containing the **exact idiom** `. "$(dirname "$0")/fixtures/test_helpers.sh"` — **61 → 76**
- files **mentioning** `test_helpers.sh` at all — **62 → 77**

Both moved by exactly +15. The single file in the gap is
`test_plain_result_emitters.sh` itself, which references the helper via
`HELPER="$TESTS_DIR/fixtures/test_helpers.sh"` in order to *probe* it — it is the guard,
not a consumer, and it correctly does not source it.

## Scope decisions

**Deliberately not edited:**

- `cogni-knowledge/tests/fixtures/test_helpers.sh` — already correct; this PR only adds consumers.
- `cogni-knowledge/tests/README.md` — line 42 already reads "Source `fixtures/test_helpers.sh`
  for `red`/`green` rather than inlining". **AC 6 is satisfied by verification, not by a diff** —
  an untouched README is the correct outcome here, not a missed criterion.
- `test_plain_result_emitters.sh:142` — the floor logic, see above.
- Any `plugin.json` / `marketplace.json` version — the post-merge workflow owns the bump.

**Preserved hazards** (both found before editing, both verified in the diff):

- `test_portal_store.sh` — `fail() { red "FAIL: $1"; … }` sits immediately below the def
  block. Only the two definition lines were removed; `fail()` is intact.
- `test_cycle_guard_direct.sh` — `# shellcheck source=fixtures/_cycle_guard_lib.sh` pins the
  *lib* source, so the new helper source line was placed above the pragma, keeping the
  pragma adjacent to the line it pins.

`$(dirname "$0")` is safe in all 15: none reassigns `$0`, none sources via `BASH_SOURCE`,
and every `cd` is confined to a `$(cd … && pwd)` subshell. The anchor is load-bearing rather
than stylistic — `scripts/run-plugin-tests.py` executes each suite with `cwd=repo root`, so a
relative `. fixtures/test_helpers.sh` would break under CI while still passing by hand from
inside the tests directory.

`test_resolve_wiki_scripts.sh` drives snippet bodies through `bash -c`, but every emitter
call happens in the outer shell, so sourcing versus inlining is neutral there.

## Mutation recipe

Run from the PR-head checkout root — a non-PR-head `--root` false-blocks.

Proves case `helper` of the touched guard is falsifiable. The mutation rewrites only the
`EXPECTED=` literal, so the captured helper output no longer matches it and the case flips
`PASS: helper emits plain result lines on stdout` → `FAIL: helper did not emit the expected
plain result lines`.

```sh
bash mutation-check.sh --root . --file cogni-knowledge/tests/test_plain_result_emitters.sh --expr "s/EXPECTED='PASS: probe-green/EXPECTED='PASS: probe-lime/" --test "bash cogni-knowledge/tests/test_plain_result_emitters.sh" --case helper
```

Three things this recipe is deliberate about, each a way an earlier draft failed:

- **No `^` anchor.** The harness runs `perl -0pi -e` (slurp mode), where `^` matches only the
  start of the *file*, not of a line. An anchored expression matches nothing and the harness
  hard-errors `expr_no_op` (exit 2) rather than proving anything.
- **The `EXPECTED='` prefix is load-bearing.** `probe-green` appears twice — on the
  `CAPTURED=` line and on the `EXPECTED=` line directly below it. Mutating both would move the
  two sides together and leave the case green, proving nothing; the prefix pins the match to
  exactly one site.
- **The replacement is disjoint from the literal it replaces** (`probe-lime` does not contain
  `probe-green`), so the mutation genuinely changes the compared text.

`--case helper` is correct because the harness matches the first whitespace-delimited token,
whole-token, against both the green and red labels — and both
`PASS: helper emits …` and `FAIL: helper did not emit …` begin with `helper`.

This recipe was executed, not merely written.