### PR TITLE
cogni-workspace: register the wiki-tree record and its guard

### DIFF
--- a/cogni-workspace/CLAUDE.md
+++ b/cogni-workspace/CLAUDE.md
@@ -96,6 +96,13 @@ Plugins do not duplicate shared market fields. The `manage-markets` skill is the
 - Obsidian templates live in `templates/obsidian/`
 - See `references/note-frontmatter-standard.md` for the YAML frontmatter convention used by all plugin outputs
 
+## Wiki Trees
+
+The wiki ships twice: `wiki/` at the repository root is the editing surface maintainers change, and `cogni-workspace/wiki/` is the vendored copy that travels inside this plugin so marketplace users get it in their plugin cache. The two trees are allowed to differ, and they do.
+
+- See `references/wiki-tree-reconciliation.md` for the decisions record covering both trees — every way `wiki/` and `cogni-workspace/wiki/` currently disagree, what was decided for each delta, and what reversing it would cost. Counts and figures live there, each attributed to the command that produced it; read them off the record rather than restating them here, where they would go stale silently.
+- `tests/test-wiki-tree-parity.sh` is that record's enforcement arm. It asserts, per tree and never tree-wide: each `.cogni-wiki/config.json` `entries_count` equals a live count of that same tree's pages; every wiki reference in a tree resolves to a page in that same tree; and every page present in only one tree is named in the decisions record. It deliberately does **not** assert that the two trees are equal — they are not, by design, and the record explains each surviving difference. So a one-sided page with no decision written down turns the suite red: the fix is to record the decision in `references/wiki-tree-reconciliation.md`, not to route around the guard.
+
 ## Issue Reporting and Diagnostics
 
 Two skills absorbed from cogni-help when it was retired. These are now the only copies.

--- a/cogni-workspace/references/wiki-tree-reconciliation.md
+++ b/cogni-workspace/references/wiki-tree-reconciliation.md
@@ -247,7 +247,7 @@ Kept as a permanent inventory so the set stays auditable rather than being redis
 | 7 bundled-only pages held | awaiting a maintainer ruling | #1402 |
 | `ecosystem-command-reference` names a retired command surface | held with the page above | #1402 |
 | Sync script destroys bundle-only content | closed — refuses by default; `--force` is the opt-in | #1403 |
-| This record and its guard are unregistered in the plugin guide | open | #1404 |
+| This record and its guard are unregistered in the plugin guide | closed — `cogni-workspace/CLAUDE.md` names both under `## Wiki Trees` | #1404 |
 
 ## Deliberately left standing
 


### PR DESCRIPTION
Closes #1404.

## Summary

- Add a `## Wiki Trees` section to `cogni-workspace/CLAUDE.md`, between `## Obsidian Integration` and `## Issue Reporting and Diagnostics`, registering `references/wiki-tree-reconciliation.md` as the decisions record for the two wiki trees (`wiki/` the root editing surface, `cogni-workspace/wiki/` the vendored copy that reaches users).
- Register `tests/test-wiki-tree-parity.sh` in the same section with the three assertions it actually makes — per-tree `entries_count` against a live page count, every wiki reference resolving inside the same tree, and every one-sided page being named in the record — plus the explicit guard→record pointer: a one-sided page with no decision written down turns the suite red, and the fix is to record the decision, not to route around the guard.
- State the negative the suite states about itself: it deliberately does **not** assert the two trees are equal. They differ by design and the record explains each difference.
- Close the record's own `Known remaining contradictions` row that still reported this registration as open.

## Why the prose is written from the guard's header, not from its name

A suite called *parity* reads as "keeps the two trees identical" — and that is exactly what it refuses to assert. Its own header says so twice, and the decisions record explains the stakes: a blanket `release-bundle-wiki.sh` sync would destroy bundle-only content, which is why #1403 taught that script to refuse by default. A registration asserting equality would have pointed the next maintainer straight at the command the record exists to rule out. So the section states the non-assertion explicitly rather than leaving it to be inferred.

## Scope decisions

- **In:** exactly two files — `cogni-workspace/CLAUDE.md` and the single `#1404` row of the reconciliation record's contradictions table. Leaving that row saying `open` would ship a record contradicting this PR.
- **Out:** `cogni-workspace/tests/test-wiki-namespace-sync.sh` is also unregistered in `CLAUDE.md`, but no acceptance criterion names it, and #1404 was deliberately split off #1384 to keep the diff on a shared registration file small while a second author drains the same repo. Flagged, not actioned.
- **Out:** no version bump — the post-merge workflow owns it.
- **No figures inlined.** Page counts, `changes_pending`, and the bundled-only page count are not repeated in `CLAUDE.md`; they are measured against a specific commit and go stale silently. The prose points at the record, which attributes each figure to the command that produced it.
- **No mutation recipe applies.** This PR modifies no `tests/test-*.sh` and no `scripts/check-*.sh`. Both suites below are run unchanged, as regression checks.

## Test plan — all run on this branch head

- [x] `bash cogni-workspace/tests/test-layering-claim-reconciled.sh` → **9/9 PASS, rc 0**. This is the issue's third acceptance criterion: `cogni-workspace/CLAUDE.md` is not on that suite's `EXCLUDED` list, so case L1 scans the new prose against all 14 forbidden fixed-string literals.
- [x] `bash cogni-workspace/tests/test-wiki-tree-parity.sh` → **8/8 PASS, rc 0**. W1/W2 counts, W4/W5 links and W7 recorded-pages all still green, so the record edit disturbed no page name W7 reads.
- [x] `python3 scripts/run-plugin-tests.py --filter cogni-workspace` → **rc 0**, whole plugin suite set.
- [x] `git diff --name-only` lists exactly `cogni-workspace/CLAUDE.md` and `cogni-workspace/references/wiki-tree-reconciliation.md` — no third file, no manifest version change.
- [x] `grep -cF` on the branch head: `references/wiki-tree-reconciliation.md` → 2, `tests/test-wiki-tree-parity.sh` → 1. Both were 0 at base.
- [x] `grep -n '^## '` shows all eight base headings present and in order, with `Wiki Trees` inserted before the last. `git diff --numstat` on `CLAUDE.md` is `7 0` — seven insertions, zero deletions.

## Base note

Planned and built against `origin/main@489e361b`. The base advanced from `a9bd464e` mid-run when PR #1407 merged; that PR touched the **root** `CLAUDE.md`, not `cogni-workspace/CLAUDE.md`, and every premise was re-verified against the new base before the branch was cut.