### PR TITLE
release-bundle-wiki: refuse to destroy bundle-only content by default

### DIFF
--- a/cogni-workspace/references/wiki-tree-reconciliation.md
+++ b/cogni-workspace/references/wiki-tree-reconciliation.md
@@ -205,8 +205,26 @@ Rejected on three grounds:
    the counts still match after the content is gone.
 
 The script's own header states the root tree is the editing surface, so the deletion is
-intentional in principle. What is missing is any refusal when the bundle holds something the
-sync is about to destroy. Issue #1403 carries that.
+intentional in principle. What was missing was any refusal when the bundle holds something the
+sync is about to destroy.
+
+The script now carries that refusal. It classifies the bundled tree *before* writing any bytes
+and exits non-zero, naming every path it would have destroyed, in two classes: a bundled file
+with no source counterpart (ground 1), and a bundled file carrying non-blank lines the source
+copy lacks (ground 2 — the class the count-based check of ground 3 structurally cannot see,
+since an overwrite leaves the file count unchanged). Taking this rejected alternative therefore
+now requires passing `--force` explicitly, which makes converting a held decision into an
+executed one a deliberate act rather than an accident.
+
+Ground 3 still describes the post-sync check accurately. That check is left in place, and it is
+the new pre-sync gate rather than any change to it that supplies the defence.
+
+On the tree as recorded here a bare sync refuses on 27 paths: the 7 of Decision 4, the 4
+group-B pages, and — because the root re-ingest reworded lines rather than only appending — the
+13 group-A pages together with `wiki/index.md`, `wiki/log.md` and `.cogni-wiki/config.json`. The
+gate is deliberately blind to Decision 3's ruling that root wins for group A: a script cannot
+read this document, so it refuses and defers to the operator. Executing #1401 and #1402 is what
+returns a bare sync to silence.
 
 ## Rejected alternative — regenerate `entries_count` with the wiki linter
 
@@ -228,7 +246,7 @@ Kept as a permanent inventory so the set stays auditable rather than being redis
 | `wiki/index.md` needs a merge, not a copy | recorded, not executed | #1401 |
 | 7 bundled-only pages held | awaiting a maintainer ruling | #1402 |
 | `ecosystem-command-reference` names a retired command surface | held with the page above | #1402 |
-| Sync script destroys bundle-only content | open defect | #1403 |
+| Sync script destroys bundle-only content | closed — refuses by default; `--force` is the opt-in | #1403 |
 | This record and its guard are unregistered in the plugin guide | open | #1404 |
 
 ## Deliberately left standing
@@ -246,3 +264,10 @@ that every wiki reference in a tree resolves to a page in that same tree; and th
 present in only one tree is named in this document. The last of those is what makes adding or
 promoting a page without recording a decision here fail rather than pass silently. It does not
 assert the two trees are equal — they are not, by Decisions 1, 4 and 5.
+
+`tests/test_release_bundle_wiki.sh` guards the other direction: that
+`scripts/release-bundle-wiki.sh` refuses, by default, to destroy what this document holds. It
+covers both refused classes, the `--force` opt-in, and — as the case that matters most for the
+gate staying usable — that a bundle which loses nothing still syncs without `--force`. It runs
+entirely against `mktemp` fixtures, never these two trees, because a bare sync against them is
+the data loss the gate exists to prevent.

--- a/scripts/release-bundle-wiki.sh
+++ b/scripts/release-bundle-wiki.sh
@@ -13,6 +13,12 @@
 # Usage:
 #   scripts/release-bundle-wiki.sh                    # full sync (rsync --delete)
 #   scripts/release-bundle-wiki.sh --check            # dry-run; report diff but don't write
+#   scripts/release-bundle-wiki.sh --force            # sync even when it would destroy content
+#
+# A bare sync REFUSES, exits 1 and writes nothing when the bundled tree holds
+# content the source does not: a file absent from source, or a shared file whose
+# bundled copy carries non-blank lines the source copy lacks. The refusal names
+# every such path in its JSON payload. Pass --force to sync anyway.
 #
 # Output: JSON to stdout per insight-wave script convention.
 #   {"success": true, "data": {...}, "error": ""}
