### PR TITLE
repo: floor the fixtures-depth coverage the knowledge suite owns

### DIFF
--- a/cogni-knowledge/tests/test_plain_result_emitters.sh
+++ b/cogni-knowledge/tests/test_plain_result_emitters.sh
@@ -29,8 +29,23 @@
 #
 # The scan root defaults to this file's directory and can be overridden by the
 # first argument, so a wider guard can reuse this file rather than fork it.
-# A wider guard must re-home the liveness floor below — that count is scoped to
-# this plugin.
+# A wider guard must re-home the floors below — the liveness count and the
+# fixtures-arm coverage floor are both scoped to this plugin's tree.
+#
+# This suite owns the deeper fixtures segment, and that ownership is settled
+# rather than incidental. The repo-root result-line plainness guard discovers
+# suites through two non-recursive globs mirroring run-plugin-tests.py, so a
+# shared emitter helper parked one path segment below a tests/ directory is
+# structurally out of its reach. A third, deeper glob was considered and
+# rejected: that two-glob boundary is exactly what keeps the parked _archive/
+# carrier out of the population, and the guard ships no exclusion list,
+# allowlist or baseline to compensate — widening it would have forced the very
+# exemption machinery the guard exists to avoid, to close a gap nothing is
+# failing on today. The accepted cost is that this coverage stays plugin-local
+# and is not discoverable from the repo root. The D1 floor below is what stops
+# it from being dropped silently: break the deeper arm of the discovery loop
+# and the only definer leaves the scanned population, while every sourcing file
+# still counts toward the liveness floor above.
 #
 # bash 3.2 + python3 stdlib only (no pytest, no pip). Matches tests/README.md.
 
@@ -90,6 +105,7 @@ fi
 # carries its own body and feeds every check below from a single read.
 
 definers=0
+fixtures_definers=0
 exercisers=0
 shape_errors=0
 
