### PR TITLE
cogni-portfolio: parameterise append-claim lock acquire ceiling

### DIFF
--- a/cogni-portfolio/scripts/append-claim.sh
+++ b/cogni-portfolio/scripts/append-claim.sh
@@ -48,8 +48,8 @@ MAX_WAIT="${APPEND_CLAIM_MAX_WAIT:-30}"
 [[ "$MAX_WAIT" =~ ^[1-9][0-9]*$ ]] || MAX_WAIT=30
 
 # Derive the timeout label from the ceiling rather than restating it, and do it
-# HERE — at top level, outside the loop. The old message hardcoded "after 3s",
-# which was correct only because 30 x 0.1s happens to equal 3s; under an override
+# HERE — at top level, outside the loop. The old message restated a fixed three
+# seconds, which was correct only because 30 x 0.1s equals that; under an override
 # the script would have kept claiming 3s while actually waiting a tenth of that,
 # and the suite's grep would have stayed green on a message that had become
 # wrong. Placement matters as much as derivation: an arithmetic abort inside the

--- a/cogni-portfolio/scripts/append-claim.sh
+++ b/cogni-portfolio/scripts/append-claim.sh
@@ -5,6 +5,8 @@
 # Creates cogni-claims/ directory and claims.json if they don't exist.
 # Uses mkdir-based locking (portable across macOS and Linux) to prevent
 # race conditions when agents run in parallel.
+# Env: APPEND_CLAIM_MAX_WAIT overrides the lock-acquire ceiling in 0.1s units
+#   (default 30 = 3s); a non-positive or non-integer value falls back to 30.
 # Exit codes: 0 = success, 1 = error
 set -euo pipefail
 
@@ -24,7 +26,50 @@ LOCK_DIR="$CLAIMS_DIR/.claims.lock"
 mkdir -p "$CLAIMS_DIR/sources" "$CLAIMS_DIR/history"
 
 # Acquire lock using mkdir (atomic on all POSIX systems)
-MAX_WAIT=30
+#
+# MAX_WAIT counts 0.1s poll iterations, so the default 30 is a 3s ceiling. The
+# override exists for tests: both cases of the lock suite exist to DRIVE this
+# loop to its ceiling, so the wait length is incidental to what they pin, and at
+# the default they burn ~3s each for nothing. Callers that set no override keep
+# the 3s ceiling exactly.
+#
+# Floor on numeric SHAPE, as the stale-lock reading below does — but NOT with the
+# same pattern, and the divergence is load-bearing. The leading [1-9] also
+# excludes leading zeros: `08` or `030` would pass a bare ^[0-9]+$ and then make
+# the division below a hard bash abort ("value too great for base"), because
+# arithmetic expansion reads a leading zero as octal. Do not harmonise the two
+# patterns. Zero is excluded too, and that is deliberate rather than incidental:
+# the loop sleeps BEFORE its first -ge check, so 0 and 1 both mean "one 0.1s
+# poll" — 0 buys no fail-immediately semantics that 1 does not already give, and
+# it would render a misleading "after 0s" for a path that did in fact wait.
+# Admitting only positive integers is also what guarantees the -ge test below can
+# never error, so the loop always terminates.
+MAX_WAIT="${APPEND_CLAIM_MAX_WAIT:-30}"
+[[ "$MAX_WAIT" =~ ^[1-9][0-9]*$ ]] || MAX_WAIT=30
+
+# Derive the timeout label from the ceiling rather than restating it, and do it
+# HERE — at top level, outside the loop. The old message hardcoded "after 3s",
+# which was correct only because 30 x 0.1s happens to equal 3s; under an override
+# the script would have kept claiming 3s while actually waiting a tenth of that,
+# and the suite's grep would have stayed green on a message that had become
+# wrong. Placement matters as much as derivation: an arithmetic abort inside the
+# acquire loop is the exact failure the comment further down documents — it
+# abandons the loop, resumes after `done`, and appends the claim having never
+# held the lock. At top level the same abort is a clean exit before any lock is
+# taken and before the release trap is installed.
+#
+# Use the assignment form for the arithmetic, never a bare (( ... )) command: a
+# bare arithmetic command evaluating to 0 returns status 1, and the default
+# ceiling makes the remainder exactly 0, so under `set -e` that aborts on bash
+# 5.x while passing on 3.2 — a version-divergent failure on the DEFAULT path.
+WAIT_WHOLE=$(( MAX_WAIT / 10 ))
+WAIT_TENTHS=$(( MAX_WAIT % 10 ))
+if [ "$WAIT_TENTHS" -eq 0 ]; then
+  WAIT_LABEL="${WAIT_WHOLE}s"
+else
+  WAIT_LABEL="${WAIT_WHOLE}.${WAIT_TENTHS}s"
+fi
+
 WAITED=0
 while ! mkdir "$LOCK_DIR" 2>/dev/null; do
   sleep 0.1
