### PR TITLE
cogni-workspace: execute the recorded wiki-tree content deltas

### DIFF
--- a/cogni-workspace/references/wiki-tree-reconciliation.md
+++ b/cogni-workspace/references/wiki-tree-reconciliation.md
@@ -12,24 +12,35 @@ are decided here and carried out elsewhere; the issue that carries them is named
 
 ## On the figures in this document
 
-Every count below is attributed to the command that produced it, measured against
-`origin/main` at `0698cb2c`. Where a previously-quoted figure could not be reproduced, that is
-recorded plainly rather than smoothed over.
+Every count below is attributed to the command that produced it, measured against the ref named
+beside it. Where a previously-quoted figure could not be reproduced, that is recorded plainly
+rather than smoothed over.
 
-| Figure | Command | Value |
-|---|---|---|
-| Pending changes | `bash scripts/release-bundle-wiki.sh --check` | `changes_pending: 28` |
-| Root page count | same command, `source_page_count` | `170` |
-| Bundled page count | `find cogni-workspace/wiki/wiki/pages -maxdepth 1 -name '*.md' \| wc -l` | `176` |
-| Itemised breakdown | `rsync -anci --delete wiki/ cogni-workspace/wiki/` | 20 content + 7 delete + 1 add |
+The figures were re-measured when Decision 3 was executed. The table now carries the **post-
+execution** state; the pre-execution values it replaces are kept in the paragraph below rather
+than overwritten, because the difference between them is what Decision 3 actually did.
 
-**The originating issue says 29; measurement says 28.** Both figures were taken with the same
-command at different times, and the difference is not a miscount — it is the metric moving. An
-earlier measurement at `bab6a9cd` reported `128`, of which 100 lines were attribute-only
-(96 `.f..t....` files plus 4 `.d..t....` directories) produced by `rsync -i` itemising mtime
-differences on a fresh checkout. At `0698cb2c` that class is **empty**: all 28 lines are genuine
-content differences. Anyone re-measuring on a freshly-cloned tree may see the attribute lines
-return, because they are an artefact of checkout order rather than of the trees themselves.
+| Figure | Command | Value | Measured at |
+|---|---|---|---|
+| Substantive pending changes | `rsync -anci --delete wiki/ cogni-workspace/wiki/`, excluding attribute-only lines | 3 content + 7 delete + 1 add = **11** | Decision 3 execution branch |
+| Raw pending changes | `bash scripts/release-bundle-wiki.sh --check` | `changes_pending: 167` on a fresh checkout | Decision 3 execution branch |
+| Root page count | same command, `source_page_count` | `151` | Decision 3 execution branch |
+| Bundled page count | `find cogni-workspace/wiki/wiki/pages -maxdepth 1 -name '*.md' \| wc -l` | `157` | Decision 3 execution branch |
+
+**Read the substantive row, not the raw one.** The two rows disagree by 156 lines and neither is
+wrong: `changes_pending` counts every `rsync` itemise line, and on a freshly-checked-out tree 152
+`.f..t....` files plus 4 `.d..t....` directories are attribute-only mtime differences rather than
+content. This is the same artefact class described below, and it is why the substantive figure is
+quoted first and derived from the itemised command.
+
+**The moving figures, in order.** The originating issue said 29. Measurement at `bab6a9cd` said
+`128`, of which 100 lines were attribute-only. Measurement at `0698cb2c` said `28` with that class
+empty. Measurement at `563098e0` — the base of the Decision 3 execution branch — said **21**
+substantive lines (13 content + 7 delete + 1 add). None of those moves is a miscount; each is the
+metric moving. The `28` → `21` step was not reconciliation work at all: it is the cogni-claims and
+cogni-narrative/cogni-copywriting absorptions deleting pages out of both trees, which retired five
+group-A entries outright and left two more already identical. Executing Decision 3 then took the
+substantive figure from 21 to **11** by closing 10 of the 13 content deltas.
 
 ## Decision 1 — `entries_count` is corrected by hand, per tree
 
@@ -52,32 +63,43 @@ should not read `170 != 176` as fresh drift.
 **Reversing it** restores a count that overstates both trees, which is the state that let three
 page-deleting commits pass unnoticed.
 
-## Decision 2 — the expected pending-changes figure is 28, and the residual is explained
+## Decision 2 — the expected substantive residual is 11 lines, and every one is explained
 
-**Decision.** After this reconciliation, `bash scripts/release-bundle-wiki.sh --check` is
-expected to keep reporting `changes_pending: 28`. That figure is understood and intended.
+**Decision.** After this reconciliation *and* the execution of Decision 3, the itemised
+`rsync -anci --delete wiki/ cogni-workspace/wiki/` is expected to keep reporting **11 substantive
+lines**, plus a checkout-dependent number of attribute-only lines that carry no meaning. That
+residual is understood and intended.
 
-**Why.** The metric counts `rsync` itemise lines, and none of the three classes it counts is
-closed by the changes recorded here:
+**Why.** Each surviving line belongs to a decision that deliberately keeps the two trees apart:
 
 | Class | Lines | Why it survives |
 |---|---:|---|
 | `*deleting` | 7 | The bundled-only pages stay in place pending Decision 4 |
 | `>f+++++++` | 1 | The dated lint page is root-only by design (Decision 5) |
-| Content deltas | 20 | Recorded in Decision 3, executed separately |
+| Content delta — `.cogni-wiki/config.json` | 1 | Each config describes its own tree; the values are *supposed* to differ (Decision 1) |
+| Content delta — `wiki/log.md` | 1 | Frozen dated history, divergent on purpose (Decision 5) |
+| Content delta — `wiki/index.md` | 1 | Merged, never copied: the bundle keeps the seven Decision-4 bullets, the root keeps its maintenance section (Decision 3, group C) |
 
-The wikilink change in Decision 6 lands identically on both sides, so it adds no line. The
-`entries_count` change in Decision 1 does not add a line either: the two configs already
-differed, and they still differ.
+Decision 3's execution closed the other 10 content deltas — the six live group-A pages and the
+four group-B pages are now byte-identical across the trees. The wikilink change in Decision 6
+lands identically on both sides, so it adds no line. The `entries_count` change in Decision 1
+does not add a line either: the two configs already differed, and they still differ.
 
-**Reversing it** means the next person to read `28` treats it as unexplained drift and reaches
-for the sync script — the outcome Decision 3's rejected alternative exists to prevent.
+**Do not gate on `changes_pending`.** `bash scripts/release-bundle-wiki.sh --check` reported
+`changes_pending: 167` on the execution branch, and 156 of those were attribute-only. The
+substantive figure is the one to compare against, and it comes from the itemised command.
 
-## Decision 3 — the 20 content deltas resolve in two opposite directions
+**Reversing it** means the next person to read a large `changes_pending` treats it as unexplained
+drift and reaches for the sync script — the outcome Decision 3's rejected alternative exists to
+prevent.
 
-*Recorded, not executed. Carried out in issue #1401.*
+## Decision 3 — the content deltas resolve in two opposite directions
 
-**Rule.** Direction is decided per group, never by a blanket copy. Thirteen files are newer at
+*Executed in issue #1401.* Six live group-A pages were copied root → bundle, four group-B pages
+were back-ported bundle → root, and `wiki/index.md` was merged. The three structural files remain
+divergent by design; see Decision 2's residual table.
+
+**Rule.** Direction is decided per group, never by a blanket copy. The group-A files are newer at
 the root; four are newer in the bundle; three are structural and take bespoke handling.
 
 **Why.** The root copy is the editing surface, so the reflex is to treat it as correct
@@ -86,16 +108,27 @@ everywhere. For four pages that reflex would delete work. Commit `c44d52c3` appe
 directly to the *bundled* copies. Those sections have no root counterpart, so copying root over
 bundle discards them.
 
