### PR TITLE
cogni-workspace: reconcile wiki entries_count and unresolved page references, record per-delta decisions

### DIFF
--- a/cogni-workspace/references/wiki-tree-reconciliation.md
+++ b/cogni-workspace/references/wiki-tree-reconciliation.md
@@ -1,0 +1,248 @@
+# Wiki-tree reconciliation — decisions record
+
+insight-wave carries two copies of the same wiki. `wiki/` at the repository root is edited by
+maintainers; `cogni-workspace/wiki/` is the vendored copy that ships inside the plugin so
+marketplace users get it in their plugin cache on install. `scripts/release-bundle-wiki.sh`
+copies the first over the second. This document records what was decided about every way the
+two copies currently disagree.
+
+This is a decisions record, not a delivery plan. Each decision below states what was decided,
+the rule behind it, and the consequence of reversing it. Items marked *recorded, not executed*
+are decided here and carried out elsewhere; the issue that carries them is named inline.
+
+## On the figures in this document
+
+Every count below is attributed to the command that produced it, measured against
+`origin/main` at `0698cb2c`. Where a previously-quoted figure could not be reproduced, that is
+recorded plainly rather than smoothed over.
+
+| Figure | Command | Value |
+|---|---|---|
+| Pending changes | `bash scripts/release-bundle-wiki.sh --check` | `changes_pending: 28` |
+| Root page count | same command, `source_page_count` | `170` |
+| Bundled page count | `find cogni-workspace/wiki/wiki/pages -maxdepth 1 -name '*.md' \| wc -l` | `176` |
+| Itemised breakdown | `rsync -anci --delete wiki/ cogni-workspace/wiki/` | 20 content + 7 delete + 1 add |
+
+**The originating issue says 29; measurement says 28.** Both figures were taken with the same
+command at different times, and the difference is not a miscount — it is the metric moving. An
+earlier measurement at `bab6a9cd` reported `128`, of which 100 lines were attribute-only
+(96 `.f..t....` files plus 4 `.d..t....` directories) produced by `rsync -i` itemising mtime
+differences on a fresh checkout. At `0698cb2c` that class is **empty**: all 28 lines are genuine
+content differences. Anyone re-measuring on a freshly-cloned tree may see the attribute lines
+return, because they are an artefact of checkout order rather than of the trees themselves.
+
+## Decision 1 — `entries_count` is corrected by hand, per tree
+
+**Decision.** Set each tree's `.cogni-wiki/config.json` `entries_count` to that tree's own
+measured page count. Root `179` → `170`; bundled `178` → `176`.
+
+**Why.** The field had drifted in both trees, in both cases by omission rather than by error.
+It was last set correctly by hand; three later commits deleted pages from one tree or the other
+without updating either config.
+
+| Tree | Config path | Recorded | Measured | Drift |
+|---|---|---:|---:|---:|
+| Root | `wiki/.cogni-wiki/config.json` | 179 | 170 | +9 overstated |
+| Bundled | `cogni-workspace/wiki/.cogni-wiki/config.json` | 178 | 176 | +2 overstated |
+
+**The two values stay different, and that is correct.** Each config describes its own tree, and
+the trees hold different numbers of pages for as long as Decision 4 is open. A future reader
+should not read `170 != 176` as fresh drift.
+
+**Reversing it** restores a count that overstates both trees, which is the state that let three
+page-deleting commits pass unnoticed.
+
+## Decision 2 — the expected pending-changes figure is 28, and the residual is explained
+
+**Decision.** After this reconciliation, `bash scripts/release-bundle-wiki.sh --check` is
+expected to keep reporting `changes_pending: 28`. That figure is understood and intended.
+
+**Why.** The metric counts `rsync` itemise lines, and none of the three classes it counts is
+closed by the changes recorded here:
+
+| Class | Lines | Why it survives |
+|---|---:|---|
+| `*deleting` | 7 | The bundled-only pages stay in place pending Decision 4 |
+| `>f+++++++` | 1 | The dated lint page is root-only by design (Decision 5) |
+| Content deltas | 20 | Recorded in Decision 3, executed separately |
+
+The wikilink change in Decision 6 lands identically on both sides, so it adds no line. The
+`entries_count` change in Decision 1 does not add a line either: the two configs already
+differed, and they still differ.
+
+**Reversing it** means the next person to read `28` treats it as unexplained drift and reaches
+for the sync script — the outcome Decision 3's rejected alternative exists to prevent.
+
+## Decision 3 — the 20 content deltas resolve in two opposite directions
+
+*Recorded, not executed. Carried out in issue #1401.*
+
+**Rule.** Direction is decided per group, never by a blanket copy. Thirteen files are newer at
+the root; four are newer in the bundle; three are structural and take bespoke handling.
+
+**Why.** The root copy is the editing surface, so the reflex is to treat it as correct
+everywhere. For four pages that reflex would delete work. Commit `c44d52c3` appended
+`## Steps` and `## Common pitfalls` sections — and a `## Two scenarios` section on one page —
+directly to the *bundled* copies. Those sections have no root counterpart, so copying root over
+bundle discards them.
+
+### Group A — 13 files, root copy wins
+
+Re-ingest commits enriched the root pages; the bundle was never re-synced afterwards and still
+holds the thinner generated stub.
+
+`agent-cogni-claims-claim-verifier.md`, `agent-cogni-claims-source-inspector.md`,
+`agent-cogni-portfolio-proposition-generator.md`,
+`agent-cogni-portfolio-proposition-quality-assessor.md`, `concept-claim-lifecycle.md`,
+`concept-claims-propagation.md`, `plugin-cogni-claims.md`, `plugin-cogni-portfolio.md`,
+`skill-cogni-portfolio-portfolio-verify.md`, `skill-cogni-portfolio-propositions.md`,
+`skill-cogni-trends-trend-report.md`, `skill-cogni-claims-claim-entity.md`,
+`skill-cogni-claims-claims.md`
+
+### Group B — 4 files, bundled copy wins
+
+| Page | Root lines | Bundled lines | Sections only in the bundle |
+|---|---:|---:|---|
+| `workflow-portfolio-to-website.md` | 55 | 76 | Steps, Common pitfalls |
+| `workflow-content-pipeline.md` | 50 | 79 | Steps, Common pitfalls |
+| `workflow-portfolio-to-pitch.md` | 56 | 72 | Steps, Common pitfalls |
+| `workflow-trends-to-solutions.md` | 52 | 79 | Two scenarios, Steps, Common pitfalls |
+
+These must be back-ported bundle → root *before* any sync runs, then maintained from the root
+like everything else.
+
+### Group C — 3 structural files
+
+`wiki/index.md` — the bundle's seven extra bullets are correct for the tree that holds those
+seven pages, so they are not drift. Separately, the root copy carries five description
+corrections and a root-only maintenance section. Neither side is wholly right; this one is
+merged, not copied.
+
+Both `.cogni-wiki/config.json` files — closed by Decision 1.
+
+`wiki/log.md` — frozen by Decision 5.
+
+**Reversing it** and running a blanket sync destroys the group-B sections and cannot be
+recovered from the bundled tree afterwards.
+
+## Decision 4 — the 7 bundled-only pages are held pending a maintainer ruling
+
+*Recorded, not executed. Carried out in issue #1402.*
+
+**Decision.** Neither promote these pages into the root tree nor delete them from the bundle.
+They stay exactly as they are, and are listed here so the state is deliberate rather than
+forgotten.
+
+| Page | Named entities resolved | Verdict | Proposal |
+|---|---|---|---|
+| `concept-canonical-workflow-ids` | none asserted | current | promote |
+| `ecosystem-plugin-selection` | 12/12 resolve | current | promote |
+| `workflow-consulting-engagement` | 8 resolve, 1 self-documented removal | current | promote |
+| `workflow-docs-pipeline` | 9 resolve, all in another marketplace | current | promote |
+| `workflow-full-onboarding` | 5/5 resolve | current | promote |
+| `workflow-research-to-report` | 7/7 resolve | current | promote |
+| `ecosystem-command-reference` | 18 resolve, 1 mislabelled, 2 stale | lightly stale | update, then promote |
+
+**Why the ruling is reserved.** Accepting a page into the root tree is what makes
+`cogni-workspace:ask` serve it as a grounded answer. Promoting a stale page therefore does not
+degrade gracefully — it makes the assistant answer confidently and wrongly, which is worse than
+the dangling reference it would have fixed.
+
+**The one page that is stale, and how.** `ecosystem-command-reference` states that
+cogni-workspace ships no commands directory, lists 9 of its 11 skills, and counts
+`render-infographic-editorial` as a skill when it is a command. The first two are the
+cogni-help retirement seam: `troubleshoot` and `cogni-issues` moved into cogni-workspace and the
+page predates the move. Three table rows, not a rewrite.
+
+**Reversing it** — promoting all seven without the ruling — ships the stale page into the
+grounded answer set.
+
+## Decision 5 — dated records are history and are never rewritten
+
+**Rule.** A dated snapshot records what was true on its date. Editing it is not reconciliation.
+
+This extends an exemption the repository already recorded for `lint-2026-04-20.md`, and applies
+it to the other dated record carrying the same figure.
+
+| Path | Content | Treatment |
+|---|---|---|
+| `wiki/wiki/pages/lint-2026-04-20.md` | quotes a roster count true on its date | byte-identical, both trees |
+| `wiki/wiki/log.md` | ingest entries quoting the same count | byte-identical, both trees |
+
+The two trees' `log.md` copies additionally record two genuinely separate cleanup events on
+different dates. That is divergent history, not staleness, and merging them would fabricate a
+record of something that did not happen.
+
+**Consequence for grading.** The requirement that no document assert a roster count disagreeing
+with the marketplace manifest applies to current-state documents only. A change that "corrects"
+a count inside a dated record violates this decision rather than satisfying that requirement.
+
+## Decision 6 — the two unresolved references are removed from both copies
+
+**Decision.** `workflow-install-to-infographic.md` line 60 listed six follow-on workflows, two
+of which name pages absent from the root tree. Both are removed, identically, from both copies.
+
+**Why not the other direction.** The obvious fix is to make the two pages exist at the root —
+but those are two of the seven pages Decision 4 holds, so taking that route would decide
+Decision 4 as a side effect. Removing the two references decides nothing and leaves four valid
+options in the sentence.
+
+**Why both copies.** This page is one of four pinned to byte-identity between the trees by
+`cogni-workspace/tests/test-layering-claim-reconciled.sh`. A one-sided edit turns that suite red.
+
+**On promotion.** If Decision 4 resolves toward promoting, restore both references — in both
+copies — as part of that work. Issue #1402 carries this.
+
+## Rejected alternative — run the sync script and accept the deletions
+
+Rejected on three grounds:
+
+1. It deletes the seven pages of Decision 4, converting a held decision into an executed one
+   with no ruling.
+2. It overwrites the four group-B pages with shorter root copies, destroying content that
+   exists nowhere else.
+3. Its post-sync check compares page *counts*, so it cannot detect the second failure at all —
+   the counts still match after the content is gone.
+
+The script's own header states the root tree is the editing surface, so the deletion is
+intentional in principle. What is missing is any refusal when the bundle holds something the
+sync is about to destroy. Issue #1403 carries that.
+
+## Rejected alternative — regenerate `entries_count` with the wiki linter
+
+The repository does contain a writer for this field, reached through the wiki linter's
+drift fix. It does not apply here. That tool enumerates pages by walking a fixed set of
+per-type subdirectories, and this wiki stores every page in one flat directory that is not in
+that set — pointed at either tree it would count zero pages rather than 170 or 176, and write
+that. The field is informational for this wiki, no test asserts on it, no schema documents it,
+and the sync script never reads it. Setting it by hand matches how it was last set correctly.
+
+## Known remaining contradictions
+
+Kept as a permanent inventory so the set stays auditable rather than being rediscovered.
+
+| Item | State | Carried by |
+|---|---|---|
+| 13 group-A pages thinner in the bundle | recorded, not executed | #1401 |
+| 4 group-B pages missing sections at the root | recorded, not executed | #1401 |
+| `wiki/index.md` needs a merge, not a copy | recorded, not executed | #1401 |
+| 7 bundled-only pages held | awaiting a maintainer ruling | #1402 |
+| `ecosystem-command-reference` names a retired command surface | held with the page above | #1402 |
+| Sync script destroys bundle-only content | open defect | #1403 |
+| This record and its guard are unregistered in the plugin guide | open | #1404 |
+
+## Deliberately left standing
+
+The two `log.md` copies and `lint-2026-04-20.md` are untouched, per Decision 5 — a future reader
+should not read them as misses. The two `entries_count` values remain different from each other,
+per Decision 1. The pending-changes figure remains 28, per Decision 2. None of the seven
+bundled-only pages is edited, promoted or deleted, per Decision 4.
+
+## What guards this
+
+`cogni-workspace/tests/test-wiki-tree-parity.sh` asserts, per tree and never tree-wide: that
+each `.cogni-wiki/config.json` `entries_count` equals a live count of that same tree's pages;
+that every wiki reference in a tree resolves to a page in that same tree; and that every page
+present in only one tree is named in this document. The last of those is what makes adding or
+promoting a page without recording a decision here fail rather than pass silently. It does not
+assert the two trees are equal — they are not, by Decisions 1, 4 and 5.

