### PR TITLE
docs: finish the cogni-claims bare-name sweep in consumer plugins

### DIFF
--- a/Cogni Work Design System/_ds_bundle.js
+++ b/Cogni Work Design System/_ds_bundle.js
@@ -856,7 +856,7 @@ function CogniWorkThemeShowcase() {
       borderBottom: "1px solid rgba(255,255,255,0.06)"
     }
   }, h)))), /*#__PURE__*/React.createElement("tbody", null, [{
-    name: "cogni-claims",
+    name: "cogni-workspace",
     status: "Aktiv",
     statusColor: theme.success,
     score: 94,

--- a/Cogni Work Design System/preview/components-table.html
+++ b/Cogni Work Design System/preview/components-table.html
@@ -5,7 +5,7 @@
 <table>
 <thead><tr><th>Plugin</th><th>Status</th><th>Score</th><th>Trend</th></tr></thead>
 <tbody>
-<tr><td>cogni-claims</td><td><span class="dot" style="background:#2E7D32"></span><span style="color:#2E7D32">Active</span></td><td><span class="d"><i style="width:94%"></i></span><span class="mono">94</span></td><td class="mono">+12%</td></tr>
+<tr><td>cogni-workspace</td><td><span class="dot" style="background:#2E7D32"></span><span style="color:#2E7D32">Active</span></td><td><span class="d"><i style="width:94%"></i></span><span class="mono">94</span></td><td class="mono">+12%</td></tr>
 <tr><td>cogni-portfolio</td><td><span class="dot" style="background:#E5A100"></span><span style="color:#E5A100">In progress</span></td><td><span class="d"><i style="width:78%"></i></span><span class="mono">78</span></td><td class="mono">+5%</td></tr>
 <tr><td>cogni-trends</td><td><span class="dot" style="background:#1565C0"></span><span style="color:#6B8DBF">Planning</span></td><td><span class="d"><i style="width:62%"></i></span><span class="mono">62</span></td><td class="mono" style="color:#9CA3AF">New</td></tr>
 </tbody></table>

--- a/Cogni Work Design System/raw/cogni-work-theme-showcase.jsx
+++ b/Cogni Work Design System/raw/cogni-work-theme-showcase.jsx
@@ -541,7 +541,7 @@ export default function CogniWorkThemeShowcase() {
             </thead>
             <tbody>
               {[
-                { name: "cogni-claims", status: "Aktiv", statusColor: theme.success, score: 94, trend: "+12%" },
+                { name: "cogni-workspace", status: "Aktiv", statusColor: theme.success, score: 94, trend: "+12%" },
                 { name: "cogni-portfolio", status: "In Arbeit", statusColor: theme.warning, score: 78, trend: "+5%" },
                 { name: "trend-scout", status: "Planung", statusColor: theme.info, score: 62, trend: "Neu" },
               ].map((row) => (

--- a/cogni-marketing/CLAUDE.md
+++ b/cogni-marketing/CLAUDE.md
@@ -70,7 +70,7 @@ Formats with `evidence: true` embed TIPS claims inline as `[claim_id](source_url
 | cogni-copywriting | No | Polish generated content with messaging frameworks |
 | cogni-narrative | No | Arc-driven transformation for long-form thought leadership |
 | cogni-visual | No | Slide decks and visual assets from content briefs |
-| cogni-claims | No | Evidence verification for sourced claims in content |
+| cogni-workspace | No | Evidence verification for sourced claims in content via `cogni-workspace:claims` |
 
 ## Key Conventions
 

--- a/cogni-marketing/references/data-model.md
+++ b/cogni-marketing/references/data-model.md
@@ -183,7 +183,7 @@ created: ISO-8601
 - **cogni-copywriting**: Generated content can be piped to `copywriter` skill for polishing
 - **cogni-narrative**: Long-form thought leadership can be piped to `narrative` skill for arc-driven transformation
 - **cogni-visual**: Content briefs can be piped to `story-to-slides` or `canvas` for visual deliverables
-- **cogni-claims**: Evidence claims in content inherit verification status from TIPS claims registry
+- **cogni-workspace**: Evidence claims in content inherit verification status from TIPS claims registry via `cogni-workspace:claims`
 
 ## Naming Conventions
 

--- a/cogni-narrative/README.md
+++ b/cogni-narrative/README.md
@@ -175,7 +175,7 @@ cogni-narrative/
 | cogni-copywriting | No | Arc-aware executive polish (downstream) |
 | cogni-visual | No | Slide decks and visual assets from narrative output (downstream) |
 | cogni-sales | No | Consumes Corporate Visions arc patterns (downstream) |
-| cogni-claims | No | company-credo arc references cogni-claims data files for claim-backed credibility sections |
+| cogni-workspace | No | company-credo arc reads the `cogni-claims/` claim store for claim-backed credibility sections |
 
 cogni-narrative is standalone. It transforms structured input from any source — cogni-x plugins or plain markdown files.
 

--- a/cogni-portfolio/CLAUDE.md
+++ b/cogni-portfolio/CLAUDE.md
@@ -189,9 +189,8 @@ Research agents auto-log claims with source URLs and entity provenance (`entity_
 
 | Plugin | Direction | Mechanism |
 |--------|-----------|-----------|
-| cogni-workspace | bidirectional | portfolio-verify orchestrates claim verification and propagates corrections back to entity files; research agents auto-log claims with entity_ref provenance |
+| cogni-workspace | bidirectional | portfolio-verify orchestrates claim verification and propagates corrections back to entity files; research agents auto-log claims with entity_ref provenance; portfolio-dashboard uses pick-theme for theme selection |
 | cogni-trends | bidirectional | trends-bridge imports solution templates, exports portfolio anchors |
-| cogni-workspace | upstream | portfolio-dashboard uses pick-theme for theme selection |
 | document-skills | downstream | portfolio-ingest uses docx/pptx/xlsx readers; portfolio-communicate workbook uses XLSX writer |
 | cogni-narrative | downstream | portfolio-communicate pitch use case reads arc definitions for narrative structure |
 | cogni-visual | downstream | portfolio-communicate output consumable by story-to-slides, story-to-web; markdown output enrichable via enrich-report (concept diagrams + charts) |

--- a/cogni-portfolio/README.md
+++ b/cogni-portfolio/README.md
@@ -220,10 +220,9 @@ cogni-portfolio/
 | cogni-narrative | No | Pitch use case reads arc definitions for narrative structure; output is directly consumable by story-to-slides and story-to-web |
 | cogni-visual | No | Pitch output consumable by story-to-slides, story-to-web, and story-to-storyboard |
 | cogni-marketing | No | Customer narratives from portfolio-communicate are auto-discovered by marketing-setup for voice/messaging enrichment |
-| cogni-claims | No | Claim verification for research-backed assertions via portfolio-verify |
 | cogni-trends | No | Bidirectional TIPS integration via trends-bridge |
 | cogni-knowledge | No | Pitch arcs (technology-futures, strategic-foresight, trend-panorama, theme-thesis) in portfolio-communicate draw on cogni-knowledge research syntheses for evidence |
-| cogni-workspace | No | Theme selection for portfolio-dashboard via pick-theme |
+| cogni-workspace | No | Theme selection for portfolio-dashboard via pick-theme; claim verification for research-backed assertions via portfolio-verify |
 | cogni-sales | No | Downstream consumer — why-change pitch builds on portfolio features and propositions |
 | cogni-copywriting | No | portfolio-communicate pitch templates tune acronym-expansion depth via the `copywriter` audience field |
 | document-skills | No | Document ingestion (docx, pptx, xlsx, pdf) via portfolio-ingest; XLSX export via portfolio-communicate |

--- a/cogni-portfolio/agents/competitor-researcher.md
+++ b/cogni-portfolio/agents/competitor-researcher.md
@@ -80,7 +80,7 @@ These rules implement [Anthropic's recommended hallucination reduction technique
 1. Does it have a supporting source URL from actual search results?
 2. Does the number/positioning match exactly what the source reported?
 3. Is the competitor attribution correct (not a subsidiary or deprecated product)?
-4. **Remove unsourced claims** rather than submitting them — catching them here is cheaper than downstream cogni-claims verification
+4. **Remove unsourced claims** rather than submitting them — catching them here is cheaper than downstream cogni-workspace claim verification
 
 *Confidence Assessment:*
 

--- a/cogni-portfolio/agents/customer-researcher.md
+++ b/cogni-portfolio/agents/customer-researcher.md
@@ -135,7 +135,7 @@ These rules implement [Anthropic's recommended hallucination reduction technique
 1. Does it have a supporting source URL from actual search results?
 2. Does the number match exactly what the source reported?
 3. Is the company attribution correct, or could it refer to a subsidiary/parent?
-4. **Remove unsourced data points** rather than submitting them as claims — catching them here is cheaper than downstream cogni-claims verification
+4. **Remove unsourced data points** rather than submitting them as claims — catching them here is cheaper than downstream cogni-workspace claim verification
 
 *Confidence Assessment:*
 

--- a/cogni-portfolio/agents/feature-deep-diver.md
+++ b/cogni-portfolio/agents/feature-deep-diver.md
@@ -323,7 +323,7 @@ These rules implement [Anthropic's recommended hallucination reduction technique
 1. Does it have a supporting source URL from actual WebSearch/WebFetch results?
 2. Does the number/positioning match exactly what the source reported?
 3. Is the competitor attribution correct (not a subsidiary, deprecated product, or different market segment)?
-4. **Remove unsourced findings** rather than including them — catching them here is cheaper than downstream cogni-claims verification
+4. **Remove unsourced findings** rather than including them — catching them here is cheaper than downstream cogni-workspace claim verification
 
 *Confidence Assessment:*
 

--- a/cogni-portfolio/agents/market-researcher.md
+++ b/cogni-portfolio/agents/market-researcher.md
@@ -81,7 +81,7 @@ These rules implement [Anthropic's recommended hallucination reduction technique
 1. Does it have a supporting source URL from actual search results?
 2. Does the number match exactly what the source reported?
 3. Is the inference reasonable, or are you filling a gap?
-4. **Remove unsourced values** rather than submitting them as claims — catching them here is cheaper than downstream cogni-claims verification
+4. **Remove unsourced values** rather than submitting them as claims — catching them here is cheaper than downstream cogni-workspace claim verification
 
 *Confidence Assessment:*
 

--- a/cogni-portfolio/agents/proposition-deep-diver.md
+++ b/cogni-portfolio/agents/proposition-deep-diver.md
@@ -455,7 +455,7 @@ These rules implement [Anthropic's recommended hallucination reduction technique
 1. Does it have a supporting source URL from actual WebSearch/WebFetch results?
 2. Does the buyer language come from actual buyer sources (reviews, RFPs, forums) — not vendor marketing?
 3. Does the competitive messaging accurately reflect the competitor's stated positioning?
-4. **Remove unsourced findings** rather than including them — catching them here is cheaper than downstream cogni-claims verification
+4. **Remove unsourced findings** rather than including them — catching them here is cheaper than downstream cogni-workspace claim verification
 
 *Confidence Assessment:*
 

--- a/cogni-sales/CLAUDE.md
+++ b/cogni-sales/CLAUDE.md
@@ -83,7 +83,7 @@ Each phase has a **quality gate** — the orchestrator presents key findings to 
 | cogni-portfolio | Yes | upstream | Products, features, propositions (IS/DOES/MEANS), solutions (pricing tiers), markets (TAM/SAM/SOM, revenue range), competitors, customers (reference accounts) |
 | cogni-narrative | Yes | upstream | Corporate Visions arc definition + per-phase pattern files (why-change-patterns.md, why-now-patterns.md, why-you-patterns.md, why-pay-patterns.md) |
 | cogni-trends | No | upstream | TIPS value-model themes, regulatory timelines, solution templates, gap analysis — enriches all 4 phases when available |
-| cogni-claims | No | downstream | Claims registered during research with source URLs; `/claims verify` validates them |
+| cogni-workspace | No | downstream | Claims registered during research with source URLs; `cogni-workspace:claims` verifies them |
 | cogni-copywriting | No | downstream | Executive polish on final deliverables (`/copywrite sales-presentation.md`) |
 | cogni-visual | No | downstream | PPTX generation from sales presentation (`/pptx create sales-presentation.md`) |
 

--- a/cogni-sales/README.md
+++ b/cogni-sales/README.md
@@ -40,7 +40,7 @@ A pitch-generation pipeline organized around the Corporate Visions Why Change me
 - **Pitch in hours, not days.** The researcher agent runs the web research, company analysis, and evidence gathering across all four phases — you review and steer instead of starting from a blank deck.
 - **Stay on-method every time.** Every pitch follows all four Why Change phases with structured evidence — no phase skipped, no message diluted, even under deadline pressure.
 - **Serve 1:1 and 1:many from one engine.** Customer mode researches the named account; segment mode produces a reusable template for the whole vertical — zero pipeline rebuild between deal-specific and market pitches.
-- **Present numbers you can defend.** Every factual claim is registered with a source URL, and optional cogni-claims verification checks them in one pass — no unsourced statistics in front of the buyer.
+- **Present numbers you can defend.** Every factual claim is registered with a source URL, and optional cogni-workspace claim verification checks them in one pass — no unsourced statistics in front of the buyer.
 
 ## Install
 
@@ -156,7 +156,7 @@ cogni-sales/
 | cogni-portfolio | Yes | Products, features, propositions, solutions, markets, competitors, customers |
 | cogni-narrative | Yes | Corporate Visions story arc patterns (why-change, why-now, why-you, why-pay) |
 | cogni-trends | No | TIPS strategic theme enrichment — value-modeler themes, regulatory timelines, gap analysis |
-| cogni-claims | No | Source verification for web-sourced claims |
+| cogni-workspace | No | Source verification for web-sourced claims via `cogni-workspace:claims` |
 | cogni-copywriting | No | Executive polish on final deliverables |
 | cogni-visual | No | PPTX generation from sales presentation |
 

--- a/cogni-sales/agents/why-change-researcher.md
+++ b/cogni-sales/agents/why-change-researcher.md
@@ -387,7 +387,7 @@ These rules implement [Anthropic's recommended hallucination reduction technique
 1. Review each finding — does it have a supporting source URL in its evidence array?
 2. Check each number — does it match exactly what the source reported?
 3. Verify each inference — is it directly supported, or are you filling a gap?
-4. **Remove unsupported findings** rather than registering them as claims — catching them here is cheaper than downstream cogni-claims verification
+4. **Remove unsupported findings** rather than registering them as claims — catching them here is cheaper than downstream cogni-workspace claim verification
 
 **Confidence Assessment:** Rate each finding's evidence strength:
 

--- a/cogni-sales/skills/why-change/references/pitch-data-model.md
+++ b/cogni-sales/skills/why-change/references/pitch-data-model.md
@@ -230,7 +230,7 @@ In customer mode, the narrative addresses the named customer directly. In segmen
 
 ## Claims Registration
 
-Claims with web URLs are registered for optional cogni-claims verification. Each claim entry:
+Claims with web URLs are registered for optional `cogni-workspace:claims` verification. Each claim entry:
 
 ```json
 {

--- a/cogni-trends/agents/trend-report-revisor.md
+++ b/cogni-trends/agents/trend-report-revisor.md
@@ -18,7 +18,7 @@ You revise a TIPS trend report after claims verification. You apply user-resolve
 |-----------|----------|-------------|
 | `PROJECT_PATH` | Yes | Absolute path to the TIPS project directory |
 | `REPORT_PATH` | Yes | Path to the current report (typically `tips-trend-report.md`) |
-| `CLAIMS_PATH` | Yes | Path to cogni-claims workspace (`cogni-claims/claims.json`) |
+| `CLAIMS_PATH` | Yes | Path to the workspace claim store (`cogni-claims/claims.json`) |
 | `NEW_VERSION` | Yes | Version number for the revised report (e.g., 2) |
 | `OUTPUT_LANGUAGE` | No | ISO 639-1 code (default: from report YAML frontmatter). Controls language of any new text |
 | `MARKET` | No | Region code (default: "global"). For market-localized evidence search |
@@ -33,13 +33,13 @@ Phase 0 (Load) → Phase 1 (Triage) → Phase 2 (Revise) → Phase 3 (Output)
 
 1. Read the current report (`REPORT_PATH`)
 2. Extract `language` from report YAML frontmatter (fallback to `OUTPUT_LANGUAGE` parameter)
-3. Read `CLAIMS_PATH` — the cogni-claims registry containing all claim records with their resolution status
+3. Read `CLAIMS_PATH` — the workspace claim registry containing all claim records with their resolution status
 4. Read `{PROJECT_PATH}/tips-trend-report-claims.json` — the original claims registry from report generation
 5. If present, read `{PROJECT_PATH}/.metadata/user-claims-review.json` — explicit user decisions beyond what's in claims.json
 
 ### Understanding Claims Resolution Data
 
-The cogni-claims `claims.json` contains claim records with resolution data nested inside the `verification` object:
+The `cogni-claims/claims.json` store contains claim records with resolution data nested inside the `verification` object:
 
 ```json
 {

--- a/cogni-trends/agents/trend-report-writer.md
+++ b/cogni-trends/agents/trend-report-writer.md
@@ -37,7 +37,7 @@ Before writing the dimension section and extracting claims to JSON:
 1. Review each citation — does the URL come from actual WebSearch results or raw signal sources?
 2. Check each number — does it match exactly what the source reported?
 3. Verify each claim extracted for the claims registry — is it directly supported by a source?
-4. **Remove unsourced claims** rather than registering them — catching them here prevents downstream cogni-claims verification failures
+4. **Remove unsourced claims** rather than registering them — catching them here prevents downstream cogni-workspace claim verification failures
 
 ### Confidence Assessment
 

--- a/cogni-trends/skills/trend-research/references/claims-format.md
+++ b/cogni-trends/skills/trend-research/references/claims-format.md
@@ -115,7 +115,7 @@ When extracting claims from the generated report section:
 
 ---
 
-## Compatibility with cogni-claims
+## Compatibility with `cogni-workspace:claims`
 
 The merged claims file is directly consumable by `cogni-workspace:claims` via:
 

--- a/cogni-trends/skills/trend-synthesis/references/claims-registry-format.md
+++ b/cogni-trends/skills/trend-synthesis/references/claims-registry-format.md
@@ -77,7 +77,7 @@ The macro-label localizations for the Dimension column come from the same labels
 
 ---
 
-## Compatibility with `cogni-claims`
+## Compatibility with `cogni-workspace:claims`
 
 The merged claims file `tips-trend-report-claims.json` (written in Step 2.7) is the machine-readable companion to this human-readable table. Its schema is documented in `trend-research/references/claims-format.md § Merged Claims File`.
 

--- a/cogni-workspace/themes/cogni-work/cogni-work-theme-showcase.jsx
+++ b/cogni-workspace/themes/cogni-work/cogni-work-theme-showcase.jsx
@@ -541,7 +541,7 @@ export default function CogniWorkThemeShowcase() {
             </thead>
             <tbody>
               {[
-                { name: "cogni-claims", status: "Aktiv", statusColor: theme.success, score: 94, trend: "+12%" },
+                { name: "cogni-workspace", status: "Aktiv", statusColor: theme.success, score: 94, trend: "+12%" },
                 { name: "cogni-portfolio", status: "In Arbeit", statusColor: theme.warning, score: 78, trend: "+5%" },
                 { name: "trend-scout", status: "Planung", statusColor: theme.info, score: 62, trend: "Neu" },
               ].map((row) => (

--- a/cogni-workspace/themes/cogni-work/components/web/table.html
+++ b/cogni-workspace/themes/cogni-work/components/web/table.html
@@ -4,7 +4,7 @@
 <table>
 <thead><tr><th>Plugin</th><th>Status</th><th>Score</th><th>Trend</th></tr></thead>
 <tbody>
-<tr><td>cogni-claims</td><td><span class="dot" style="background:#2E7D32"></span><span style="color:#2E7D32">Active</span></td><td><span class="d"><i style="width:94%"></i></span><span class="mono">94</span></td><td class="mono">+12%</td></tr>
+<tr><td>cogni-workspace</td><td><span class="dot" style="background:#2E7D32"></span><span style="color:#2E7D32">Active</span></td><td><span class="d"><i style="width:94%"></i></span><span class="mono">94</span></td><td class="mono">+12%</td></tr>
 <tr><td>cogni-portfolio</td><td><span class="dot" style="background:#E5A100"></span><span style="color:#E5A100">In progress</span></td><td><span class="d"><i style="width:78%"></i></span><span class="mono">78</span></td><td class="mono">+5%</td></tr>
 <tr><td>cogni-trends</td><td><span class="dot" style="background:#1565C0"></span><span style="color:#6B8DBF">Planning</span></td><td><span class="d"><i style="width:62%"></i></span><span class="mono">62</span></td><td class="mono" style="color:#9CA3AF">New</td></tr>
 </tbody></table>

--- a/shared/references/grounding-principles.md
+++ b/shared/references/grounding-principles.md
@@ -40,7 +40,7 @@ Before finalizing output, run a self-audit on every factual claim:
 3. **Verify each inference** — is it directly supported, or are you filling a gap?
 4. **Retract unsupported claims** — if a finding cannot be traced to a specific source, remove it from the output rather than submitting it for downstream verification
 
-The self-audit reduces load on cogni-claims by catching unsupported claims at generation time rather than verification time.
+The self-audit reduces load on `cogni-workspace:claims` by catching unsupported claims at generation time rather than verification time.
 
 ## Confidence Assessment
 


### PR DESCRIPTION
## Description

The cogni-claims → cogni-workspace absorption (#1396) rewrote the plugin's own surfaces and its
direct dispatch callers, but bare-name prose naming the retired plugin survived in five consumer
plugins that were never in that change's file set, plus the theme showcase demo data.

Some of this is user-visible. The dependency tables are what a reader consults to learn which
plugins a pipeline needs, and the theme showcase renders in the preview a user sees when picking
a theme — both currently name a plugin that no longer exists.

This is the residue #1398 was filed to track. Two of its four findings turned out to be already
satisfied on `main` (the workspace plugin guide gained its `claims` / `claim-entity` sections, and
no doc page still miscounts the roster or enumerates a plugin twice), so this PR covers the two
that remained plus a duplicate row and one shared-reference site found while sweeping.

## Changes

- **Dependency tables.** `cogni-sales` (CLAUDE.md, README.md), `cogni-marketing/CLAUDE.md` and
  `cogni-narrative/README.md` rename in place — none of those tables already listed the adopting
  plugin. `cogni-portfolio/README.md` **folds** claim verification into its existing
  `cogni-workspace` row instead, because renaming in place where the adopting plugin is already
  listed is precisely what produces a duplicate entity. `cogni-portfolio/CLAUDE.md` had already
  acquired one such duplicate (the same plugin at `bidirectional` and `upstream`) and is folded here too.
- **Research agents.** The repeated "downstream cogni-claims verification" line in seven agents
  across `cogni-sales`, `cogni-portfolio` and `cogni-trends`.
- **cogni-trends references.** Two "Compatibility with cogni-claims" headings whose bodies already
  named `cogni-workspace:claims`, plus the `trend-report-revisor` parameter table and Phase 0 prose.
- **Theme showcase demo data.** Five mirrored copies listed the retired plugin as active with a
  health score — the workspace `.jsx` and `table.html`, and the design-system `raw/`, `preview/`
  and `_ds_bundle.js` mirrors, changed together so they do not drift.
- **`shared/references/grounding-principles.md`** named the retired plugin as the downstream
  verification load-bearer.

### Deliberately not touched

The rewrite discriminator is the colon: a colon-qualified dispatch token is rewritten, an on-disk
`cogni-claims/` path never is. Renaming the store would orphan every claim store already on users'
disks with no migration path.

Also left alone: historical records (`cogni-knowledge` CHANGELOG and dated `references/`, the wiki
`log.md` ingest lines), the hygiene guard's own forbidden-token lookup table in
`cogni-workspace/tests/test-relocated-skill-hygiene.sh` — removing the literal makes the guard
vacuous — and the generated audit reports, which belong to #1395 and would drift from their
generator if hand-edited.

## Testing

- `scripts/check-external-dispatch.py` — clean zero (`summary.total: 0`)
- `scripts/check-version-bump.py` — 11 plugins scanned, **0 touched**, 0 violations
- `scripts/check-breadcrumbs.py`, `check-result-line-plainness.py`, `check-workflow-yaml.py` — all exit 0
- `tests/test_check_plugin_inventory.sh`, `cogni-workspace/tests/test-relocated-skill-hygiene.sh`,
  `cogni-workspace/scripts/check-skill-names.sh` — green
- `scripts/run-plugin-tests.py` — 116 of 118 suites pass. The two failures are **container-environment
  artifacts, verified pre-existing**: they reproduce with an identical failure set on a clean worktree
  at `44cc4b0` with none of these changes applied.
  - `tests/test_release_bundle_wiki.sh` — `rsync` is not installed in this container; the script under
    test requires it.
  - `cogni-consult/tests/test_resolve_assumptions.sh` — simulates a write failure via `chmod 555`,
    which does not deny writes when the suite runs as root.
- **Store-path audit** (the failure mode worth guarding — silently breaking every existing claim
  store): no `cogni-claims/` path is removed anywhere in the diff. Every removed line carrying one
  has a replacement carrying the same path verbatim; the repo-wide `cogni-claims/claims.json` count
  goes 65 → 66, the increase being one bare-name reference made explicit.

## Checklist

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md)
- [x] My changes follow the existing code style
- [x] I have updated documentation where applicable
- [x] I have tested my changes

---

No `plugin.json` / `marketplace.json` version touched — the post-merge workflow owns the bump.

Closes #1398
Refs #1350

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KK6Sowc7TbncVL4UrSLb8J

---
_Generated by [Claude Code](https://claude.ai/code/session_01KK6Sowc7TbncVL4UrSLb8J)_