### PR TITLE
Slicing convention for plugin-absorption changes

### DIFF
--- a/docs/contributing/plugin-absorption-slicing.md
+++ b/docs/contributing/plugin-absorption-slicing.md
@@ -1,0 +1,171 @@
+# Plugin Absorption Slicing
+
+How to slice a plugin-absorption change — folding one plugin's skills, agents and commands
+into another and retiring the source — so that each stage is reviewable on its own and
+leaves CI green at its merge.
+
+Read this before planning an absorption. The sequencing below is not a style preference:
+three of this repo's guards grade the *real* tree against the *real* manifest, so a
+plausible-looking decomposition can leave the build red between stages. Those constraints
+are stated with the stage they bind.
+
+## Why this exists
+
+The first absorption landed as one pull request of 1736 changed lines across 97 files. The
+review gate flagged the size, and the coupling that produced it was real: delete a plugin
+and relocate it, and every consumer reference has to move in the same commit or the tree
+names a plugin that no longer exists.
+
+The coupling is real but it is not total. It binds *deletion* to *consumer rewrite*, not
+*adoption* to either. Adding the adopted trees while the source still exists dangles
+nothing, so adoption can land first, on its own, and be reviewed closely. That is the seam
+this convention cuts along.
+
+## The four stages
+
+Plan an absorption as four pull requests in this order. Each row states what lands and the
+invariant that keeps the tree working when it merges.
+
+| # | Stage | What lands | Invariant at merge |
+|---|---|---|---|
+| 1 | Adopter | The adopted skills / agents / commands under the adopting plugin, plus the hygiene guard for those trees | Both plugins exist. Every dispatch token in the tree resolves. The adopted copies contain no source-prefixed dispatch token. |
+| 2 | Consumer rewrite | Every consuming plugin's dispatch tokens and prose repointed at the new home | Both plugins still exist, so a token resolves whether it was rewritten yet or not. Splittable per consumer group. |
+| 3 | Retirement | Source directory, its `plugins[]` entry, both wiki trees' roster pages, and the retired-prefix registration — **atomically** | Manifest and directories are back in bijection, the wiki roster matches the manifest, and no live surface dispatches the newly registered prefix. |
+| 4 | Narrative docs | Prose, diagrams and counts that no guard grades — architecture pages, ecosystem overview, README narrative | Nothing is enforced here; correctness is editorial. |
+
+### This departs from the obvious sketch, on purpose
+
+The intuitive decomposition ends with a "docs and wiki" stage that regenerates every roster
+surface after the deletion. Do not plan it that way. The **wiki** half of that stage is
+graded against the manifest, so it must merge *with* the deletion — see stage 3. Only the
+ungraded narrative surfaces can defer to stage 4.
+
+## Per-stage size bound
+
+Target **400 changed lines per stage**. That figure is the review gate's advisory
+bound — it is a fail-visible flag raised by the `cogni-service` review tooling, which lives
+outside this repository, not a check in `.github/workflows/`. Nothing fails a build at 401
+lines.
+
+Stage 3 is the one stage that may not fit. Its contents are bound together by the guards
+below, so splitting it to hit the bound trades a review-size flag for a red build — take
+the flag. When a stage exceeds the bound because an atomicity rule forces it, say so in the
+pull-request body so the reviewer reads the size as intentional.
+
+## What binds stage 3 together
+
+Three guards make stage 3 atomic. Each is enforced by CI, so none of these is advisory.
+
+### The manifest and the directories must move together
+
+`scripts/check-plugin-inventory.py` asserts a bijection in both directions: every
+`plugins[].source` in `.claude-plugin/marketplace.json` resolves to a directory carrying
+`.claude-plugin/plugin.json`, and every top-level plugin directory appears in `plugins[]`.
+`tests/test_check_plugin_inventory.sh` runs it against the real repository, and
+`scripts/run-plugin-tests.py` runs that under CI.
+
+Delete the directory without removing the entry and direction 1 fails; remove the entry
+without deleting the directory and direction 2 fails. Both edits belong in one commit.
+
+### The wiki roster dies with the manifest entry
+
+`cogni-workspace/tests/test-wiki-namespace-sync.sh` builds its allowed-namespace roster at
+runtime from `plugins[].name`, and its first case scans the real wiki trees against that
+roster. The moment the source plugin leaves `plugins[]`, every
+`plugin-<source>*`, `skill-<source>-*` and `agent-<source>-*` page in both wiki trees
+becomes an off-roster offender.
+
+Delete those pages in the same pull request that removes the manifest entry. Do not hand-
+edit generated wiki output for any other purpose in an absorption — regenerate it instead.
+
+### Register the retired prefix last
+
+`scripts/check-external-dispatch.py` enforces a hard clean-zero — no ratchet, no
+baseline — for every prefix listed in `scripts/retired-plugins.json`, across
+`*/skills/*/SKILL.md`, `*/agents/*.md`, `*/commands/*.md` and `*/hooks/**`. Directories
+named `references/` and `docs/` are excluded by design, so lineage prose is safe.
+
+Add the source prefix to the registry **in stage 3, never earlier**. Register it while
+stage 2 is still in flight and every not-yet-rewritten consumer becomes a build failure.
+
+```json
+{
+  "retired_prefixes": ["cogni-wiki", "cogni-research", "cogni-help"]
+}
+```
+
+## The relocated-skill hygiene guard
+
+`cogni-workspace/tests/test-relocated-skill-hygiene.sh` is the pattern to copy for a new
+adoption. Read what it actually asserts before reasoning about it, because it is easy to
+assume a scope it does not have.
+
+Its first case walks **only the adopted trees under the adopting plugin** and fails if any
+file contains the source plugin's qualified dispatch token. It never scans consumers. Its
+own header states that every assertion reads the destination tree alone and that it passes
+the same whether or not a source tree exists anywhere in the repository.
+
+Two consequences for slicing:
+
+- **The consumer-rewrite stage does not violate this guard.** Tokens surviving in consuming
+  plugins are invisible to it. The guard that governs those tokens is
+  `check-external-dispatch.py`, and it is inert until the prefix is registered — which is
+  why registration waits for stage 3.
+- **Author the guard in stage 1.** The adopted trees must be clean of source-prefixed
+  dispatch tokens the moment they land, and the guard carries a liveness floor that fails
+  when it scans zero files. A guard added before the trees exist fails; a guard added after
+  leaves the adoption ungraded in between.
+
+Write a new guard for each adoption rather than widening the existing one. Do not retrofit
+`test-relocated-skill-hygiene.sh` — it is scoped to the trees cogni-workspace adopted from
+cogni-help, and that scoping is what makes it readable.
+
+## The duplicate-plugin window
+
+Stages 1 and 2 leave both plugins shipping the same skills. **Accept that window, and
+time-box it to a single planning sequence** — open stage 2 as soon as stage 1 merges, and
+do not start an unrelated absorption while one is open.
+
+It is accepted because the alternative is the coupling this convention exists to break:
+avoiding the window means adoption, rewrite and deletion collapse back into one
+unreviewable commit. It is time-boxed because its two costs are real and neither is caught
+by CI.
+
+**A duplicate skill name is reported, but not by CI.**
+`cogni-workspace/scripts/check-skill-names.sh` globs `cogni-*/skills/*/SKILL.md` across
+every plugin and reports a duplicate when two plugins carry the same frontmatter `name:`.
+It is a documented pre-pull-request check, not a workflow step, and its own suite exercises
+fixtures rather than the real tree. So during the window the check reports errors that are
+expected. Note that in the stage-1 and stage-2 pull-request bodies, naming the duplicated
+skills, so a reviewer can tell an expected report from a regression.
+
+**A trigger-phrase collision is caught by nothing.**
+`cogni-workspace/tests/test-skill-trigger-phrases.sh` is scoped to a single plugin
+deliberately — two plugins may legitimately quote the same phrase, because the host
+disambiguates by plugin. Across the duplicate window that assumption does not hold: the
+source and the adopted copy are the same skill, and the host has no tiebreaker.
+
+Therefore, during the window:
+
+- Do not duplicate a slash command. Land the command definition in stage 3, with the
+  deletion, or leave it on the source plugin until then.
+- Do not rename an adopted skill to dodge the duplicate report. A rename is a user-visible
+  dispatch change and does not belong inside a hygiene workaround.
+
+## Absorptions this governs
+
+The queued absorption work is planned against this convention. Slice each of these into the
+stages above rather than filing one pull request per issue:
+
+- **#1351** — absorb cogni-narrative and cogni-copywriting into cogni-workspace
+- **#1352** — move the excalidraw `.mcp.json` out of the plugin into `install-mcp`
+- **#1353** — absorb cogni-visual into cogni-workspace
+- **#1354** — reconcile docs, marketplace metadata, diagrams and wiki for the reduced roster
+
+#1352 is not itself an absorption; it is a gate one of them depends on, and it stays a
+single pull request.
+
+## Related Documents
+
+- [plugin-development.md](plugin-development.md) — how to build a plugin, and the conventions an adopted tree must still satisfy
+- [../architecture/plugin-anatomy.md](../architecture/plugin-anatomy.md) — every file type an absorption relocates