@@ -22,12 +28,18 @@ set -eu
 SOURCE_WIKI="$(cd "$(dirname "$0")/.." && pwd)/wiki"
 BUNDLED_WIKI="$(cd "$(dirname "$0")/.." && pwd)/cogni-workspace/wiki"
 MODE="sync"
+FORCE=0
 
 while [ $# -gt 0 ]; do
   case "$1" in
     --check) MODE="check"; shift ;;
+    --force) FORCE=1; shift ;;
     -h|--help)
-      sed -n '2,18p' "$0"
+      # The upper bound must equal the last line of the header comment block.
+      # tests/test_release_bundle_wiki.sh case RBW7 pins both directions: it
+      # fails if the range truncates the usage text, and it fails if the range
+      # runs past the header into the code below.
+      sed -n '2,24p' "$0"
       exit 0
       ;;
     *)
@@ -68,6 +80,105 @@ fi
 if ! command -v rsync >/dev/null 2>&1; then
   printf '{"success": false, "data": {}, "error": "rsync not found in PATH"}\n'
   exit 1
+fi
+
+# Pre-sync destruction gate.
+#
+# rsync --delete treats the bundled tree as a pure mirror, so anything the bundle
+# holds and the source does not is destroyed without trace. The post-sync page
+# count check below cannot defend against this: by the time it runs, rsync has
+# already made both trees identical, so it compares a number to itself. It also
+# cannot see an overwrite at all, since replacing a file's contents leaves the
+# file count unchanged.
+#
+# So classify BEFORE writing. This block sits ahead of `mkdir -p`, the first
+# write-capable call in this script, which is what makes the refusal a true
+# no-op on disk rather than merely an early exit.
+#
+# Two destructive classes, both reported:
+#   would_delete    — a path in the bundle with no counterpart in the source.
+#   would_overwrite — a path on both sides whose bundled copy carries non-blank
+#                     lines the source copy lacks, i.e. content that is not
+#                     derivable from the source and would be lost.
+#
+# A bundled file that is merely a subset of its source counterpart is NOT
+# destructive: the source is enriching it, nothing is lost. That asymmetry is
+# deliberate. A gate that fired on any difference would refuse every ordinary
+# sync, and an override the operator must pass every time is an override they
+# stop reading — which would reinstate exactly the data loss this gate prevents.
+if [ "$FORCE" -eq 0 ] && [ -d "$BUNDLED_WIKI" ]; then
+  # No pipe here, so rsync's own exit status would trip `set -e`; exit 24
+  # (files vanished mid-scan) is benign on a live tree.
+  ITEMS=$(rsync -anci --delete "$SOURCE_WIKI/" "$BUNDLED_WIKI/" 2>/dev/null || true)
+
+  # Itemise lines are `*deleting <path>` and `>fcst.... <path>`. The flag field
+  # is not fixed-width across rsync builds, so take everything from the start of
+  # field 2 rather than a hardcoded column; that also keeps a path containing a
+  # space intact.
+  WOULD_DELETE=$(printf '%s\n' "$ITEMS" | awk '$1 == "*deleting" { print substr($0, index($0, $2)) }' | LC_ALL=C sort)
+  CANDIDATES=$(printf '%s\n' "$ITEMS" | awk '$1 ~ /^>f/ { print substr($0, index($0, $2)) }')
+
+  WOULD_OVERWRITE=""
+  while IFS= read -r REL; do
+    [ -n "$REL" ] || continue
+    SRC_FILE="$SOURCE_WIKI/$REL"
+    BUN_FILE="$BUNDLED_WIKI/$REL"
+    # A `>f+++++++` addition has no bundled counterpart, so nothing to lose.
+    { [ -f "$SRC_FILE" ] && [ -f "$BUN_FILE" ]; } || continue
+    # Lines present in the bundle but in no line of the source. grep -c exits 1
+    # at a count of zero, hence `|| true`.
+    EXTRA=$(grep -Fxv -f "$SRC_FILE" "$BUN_FILE" 2>/dev/null | grep -cv '^[[:space:]]*$' || true)
+    [ "${EXTRA:-0}" -gt 0 ] || continue
+    WOULD_OVERWRITE="${WOULD_OVERWRITE}${REL}
+"
+  done <<EOF
+$CANDIDATES
+EOF
+
+  # `grep -c .` and not `wc -l`: printf appends a newline, so `wc -l` reports 1
+  # for an empty value and the gate would refuse every clean sync.
+  DELETE_COUNT=$(printf '%s' "$WOULD_DELETE" | grep -c . || true)
+  OVERWRITE_COUNT=$(printf '%s' "$WOULD_OVERWRITE" | grep -c . || true)
+  DESTRUCTIVE_COUNT=$(( DELETE_COUNT + OVERWRITE_COUNT ))
+
+  if [ "$DESTRUCTIVE_COUNT" -gt 0 ]; then
+    # json.dumps the whole envelope. Every other printf in this file
+    # interpolates %s raw into a JSON format string, which is safe only for the
+    # integers and self-derived absolute paths those call sites emit; a list of
+    # arbitrary repository paths is not in that category.
+    SRC="$SOURCE_WIKI" BUN="$BUNDLED_WIKI" DEL="$WOULD_DELETE" OVR="$WOULD_OVERWRITE" \
+      COUNT="$DESTRUCTIVE_COUNT" python3 - <<'PY'
+import json
+import os
+
+
+def paths(raw):
+    return sorted(line for line in raw.splitlines() if line.strip())
+
+
+would_delete = paths(os.environ["DEL"])
+would_overwrite = paths(os.environ["OVR"])
+count = int(os.environ["COUNT"])
+
+print(json.dumps({
+    "success": False,
+    "data": {
+        "mode": "sync",
+        "source": os.environ["SRC"],
+        "bundled": os.environ["BUN"],
+        "would_delete": would_delete,
+        "would_overwrite": would_overwrite,
+        "destructive_path_count": count,
+        "override": "re-run with --force to sync anyway",
+    },
+    "error": (
+        "refusing to sync: %d bundled path(s) would be destroyed; "
+        "re-run with --force to sync anyway" % count
+    ),
+}))
+PY
+    exit 1
+  fi
 fi
 
 mkdir -p "$BUNDLED_WIKI"