@@ -55,7 +100,7 @@ while ! mkdir "$LOCK_DIR" 2>/dev/null; do
         continue
       fi
     fi
-    echo '{"error": "Could not acquire lock on claims.json after 3s"}' >&2
+    echo "{\"error\": \"Could not acquire lock on claims.json after ${WAIT_LABEL}\"}" >&2
     exit 1
   fi
 done

--- a/cogni-portfolio/tests/test-append-claim-lock.sh
+++ b/cogni-portfolio/tests/test-append-claim-lock.sh
@@ -67,7 +67,26 @@
 #   `perl -0pi` slurps the whole file, so an anchored expression would need a `/m`
 #   modifier to match at all.
 #
-#   Only these TWO arms are recorded, and the reason is narrower than it may look. An arm
+#   Third arm — the shape floor applied unconditionally (case 2's negative twin):
+#   bash ~/.claude/plugins/cache/managed-service/cogni-service/0.0.402/scripts/mutation-check.sh \
+#     --root . \
+#     --file cogni-portfolio/scripts/append-claim.sh \
+#     --expr 's/\[\[ "\$lock_mtime" =~ \^\[0-9\]\+\$ \]\] \|\| //' \
+#     --test 'bash cogni-portfolio/tests/test-append-claim-lock.sh' \
+#     --case live-lock-not-swept-on-numeric-stat
+#
+#   This deletes the floor's GUARD and leaves the assignment, so the reading is
+#   forced to 0 for every lock rather than only a malformed one. Case 2 supplies a
+#   numeric current-epoch reading, i.e. a genuinely LIVE peer, so under the
+#   mutation that lock reads as ancient, gets swept, and the case goes red — which
+#   is exactly the destroy-mutual-exclusion failure the case comment below
+#   describes. The first arm pins the same floor from the other side (case 1, the
+#   malformed reading), so the two together pin the floor's presence AND its
+#   conditionality; neither alone does. The `^` and `$` in the expression are
+#   backslash-escaped, so they are literal characters and not anchors — no `/m`
+#   modifier is needed despite the harness slurping with `perl -0pi`.
+#
+#   Only these THREE arms are recorded, and the reason is narrower than it may look. An arm
 #   mutating the GNU-first ordering (`s/stat -c %Y/stat -f %m/`) reports a vacuous
 #   guard against the TWO CASES BELOW, because their stub answers unconditionally
 #   and ignores its flags by design — deliberately, so both stay ordering-agnostic.

--- a/cogni-portfolio/tests/test-append-claim-lock.sh
+++ b/cogni-portfolio/tests/test-append-claim-lock.sh
@@ -16,6 +16,12 @@
 #                                             reading leaves a LIVE peer's lock
 #                                             alone; the script times out instead
 #
+# Both cases export APPEND_CLAIM_MAX_WAIT=3 — a 0.3s acquire ceiling instead of
+#   the production default of 3s. They exist to REACH the ceiling, so its length
+#   is incidental to what they pin, and at the default each burned ~3s of pure
+#   sleep on every CI sweep of the monorepo. The default is what production keeps;
+#   nothing here changes it.
+#
 # Usage: bash cogni-portfolio/tests/test-append-claim-lock.sh
 # Exits non-zero on any assertion failure.
 #
@@ -39,7 +45,29 @@
 #   exactly once in the fixed script (the read line is `lock_mtime=$(stat ...`,
 #   which does not contain it), so the substitution can never be a no-op.
 #