--- a/docs/contributing/plugin-development.md
+++ b/docs/contributing/plugin-development.md
@@ -319,3 +319,4 @@ For PRs to your own plugin from other contributors, set up your own contribution
 - [architecture/plugin-anatomy.md](../architecture/plugin-anatomy.md) — reference for every file type and naming convention
 - [architecture/design-philosophy.md](../architecture/design-philosophy.md) — the principles behind the structure
 - [architecture/er-diagram.md](../architecture/er-diagram.md) — cross-plugin entity relationships to understand integration points
+- [plugin-absorption-slicing.md](plugin-absorption-slicing.md) — how to slice a plugin-absorption change so each stage is reviewable and leaves CI green


### PR DESCRIPTION
Closes #1397.

## Summary

Adds `docs/contributing/plugin-absorption-slicing.md` — a stage-ordered slicing convention
for plugin-absorption changes — and registers it in `plugin-development.md`'s
`## Related Documents` list.

The first absorption landed as one PR of 1736 changed lines across 97 files. The coupling
that produced it is real, but it binds *deletion* to *consumer rewrite*, not *adoption* to
either: adding the adopted trees while the source still exists dangles nothing. The
convention cuts along that seam into four stages, each stating what lands and the invariant
that keeps the tree green at its merge.

## The parts that are not just restating the issue