--- a/tests/test_release_bundle_wiki.sh
+++ b/tests/test_release_bundle_wiki.sh
@@ -11,6 +11,8 @@
 #   RBW6  --force performs the destructive sync the bare run refused
 #   RBW7  --help prints the whole header and nothing below it
 #   RBW8  an unknown argument still yields the error envelope and exit 1
+#   RBW9  a bundled tree that is absent, or present but holding no pages, still
+#         syncs bare — there is nothing there to destroy
 #
 # Satisfies the runner's three-property contract: it exits non-zero on failure
 # and zero otherwise, runs as `bash <path>` with no arguments from any working
@@ -237,6 +239,29 @@ check_eq "RBW8 an unknown argument reports success false" "False" \
   "$(json_field "$OUT" 'd["success"]')"
 check_eq "RBW8 the error names the offending argument" "True" \
   "$(json_field "$OUT" '"--definitely-not-a-flag" in d["error"]')"
+
+# ---------------------------------------------------------------------------- RBW9
+# Nothing in the bundle means nothing to destroy, so the gate must stay out of
+# the way. Two shapes: the bundled tree missing entirely (a first-ever publish),
+# and present but holding no pages. Both are the bootstrap path, and a gate that
+# refused here would make the bundle impossible to create in the first place.
+make_fixture rbw9a
+rm -rf "$WORK/rbw9a/cogni-workspace/wiki"
+run_fixture rbw9a
+
+check_eq "RBW9 an absent bundled tree syncs bare" "0" "$CODE"
+check_eq "RBW9 that bootstrap sync reports success" "True" "$(json_field "$OUT" 'd["success"]')"
+[ -f "$WORK/rbw9a/cogni-workspace/wiki/wiki/pages/shared.md" ]
+check "RBW9 the bootstrap sync populated the bundled tree" "$?"
+
+make_fixture rbw9b
+rm -f "$WORK/rbw9b/cogni-workspace/wiki/wiki/pages/shared.md"
+run_fixture rbw9b
+
+check_eq "RBW9 an empty bundled page set syncs bare" "0" "$CODE"
+check_eq "RBW9 that sync reports success" "True" "$(json_field "$OUT" 'd["success"]')"
+[ -f "$WORK/rbw9b/cogni-workspace/wiki/wiki/pages/shared.md" ]
+check "RBW9 the empty bundled tree was populated" "$?"
 
 # ----------------------------------------------------------------------------
 if [ "$FAILED" -eq 0 ]; then