-### Group A — 13 files, root copy wins
+### Group A — originally 13 files, 6 live at execution, root copy wins
 
 Re-ingest commits enriched the root pages; the bundle was never re-synced afterwards and still
-holds the thinner generated stub.
+held the thinner generated stub. The six that were still divergent when Decision 3 executed were
+copied root → bundle verbatim and are now byte-identical:
 
 `agent-cogni-portfolio-proposition-generator.md`,
-`agent-cogni-portfolio-proposition-quality-assessor.md`, `concept-claim-lifecycle.md`,
-`concept-claims-propagation.md`, `plugin-cogni-portfolio.md`,
+`agent-cogni-portfolio-proposition-quality-assessor.md`, `plugin-cogni-portfolio.md`,
 `skill-cogni-portfolio-portfolio-verify.md`, `skill-cogni-portfolio-propositions.md`,
 `skill-cogni-trends-trend-report.md`
+
+The copy was verified non-destructive before it ran: on all six the root copy strictly enriched
+the bundled one — added `related:` entries, added wikilinks, expanded summary lines, and on
+`skill-cogni-portfolio-propositions.md` an 87-line rewrite over a 19-line stub — so no bundled
+line was lost. Every wikilink the copies carry already resolved in the destination tree, which is
+what kept parity cases W4 and W5 green.
+
+**Already identical at execution — 2 entries.** `concept-claim-lifecycle.md` and
+`concept-claims-propagation.md` were byte-identical in both trees by the time Decision 3 ran, so
+nothing was copied for them. They were live group-A entries when this was recorded; the re-ingest
+that closed them is the same class of movement the figures section describes.
 
 **Resolved by deletion — 5 former entries.** `agent-cogni-claims-claim-verifier.md`,
 `agent-cogni-claims-source-inspector.md`, `plugin-cogni-claims.md`,
@@ -107,8 +140,9 @@ The root-wins direction above is moot for them — there is no copy left on eith
 They are recorded here rather than silently dropped because a reconciliation run that still
 expected them would look for files that no longer exist, and the deletion is the *reason* the
 enrichment asymmetry stopped mattering, not evidence the ledger was wrong. `concept-claim-lifecycle.md`
-and `concept-claims-propagation.md` survive in both trees and stay live Group A entries — they are
-claim *concepts*, not namespaced plugin pages, so C1 never covered them.
+and `concept-claims-propagation.md` survive in both trees — they are claim *concepts*, not
+namespaced plugin pages, so C1 never covered them. They were live Group A entries when this was
+recorded and had converged to byte-identical by the time Decision 3 executed, as noted above.
 
 **Resolved by deletion — 14 further entries per tree.** The same mechanism fired again when
 cogni-narrative and cogni-copywriting were absorbed: `plugin-cogni-narrative.md`,
@@ -143,15 +177,36 @@ on the date they name, which is the same treatment the cogni-claims re-ingest li
 | `workflow-portfolio-to-pitch.md` | 56 | 72 | Steps, Common pitfalls |
 | `workflow-trends-to-solutions.md` | 52 | 79 | Two scenarios, Steps, Common pitfalls |
 
-These must be back-ported bundle → root *before* any sync runs, then maintained from the root
-like everything else.
+These were back-ported bundle → root *before* any sync ran, and are now maintained from the root
+like everything else. Each was a pure insertion — the shared prefix was byte-identical on both
+sides and `**Source**:` was the last line of both — so the back-port was a verbatim copy with zero
+root-only lines to lose.
+
+All four are now pinned to byte-identity by `PAGE_PARITY` in
+`cogni-workspace/tests/test-layering-claim-reconciled.sh`, so the sections that once existed only
+in the bundle cannot drift back out of the root tree unnoticed.
 
 ### Group C — 3 structural files
 
-`wiki/index.md` — the bundle's seven extra bullets are correct for the tree that holds those
-seven pages, so they are not drift. Separately, the root copy carries five description
-corrections and a root-only maintenance section. Neither side is wholly right; this one is
-merged, not copied.
+`wiki/index.md` — merged, not copied, and **still divergent after the merge, on purpose**. The
+bundle's seven extra bullets are correct for the tree that holds those seven pages, so they are not
+drift and were left in place; promoting them into the root tree would create seven dangling
+references there and pre-decide Decision 4. The root's `### Maintenance` section stays root-only
+for the same reason in reverse: it links `[[lint-2026-04-20]]`, a root-only page.
+
+Measured at execution, the two copies differed on **four** description/intro lines, not the five
+recorded here. Three resolved root-wins: the `### Skills` and `### Agents` preambles (the bundle
+asserted "across all 11 plugins", which the nine-plugin marketplace roster contradicts) and the
+`skill-cogni-portfolio-propositions` bullet (the bundle still carried the terse stub, matching the
+stub page group A replaced).
+
+The fourth is the case this rule was written for — **neither side was right.** The root said the
+website-setup skill discovers content from "cogni-portfolio, cogni-marketing, cogni-trends, and
+cogni-research"; the bundle omitted the fourth source entirely. `cogni-research` has no directory
+and is not on the marketplace roster, and the generating source
+`cogni-website/skills/website-setup/SKILL.md` names `cogni-knowledge`. Both trees now carry that
+corrected text. A blanket root-wins merge would have propagated a plugin name that does not exist;
+a blanket bundle-wins merge would have dropped a real source.
 
 Both `.cogni-wiki/config.json` files — closed by Decision 1.
 
@@ -222,7 +277,7 @@ but those are two of the seven pages Decision 4 holds, so taking that route woul
 Decision 4 as a side effect. Removing the two references decides nothing and leaves four valid
 options in the sentence.
 
-**Why both copies.** This page is one of four pinned to byte-identity between the trees by
+**Why both copies.** This page is one of eight pinned to byte-identity between the trees by
 `cogni-workspace/tests/test-layering-claim-reconciled.sh`. A one-sided edit turns that suite red.
 
 **On promotion.** If Decision 4 resolves toward promoting, restore both references — in both
@@ -254,12 +309,16 @@ executed one a deliberate act rather than an accident.
 Ground 3 still describes the post-sync check accurately. That check is left in place, and it is
 the new pre-sync gate rather than any change to it that supplies the defence.
 
-On the tree as recorded here a bare sync refuses on 27 paths: the 7 of Decision 4, the 4
-group-B pages, and — because the root re-ingest reworded lines rather than only appending — the
-13 group-A pages together with `wiki/index.md`, `wiki/log.md` and `.cogni-wiki/config.json`. The
-gate is deliberately blind to Decision 3's ruling that root wins for group A: a script cannot
-read this document, so it refuses and defers to the operator. Executing #1401 and #1402 is what
-returns a bare sync to silence.
+On the tree as originally recorded here a bare sync refused on 27 paths: the 7 of Decision 4, the
+4 group-B pages, and — because the root re-ingest reworded lines rather than only appending — the
+13 group-A pages together with `wiki/index.md`, `wiki/log.md` and `.cogni-wiki/config.json`.
+
+Once Decision 3 executed, that inventory narrowed to **10**: the 7 of Decision 4, plus
+`wiki/index.md`, `wiki/log.md` and `.cogni-wiki/config.json`. The group-A and group-B pages no
+longer appear, because they are now byte-identical across the trees and a sync has nothing to
+change on them. The gate is deliberately blind to Decision 3's ruling that root wins for group A: a
+script cannot read this document, so it refuses and defers to the operator. Decision 4 is now the
+only decision standing between a bare sync and silence, and #1402 carries it.
 
 ## Rejected alternative — regenerate `entries_count` with the wiki linter
 
@@ -276,9 +335,9 @@ Kept as a permanent inventory so the set stays auditable rather than being redis
 
 | Item | State | Carried by |
 |---|---|---|