Three CI-enforced guards constrain the ordering, and two of them **falsify the issue's own
four-stage sketch**. Each was verified against `origin/main` before the doc was written.

| Guard | Constraint | Effect on the sketch |
|---|---|---|
| `scripts/check-plugin-inventory.py` | Bijection between `marketplace.json` `plugins[]` and top-level plugin directories; `tests/test_check_plugin_inventory.sh` grades the real repo | Directory deletion and manifest removal cannot be split |
| `cogni-workspace/tests/test-wiki-namespace-sync.sh` | Derives its allowed roster from `plugins[].name` at runtime; case C1 scans the real wiki trees | **Falsifies stage 4** — the source plugin's wiki roster pages must die with the manifest entry, not in a later docs PR |
| `scripts/check-external-dispatch.py` | Hard clean-zero (no ratchet) for every prefix in `scripts/retired-plugins.json` | Registration must not precede the consumer rewrite, or the whole window goes red |

**The issue's hygiene-guard premise is also wrong, and the doc corrects it.**
`cogni-workspace/tests/test-relocated-skill-hygiene.sh` case P1 walks only the *adopted*
trees under the adopting plugin and never scans consumers — its own header states it passes
whether or not a source tree exists. So the consumer-rewrite window does not violate it.
Its real constraint is a liveness floor (a scan of zero files fails), which means the guard
must be authored in the same PR that creates those trees.