--- a/cogni-workspace/tests/test-wiki-tree-parity.sh
+++ b/cogni-workspace/tests/test-wiki-tree-parity.sh
@@ -1,0 +1,377 @@
+#!/usr/bin/env bash
+# Wiki two-tree parity guard: each tree must be internally consistent, and any
+# page that exists in only one tree must carry a recorded decision.
+#
+# Why this exists. insight-wave ships the wiki twice — `wiki/` is the editing
+# surface, `cogni-workspace/wiki/` is the vendored copy that reaches users. The
+# two are allowed to differ between releases, so a tree-wide equality check would
+# be wrong. What is NOT allowed is a tree that misdescribes itself, or a
+# one-sided page nobody decided on. Nothing enforced either before this suite:
+#   - test-wiki-namespace-sync.sh compares filename stems against the marketplace
+#     roster, so it never looks inside a page or at either config
+#   - test-layering-claim-reconciled.sh pins four named pages to byte-identity
+#     and scans for retired wording, so it is silent on every other page
+# Both would stay green while a config overstated its tree by nine pages and a
+# page linked to something that had been deleted out from under it. That is the
+# gap this closes.
+#
+# Contract under test:
+#   - each tree's .cogni-wiki/config.json entries_count equals a LIVE count of
+#     that same tree's pages — derived, never hardcoded, one call per arm
+#   - every wiki reference in a tree resolves to a page in that SAME tree
+#   - every page present in only one tree is named in the decisions record at
+#     cogni-workspace/references/wiki-tree-reconciliation.md
+#   - an empty, missing or config-less arm fails rather than reporting clean
+#
+# The third item is the one that makes the record load-bearing rather than
+# decorative: adding a page to one tree, or promoting one across, goes red until
+# a decision for it is written down. Reversing that check is what lets the two
+# trees drift apart again silently.
+#
+# Deliberately NOT asserted: that the trees are equal. They are not, and by
+# design — the decisions record explains each surviving difference.
+#
+# Case-label shape follows test-wiki-namespace-sync.sh: "PASS: <id> <label>" /
+# "FAIL: <id> <label>", ids W-prefixed and never bare numerals. The cogni-service
+# mutation harness classifies a case GREEN only on ^[[:space:]]*(ok|PASS):[[:space:]]+<case>
+# and RED on the matching FAIL: form, so a replay against an "OK   " label would
+# report case_not_found instead of a verdict. Do not restyle these labels.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+RECORD_REL="cogni-workspace/references/wiki-tree-reconciliation.md"
+
+TMPROOT="$(mktemp -d)"
+trap 'rm -rf "$TMPROOT"' EXIT
+
+PASSED=0
+FAILED=0
+pass() { echo "PASS: $1"; PASSED=$((PASSED + 1)); }
+fail() { echo "FAIL: $1"; FAILED=$((FAILED + 1)); }
+
+# ---------------------------------------------------------------------------
+# The checkers. Fixture cases and the real-repo cases drive these same
+# functions, so pointing a case at a broken checker turns that case red.
+# ---------------------------------------------------------------------------
+
+# count_pages <tree_root> -> prints the number of *.md directly under wiki/pages.
+count_pages() {
+  find "$1/wiki/pages" -maxdepth 1 -name '*.md' 2>/dev/null | wc -l | tr -d ' '
+}
+
+# check_count <tree_root> <label> -> 0 when entries_count matches the live count.
+check_count() {
+  local root="$1" label="$2" cfg recorded actual
+  cfg="$root/.cogni-wiki/config.json"
+
+  if [ ! -f "$cfg" ]; then
+    echo "ERROR [$label] config not found: $cfg"
+    return 1
+  fi
+  if [ ! -d "$root/wiki/pages" ]; then
+    echo "ERROR [$label] pages directory not found: $root/wiki/pages"
+    return 1
+  fi
+
+  actual="$(count_pages "$root")"
+  # Liveness floor, same reasoning as the sibling suite: an arm pointed at an
+  # empty directory would otherwise compare 0 against 0 and report clean.
+  if [ "$actual" -eq 0 ]; then
+    echo "ERROR [$label] no .md pages found under $root/wiki/pages"
+    return 1
+  fi
+
+  recorded="$(python3 -c '
+import json, sys
+with open(sys.argv[1]) as fh:
+    print(json.load(fh).get("entries_count", "MISSING"))
+' "$cfg")" || return 1
+
+  if [ "$recorded" != "$actual" ]; then
+    echo "COUNT-DRIFT [$label] entries_count=$recorded but $actual pages on disk"
+    return 1
+  fi
+  return 0
+}
+
+# check_links <tree_root> <label> -> 0 when every reference resolves in-tree.
+check_links() {
+  local root="$1" label="$2" out rc
+
+  if [ ! -d "$root/wiki/pages" ]; then
+    echo "ERROR [$label] pages directory not found: $root/wiki/pages"
+    return 1
+  fi
+
+  out="$(python3 -c '
+import os, re, sys
+
+root, label = sys.argv[1], sys.argv[2]
+pages_dir = os.path.join(root, "wiki", "pages")
+wiki_dir = os.path.join(root, "wiki")
+
+stems = set()
+for name in os.listdir(pages_dir):
+    if name.endswith(".md"):
+        stems.add(name[:-3])
+# index / log / overview live one level up, beside pages/, and are legitimate
+# link targets. Resolving against both locations is what keeps a correct
+# [[index]] from reading as a dangling reference.
+for name in os.listdir(wiki_dir):
+    if name.endswith(".md"):
+        stems.add(name[:-3])
+
+if not stems:
+    print("ERROR [%s] no pages to scan under %s" % (label, pages_dir))
+    sys.exit(1)
+
+pattern = re.compile(r"\[\[([^\]]+)\]\]")
+offenders = 0
+scanned = 0
+for name in sorted(os.listdir(pages_dir)):
+    if not name.endswith(".md"):
+        continue
+    scanned += 1
+    with open(os.path.join(pages_dir, name), encoding="utf-8") as fh:
+        body = fh.read()
+    for raw in pattern.findall(body):
+        # Strip a display alias and an in-page anchor before resolving.
+        target = raw.split("|", 1)[0].split("#", 1)[0].strip()
+        if not target:
+            continue
+        if target not in stems:
+            print("DANGLING [%s] %s -> [[%s]]" % (label, name, target))
+            offenders += 1
+
+if scanned == 0:
+    print("ERROR [%s] no pages scanned under %s" % (label, pages_dir))
+    sys.exit(1)
+sys.exit(1 if offenders else 0)
+' "$root" "$label" 2>&1)"
+  rc=$?
+  [ -n "$out" ] && echo "$out"
+  return "$rc"
+}
+
+# check_recorded <repo_root> -> 0 when every one-sided page is named in the record.
+#
+# The set difference is computed at runtime in BOTH directions, so this never
+# encodes today's seven-and-one split as a constant.
+check_recorded() {
+  local root="$1" record out rc
+  record="$root/$RECORD_REL"
+
+  if [ ! -f "$record" ]; then
+    echo "ERROR decisions record not found: $record"
+    return 1
+  fi
+
+  out="$(python3 -c '
+import os, sys
+
+root, record = sys.argv[1], sys.argv[2]
+a = os.path.join(root, "wiki", "wiki", "pages")
+b = os.path.join(root, "cogni-workspace", "wiki", "wiki", "pages")
+for d in (a, b):
+    if not os.path.isdir(d):
+        print("ERROR pages directory not found: %s" % d)
+        sys.exit(1)
+
+def stems(d):
+    return set(n[:-3] for n in os.listdir(d) if n.endswith(".md"))
+
+sa, sb = stems(a), stems(b)
+if not sa or not sb:
+    print("ERROR an arm has no pages; refusing to report clean")
+    sys.exit(1)
+
+with open(record, encoding="utf-8") as fh:
+    text = fh.read()
+
+missing = 0
+for stem in sorted((sa - sb) | (sb - sa)):
+    if stem not in text:
+        side = "root-only" if stem in sa else "bundled-only"
+        print("UNRECORDED [%s] %s is in one tree only and is not named in the record" % (side, stem))
+        missing += 1
+sys.exit(1 if missing else 0)
+' "$root" "$record" 2>&1)"
+  rc=$?
+  [ -n "$out" ] && echo "$out"
+  return "$rc"
+}
+
+# ---------------------------------------------------------------------------
+# Harness
+# ---------------------------------------------------------------------------
+
+RC=0
+OUT=""
+
+run_count()    { OUT="$(check_count "$1" "$2" 2>&1)"; RC=$?; }
+run_links()    { OUT="$(check_links "$1" "$2" 2>&1)"; RC=$?; }
+run_recorded() { OUT="$(check_recorded "$1" 2>&1)"; RC=$?; }
+
+assert_rc() { # <expected-rc>
+  [ "$RC" -eq "$1" ] && return 0
+  echo "     expected rc=$1, got rc=$RC; output:"
+  echo "$OUT" | sed 's/^/       /'
+  return 1
+}
+assert_out_has() {
+  case "$OUT" in *"$1"*) return 0 ;; esac
+  echo "     expected output to contain: $1"
+  echo "$OUT" | sed 's/^/       /'
+  return 1
+}
+
+# mk_page <path> [body] — a minimal but schema-shaped fixture page.
+mk_page() {
+  mkdir -p "$(dirname "$1")"
+  printf -- '---\nid: %s\ntitle: fixture\ntype: fixture\n---\n\n%s\n' \
+    "$(basename "$1" .md)" "${2:-fixture page.}" > "$1"
+}
+
+# mk_config <tree_root> <entries_count>
+mk_config() {
+  mkdir -p "$1/.cogni-wiki"
+  printf '{\n  "version": "0.1.0",\n  "entries_count": %s,\n  "last_lint": "2026-01-01"\n}\n' \
+    "$2" > "$1/.cogni-wiki/config.json"
+}
+
+# mk_tree <tree_root> <entries_count> — one self-consistent arm with two pages.
+mk_tree() {
+  mk_page "$1/wiki/pages/alpha.md"
+  mk_page "$1/wiki/pages/beta.md"
+  mk_config "$1" "$2"
+}
+
+# mk_fixture_repo <root> — a two-armed stand-in whose arms agree, plus a record.
+mk_fixture_repo() {
+  local root="$1"
+  mk_tree "$root/wiki" 2
+  mk_tree "$root/cogni-workspace/wiki" 2
+  mkdir -p "$root/$(dirname "$RECORD_REL")"
+  printf '# fixture record\n\nNo one-sided pages.\n' > "$root/$RECORD_REL"
+}
+
+# ---------------------------------------------------------------------------
+# W1 / W2 — the real trees describe themselves correctly. Two separate calls, so
+# deleting either arm turns exactly one of these red.
+# ---------------------------------------------------------------------------
+run_count "$REPO_ROOT/wiki" "root"
+if assert_rc 0; then
+  pass "W1 root wiki tree entries_count matches its page count"
+else
+  fail "W1 root wiki tree entries_count matches its page count"
+fi
+
+run_count "$REPO_ROOT/cogni-workspace/wiki" "workspace"
+if assert_rc 0; then
+  pass "W2 workspace wiki tree entries_count matches its page count"
+else
+  fail "W2 workspace wiki tree entries_count matches its page count"
+fi
+
+# ---------------------------------------------------------------------------
+# W3 — a planted count mismatch fails and names the arm.
+# ---------------------------------------------------------------------------
+F3="$TMPROOT/w3"
+mk_fixture_repo "$F3"
+mk_config "$F3/wiki" 99
+run_count "$F3/wiki" "root"
+if assert_rc 1 && assert_out_has "COUNT-DRIFT" && assert_out_has "[root]"; then
+  pass "W3 a planted entries_count mismatch fails and names the arm"
+else
+  fail "W3 a planted entries_count mismatch fails and names the arm"
+fi
+
+# ---------------------------------------------------------------------------
+# W4 / W5 — no reference in either real tree points at a page that tree lacks.
+# ---------------------------------------------------------------------------
+run_links "$REPO_ROOT/wiki" "root"
+if assert_rc 0; then
+  pass "W4 every reference in the root tree resolves within that tree"
+else
+  fail "W4 every reference in the root tree resolves within that tree"
+fi
+
+run_links "$REPO_ROOT/cogni-workspace/wiki" "workspace"
+if assert_rc 0; then
+  pass "W5 every reference in the workspace tree resolves within that tree"
+else
+  fail "W5 every reference in the workspace tree resolves within that tree"
+fi
+
+# ---------------------------------------------------------------------------
+# W6 — a planted unresolvable reference fails and names both file and target.
+# ---------------------------------------------------------------------------
+F6="$TMPROOT/w6"
+mk_fixture_repo "$F6"
+mk_page "$F6/wiki/wiki/pages/alpha.md" 'see [[gamma-not-here]] for more.'
+run_links "$F6/wiki" "root"
+if assert_rc 1 && assert_out_has "DANGLING" && assert_out_has "gamma-not-here"; then
+  pass "W6 a planted unresolvable reference fails and names the target"
+else
+  fail "W6 a planted unresolvable reference fails and names the target"
+fi
+
+# ---------------------------------------------------------------------------
+# W7 — every page present in only one real tree is named in the decisions record.
+# This is what makes the record load-bearing: promote or add a page without
+# writing down a decision and this goes red.
+# ---------------------------------------------------------------------------
+run_recorded "$REPO_ROOT"
+if assert_rc 0; then
+  pass "W7 every one-sided page is named in the decisions record"
+else
+  fail "W7 every one-sided page is named in the decisions record"
+fi
+
+# ---------------------------------------------------------------------------
+# W8 — an unrecorded one-sided page fails, and an empty or config-less arm fails
+# rather than reporting clean. Both halves are the liveness floor: without them a
+# half-dead guard is indistinguishable from a working one.
+# ---------------------------------------------------------------------------
+W8_A=1
+F8="$TMPROOT/w8"
+mk_fixture_repo "$F8"
+mk_page "$F8/cogni-workspace/wiki/wiki/pages/orphan-page.md"
+mk_config "$F8/cogni-workspace/wiki" 3
+run_recorded "$F8"
+if [ "$RC" -eq 1 ]; then
+  case "$OUT" in *"UNRECORDED"*) W8_A=0 ;; esac
+fi
+
+W8_B=1
+F8B="$TMPROOT/w8b"
+mk_fixture_repo "$F8B"
+rm -f "$F8B/wiki/.cogni-wiki/config.json"
+run_count "$F8B/wiki" "root"
+[ "$RC" -eq 1 ] && W8_B=0
+
+W8_C=1
+F8C="$TMPROOT/w8c"
+mk_fixture_repo "$F8C"
+rm -f "$F8C/wiki/wiki/pages"/*.md
+run_count "$F8C/wiki" "root"
+[ "$RC" -eq 1 ] && W8_C=0
+
+if [ "$W8_A" -eq 0 ] && [ "$W8_B" -eq 0 ] && [ "$W8_C" -eq 0 ]; then
+  pass "W8 an unrecorded page, a missing config and an empty arm each fail"
+else
+  fail "W8 an unrecorded page, a missing config and an empty arm each fail"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo
+if [ "$FAILED" -gt 0 ]; then
+  echo "FAIL: $FAILED wiki-tree-parity test(s) failed."
+  exit 1
+fi
+echo "All wiki-tree-parity tests passed. ($PASSED cases)"
+exit 0

--- a/cogni-workspace/wiki/.cogni-wiki/config.json
+++ b/cogni-workspace/wiki/.cogni-wiki/config.json
@@ -3,7 +3,7 @@
   "slug": "insight-wave",
   "description": "Curated reference wiki for the insight-wave plugin ecosystem — vendor-published, read-only, refreshed by cogni-workspace plugin updates.",
   "created": "2026-04-17",
-  "entries_count": 178,
+  "entries_count": 176,
   "last_lint": "2026-04-17",
   "schema_version": "0.0.1"
 }

--- a/cogni-workspace/wiki/wiki/pages/workflow-install-to-infographic.md
+++ b/cogni-workspace/wiki/wiki/pages/workflow-install-to-infographic.md
@@ -57,7 +57,7 @@ It exercises every layer of the platform — workspace foundation, MCP installat
 
 **4 — Render the first infographic.** `cogni-visual:story-to-infographic` with `--style=sketchnote`, then again with `--style=economist`. A four-to-six-sentence narrative works well as a first try. Running both presets doubles as a live check that both renderers are wired up: `sketchnote` and `whiteboard` route to Excalidraw, `economist`, `editorial`, `data-viz` and `corporate` route to Pencil. Both inherit the theme from step 3, so the colors should match your website.
 
-**5 — Pick a follow-on workflow.** You now have a working workspace, a branded theme and two rendered infographics. Choose by what you want to produce next: [[workflow-research-to-report]], [[workflow-portfolio-to-pitch]], [[workflow-trends-to-solutions]], [[workflow-content-pipeline]], [[workflow-portfolio-to-website]] or [[workflow-consulting-engagement]].
+**5 — Pick a follow-on workflow.** You now have a working workspace, a branded theme and two rendered infographics. Choose by what you want to produce next: [[workflow-portfolio-to-pitch]], [[workflow-trends-to-solutions]], [[workflow-content-pipeline]] or [[workflow-portfolio-to-website]].
 
 ## Common pitfalls
 

--- a/wiki/.cogni-wiki/config.json
+++ b/wiki/.cogni-wiki/config.json
@@ -3,7 +3,7 @@
   "slug": "insight-wave",
   "description": "Curated reference wiki for the insight-wave plugin ecosystem — vendor-published, read-only, refreshed by cogni-workspace plugin updates.",
   "created": "2026-04-17",
-  "entries_count": 179,
+  "entries_count": 170,
   "last_lint": "2026-04-20",
   "schema_version": "0.0.1"
 }

--- a/wiki/wiki/pages/workflow-install-to-infographic.md
+++ b/wiki/wiki/pages/workflow-install-to-infographic.md
@@ -57,7 +57,7 @@ It exercises every layer of the platform — workspace foundation, MCP installat
 
 **4 — Render the first infographic.** `cogni-visual:story-to-infographic` with `--style=sketchnote`, then again with `--style=economist`. A four-to-six-sentence narrative works well as a first try. Running both presets doubles as a live check that both renderers are wired up: `sketchnote` and `whiteboard` route to Excalidraw, `economist`, `editorial`, `data-viz` and `corporate` route to Pencil. Both inherit the theme from step 3, so the colors should match your website.
 
-**5 — Pick a follow-on workflow.** You now have a working workspace, a branded theme and two rendered infographics. Choose by what you want to produce next: [[workflow-research-to-report]], [[workflow-portfolio-to-pitch]], [[workflow-trends-to-solutions]], [[workflow-content-pipeline]], [[workflow-portfolio-to-website]] or [[workflow-consulting-engagement]].
+**5 — Pick a follow-on workflow.** You now have a working workspace, a branded theme and two rendered infographics. Choose by what you want to produce next: [[workflow-portfolio-to-pitch]], [[workflow-trends-to-solutions]], [[workflow-content-pipeline]] or [[workflow-portfolio-to-website]].
 
 ## Common pitfalls
 


### PR DESCRIPTION
Refs #1384.

## Summary

The two wiki trees disagree in 28 places. This lands the half that needs no judgment call, and
records a decision for the half that does.

- **`entries_count` corrected in both configs** — root `179` → `170`, bundled `178` → `176`.
  Both overstated their own tree, by omission: the field was last set correctly by hand and three
  later commits deleted pages without touching either config. Corrected by hand for the same
  reason it was set by hand — the only writer in the repo enumerates pages by walking a fixed set
  of per-type subdirectories, and this wiki keeps every page in one flat directory that is not in
  that set, so pointed at either tree it would write `0`. The two values stay different from each
  other because each describes its own tree.
- **The two unresolved page references at `workflow-install-to-infographic.md:60` are removed**,
  identically in both copies. That page is pinned to byte-identity between the trees by
  `cogni-workspace/tests/test-layering-claim-reconciled.sh` (`PAGE_PARITY`), so a one-sided edit
  turns case `L7` red.
- **`cogni-workspace/references/wiki-tree-reconciliation.md`** — the per-delta decisions record,
  in the house style of `references/absorption-roadmap.md`, with every figure attributed to the
  command that produced it.
- **`cogni-workspace/tests/test-wiki-tree-parity.sh`** — a new guard, discovered by
  `scripts/run-plugin-tests.py` (CI job "Plugin test suites").

## The finding worth reading

**The 20 content deltas do not all resolve in the same direction.** Thirteen files are newer at
the root — but four workflow pages are newer in the *bundle*, because an earlier change appended
`## Steps` and `## Common pitfalls` sections (and `## Two scenarios` on one) directly to the
bundled copies, bypassing the one-way sync contract.

| Page | Root lines | Bundled lines |
|---|---:|---:|
| `workflow-portfolio-to-website.md` | 55 | 76 |
| `workflow-content-pipeline.md` | 50 | 79 |
| `workflow-portfolio-to-pitch.md` | 56 | 72 |
| `workflow-trends-to-solutions.md` | 52 | 79 |

A blanket root-over-bundle sync would destroy content that exists nowhere else, on top of
deleting the seven bundled-only pages. `scripts/release-bundle-wiki.sh` is documented as "Run
BEFORE every cogni-workspace marketplace publish", and its post-sync guard compares page *counts*,
so it cannot detect the second class at all. Filed separately as #1403.

## Why `changes_pending` stays 28

Intended, and explained in the record so the next reader does not treat it as unexplained drift:
7 `*deleting` lines (the bundled-only pages, held), 1 `>f+++++++` (the dated lint page, root-only
by design), and the 20 content deltas (recorded, executed in #1401). The wikilink fix lands
identically on both sides so it adds no line; the `entries_count` change does not add one either,
since the two configs already differed.

## Scope

**Out, deliberately.** The seven bundled-only pages are neither promoted nor removed — that
ruling is reserved to a maintainer, and the per-page staleness evidence is posted on #1384. The
20 content deltas are recorded, not executed. `wiki/wiki/log.md` and
`wiki/wiki/pages/lint-2026-04-20.md` are untouched in both trees: dated records are history, so a
count "fix" inside one violates that decision rather than satisfying the issue's plugin-count
criterion. No `version` field is touched.

**The blessing is still pending as this ships.** Per the ruling on #1384, saying so here rather
than leaving the two references silently broken. If promotion is chosen, both references should
be restored in both copies — #1402 carries that.

## Test plan

- [x] `bash cogni-workspace/tests/test-wiki-tree-parity.sh` — 8/8 pass
- [x] `bash cogni-workspace/tests/test-layering-claim-reconciled.sh` — 9/9 pass, `L7` byte-parity green, `L1` clean against the new record
- [x] `bash cogni-workspace/tests/test-wiki-namespace-sync.sh` — 8/8 pass
- [x] `python3 scripts/run-plugin-tests.py --filter cogni-workspace` — rc 0, new suite discovered
- [x] `bash scripts/release-bundle-wiki.sh --check` → `changes_pending: 28`, `source_page_count: 170`
- [x] `python3 scripts/check-version-bump.py` — 12 scanned, 0 touched, 0 violations
- [x] Both configs parse; `diff` of the two `workflow-install-to-infographic.md` copies is empty

## Mutation recipe

Two assertions verified, both returning `guard_verified` (mutated `red`, restored `green`):

```bash
bash "$HOME/.claude/plugins/cache/managed-service/cogni-service/0.0.402/scripts/mutation-check.sh" --root . --file wiki/.cogni-wiki/config.json --expr 's/"entries_count": 170/"entries_count": 999/' --test 'bash cogni-workspace/tests/test-wiki-tree-parity.sh' --case W1
```

```bash
bash "$HOME/.claude/plugins/cache/managed-service/cogni-service/0.0.402/scripts/mutation-check.sh" --root . --file cogni-workspace/references/wiki-tree-reconciliation.md --expr 's/workflow-docs-pipeline/redacted-page-stem/' --test 'bash cogni-workspace/tests/test-wiki-tree-parity.sh' --case W7
```

The second is the one that matters: it proves the decisions record is load-bearing rather than
decorative — drop a one-sided page's name from the record and `W7` goes red. Both replacement
strings are disjoint from their matched literals, and both `--case` values match the first token
of a label the suite prints verbatim.

## Follow-up issues

- #1401 — execute the 20 content deltas (group A root-authoritative, group B bundle-authoritative)
- #1402 — execute the maintainer ruling on the 7 bundled-only pages once blessed
- #1403 — `release-bundle-wiki.sh` should refuse to destroy bundle-only content (S2-major)
- #1404 — register the new record and guard in `cogni-workspace/CLAUDE.md`

## Open questions

- **Promotion of the 7 bundled-only pages is a maintainer call.** Evidence and a per-page proposal
  are on #1384 and carried into the decisions record; this PR changes none of them. The ruling also
  determines whether the two references removed at `workflow-install-to-infographic.md:60` should be
  restored.