-| 13 group-A pages thinner in the bundle | recorded, not executed | #1401 |
-| 4 group-B pages missing sections at the root | recorded, not executed | #1401 |
-| `wiki/index.md` needs a merge, not a copy | recorded, not executed | #1401 |
+| Group-A pages thinner in the bundle | closed — the 6 still divergent were copied root → bundle; 5 had been deleted from both trees and 2 had already converged | #1401 |
+| 4 group-B pages missing sections at the root | closed — back-ported bundle → root and pinned by `PAGE_PARITY` | #1401 |
+| `wiki/index.md` needs a merge, not a copy | closed — merged per the group-C rule; the two copies still differ by design | #1401 |
 | 7 bundled-only pages held | awaiting a maintainer ruling | #1402 |
 | `ecosystem-command-reference` names a retired command surface | held with the page above | #1402 |
 | Sync script destroys bundle-only content | closed — refuses by default; `--force` is the opt-in | #1403 |
@@ -288,8 +347,9 @@ Kept as a permanent inventory so the set stays auditable rather than being redis
 
 The two `log.md` copies and `lint-2026-04-20.md` are untouched, per Decision 5 — a future reader
 should not read them as misses. The two `entries_count` values remain different from each other,
-per Decision 1. The pending-changes figure remains 28, per Decision 2. None of the seven
-bundled-only pages is edited, promoted or deleted, per Decision 4.
+per Decision 1. The substantive residual remains 11 lines, per Decision 2 — and the two
+`wiki/index.md` copies remain different from each other, per Decision 3's group-C rule. None of the
+seven bundled-only pages is edited, promoted or deleted, per Decision 4.
 
 ## What guards this
 

--- a/cogni-workspace/tests/test-layering-claim-reconciled.sh
+++ b/cogni-workspace/tests/test-layering-claim-reconciled.sh
@@ -17,7 +17,7 @@
 #   - none of the FORBIDDEN literals appears anywhere outside the excluded paths
 #   - every one of those literals is actually caught when present (no dead config)
 #   - a literal under an excluded path is NOT flagged
-#   - the four pages this reconciliation touched are byte-identical across the
+#   - the eight pages this reconciliation touched are byte-identical across the
 #     two wiki trees
 #   - a scan pointed at a missing or empty tree fails rather than reporting clean
 #
@@ -103,8 +103,11 @@
 # one does not), and scripts/release-bundle-wiki.sh states that drift between
 # releases is acceptable. A tree-wide diff would be red on arrival and would
 # pressure someone into running that rsync --delete sync, which sweeps unrelated
-# drift. Naming the four pages this change touched keeps the assertion true and
-# useful at the same time.
+# drift. Naming the eight pages this change touched keeps the assertion true and
+# useful at the same time. Four are the layering-claim pages; the other four are
+# the group-B workflow pages back-ported bundle -> root, pinned here so the
+# sections that once existed only in the bundle cannot drift back out of the
+# root tree unnoticed.
 #
 # Case-label shape matches test-wiki-namespace-sync.sh on purpose: "PASS: <case>"
 # / "FAIL: <case>", because the cogni-service mutation harness classifies a case
@@ -159,7 +162,11 @@ cogni-visual/libraries/
 PAGE_PARITY='plugin-cogni-workspace.md
 workflow-install-to-infographic.md
 arch-er-diagram.md
-concept-four-layer-architecture.md'
+concept-four-layer-architecture.md
+workflow-portfolio-to-website.md
+workflow-content-pipeline.md
+workflow-portfolio-to-pitch.md
+workflow-trends-to-solutions.md'
 
 # ---------------------------------------------------------------------------
 # The checkers. Fixture cases and the real-repo cases drive these same two

--- a/cogni-workspace/tests/test-wiki-tree-parity.sh
+++ b/cogni-workspace/tests/test-wiki-tree-parity.sh
@@ -9,7 +9,7 @@
 # one-sided page nobody decided on. Nothing enforced either before this suite:
 #   - test-wiki-namespace-sync.sh compares filename stems against the marketplace
 #     roster, so it never looks inside a page or at either config
-#   - test-layering-claim-reconciled.sh pins four named pages to byte-identity
+#   - test-layering-claim-reconciled.sh pins eight named pages to byte-identity
 #     and scans for retired wording, so it is silent on every other page
 # Both would stay green while a config overstated its tree by nine pages and a
 # page linked to something that had been deleted out from under it. That is the

--- a/cogni-workspace/wiki/wiki/index.md
+++ b/cogni-workspace/wiki/wiki/index.md
@@ -64,7 +64,7 @@ This is the content catalog for **insight-wave**. Every wiki page is listed here
 
 ### Skills
 
-One page per skill across all 11 plugins. Grouped by plugin, alphabetical within each.
+One page per skill, grouped by plugin, alphabetical within each.
 
 #### cogni-copywriting
 
@@ -111,7 +111,7 @@ One page per skill across all 11 plugins. Grouped by plugin, alphabetical within
 - [[skill-cogni-portfolio-portfolio-setup]] — Initialize a new cogni-portfolio project with company context and directory structure.
 - [[skill-cogni-portfolio-portfolio-verify]] — Verify web-sourced claims in portfolio entities against their cited sources.
 - [[skill-cogni-portfolio-products]] — Define and manage the top-level product offerings in the portfolio.
-- [[skill-cogni-portfolio-propositions]] — Generate and manage IS/DOES/MEANS (FAB) value propositions per Feature x Market pair.
+- [[skill-cogni-portfolio-propositions]] — IS/DOES/MEANS (FAB) value-messaging engine: turns features into market-specific propositions per Feature × Market pair, with consulting-style critique and four mandatory tests built in.
 - [[skill-cogni-portfolio-solutions]] — Define implementation plans and pricing tiers for propositions to build customer business cases.
 - [[skill-cogni-portfolio-trends-bridge]] — Bidirectional integration between cogni-trends TIPS analysis and cogni-portfolio product portfolio.
 
@@ -145,7 +145,7 @@ One page per skill across all 11 plugins. Grouped by plugin, alphabetical within
 - [[skill-cogni-website-website-plan]] — This skill plans the site structure for a cogni-website project interactively — discovering available content, proposing pages, mapping content to page sections, and generating website-plan.
 - [[skill-cogni-website-website-preview]] — This skill previews the generated website in a browser, validates links, and reports structural issues.
 - [[skill-cogni-website-website-resume]] — This skill resumes, continues, or checks status of a cogni-website project.
-- [[skill-cogni-website-website-setup]] — This skill initializes a cogni-website project by discovering content sources from cogni-portfolio, cogni-marketing, and cogni-trends, selecting a theme, and scaffolding the project....
+- [[skill-cogni-website-website-setup]] — This skill initializes a cogni-website project by discovering content sources from cogni-portfolio, cogni-marketing, cogni-trends, and cogni-knowledge, selecting a theme, and scaffolding the project....
 
 #### cogni-workspace
 
@@ -158,7 +158,7 @@ One page per skill across all 11 plugins. Grouped by plugin, alphabetical within
 
 ### Agents
 
-One page per agent role across all 11 plugins. Grouped by plugin, alphabetical within each.
+One page per agent role, grouped by plugin, alphabetical within each.
 
 #### cogni-copywriting
 

--- a/cogni-workspace/wiki/wiki/pages/agent-cogni-portfolio-proposition-generator.md
+++ b/cogni-workspace/wiki/wiki/pages/agent-cogni-portfolio-proposition-generator.md
@@ -4,16 +4,16 @@ title: "cogni-portfolio:proposition-generator (agent)"
 type: entity
 tags: [cogni-portfolio, portfolio, agent, inherit]
 created: 2026-04-17
-updated: 2026-04-17
+updated: 2026-04-18
 sources:
   - https://github.com/cogni-work/insight-wave/blob/main/cogni-portfolio/agents/proposition-generator.md
 status: stable