**Position on the duplicate-plugin window: accepted, time-boxed to a single sequence.**
Neither of its two costs is caught by CI, which is why the doc states them explicitly:
`check-skill-names.sh` reports duplicate skill names but is absent from `lint.yml` and its
own suite only exercises fixtures; `test-skill-trigger-phrases.sh` is single-plugin by
design, so a cross-plugin trigger or slash-command collision is caught by nothing. Hence
the window's two rules — do not duplicate a slash command, and do not rename an adopted
skill to dodge the duplicate report.

The 400-line per-stage bound is cited as what it is: the external `cogni-service` review
gate's fail-visible advisory flag, with no in-repo path, plus the escape hatch for when
stage 3's atomicity forces it over.

## Scope decisions

- **Documentation only.** No new guard: no deterministic check can decide whether a change
  was sliced correctly, and adding one would ship an unfalsifiable suite.
- **Not appended to `cogni-workspace/references/absorption-roadmap.md`** — that file is a
  decisions record, not a process doc.
- **One registration surface, chosen for concurrency.** PR #1396 is open and in active
  revision across 100 files, including repo-root `CLAUDE.md`, the absorption roadmap,
  `test-relocated-skill-hygiene.sh`, `retired-plugins.json`, `README.md`, both architecture
  pages, `docs/ecosystem-overview.md` and `cogni-workspace/CLAUDE.md`. All are avoided.
  `docs/contributing/plugin-development.md` is the only clear surface — and it is itself
  linked from four of those pages, so discoverability is inherited rather than duplicated.
- **No version bump** — the post-merge workflow owns it.

## Verification

- `python3 scripts/run-plugin-tests.py` — **all 115 suites pass**
- `python3 scripts/check-breadcrumbs.py` — 0 new breadcrumbs (`docs/` is outside the
  guard's `*/skills/*/SKILL.md` + `*/agents/*.md` globs, so the issue refs in the doc are
  intentional narrative, not breadcrumbs)
- `python3 scripts/check-plugin-inventory.py` — 0 violations
- `python3 scripts/check-version-bump.py` — 12 plugins scanned, 0 touched
- Diff is exactly two paths, neither in PR #1396's file set
- Every repo path the new doc cites resolves in the tree (full path at first mention, bare
  basename thereafter)

## Acceptance criterion 3 — the children now reference the convention

Each of the four queued absorption children already carried a populated `## Depends on`
section, so this landed as a posted comment per child rather than a body edit, which would
have risked clobbering it. All four are posted:

- #1351 — absorb cogni-narrative + cogni-copywriting — https://github.com/cogni-work/insight-wave/issues/1351#issuecomment-5305656041
- #1352 — move the excalidraw `.mcp.json` into `install-mcp` — https://github.com/cogni-work/insight-wave/issues/1352#issuecomment-5305656125
- #1353 — absorb cogni-visual — https://github.com/cogni-work/insight-wave/issues/1353#issuecomment-5305656234
- #1354 — reconcile docs / marketplace / diagrams / wiki — https://github.com/cogni-work/insight-wave/issues/1354#issuecomment-5305656325

## Open questions for the reviewer

Two points in the doc are judgment calls that no gate can settle, and a human should read
the argument rather than confirm a position exists:

1. Whether **400 changed lines** is the right per-stage target, given stage 3 is
   irreducibly atomic and may exceed it.
2. Whether the duplicate window's **uncaught router ambiguity** is an acceptable price for
   reviewability, or whether the window should instead be forbidden outright.