@@ -109,6 +125,12 @@ for f in "$SCAN_ROOT"/*.sh "$SCAN_ROOT"/fixtures/*.sh; do
 
   definers=$((definers + 1))
   exercisers=$((exercisers + 1))
+
+  # Tally definers found under the deeper segment separately — the D1 floor
+  # below keys on this, not on the whole-population count.
+  case "$f" in
+    */fixtures/*) fixtures_definers=$((fixtures_definers + 1)) ;;
+  esac
 
   n_red=0
   n_green=0
@@ -144,6 +166,25 @@ if [ "$exercisers" -lt 50 ]; then
   errors=$((errors + 1))
 elif [ "$shape_errors" -eq 0 ]; then
   green "PASS: $definers emitter-defining file(s) are paired and plain, of $exercisers exercising the contract"
+fi
+
+# Coverage floor — the shared emitter helper must stay inside the scanned
+# population. Keyed per-arm on definers found under the deeper segment, NOT on
+# the exercisers floor above and NOT on the whole-population definer count:
+# break the deeper arm of the discovery loop and the only definer leaves the
+# population while every sourcing file still counts as an exerciser, so that
+# floor stays green, shape_errors stays 0 because there is nothing left to
+# shape-check, and the dropped coverage reports as a pass. A whole-population
+# definer count would also be satisfied by any future suite that inlines its
+# own emitters, which would mask the same drop. Only the per-arm count sees it.
+# The label carries a stable first-token case id, space-separated and never
+# colon-abutted, so a mutation harness classifies this case instead of
+# reporting case_not_found.
+if [ "$fixtures_definers" -lt 1 ]; then
+  red "FAIL: D1 no emitter-defining file under the fixtures segment was scanned — the shared helper left the scanned population"
+  errors=$((errors + 1))
+else
+  green "PASS: D1 $fixtures_definers emitter-defining file(s) scanned under the fixtures segment, so shared-helper coverage holds"
 fi
 
 echo


### PR DESCRIPTION
Closes #1406.

## Summary

Records the settled disposition for the fixtures-depth coverage gap and floors it so it cannot be dropped silently.

- **Disposition (b).** `cogni-knowledge/tests/test_plain_result_emitters.sh` is designated owner of the `tests/fixtures/` depth (already true in behaviour). `scripts/check-result-line-plainness.py` is **not** touched — no third glob, per the ruling recorded on the originating issue.
- **New `D1` coverage floor** — the suite now fails loudly if no emitter-defining file is scanned under its deeper discovery arm.
- **The existing scan-root note is amended** from the singular "liveness floor" to cover both floors, since a wider guard reusing this file must now re-home two plugin-scoped counts.

One file, +43/-2.

## The gap, reproduced

This was verified by running it, not by reading. Breaking the deeper arm of the discovery loop on the pre-change file gives:

```
PASS: helper emits plain result lines on stdout
PASS: no file under the scanned tree carries an escape literal
PASS: 0 emitter-defining file(s) are paired and plain, of 77 exercising the contract

plain result-emitter contract all pass.
exit=0
```

The shared helper is the repo's only emitter definer, so it leaves the scanned population — while all 77 sourcing files still count as exercisers, keeping the liveness floor (50) green, and `shape_errors` stays 0 because nothing is left to shape-check. Coverage drops; the suite passes.

## Scope decisions

- **The floor is keyed per-arm, not on the whole-population definer count.** A whole-population count would also be satisfied by any future suite that inlines its own emitters, which would mask the same drop. Only the per-arm count falsifies both shapes.
- **The floor is deliberately not conditioned on `SCAN_ROOT`.** The scan root is overridable by `$1`, but CI runs the suite with no argument, and the pre-existing liveness floor is unconditioned for the same reason. Gating it would create a path where it never evaluates — the exact vacuity class this change closes. The header instead states that a wider guard must re-home both floors.
- **No copy of the mutation recipe is embedded in the suite.** Beyond staleness, there is a concrete failure mode: the recipe substitutes with `perl -0pi` in slurp mode with no `/g`, so it rewrites the **first** occurrence only. The header sits above the discovery loop, so a header copy of that literal would swallow the mutation, leave the loop intact, and `D1` would stay green — the check would prove nothing. The header refers to the arm in prose; the literal occurs exactly once in the committed file (verified).
- **The repo-root `CLAUDE.md` bullet is not touched.** It already records the load-bearing half — that suites one path segment deeper are out of scope by glob depth, not by exclusion — and the issue itself accepts repo-root undiscoverability as the cost of disposition (b).

## Mutation recipe

The harness ships with the `cogni-service` plugin, not this repo — `${CLAUDE_PLUGIN_ROOT}` resolves to the installed plugin root, so do not look for it under this repo's `scripts/`. Run with `--root` pointing at the PR-head checkout.

```
bash "${CLAUDE_PLUGIN_ROOT}/scripts/mutation-check.sh" \
  --root . \
  --file cogni-knowledge/tests/test_plain_result_emitters.sh \
  --expr 's{/fixtures/\*\.sh; do}{/fixtures-absent/*.sh; do}' \
  --test 'bash cogni-knowledge/tests/test_plain_result_emitters.sh' \
  --case D1
```

Falsifies the `D1` floor: with the deeper arm redirected at a directory that does not exist, the shared helper leaves the scanned population, `fixtures_definers` drops to 0, and `D1` goes red — while the pre-existing `exercisers` floor stays green throughout, which is precisely why `D1` had to be added rather than reused.

The expression is anchored on the `; do` suffix so it can only match the discovery loop, never prose. Pattern and replacement are disjoint, so the substitution cannot re-match itself. `D1` is the first whitespace-delimited token of both the `PASS:` and `FAIL:` labels, with no colon abutting it, so the harness resolves the case in both directions.

**Result when run against this branch:**

```json
"mutated_result": "red",
"restored_result": "green",
"verdict": "guard_verified"
```

## Acceptance criteria

| Criterion | Status |
|---|---|
| A decision is recorded between (a) and (b), with the reasoning | Header paragraph records disposition (b) and why the two-glob boundary is load-bearing |
| (b): a guard assertion fails if the suite stops scanning `fixtures/` | The `D1` per-arm floor; `errors` drives the exit, so a red `D1` exits 1 |
| Provable by a mutation check returning a real verdict rather than `case_not_found` | `guard_verified` above |
| `python3 scripts/run-plugin-tests.py` stays green | All 118 suites passed on this branch; all 118 also passed on the `main` baseline |

## Testing

- `python3 scripts/run-plugin-tests.py` — **118/118 passed** on the branch (and on the `main` baseline, so the branch introduces no delta).
- `python3 scripts/check-result-line-plainness.py` — clean: 118 discovered, 118 scanned, 85 definitions inspected, 0 violations. Both per-arm liveness floors (`>= 80` / `>= 40`) hold with margin.
- `bash cogni-knowledge/tests/test_plain_result_emitters.sh` — gains `PASS: D1 1 emitter-defining file(s) scanned under the fixtures segment, so shared-helper coverage holds`; the three pre-existing cases are unchanged.
- No `plugin.json` / `marketplace.json` version line is touched.