-#   Only ONE arm is recorded, and the reason is narrower than it may look. An arm
+#   Second arm — the derived timeout label:
+#   bash ~/.claude/plugins/cache/managed-service/cogni-service/0.0.402/scripts/mutation-check.sh \
+#     --root . \
+#     --file cogni-portfolio/scripts/append-claim.sh \
+#     --expr 's/\$\{WAIT_LABEL\}/3s/' \
+#     --test 'bash cogni-portfolio/tests/test-append-claim-lock.sh' \
+#     --case live-lock-not-swept-on-numeric-stat
+#
+#   This expression restates the derived label as the old hardcoded literal, which
+#   is precisely the regression it guards. The ceiling is overridable, so a
+#   restated duration is correct only at the default: under this suite's override
+#   the script would wait 0.3s while still claiming 3s, and case 2's grep would
+#   miss. The braced form occurs exactly once in the fixed script — the `echo`
+#   itself; the two assignments read `WAIT_LABEL=`, and the surrounding comments
+#   deliberately name the variable bare. That matters because the harness applies
+#   the expression with `perl -0pi` and NO `/g`: a second occurrence anywhere
+#   above the echo would absorb the substitution, leave the echo untouched, and
+#   silently degrade this arm to a behavioural no-op that does not even trip
+#   `expr_no_op`. The expression also carries no `^`/`$` anchors on purpose —
+#   `perl -0pi` slurps the whole file, so an anchored expression would need a `/m`
+#   modifier to match at all.
+#
+#   Only these TWO arms are recorded, and the reason is narrower than it may look. An arm
 #   mutating the GNU-first ordering (`s/stat -c %Y/stat -f %m/`) reports a vacuous
 #   guard against the TWO CASES BELOW, because their stub answers unconditionally
 #   and ignores its flags by design — deliberately, so both stay ordering-agnostic.