-related: [plugin-cogni-portfolio, concept-agent-model-strategy]
+related: [plugin-cogni-portfolio, concept-agent-model-strategy, skill-cogni-portfolio-propositions]
 ---
 
 > One of the agents inside [[plugin-cogni-portfolio]]. Model tier: **inherit** — see [[concept-agent-model-strategy]].
 
-Generate IS/DOES/MEANS messaging for a single Feature x Market combination.
+Generate IS/DOES/MEANS messaging for a single Feature x Market combination. Dispatched in parallel by [[skill-cogni-portfolio-propositions]] during batch generation — one agent per Feature × Market pair, with the customer profile passed in when `customers/{market-slug}.json` exists for buyer-grounded messaging.
 
 **Source**: agent definition
 ([proposition-generator.md on GitHub](https://github.com/cogni-work/insight-wave/blob/main/cogni-portfolio/agents/proposition-generator.md))

--- a/cogni-workspace/wiki/wiki/pages/agent-cogni-portfolio-proposition-quality-assessor.md
+++ b/cogni-workspace/wiki/wiki/pages/agent-cogni-portfolio-proposition-quality-assessor.md
@@ -4,16 +4,16 @@ title: "cogni-portfolio:proposition-quality-assessor (agent)"
 type: entity
 tags: [cogni-portfolio, portfolio, agent, haiku]
 created: 2026-04-17
-updated: 2026-04-17
+updated: 2026-04-18
 sources:
   - https://github.com/cogni-work/insight-wave/blob/main/cogni-portfolio/agents/proposition-quality-assessor.md
 status: stable
-related: [plugin-cogni-portfolio, concept-agent-model-strategy]
+related: [plugin-cogni-portfolio, concept-agent-model-strategy, skill-cogni-portfolio-propositions]
 ---
 
 > One of the agents inside [[plugin-cogni-portfolio]]. Model tier: **haiku** — see [[concept-agent-model-strategy]].
 
-Assess DOES/MEANS messaging quality in propositions — works in any language.
+Assess DOES/MEANS messaging quality in propositions — works in any language. Called by [[skill-cogni-portfolio-propositions]]'s post-check across 12 dimensions: 7 for DOES (including the load-bearing **need correctness** that catches provider-lens contamination) and 5 for MEANS (outcome specificity, escalation, quantification, emotional resonance, conciseness). A "fail" verdict blocks downstream flow until the proposition is rewritten.
 
 **Source**: agent definition
 ([proposition-quality-assessor.md on GitHub](https://github.com/cogni-work/insight-wave/blob/main/cogni-portfolio/agents/proposition-quality-assessor.md))

--- a/cogni-workspace/wiki/wiki/pages/plugin-cogni-portfolio.md
+++ b/cogni-workspace/wiki/wiki/pages/plugin-cogni-portfolio.md
@@ -4,12 +4,12 @@ title: "cogni-portfolio (plugin)"
 type: entity
 tags: [cogni-portfolio, plugin, portfolio, propositions, fab, is-does-means, b2b]
 created: 2026-04-17
-updated: 2026-04-17
+updated: 2026-04-18
 sources:
   - https://github.com/cogni-work/insight-wave/blob/main/cogni-portfolio/README.md
   - https://github.com/cogni-work/insight-wave/blob/main/docs/plugin-guide/cogni-portfolio.md
 status: stable
-related: [concept-data-model-patterns, concept-quality-gates, concept-trends-portfolio-bridge]
+related: [concept-data-model-patterns, concept-quality-gates, concept-trends-portfolio-bridge, skill-cogni-portfolio-propositions]
 ---
 
 > **Preview** (v0.9.8) — core skills defined but may change.
@@ -22,7 +22,7 @@ cogni-portfolio gives B2B companies a structured way to build market-specific me
 
 ## Core data model
 
-The Feature × Market join is the unit of work — see [[concept-data-model-patterns]]. Propositions, solutions, competitors, and packages all live at this intersection. Slugs follow the double-dash convention (`feature--market`) — see [[concept-slug-based-lookups]].
+The Feature × Market join is the unit of work — see [[concept-data-model-patterns]]. [[skill-cogni-portfolio-propositions|Propositions]], solutions, competitors, and packages all live at this intersection. Slugs follow the double-dash convention (`feature--market`) — see [[concept-slug-based-lookups]].
 
 Eight pluggable industry taxonomies (b2b-ict, b2b-saas, b2b-fintech, b2b-healthtech, b2b-martech, b2b-industrial-tech, b2b-professional-services, b2b-opensource) auto-classify features and markets.
 

--- a/cogni-workspace/wiki/wiki/pages/skill-cogni-portfolio-portfolio-verify.md
+++ b/cogni-workspace/wiki/wiki/pages/skill-cogni-portfolio-portfolio-verify.md
@@ -4,7 +4,7 @@ title: "cogni-portfolio:portfolio-verify"
 type: entity
 tags: [cogni-portfolio, portfolio, fab, skill, portfolio-verify]
 created: 2026-04-17
-updated: 2026-04-17
+updated: 2026-04-20
 sources:
   - https://github.com/cogni-work/insight-wave/blob/main/cogni-portfolio/skills/portfolio-verify/SKILL.md
 status: stable
@@ -17,3 +17,7 @@ Verify web-sourced claims in portfolio entities against their cited sources.
 
 **Source**: `cogni-portfolio:portfolio-verify`
 ([SKILL.md on GitHub](https://github.com/cogni-work/insight-wave/blob/main/cogni-portfolio/skills/portfolio-verify/SKILL.md))
+
+Claims submitted by this skill conform to the contract in `cogni-workspace:claim-entity`, which preserves `entity_ref` so corrections cascade back to portfolio files.
+
+Submission and verification of portfolio claims go through `cogni-workspace:claims`.

--- a/cogni-workspace/wiki/wiki/pages/skill-cogni-portfolio-propositions.md
+++ b/cogni-workspace/wiki/wiki/pages/skill-cogni-portfolio-propositions.md
@@ -1,19 +1,87 @@
 ---
 id: skill-cogni-portfolio-propositions
-title: "cogni-portfolio:propositions"
+title: "cogni-portfolio:propositions (skill)"
 type: entity
-tags: [cogni-portfolio, portfolio, fab, skill, propositions]
+tags: [cogni-portfolio, propositions, fab, is-does-means, messaging, b2b, multilingual, skill]
 created: 2026-04-17
-updated: 2026-04-17
+updated: 2026-04-18
 sources:
   - https://github.com/cogni-work/insight-wave/blob/main/cogni-portfolio/skills/propositions/SKILL.md
 status: stable
-related: [plugin-cogni-portfolio]
+related: [plugin-cogni-portfolio, concept-quality-gates, concept-multilingual-support, concept-claims-propagation, concept-data-model-patterns, skill-cogni-portfolio-features, skill-cogni-portfolio-markets, skill-cogni-portfolio-customers, skill-cogni-portfolio-solutions, skill-cogni-portfolio-compete, skill-cogni-portfolio-trends-bridge, agent-cogni-portfolio-proposition-generator, agent-cogni-portfolio-proposition-quality-assessor, agent-cogni-portfolio-proposition-review-assessor, agent-cogni-portfolio-proposition-deep-diver, agent-cogni-portfolio-quality-enricher]
 ---
 
-> One of the skills inside [[plugin-cogni-portfolio]].
+> The IS/DOES/MEANS (FAB) value-messaging engine inside [[plugin-cogni-portfolio]] — generates and manages market-specific propositions per Feature × Market pair, with consulting-style critique built in.
 
-Generate and manage IS/DOES/MEANS (FAB) value propositions per Feature x Market pair.
+The skill that turns a portfolio's market-independent features into market-specific value claims that buyers recognize and pay for. It is deliberately **not** a template-filler — the agent takes a position on messaging quality and pushes back on generic copy.
 
-**Source**: `cogni-portfolio:propositions`
-([SKILL.md on GitHub](https://github.com/cogni-work/insight-wave/blob/main/cogni-portfolio/skills/propositions/SKILL.md))
+## Key takeaways
+
+- **Consulting stance, not template-fill.** The skill explicitly rejects mechanical generation. It critiques generic DOES statements, calls out market-agnostic claims, demands a position on which 10-15 of the possible 160 Feature × Market pairs actually deserve a proposition, and refuses to generate every pair as noise. "Generating a proposition for every pair creates noise" is a load-bearing rule.
+- **Four entry modes, four response shapes.** explore (conversational, 3-5 questions max, lead with sharp observations) · batch (gated — confirmation required before generating) · single pair (collaborative draft + critique) · review (jump straight to critique, no discovery). The skill warns against collapsing them into the same response.
+- **Pre-generation gate has three checks plus a coverage gate.** Structural validation script → `feature-quality-assessor` (haiku) → `feature-review-assessor` (haiku). Then a customer-profile coverage gate: markets without `customers/{market-slug}.json` produce weaker, inferred-buyer messaging — the user must explicitly opt in to bypass. See [[concept-quality-gates]] for the broader three-layer pattern.
+- **Four mandatory tests per proposition** before it ships:
+  1. **Market-swap** — substituting a different market should break the messaging; if it still works, the DOES is too generic
+  2. **Competitor** — could a direct competitor credibly make this same claim? If yes, the messaging describes the category, not the product
+  3. **"So what?"** — would a CFO approve budget for this MEANS? Aspirational language ("drives transformation") fails this gate
+  4. **Circularity** — IS/DOES/MEANS must each introduce new information, not rephrase the layer above
+- **Strict word-count discipline.** IS 20-35 words, DOES 15-30, MEANS 15-30 — language-agnostic (German compound nouns count as one word). Validated by `scripts/validate-entities.sh`.
+- **JSON schema lives at `propositions/{feature-slug}--{market-slug}.json`** — `feature_slug` + `market_slug` + IS/DOES/MEANS + optional `evidence[]` array. Each evidence item with a `source_url` is auto-logged as a claim via `scripts/append-claim.sh` for downstream verification through [[concept-claims-propagation]].
+- **Three-layer post-check** — `proposition-quality-assessor` (haiku) evaluates 12 dimensions: 7 for DOES (Buyer-centricity, Buyer-perspective correctness, **Need correctness**, Market-specificity, Differentiation, Status-quo contrast, Conciseness) + 5 for MEANS (Outcome specificity, Escalation, Quantification, Emotional resonance, Conciseness); then structural validation; then `proposition-review-assessor` from three perspectives: buyer persona, sales person, product marketer.
+- **Need correctness is the load-bearing dimension** — catches the subtlest failure: propositions that correctly classify the buyer archetype but frame value through the provider's lens (e.g., telling an SME buyer "your consultant delivers better results" when their actual need is "I can do this without a consultant"). Specifically detects provider-lens contamination in consumer-market propositions.
+- **Variants** allow multiple DOES/MEANS angles per proposition (`regulatory-compliance`, `cost-optimization`, etc.). `variants list / add / promote / delete` operations preserve the primary messaging while accumulating angles; TIPS-derived variants flow in via [[skill-cogni-portfolio-trends-bridge]].
+- **Two enrichment paths.** Quick Fix delegates to [[agent-cogni-portfolio-quality-enricher]] for reactive, targeted gap repair (1-2 warn/fail dimensions on overall pass/warn). Deep Dive delegates to [[agent-cogni-portfolio-proposition-deep-diver]] for buyer-language validation, competitive messaging analysis, evidence enrichment, or co-creation — required when `need_correctness` or `buyer_perspective` failed, when 3+ dimensions failed, or when stakeholder-review verdict is "reject".
+- **Multilingual by design.** Both content language (IS/DOES/MEANS text) and communication language (status messages, recommendations, questions) are driven by `portfolio.json`'s `language` field — see [[concept-multilingual-support]]. Word counts apply equally across languages.
+
+## Inputs
+
+The skill reads (silently, before any user-facing question):
+
+| File / Pattern | Purpose |
+|---|---|
+| `portfolio.json` | Company context, language |
+| `features/*.json` | The IS layer source — every feature description becomes a proposition's IS statement |
+| `markets/*.json` | Market segmentation, pain points, regional context |
+| `propositions/*.json` | Existing propositions (coverage and quality state) |
+| `customers/*.json` | Buyer personas with pain points, decision roles, buyer language — the gate for buyer-grounded vs inferred messaging |
+| `competitors/*.json` | Competitive positioning, claims, white-space opportunities |
+| `context/context-index.json` | Strategic intelligence from uploaded documents — `by_relevance["propositions"]` is queried first |
+
+The data-first pattern (read everything, state inferences, ask only about gaps) is enforced — buyer-language questions are not allowed when `customers/{market-slug}.json` exists.
+
+## Outputs
+
+- One `propositions/{feature-slug}--{market-slug}.json` per generated pair (with optional `variants[]` array)
+- Updated `excluded_markets[]` entries on `features/*.json` when the user confirms a skip recommendation (so decisions persist across sessions)
+- Quality-assessor and review-assessor verdicts, presented in summary tables before downstream skills (solutions, compete) can run
+- Auto-logged claims to `cogni-claims/claims.json` for every evidence URL (verifiable via [[concept-claims-propagation]])
+
+## Pipeline position
+
+```
+features ──┐
+markets ───┼──> propositions ──> solutions ──> packages
+customers ─┤        │
+           │        ├──> compete (per proposition)
+           │        ├──> portfolio-verify (claim verification)
+           │        └──> trends-bridge (TIPS variant generation)
+           └──> propositions
+```
+
+Propositions are the messaging foundation for everything downstream — competitor battlecards, customer profiles, pitch decks, proposals — so the gates are conservative on purpose: weak propositions cascade into weak sales materials.
+
+## Related operations
+
+- **Per-pair editing** — read existing JSON, apply user changes, write back; the skill explicitly considers whether an edit reveals a deeper issue across the feature's other propositions
+- **Slug rename** — when a feature or market slug changes, file rename + `scripts/cascade-rename.sh` to update solutions and competitors that reference the old slug
+- **Variant operations** — `list / add / promote / delete` for multi-angle messaging, including TIPS value-chain variants generated via [[skill-cogni-portfolio-trends-bridge]]
+- **Source registry integration** — when an evidence URL is added, it's also registered in `source-registry.json` with `evidence_refs` pointing back to this proposition; staleness warnings surface when the source has changed since last check
+
+## Why the gates matter
+
+The single sharpest line in the SKILL.md captures the philosophy: *"Five minutes of review here saves hours of rework later."* Once propositions ship into solutions and competitors, fixing a weak DOES or a missing evidence gap means cascading the fix through every dependent entity — and through every pitch and proposal already drafted on top.
+
+## Sources
+
+- [`cogni-portfolio/skills/propositions/SKILL.md`](https://github.com/cogni-work/insight-wave/blob/main/cogni-portfolio/skills/propositions/SKILL.md) — full skill definition (~620 lines)
+- [`cogni-portfolio/skills/propositions/references/quality-dimensions.md`](https://github.com/cogni-work/insight-wave/blob/main/cogni-portfolio/skills/propositions/references/quality-dimensions.md) — DOES/MEANS quality-dimension definitions used by `proposition-quality-assessor`

--- a/cogni-workspace/wiki/wiki/pages/skill-cogni-trends-trend-report.md
+++ b/cogni-workspace/wiki/wiki/pages/skill-cogni-trends-trend-report.md
@@ -4,7 +4,7 @@ title: "cogni-trends:trend-report"
 type: entity
 tags: [cogni-trends, trends, tips, skill, trend-report]
 created: 2026-04-17
-updated: 2026-04-17
+updated: 2026-04-20
 sources:
   - https://github.com/cogni-work/insight-wave/blob/main/cogni-trends/skills/trend-report/SKILL.md
 status: stable
@@ -17,3 +17,5 @@ Generate a strategic TIPS trend report organized around investment themes (Handl
 
 **Source**: `cogni-trends:trend-report`
 ([SKILL.md on GitHub](https://github.com/cogni-work/insight-wave/blob/main/cogni-trends/skills/trend-report/SKILL.md))
+
+Post-generation claim verification is handed to `cogni-workspace:claims` in submit mode.

--- a/wiki/wiki/index.md
+++ b/wiki/wiki/index.md
@@ -138,7 +138,7 @@ One page per skill, grouped by plugin, alphabetical within each.
 - [[skill-cogni-website-website-plan]] — This skill plans the site structure for a cogni-website project interactively — discovering available content, proposing pages, mapping content to page sections, and generating website-plan.
 - [[skill-cogni-website-website-preview]] — This skill previews the generated website in a browser, validates links, and reports structural issues.
 - [[skill-cogni-website-website-resume]] — This skill resumes, continues, or checks status of a cogni-website project.
-- [[skill-cogni-website-website-setup]] — This skill initializes a cogni-website project by discovering content sources from cogni-portfolio, cogni-marketing, cogni-trends, and cogni-research, selecting a theme, and scaffolding the project....
+- [[skill-cogni-website-website-setup]] — This skill initializes a cogni-website project by discovering content sources from cogni-portfolio, cogni-marketing, cogni-trends, and cogni-knowledge, selecting a theme, and scaffolding the project....
 
 #### cogni-workspace
 

--- a/wiki/wiki/pages/workflow-content-pipeline.md
+++ b/wiki/wiki/pages/workflow-content-pipeline.md
@@ -47,4 +47,33 @@ Optional final hop: [[plugin-cogni-visual]] turns polished long-form into slide 
 
 Each step adds value the previous can't: marketing knows the strategic positioning, narrative knows arc structure, copywriting knows messaging frameworks and polish, visual knows rendering. Bypassing a step works for the simple case but produces visibly weaker output for sophisticated channels.
 
+## Steps
+
+**1 — Set up the marketing project.** `/marketing-setup`. Takes a cogni-portfolio project and optionally a TIPS project from cogni-trends; writes `marketing-project.json` with brand voice, target markets, and the GTM-path-to-theme mapping. Tone, language and industry conventions are set here and apply to every generated piece. Without a TIPS project the engine falls back to generic themes — run `cogni-trends:trend-scout` first if you want strategy-connected content. For bilingual projects pick `de` or `en` as primary; content can be regenerated in the other language later.
+
+**2 — Build the content strategy.** `/content-strategy`. Produces a three-dimensional matrix across markets × GTM paths × content types with priority sequencing. The matrix surfaces gaps — start at the intersection of your most important market and strongest theme. Treat it as a plan, not a target: you do not have to fill every cell to ship a campaign. Re-run after adding propositions; the diff shows where coverage changed.
+
+**3 — Generate content.** One command per funnel stage:
+
+| Funnel stage | Content type | Command |
+|---|---|---|
+| Awareness | Thought leadership | `/thought-leadership` |
+| Engagement | Demand generation | `/demand-gen` |
+| Conversion | Lead generation | `/lead-gen` |
+| Decision | Sales enablement | `/sales-enablement` |
+| Account-specific | ABM | `/abm` |
+
+Output is raw content in up to sixteen formats. Content-writer agents run in parallel, so request several pieces in one prompt to generate a batch. Each piece records the TIPS claims and portfolio propositions it draws from, so sourced content traces back to data. For named-account work, skip steps 2–3 and go straight to `/abm` with the target account.
+
+**4 — Polish.** `/copywrite <content-path>` per piece, or describe the batch. Applies Pyramid Principle, BLUF, active voice and readability scoring. For multi-stakeholder content run `/review-doc` afterwards — reader personas score and synthesize feedback. German content auto-detects and applies Wolf Schneider rules with Amstad readability scoring.
+
+**5 — Render (optional).** Describe the output you want. cogni-visual reads the polished narrative, detects the story arc, and maps content to layouts with assertion headlines. Prefer the web-narrative format over slides for a leave-behind or microsite. Stop at step 4 if the content stays in markdown — rendering is opt-in.
+
+## Common pitfalls
+
+- **Channel overload.** Sixteen formats is what the plugin supports, not a target for one sprint. Start with three or four priority channels and expand after the first batch performs.
+- **Skipping the content strategy.** Without the matrix there is no coverage visibility, and you end up with content for the topics that felt interesting rather than the gaps that matter.
+- **Polishing before the strategy is final.** Polish a post, then change the GTM path it targets, and the work is redone. Generate, validate strategy fit, then polish.
+- **Generic inputs.** Shallow TIPS themes or propositions without market-specific DOES/MEANS produce filler. Invest in the input data before scaling generation.
+
 **Source**: [docs/workflows/content-pipeline.md on GitHub](https://github.com/cogni-work/insight-wave/blob/main/docs/workflows/content-pipeline.md)

--- a/wiki/wiki/pages/workflow-portfolio-to-pitch.md
+++ b/wiki/wiki/pages/workflow-portfolio-to-pitch.md
@@ -53,4 +53,20 @@ Final hop through [[plugin-cogni-visual]] turns the slide narrative into a brief
 - **Deal-specific** — for a named account; `why-change` researches the customer's specific decision makers and current state
 - **Segment-reusable** — for a market segment; reusable across many accounts in the same Feature × Market
 
+## Steps
+
+**1 — Portfolio data.** `cogni-portfolio:portfolio-resume` if the project already exists, otherwise `portfolio-setup` → the entity skills → `portfolio-communicate`. Output is propositions with IS/DOES/MEANS, competitor analysis and market sizing. Skip to step 2 if you already have portfolio data. `portfolio-architecture` visualizes the product-feature structure and catches gaps before they reach the pitch narrative. Focus on the propositions relevant to this customer or segment; the competitor analysis is what carries the "why us".
+
+**2 — Narrative arc.** `/narrative`. Shapes portfolio propositions and customer context into a story arc — SCQA works well for sales. This step is skippable when you are using the Why Change methodology, since that arc is built into cogni-sales directly. For complex enterprise deals it adds strategic depth worth the extra pass.
+
+**3 — Sales pitch.** `/why-change`. Takes narrative, portfolio data and customer specifics; produces structured pitch content covering unconsidered needs, the business case and the proposal. Named-customer pitches are deal-specific and want customer research; segment pitches are reusable across similar accounts. Optionally enrich with TIPS trends to carry the "why now".
+
+**4 — Visual delivery.** `cogni-visual:story-to-slides` for the brief, then render to HTML slides or PPTX. Sales decks live on visual flow — review and adjust after generation. For a customer meeting, fewer slides with more impact beats a comprehensive deck. Consider also generating a leave-behind in the web-narrative format.
+
+## Common pitfalls
+
+- **Generic propositions.** A customer-specific pitch needs customer-specific value statements; reusing segment-level DOES/MEANS reads as boilerplate.
+- **Missing the "why change".** The methodology needs a compelling reason the status quo is untenable. Without it the deck argues why you are good, not why they should move.
+- **Skipping competitor analysis.** "Why us" is unanswerable without it, and it is the question that decides the deal.
+
 **Source**: [docs/workflows/portfolio-to-pitch.md on GitHub](https://github.com/cogni-work/insight-wave/blob/main/docs/workflows/portfolio-to-pitch.md)

--- a/wiki/wiki/pages/workflow-portfolio-to-website.md
+++ b/wiki/wiki/pages/workflow-portfolio-to-website.md
@@ -52,4 +52,25 @@ Optional `website-legal` generates Impressum/Datenschutzerklärung/Cookie-Hinwei
 
 The same workflow extends to pull from [[plugin-cogni-marketing]] (thought-leadership → blog) and [[plugin-cogni-trends]] (trend reports → insights pages).
 
+## Steps
+
+**1 — Confirm the portfolio content.** `cogni-portfolio:portfolio-resume`. You need at least one product, propositions and customer profiles. Propositions become page headlines, features become capability lists, and customer narratives become case-study blocks. If propositions or customer profiles are missing, generate them first with `propositions` and `customers` — the website plan keys off them. Operational-only entities (a market with no propositions) never reach the site.
+
+**2 — Pick or confirm a theme.** `cogni-workspace:pick-theme`. The theme drives colors, fonts and design variables across every page. Switching it later and rebuilding reskins the whole site, so theme changes are global rather than per-page. Without a theme yet, run [[workflow-install-to-infographic]] first to extract one.
+
+**3 — Set up the website project.** `cogni-website:website-setup`. Takes a target directory plus target market, primary CTA and language; writes `website-project.json` with the discovered portfolio entities. Setup walks the optional content sources — cogni-marketing for blog and lead-gen pages, cogni-trends for insights pages, cogni-knowledge for whitepapers. Skip sources you have no content for; they can be added on a later run. The chosen language is the site's primary language.
+
+**4 — Plan the sitemap.** `cogni-website:website-plan`. Produces `website-plan.json`: sitemap, content map, navigation flow. Review priorities before building — the planner picks defaults, but the running order shapes the homepage. Pages with shallow sources (a proposition without a customer narrative) generate thin landing pages; fill the gap in cogni-portfolio or drop the page. Re-run after adding propositions to see what the build will change.
+
+**5 — Build.** `cogni-website:website-build`. Renders `website/{page-slug}.html` plus `website/assets/` (themed CSS, JS, hero imagery). The build dispatches the site-assembler agent, which renders every planned page in parallel. With Pencil MCP available the hero-renderer generates hero imagery; without it, hero blocks fall back to themed gradients. Subsequent runs rebuild only modified pages — a theme change forces a full rebuild.
+
+**6 — Preview and iterate.** `cogni-website:website-preview` opens a local browser preview through claude-in-chrome. Iterate on theme tweaks, copy edits or page additions by rebuilding. The `website/` directory is self-contained, so deployment is a push to any static host.
+
+## Common pitfalls
+
+- **Missing propositions or customers.** The plan needs propositions for service-page headlines and customer profiles to seed landing pages. Building before the portfolio is populated yields a thin three-page placeholder.
+- **Theme not picked before build.** The build reads the active theme from workspace state; without one it falls back to the default and the site drifts visually from your slides and dashboards.
+- **Pencil MCP missing.** Hero sections render as themed gradients — usable, but not the generated imagery the demos show.
+- **Optional sources added late.** Installing cogni-marketing or cogni-trends after planning requires re-running plan and build to pick up the new pages.
+
 **Source**: [docs/workflows/portfolio-to-website.md on GitHub](https://github.com/cogni-work/insight-wave/blob/main/docs/workflows/portfolio-to-website.md)

--- a/wiki/wiki/pages/workflow-trends-to-solutions.md
+++ b/wiki/wiki/pages/workflow-trends-to-solutions.md
@@ -49,4 +49,31 @@ The bridge to [[plugin-cogni-portfolio]] is the most complex single integration 
 
 The TIPS framework comes with cogni-trends — Trends, Implications, Possibilities, Solutions — and is the canonical structure for investment theme reports. See [[plugin-cogni-trends]] for framework details.
 
+## Two scenarios
+
+The pipeline branches at value modeling and reconverges at the visual deliverable.
+
+- **A — Standalone.** No cogni-portfolio project. `value-modeler` anchors on the bundled generic B2B ICT portfolio (7 products, 51 features with taxonomy mappings) and generates DOES/MEANS from the research context. Taxonomy-grounded but not company-specific. Right for new-industry scouting, discovery engagements, or a CxO point of view without a defined product set.
+- **B — With portfolio connected.** `trends-bridge` exports portfolio context so Solution Templates map to real products and features, and ranked solutions can flow back into the portfolio. Right when trend signals must drive an actual roadmap.
+
+You can start in A and re-enter B later against the same scout output.
+
+## Steps
+
+**1 — Scout trends.** `cogni-trends:trend-scout`. Produces 60 scored candidates mapped to the Trendradar dimensions (4 dimensions × 3 action horizons). Set the region correctly for DACH/EU — the scout uses regional authority sources (Fraunhofer, BITKOM, VDMA, destatis) that an EN/US default would miss; see [[concept-multilingual-support]]. Cull 60 candidates down to 15–25 before value modeling: the quality of everything downstream depends on this step. Optionally run `trend-research` in parallel for a written CxO report.
+
+**2 — Model investment themes and solution blueprints.** `cogni-trends:value-modeler` directly for scenario A; for scenario B run `cogni-portfolio:trends-bridge` in the portfolio-to-tips direction first, which writes `portfolio-context.json` into the pursuit, then `value-modeler`. Output is investment themes with T→I→P→S value chains, ranked Solution Templates, SPIs, success metrics and Business Relevance scoring. In scenario B, readiness scoring reflects actual portfolio gaps. Review the Business Relevance weights in either scenario — the defaults rarely match a client's strategic priorities. Three to seven themes is the producible range; narrow to three or four before generating visuals.
+
+**3 — Backflow to the portfolio (scenario B only).** `cogni-portfolio:trends-bridge` in the tips-to-portfolio direction. Produces new features, proposition variants, evidence entries and `portfolio-opportunities.json`. Curate the generated entities in cogni-portfolio (`features`, `propositions`, `solutions`) before they propagate into pitches and marketing. This is the step that closes the loop — trend signals become portfolio mutations the team can build against. See [[concept-trends-portfolio-bridge]].
+
+**4 — Produce visual deliverables.** `cogni-visual:story-to-slides` for a deck, or `cogni-visual:enrich-report` for an interactive HTML report with Chart.js visualizations. Both work for either scenario — the underlying value-model JSON has the same shape. Generate the trend report before running `enrich-report`, and pick the workspace theme before rendering so visuals match brand.
+
+## Common pitfalls
+
+- **Weak trend selection.** Generic trends produce generic solutions. The cull in step 1 is the quality gate for the entire downstream pipeline.
+- **Too many themes.** Up to seven are producible; client decks land better with three or four. Narrow before rendering.
+- **Skipping Business Relevance scoring.** Default weights are not client-specific. Adjust before generating blueprints, in either scenario.
+- **Mistaking generic blueprints for company-specific advice (A).** The bundled portfolio is a taxonomy scaffold — useful for framing what to do about a trend, not a substitute for grounding solutions in real capabilities.
+- **Forgetting the export step (B).** Without the portfolio-to-tips bridge, `value-modeler` silently falls back to scenario A. The run "works" and the solutions reference nothing real.
+
 **Source**: [docs/workflows/trends-to-solutions.md on GitHub](https://github.com/cogni-work/insight-wave/blob/main/docs/workflows/trends-to-solutions.md)


### PR DESCRIPTION
Refs #1401.

## Summary

Decision 3 of `cogni-workspace/references/wiki-tree-reconciliation.md` has been carrying its content deltas as *recorded, not executed*. This executes them — in the two opposite directions the record specifies — marks them landed, and pins the reverse-backported pages so the drift cannot silently recur.

**Group A — root wins, 6 pages copied root → bundle verbatim.** The record's heading named 13. Five (all `cogni-claims`) exist in neither tree since the absorption and are already documented under "Resolved by deletion"; two more (`concept-claim-lifecycle`, `concept-claims-propagation`) had already converged to byte-identical. Verified before copying that the root copy *strictly enriches* the bundled one on all six — added `related:` entries, added wikilinks, expanded summaries, and an 87-line rewrite over a 19-line stub on `skill-cogni-portfolio-propositions.md` — so no bundled line is lost. Every wikilink the copies carry already resolved in the destination tree, which is what keeps parity cases W4/W5 green.

**Group B — bundle wins, 4 workflow pages back-ported bundle → root verbatim.** Each was a pure insertion (identical shared prefix, `**Source**:` last on both sides), so a verbatim copy destroys nothing at the root. `## Steps` / `## Common pitfalls` — and `## Two scenarios` on `workflow-trends-to-solutions.md` — now exist in both trees.

**Group C — `wiki/index.md` merged, not copied, and still divergent afterwards on purpose.** The bundle keeps its seven Decision-4 bullets (promoting them into the root tree would create seven dangling references there and pre-decide #1402); the root keeps its `### Maintenance` section (it links `[[lint-2026-04-20]]`, a root-only page). Of the four differing description lines, three resolved root-wins — the `### Skills` / `### Agents` preambles (the bundle asserted "across all 11 plugins", which the nine-plugin roster contradicts) and the `propositions` bullet (the bundle still carried the stub matching the page group A just replaced).

**The fourth line is the case the group-C rule exists for — neither side was right.** The root said website-setup discovers from "cogni-portfolio, cogni-marketing, cogni-trends, and **cogni-research**"; the bundle omitted the fourth source entirely. `cogni-research` has no directory and is not on the marketplace roster; the generating source `cogni-website/skills/website-setup/SKILL.md` names **cogni-knowledge**. Both trees now carry that. A blanket root-wins merge would have propagated a plugin that does not exist; a blanket bundle-wins merge would have dropped a real source.

**Guard — `PAGE_PARITY` 4 → 8.** The four back-ported pages are pinned to byte-identity. Only safe in this same commit: before the back-port those pages differ by 20+ lines and case L7 fails on arrival. Four coupled prose spots move with it — `test-layering-claim-reconciled.sh` L20 and L106, `test-wiki-tree-parity.sh` L12, and the record's Decision 6 "one of four".

## The issue's figures were stale, and are re-measured rather than predicted

| Figure | At filing | Measured here |
|---|---:|---:|
| Content deltas | 20 | **13** before, **3** after |
| Root page count | 170 | 151 |
| Bundled page count | 176 | 157 |

The `20 → 13` drop was not reconciliation work: the cogni-claims and narrative/copywriting absorptions deleted pages out of both trees, retiring five group-A entries and leaving two already identical. This PR closes 10 of the 13.

**Substantive residual after this PR is 11 lines**, every one owned by a decision that deliberately keeps the trees apart: 7 held by Decision 4 (#1402), plus `index.md` (Decision 3 group C), `log.md` (Decision 5) and `.cogni-wiki/config.json` (Decision 1 — the two values are *supposed* to differ, and both are already accurate at 151/157).

**Do not gate on `changes_pending`.** It reported `167` on this branch, of which **156 were attribute-only** `.f..t....`/`.d..t....` mtime lines from a fresh checkout — the artefact class the record already warns about. The record now quotes the substantive figure first and derives it from the itemised command.

## On AC1 being unreachable as written

> "All 13 group-A pages are byte-identical between the two trees"

Five of those 13 exist in **neither** tree, so the literal criterion cannot hold regardless of the fix. It is satisfied for all eight that exist (six copied, two already identical). The five are not recreated — doing so would break `entries_count`, W1/W2 and `test-wiki-namespace-sync.sh` case C1. AC3 has the same shape in miniature: it asks that `lint-2026-04-20.md` be byte-identical "in both trees", but that page is root-only, so the checkable form is *untouched* — which it is.

## Verification

All run against the branch head; every suite was already green on `main`, so these are a regression bar, not a target.

- [x] `bash cogni-workspace/tests/test-wiki-tree-parity.sh` — exit 0, 8/8 (W1/W2 counts unmoved at 151/157 since no page is added or deleted; W7 still finds every one-sided stem named)
- [x] `bash cogni-workspace/tests/test-layering-claim-reconciled.sh` — exit 0, 9/9, L7 now comparing 8 pages
- [x] `bash cogni-workspace/tests/test-wiki-namespace-sync.sh` — exit 0
- [x] `bash tests/test_release_bundle_wiki.sh` — exit 0
- [x] `python3 scripts/run-plugin-tests.py --filter cogni-workspace` — returncode 0
- [x] `python3 scripts/check-breadcrumbs.py` — exit 0 · `check-version-bump.py` — 0 touched, 0 violations · `check-result-line-plainness.py` — exit 0
- [x] All 10 page pairs `cmp`-identical across the trees
- [x] `diff wiki/wiki/index.md cogni-workspace/wiki/wiki/index.md` still differs, and **only** by the 7 bundle bullets + root `### Maintenance`
- [x] Zero hunks in `log.md` (both trees), `lint-2026-04-20.md`, both `.cogni-wiki/config.json`, `scripts/release-bundle-wiki.sh`, `plugin.json`, `marketplace.json`
- [x] `scripts/release-bundle-wiki.sh` never run without `--check`

## Mutation recipe

Proves the `PAGE_PARITY` expansion has teeth rather than being four inert strings. **I ran this and it behaves as claimed:** mutating a newly-pinned page printed `FAIL: L7 the real wiki trees agree on every page this change touched` and the suite exited 1; restoring returned exit 0. Before the expansion the same mutation is invisible, because the page is not in the list at all.

```
bash cogni-service/scripts/mutation-check.sh \
  --root . \
  --file wiki/wiki/pages/workflow-content-pipeline.md \
  --expr 's/## Common pitfalls/## Common pitfallz/' \
  --test 'bash cogni-workspace/tests/test-layering-claim-reconciled.sh' \
  --case L7
```

Two caveats, stated rather than assumed:

- **The harness is not in this repo.** `cogni-service/` does not exist at `origin/main`, so the path above is not replayable as written — it matches the form already used at `tests/test_release_bundle_wiki.sh` L35-42, which has the same limitation. The replayable path is the plugin-shipped copy under `~/.claude/plugins/cache/managed-service/cogni-service/<version>/scripts/mutation-check.sh`.
- **`--case` semantics are documented by precedent, not verified against harness source.** `test-layering-claim-reconciled.sh` L109-114 records that the harness classifies GREEN on `^[[:space:]]*(ok|PASS):[[:space:]]+<case>` — a prefix of the text after the label, so `L7` follows the same shape as the in-repo `--case RBW1`.

## Follow-up issues

- #1425 — 12 dangling `index.md` bullets for pages deleted in the narrative/copywriting retirement, plus extending `check_links` to cover `index.md` (it scans only `wiki/pages/*.md` today, so `index.md` is a link-target source and never a scanned file — all 12 dangle with W4/W5 green)
- #1426 — 4 bare retired-plugin names in page *bodies*, plus a roster-derived bare-name scan (a different class: no `[[...]]` wrapper, so the wikilink resolvers are structurally blind)

Both are **byte-identical in both trees**, so neither is a tree delta and neither is what #1401 executes. One instance of #1426's class *was* fixed here — the `cogni-research` line — because it fell inside this PR's own group-C merge surface, where the two trees disagreed and a merge had to pick something.

## Why this links `Refs` and not `Closes` — and why #1401 is nonetheless done

The pipeline mandates `--partial` whenever `deferred[]` is non-empty, so the link is `Refs`. Flagging the consequence explicitly, because it matters here: **#1401's own scope is complete** — all five acceptance criteria are satisfied (AC1 as far as it is reachable, per the section above). #1425 and #1426 are newly-discovered out-of-scope drift, not carved-out #1401 scope.

That distinction is load-bearing rather than pedantic. #1425 and #1426 both declare `## Depends on #1401`, and an issue left open behind a `Refs`-only merge is exactly the pattern that stranded this issue in the first place: #1384 merged with `Refs`, stayed open as a reap-excluded artifact, and blocked #1401 and #1402 behind it for a day. **#1401 should be closed when this merges**, or its two follow-ups inherit the same trap. The commit trailer says `Refs #1401` for that reason.