--- a/tests/test_release_bundle_wiki.sh
+++ b/tests/test_release_bundle_wiki.sh
@@ -1,0 +1,248 @@
+#!/usr/bin/env bash
+#
+# Self-test for scripts/release-bundle-wiki.sh's pre-sync destruction gate.
+#
+# Cases:
+#   RBW1  a bundle-only page makes a bare sync refuse, and writes no bytes
+#   RBW2  the refusal is one JSON object naming the path in data.would_delete
+#   RBW3  a bundled copy holding lines the source lacks is refused as would_overwrite
+#   RBW4  a bundle that is a strict subset of source still syncs bare (no over-refusal)
+#   RBW5  an already-identical bundle still syncs bare (the empty-count regression)
+#   RBW6  --force performs the destructive sync the bare run refused
+#   RBW7  --help prints the whole header and nothing below it
+#   RBW8  an unknown argument still yields the error envelope and exit 1
+#
+# Satisfies the runner's three-property contract: it exits non-zero on failure
+# and zero otherwise, runs as `bash <path>` with no arguments from any working
+# directory, and needs no network or credentials, writing only inside its own
+# mktemp -d.
+#
+# Every sync-mode case runs against a mktemp fixture, never the repository's own
+# wiki/ and cogni-workspace/wiki/ trees. That is not merely hygiene here: a bare
+# sync against the real trees is precisely the data loss this guard exists to
+# prevent, so a suite that reached for them would destroy seven pages to prove
+# they should not be destroyed.
+#
+# The fixture copies the REAL scripts/release-bundle-wiki.sh rather than
+# vendoring a replica, so the suite cannot keep passing against a frozen
+# snapshot while the script drifts — and so a mutation applied to the script
+# actually reaches the code under test. The script derives both tree paths from
+# `dirname $0/..`, so running the copy from <fixture>/scripts/ is what makes
+# both roots resolve inside the fixture; there is no path-override flag.
+#
+# Mutation recipe (proves RBW1's refusal assertion can go red):
+#
+#   bash cogni-service/scripts/mutation-check.sh \
+#     --root "$REPO_ROOT" \
+#     --file scripts/release-bundle-wiki.sh \
+#     --expr 's/DESTRUCTIVE_COUNT" -gt 0/DESTRUCTIVE_COUNT" -lt 0/' \
+#     --test 'bash tests/test_release_bundle_wiki.sh' \
+#     --case RBW1
+#
+# DESTRUCTIVE_COUNT is a sum of two non-negative counts, so `-lt 0` is
+# unconditionally false: the gate can never fire, the bare run proceeds to the
+# real rsync --delete, and RBW1 goes red on both of its assertions. The
+# replacement shares no substring with the matched literal, so it cannot be a
+# no-op. Note the harness applies --expr through `perl -0pi` in slurp mode with
+# no /g, so it rewrites only the FIRST occurrence in the file — the literal
+# `DESTRUCTIVE_COUNT" -gt 0` must therefore appear exactly once in the script,
+# on the `if` line. A comment restating the comparison would absorb the mutation
+# and leave the guard intact, reporting a false green.
+
+set -eu
+
+TESTS_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$TESTS_DIR/.." && pwd)"
+SCRIPT="$REPO_ROOT/scripts/release-bundle-wiki.sh"
+
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+# Plain, uncoloured result lines — unconditionally, matching the harness-parsable
+# suites elsewhere in the repo. A result line must start with the literal `PASS:` /
+# `FAIL:` so a mutation harness can classify it with `^[[:space:]]*FAIL:[[:space:]]+`;
+# an ANSI escape sequence precedes the label and defeats that match. Deciding by
+# `[ -t 1 ]` instead would make parsability environment-dependent.
+red()   { printf '%s\n' "$1"; }
+green() { printf '%s\n' "$1"; }
+
+FAILED=0
+
+check() {
+  # check <label> <condition-description-already-evaluated:0|1>
+  if [ "$2" -eq 0 ]; then
+    green "PASS: $1"
+  else
+    red "FAIL: $1"
+    FAILED=$((FAILED + 1))
+  fi
+}
+
+check_eq() {
+  # check_eq <label> <expected> <actual>
+  if [ "$2" = "$3" ]; then
+    green "PASS: $1"
+  else
+    red "FAIL: $1 (expected [$2], got [$3])"
+    FAILED=$((FAILED + 1))
+  fi
+}
+
+# Build a fixture tree holding a real copy of the script plus a source and a
+# bundled wiki. Mirrors the repo layout the script assumes.
+make_fixture() {
+  FIX="$WORK/$1"
+  mkdir -p "$FIX/scripts" \
+           "$FIX/wiki/.cogni-wiki" \
+           "$FIX/wiki/wiki/pages" \
+           "$FIX/cogni-workspace/wiki/.cogni-wiki" \
+           "$FIX/cogni-workspace/wiki/wiki/pages"
+  cp "$SCRIPT" "$FIX/scripts/release-bundle-wiki.sh"
+  printf '{"name": "fixture"}\n' > "$FIX/wiki/.cogni-wiki/config.json"
+  printf '{"name": "fixture"}\n' > "$FIX/cogni-workspace/wiki/.cogni-wiki/config.json"
+  printf 'shared page\n' > "$FIX/wiki/wiki/pages/shared.md"
+  printf 'shared page\n' > "$FIX/cogni-workspace/wiki/wiki/pages/shared.md"
+}
+
+# Run the fixture's copy of the script, capturing stdout and exit code.
+# Never `set -e`-fatal: the refusal path exits 1 by design.
+run_fixture() {
+  FIXDIR="$WORK/$1"
+  shift
+  set +e
+  OUT=$(bash "$FIXDIR/scripts/release-bundle-wiki.sh" "$@" 2>/dev/null)
+  CODE=$?
+  set -e
+}
+
+# A stable manifest of the bundled tree: every path plus its sha, so "wrote no
+# bytes" is asserted against content and not merely against file presence.
+bundle_manifest() {
+  ( cd "$WORK/$1/cogni-workspace/wiki" && find . -type f | LC_ALL=C sort | while IFS= read -r p; do
+      printf '%s %s\n' "$p" "$(shasum "$p" | awk '{print $1}')"
+    done )
+}
+
+json_field() {
+  # json_field <json> <python-expression-over-d>
+  printf '%s' "$1" | python3 -c "import json,sys; d=json.load(sys.stdin); print($2)"
+}
+
+# ---------------------------------------------------------------- RBW1 / RBW2
+# A page in the bundle with no source counterpart is exactly what `rsync
+# --delete` destroys silently.
+make_fixture rbw1
+printf 'only in the bundle\n' > "$WORK/rbw1/cogni-workspace/wiki/wiki/pages/bundle-only.md"
+printf 'only in the source\n' > "$WORK/rbw1/wiki/wiki/pages/source-only.md"
+BEFORE=$(bundle_manifest rbw1)
+run_fixture rbw1
+AFTER=$(bundle_manifest rbw1)
+
+check_eq "RBW1 a bundle-only page makes a bare sync exit non-zero" "1" "$CODE"
+[ "$BEFORE" = "$AFTER" ]; check "RBW1 the refusal writes no bytes to the bundled tree" "$?"
+[ -f "$WORK/rbw1/cogni-workspace/wiki/wiki/pages/bundle-only.md" ]
+check "RBW1 the bundle-only page survives the refusal" "$?"
+[ ! -f "$WORK/rbw1/cogni-workspace/wiki/wiki/pages/source-only.md" ]
+check "RBW1 no source-only page was added by the refused run" "$?"
+
+printf '%s' "$OUT" | python3 -c 'import json,sys; json.load(sys.stdin)' >/dev/null 2>&1
+check "RBW2 the whole refusal stdout parses as one JSON object" "$?"
+check_eq "RBW2 refusal reports success false" "False" "$(json_field "$OUT" 'd["success"]')"
+check_eq "RBW2 would_delete names the bundle-only page" "wiki/pages/bundle-only.md" \
+  "$(json_field "$OUT" 'd["data"]["would_delete"][0]')"
+check_eq "RBW2 destructive_path_count counts it" "1" \
+  "$(json_field "$OUT" 'd["data"]["destructive_path_count"]')"
+check_eq "RBW2 the error names the override flag" "True" \
+  "$(json_field "$OUT" '"--force" in d["error"]')"
+
+# ---------------------------------------------------------------------- RBW3
+# The overwrite class: both sides hold the file, but the bundled copy carries
+# content that exists nowhere else. A page-count check cannot see this, because
+# overwriting does not change how many files there are.
+make_fixture rbw3
+printf 'shared page\n## Steps\nbundle-only section\n' \
+  > "$WORK/rbw3/cogni-workspace/wiki/wiki/pages/shared.md"
+BEFORE=$(bundle_manifest rbw3)
+run_fixture rbw3
+AFTER=$(bundle_manifest rbw3)
+
+check_eq "RBW3 a bundled superset makes a bare sync exit non-zero" "1" "$CODE"
+[ "$BEFORE" = "$AFTER" ]; check "RBW3 the overwrite refusal writes no bytes" "$?"
+check_eq "RBW3 would_overwrite names the shared page" "wiki/pages/shared.md" \
+  "$(json_field "$OUT" 'd["data"]["would_overwrite"][0]')"
+check_eq "RBW3 would_delete stays empty for the overwrite class" "0" \
+  "$(json_field "$OUT" 'len(d["data"]["would_delete"])')"
+
+# ---------------------------------------------------------------------- RBW4
+# The anti-over-refusal case. The source enriching a bundled file loses nothing,
+# so it must not be blocked — otherwise --force becomes mandatory on every run
+# and stops being read.
+make_fixture rbw4
+printf 'shared page\nnew line from source\n' > "$WORK/rbw4/wiki/wiki/pages/shared.md"
+run_fixture rbw4
+
+check_eq "RBW4 a source-enriched bundle syncs bare, without --force" "0" "$CODE"
+check_eq "RBW4 that sync reports success" "True" "$(json_field "$OUT" 'd["success"]')"
+grep -q 'new line from source' "$WORK/rbw4/cogni-workspace/wiki/wiki/pages/shared.md"
+check "RBW4 the source content reached the bundle" "$?"
+
+# ---------------------------------------------------------------------- RBW5
+# Regression guard. Deriving the counts with `wc -l` reports 1 for an empty
+# value, which would make the gate refuse a perfectly in-sync bundle and render
+# the script unusable on its documented pre-publish path.
+make_fixture rbw5
+run_fixture rbw5
+
+check_eq "RBW5 an already-identical bundle syncs bare" "0" "$CODE"
+check_eq "RBW5 that sync reports success" "True" "$(json_field "$OUT" 'd["success"]')"
+
+# ---------------------------------------------------------------------- RBW6
+# The opt-in must be a real override, not a no-op.
+make_fixture rbw6
+printf 'only in the bundle\n' > "$WORK/rbw6/cogni-workspace/wiki/wiki/pages/bundle-only.md"
+printf 'only in the source\n' > "$WORK/rbw6/wiki/wiki/pages/source-only.md"
+run_fixture rbw6 --force
+
+check_eq "RBW6 --force performs the sync the bare run refused" "0" "$CODE"
+check_eq "RBW6 the forced sync reports success" "True" "$(json_field "$OUT" 'd["success"]')"
+[ ! -f "$WORK/rbw6/cogni-workspace/wiki/wiki/pages/bundle-only.md" ]
+check "RBW6 --force really deleted the bundle-only page" "$?"
+[ -f "$WORK/rbw6/cogni-workspace/wiki/wiki/pages/source-only.md" ]
+check "RBW6 --force really added the source-only page" "$?"
+
+# ---------------------------------------------------------------------- RBW7
+# The help range is a hand-maintained line number and the header just grew, so
+# pin it at BOTH ends: too narrow truncates the usage text, too wide leaks the
+# code below into --help.
+make_fixture rbw7
+run_fixture rbw7 --help
+
+check_eq "RBW7 --help exits 0" "0" "$CODE"
+printf '%s' "$OUT" | grep -q -- '--force'
+check "RBW7 --help documents the --force opt-in" "$?"
+printf '%s' "$OUT" | grep -q -- '--check'
+check "RBW7 --help still documents --check" "$?"
+printf '%s' "$OUT" | grep -q 'error'
+check "RBW7 --help reaches the last header line" "$?"
+! printf '%s' "$OUT" | grep -q 'set -eu'
+check "RBW7 --help does not run past the header into the code" "$?"
+
+# ---------------------------------------------------------------------- RBW8
+# The new arms must sit before the catch-all, or every flag becomes "unknown".
+make_fixture rbw8
+run_fixture rbw8 --definitely-not-a-flag
+
+check_eq "RBW8 an unknown argument exits 1" "1" "$CODE"
+check_eq "RBW8 an unknown argument reports success false" "False" \
+  "$(json_field "$OUT" 'd["success"]')"
+check_eq "RBW8 the error names the offending argument" "True" \
+  "$(json_field "$OUT" '"--definitely-not-a-flag" in d["error"]')"
+
+# ----------------------------------------------------------------------------
+if [ "$FAILED" -eq 0 ]; then
+  green "All release-bundle-wiki gate checks passed."
+  exit 0
+else
+  red "$FAILED release-bundle-wiki gate check(s) failed."
+  exit 1
+fi