@@ -137,7 +165,7 @@ seed_contended_project() {
 case1_dir="$(seed_contended_project stale-non-numeric)"
 case1_stub="$TMPROOT/stub-non-numeric"
 make_stat_stub "$case1_stub" 'echo "%m"'
-case1_out="$(PATH="$case1_stub:$PATH" bash "$SCRIPT" "$case1_dir" '{"id": "claim-1"}' 2>"$TMPROOT/case1.err")"
+case1_out="$(APPEND_CLAIM_MAX_WAIT=3 PATH="$case1_stub:$PATH" bash "$SCRIPT" "$case1_dir" '{"id": "claim-1"}' 2>"$TMPROOT/case1.err")"
 case1_rc=$?
 
 if [ "$case1_rc" -ne 0 ]; then
@@ -154,16 +182,25 @@ fi
 #
 # Without this case a fix that unconditionally sets lock_mtime=0 satisfies case 1
 # while destroying mutual exclusion — every contended lock would read as ancient
-# and get swept out from under a running peer after 3s.
+# and get swept out from under a running peer once the acquire ceiling is reached.
+#
+# The grep below tracks the DERIVED timeout label, not a fixed duration. The
+# script computes the label from the ceiling, so under this case's override it
+# reads 0.3s where production reads 3s. Asserting the derived form is what keeps
+# the message honest: a future edit that restates a literal duration passes at
+# the default and lies under every override, and this case goes red on it. That
+# is still the suite's house rule rather than an exception to it — the string is
+# append-claim.sh's own output, so text is the right instrument; only the text to
+# expect now depends on the ceiling this case sets.
 case2_dir="$(seed_contended_project live-numeric)"
 case2_stub="$TMPROOT/stub-numeric"
 make_stat_stub "$case2_stub" 'date +%s'
-PATH="$case2_stub:$PATH" bash "$SCRIPT" "$case2_dir" '{"id": "claim-2"}' >/dev/null 2>"$TMPROOT/case2.err"
+APPEND_CLAIM_MAX_WAIT=3 PATH="$case2_stub:$PATH" bash "$SCRIPT" "$case2_dir" '{"id": "claim-2"}' >/dev/null 2>"$TMPROOT/case2.err"
 case2_rc=$?
 
 if [ "$case2_rc" -ne 1 ]; then
   fail "live-lock-not-swept-on-numeric-stat" "expected exit 1, got $case2_rc"
-elif ! grep -q 'Could not acquire lock on claims.json after 3s' "$TMPROOT/case2.err"; then
+elif ! grep -q 'Could not acquire lock on claims.json after 0.3s' "$TMPROOT/case2.err"; then
   fail "live-lock-not-swept-on-numeric-stat" "stderr did not carry the timeout error: $(cat "$TMPROOT/case2.err")"
 elif [ ! -d "$case2_dir/cogni-claims/.claims.lock" ]; then
   fail "live-lock-not-swept-on-numeric-stat" "a live peer's lock was swept"


### PR DESCRIPTION
Closes #1431.

## Summary

- `cogni-portfolio/scripts/append-claim.sh` — the acquire ceiling becomes `MAX_WAIT="${APPEND_CLAIM_MAX_WAIT:-30}"` plus a numeric-shape floor. `MAX_WAIT` counts 0.1s poll iterations, so the default 30 remains a 3s ceiling.
- Same file — the timeout message is now **derived** from the ceiling instead of restating it. At the default it renders `after 3s`, byte-identical to today; under the suite's override it renders `after 0.3s`.
- `cogni-portfolio/tests/test-append-claim-lock.sh` — both cases export `APPEND_CLAIM_MAX_WAIT=3`, case 2's grep tracks the derived label, and the header records a second mutation arm covering the new derivation.

Suite wall time drops from **7.7s to ~1.1s**; roughly 94% of the old runtime was `sleep 0.1` in the acquire loop, paid on every CI sweep of the monorepo.

## Why the message change ships with the ceiling change

The issue asks only for a parameterised ceiling. But `after 3s` was hardcoded, and correct only because 30 x 0.1s happens to equal 3s. Parameterising the ceiling alone would leave the script waiting 0.3s while still claiming 3s — with case 2's grep still passing, because it matched the stale literal. That is a guard gone quietly wrong, the same defect class this suite exists to catch, so the two halves ship together. Exploration confirmed exactly one load-bearing consumer of that literal in the repo (this suite), so the change is contained.

## Verification

| Check | Result |
|---|---|
| `bash cogni-portfolio/tests/test-append-claim-lock.sh` (bash 3.2.57) | pass, **1.124s** wall |
| Same, homebrew bash 5.3.9 | pass, **1.091s** wall |
| `python3 scripts/run-plugin-tests.py --filter cogni-portfolio` | rc=0, **7/7** suites |
| Mutation arm 1 — `lock_mtime=0` dead-variable, case 1 (pre-existing) | `guard_verified` |
| Mutation arm 2 — derived label, case 2 (new) | `guard_verified` |
| Mutation arm 3 — shape floor unconditional, case 2 (new) | `guard_verified` |
| Red case fails the **suite**, not just a case line | exit 1 + `1 test(s) failed` on stderr |
| Default ceiling by execution, no override | exit 1 after 3.47s, stderr `after 3s` |
| Malformed override `APPEND_CLAIM_MAX_WAIT=abc` | floors to 30, terminates in 3.2s — no unbounded loop |
| `check-result-line-plainness.py` / `check-breadcrumbs.py` / `check-version-bump.py` / `check-workflow-yaml.py` | all rc=0 |

Label rendering was verified on both bash builds across every admitted and rejected value: unset and `30` render `3s`; `3` → `0.3s`; `1` → `0.1s`; `10` → `1s`; `105` → `10.5s`; `999` → `99.9s`. Every rejected shape (`0`, `08`, `030`, `abc`, `-5`, `3.5`, `" 3"`) floors to 30 and renders `3s`.

## Design notes worth a reviewer's attention

- **The floor regex deliberately diverges** from the `^[0-9]+$` used by the stale-lock reading below it. The leading `[1-9]` excludes leading zeros, because `08` or `030` would pass a bare `^[0-9]+$` and then make `$(( MAX_WAIT / 10 ))` a hard bash abort — arithmetic expansion reads a leading zero as octal. A comment records this so the two patterns are not later "harmonised" back into the bug.
- **Zero is excluded on purpose.** The loop sleeps before its first `-ge` check, so `0` and `1` both mean one 0.1s poll; `0` buys no fail-immediately semantics and would render a misleading `after 0s` for a path that did wait.
- **The derivation sits outside the acquire loop.** An arithmetic abort *inside* it is the exact failure the file's own comment documents: the abort abandons the loop, execution resumes after `done`, and the claim is appended having never held the lock — after which the EXIT trap removes a live peer's lock directory. At top level the same abort is a clean exit before any lock is taken.
- **Arithmetic uses the assignment form**, never a bare `(( ... ))`. A bare arithmetic command evaluating to 0 returns status 1, and the default ceiling makes the remainder exactly 0 — under `set -e` that aborts on bash 5.x while passing on 3.2, a version-divergent failure on the *default* path.

## Scope decisions

- **Option 1 only.** Triage measured Option 2 (running the two cases concurrently) at ~3.5s, which cannot clear the under-2s bar because it removes only one of the two ceilings. It would also force a subshell failure-counter rework the suite's deliberate `set -u`-only structure does not otherwise need.
- **Production timing untouched.** Exploration found **7** live call sites, not the 5 triage named — it missed `customer-researcher.md` and `proposition-generator.md`. All 7 are agent markdown files invoking the script plainly, and none sets an override, so the `:-30` default holds acceptance criterion 3 by construction.
- **Not absorbed:** #1432, #1433 and #1434 touch the same two files but are distinct deliverables.
- **No version bump** — the post-merge workflow owns `plugin.json` / `marketplace.json`.

## Mutation recipe

```bash
bash ~/.claude/plugins/cache/managed-service/cogni-service/0.0.402/scripts/mutation-check.sh --root . --file cogni-portfolio/scripts/append-claim.sh --expr 's/\$\{WAIT_LABEL\}/3s/' --test 'bash cogni-portfolio/tests/test-append-claim-lock.sh' --case live-lock-not-swept-on-numeric-stat
```

The expression restates the derived label as the old hardcoded literal, so the script claims `after 3s` while the suite drives a 0.3s ceiling — case 2's grep misses and `live-lock-not-swept-on-numeric-stat` goes red. That is precisely the greened-over failure this PR exists to prevent. Replayed above: `guard_verified`.

The braced `WAIT_LABEL` form occurs exactly once in the fixed script (the `echo`); the two assignments read `WAIT_LABEL=`, and the surrounding comments name the variable bare. That is load-bearing — the harness applies the expression with `perl -0pi` and no `/g`, so a second occurrence above the echo would absorb the substitution and silently degrade this arm to a no-op that does not even trip `expr_no_op`. The expression carries no `^`/`$` anchors for the same reason: `perl -0pi` slurps, so an anchored expression would need a `/m` modifier to match at all.

A third arm is now recorded too, closing a gap that predates this PR: the suite pinned the stale-lock shape floor from one side only. Case 1's arm proves the floor **exists**; nothing proved it stays **conditional**. Dropping the guard and forcing every reading to 0 makes a live peer's lock read as ancient and be swept — the destroy-mutual-exclusion failure case 2 exists to catch:

```bash
bash ~/.claude/plugins/cache/managed-service/cogni-service/0.0.402/scripts/mutation-check.sh --root . --file cogni-portfolio/scripts/append-claim.sh --expr 's/\[\[ "\$lock_mtime" =~ \^\[0-9\]\+\$ \]\] \|\| //' --test 'bash cogni-portfolio/tests/test-append-claim-lock.sh' --case live-lock-not-swept-on-numeric-stat
```

Its `^` and `$` are backslash-escaped, so they are literal characters rather than anchors and need no `/m` modifier despite the harness slurping.

The pre-existing arm is unchanged and still verifies:

```bash
bash ~/.claude/plugins/cache/managed-service/cogni-service/0.0.402/scripts/mutation-check.sh --root . --file cogni-portfolio/scripts/append-claim.sh --expr 's/lock_mtime=0/lock_mtime_unused=0/' --test 'bash cogni-portfolio/tests/test-append-claim-lock.sh' --case stale-lock-swept-on-non-numeric-stat
```

## Plan record

https://github.com/cogni-work/insight-wave/issues/1431#issuecomment-5318970837