### PR DESCRIPTION
Closes #1403.

## Summary

`scripts/release-bundle-wiki.sh` now classifies the bundled tree **before writing any bytes** and refuses by default when a sync would destroy content. The refusal is one `{success,data,error}` object naming every path it would have destroyed, and exits 1. `--force` is the documented opt-in.

Two refused classes:

| Class | Meaning |
|---|---|
| `would_delete` | a bundled path with no source counterpart — what `rsync --delete` removes silently |
| `would_overwrite` | a path on both sides whose bundled copy carries non-blank lines the source lacks |

The second class is the one AC 1's literal wording misses and the post-sync page-count check structurally cannot see, since an overwrite leaves the file count unchanged.

## The count check was unreachable, not merely late

The issue describes the existing guard at `:81-87` as running too late. It is worse than that: `rsync --delete` has already made both trees identical by the time it runs, so it compares **170 to 170** and can never fail. There is no input on which the current script refuses.

It is left in place — the new pre-sync gate, not any change to that check, supplies the defence. Removing it is a judgement the issue does not decide.

## Placement is the load-bearing detail

The gate sits between the rsync-availability guard and `mkdir -p "$BUNDLED_WIKI"`. `mkdir -p` is the first write-capable call in the script, so a refusal is a true no-op on disk rather than an early exit that already created a directory. Case RBW1 asserts this against a sha manifest of the whole bundled tree, not merely file presence.

## Why a subset is deliberately not refused

A bundled file that is merely a **subset** of its source counterpart loses nothing and is allowed through bare. That asymmetry is the difference between a guard and a nuisance: a gate firing on any difference would refuse every ordinary sync, and an override an operator passes every time is an override they stop reading — reinstating exactly the data loss this closes. Case RBW4 pins the additive path and RBW5 the already-identical path.

## Reviewer note — the gate refuses on 27 paths today, not 11

Worth seeing before you read the code, because it is more than the issue's 7 + 4:

```
would_delete:    7   the Decision 4 bundle-only pages
would_overwrite: 20  the 4 group-B pages, wiki/index.md, wiki/log.md,
                     .cogni-wiki/config.json, and the 13 group-A pages
```

The group-A pages appear because the root re-ingest **reworded** lines rather than only appending, so the bundled copy holds text the source does not. Decision 3 rules that root wins for group A, so that loss is sanctioned — but a shell script cannot read a decisions record. It refuses and defers to the operator, which is the safe direction. Executing #1401 and #1402 returns a bare sync to silence. If a reviewer prefers the gate encode Decision 3 directly, that is a scope call worth making explicitly rather than by tightening the predicate quietly.

## Verification

- [x] `bash tests/test_release_bundle_wiki.sh` — 30/30 assertions pass, RBW1–RBW8
- [x] `python3 scripts/run-plugin-tests.py` — **117/117 suites pass**, 0 failed
- [x] New suite auto-discovered by the `tests/*.sh` glob, zero registration
- [x] `--check` on the real tree unchanged: `changes_pending: 28`, `source_page_count: 170`
- [x] Bare run on the real tree exits 1 and leaves `git status --porcelain cogni-workspace/wiki` empty
- [x] `check-version-bump.py` — 12 plugins scanned, **0 touched**, 0 violations
- [x] `check-workflow-yaml.py` clean
- [x] Mutation check **executed**, not merely recorded — verdict `guard_verified`

## Mutation recipe

```bash
bash cogni-service/scripts/mutation-check.sh \
  --root "$REPO_ROOT" \
  --file scripts/release-bundle-wiki.sh \
  --expr 's/DESTRUCTIVE_COUNT" -gt 0/DESTRUCTIVE_COUNT" -lt 0/' \
  --test 'bash tests/test_release_bundle_wiki.sh' \
  --case RBW1
```

Executed on this branch: `mutated_result: red`, `restored_result: green`, `verdict: guard_verified`. `DESTRUCTIVE_COUNT` is a sum of two non-negative counts, so `-lt 0` is unconditionally false and the gate can never fire.

Note the harness applies `--expr` through `perl -0pi` in slurp mode with no `/g`, so it rewrites only the **first** occurrence in the file. The literal `DESTRUCTIVE_COUNT" -gt 0` therefore appears exactly once, on the `if` line — a comment restating the comparison would absorb the mutation, leave the guard intact, and report a false green. Verified: `grep -c` returns 1.

## Two defects caught in planning, recorded so they are not reintroduced

1. **`printf '%s\n' "$EMPTY" | wc -l` returns 1, not 0.** Deriving the counts that way makes `DESTRUCTIVE_COUNT` = 2 on a perfectly in-sync bundle, refusing **every clean sync** and rendering the script unusable on its documented pre-publish path. Both counts use `grep -c . || true`. Case RBW5 is what pins this.
2. The `--help` range is a hand-maintained line number and this change grows the header. The bound is now `sed -n '2,24p'`, measured rather than assumed, and RBW7 pins it at **both** ends — too narrow truncates the usage text, too wide leaks `set -eu` into `--help`.

## Scope

No file under `wiki/wiki/` or `cogni-workspace/wiki/wiki/` is touched — the content decisions belong to #1401 and #1402. This PR only stops the script from pre-empting them. No version bump; the post-merge workflow owns that.

`cogni-workspace/references/wiki-tree-reconciliation.md` is updated at three anchors that would otherwise ship describing a tool that no longer behaves that way: the rejected-alternative paragraph, the contradictions-table row, and "What guards this".

## Not done

Step 6.4's `/simplify` quality pass did **not** run — the commit was taken first to make the work durable under a tight context budget, which leaves that pass's dirty-tree guard reading clean. Quality-only; correctness is covered by the checks above. Flagged for the reviewer rather than left silent.

## Do not run `--force` against the real trees while reviewing

That is the destruction this PR exists to prevent. The `--force` path is covered inside the suite's fixtures.