### PR TITLE
cogni-portfolio: pin GNU-first stat ordering in the lock suite

### DIFF
--- a/cogni-portfolio/tests/test-append-claim-lock.sh
+++ b/cogni-portfolio/tests/test-append-claim-lock.sh
@@ -15,14 +15,20 @@
 #   2  live-lock-not-swept-on-numeric-stat    negative twin — a numeric current-epoch
 #                                             reading leaves a LIVE peer's lock
 #                                             alone; the script times out instead
+#   3  live-lock-not-swept-on-gnu-stat        the ordering pin — a FLAG-AWARE stub
+#                                             simulating GNU, where `-f` means
+#                                             --file-system and answers with a
+#                                             non-mtime, so only a chain that tries
+#                                             `-c` first reads the true mtime and
+#                                             leaves a LIVE peer's lock alone
 #
-# Both cases drive the acquire loop to its ceiling on purpose, so both set
+# Every case drives the acquire loop to its ceiling on purpose, so each sets
 #   APPEND_CLAIM_MAX_WAIT=3 as a per-invocation prefix — 0.3s each instead of the
 #   production 3s, which is what keeps the whole suite around a second rather than
 #   the ~7.3s it cost when the ceiling was a hardcoded constant. The prefix is
 #   deliberately NOT a suite-level export: run-plugin-tests.py invokes each suite
 #   as a bare `bash <path>`, so each case must carry its own ceiling.
-#   Case 2's asserted stderr literal is the DERIVED form for that ceiling
+#   Cases 2 and 3 assert the DERIVED form of that ceiling in their stderr literal
 #   (`after 0.3s`), not a fixed string — change the ceiling and the literal moves
 #   with it. That coupling is the point: it is what stops the message from
 #   drifting back into restating a number the loop no longer honours.
@@ -30,7 +36,7 @@
 # Usage: bash cogni-portfolio/tests/test-append-claim-lock.sh
 # Exits non-zero on any assertion failure.
 #
-# This suite has NO per-case selector — both cases are unconditional top-level
+# This suite has NO per-case selector — all cases are unconditional top-level
 #   code, so an argument naming one is ignored. The recipe below therefore runs
 #   the whole suite, and the harness classifies on the named case's output line.
 #
@@ -87,22 +93,34 @@
 #   `:-30` default), so the substitution can never be a no-op, and the expression
 #   carries no `^`/`$` anchor so it needs no `/m` under the harness's `perl -0pi`.
 #
-#   The remaining unrecorded arm is the GNU-first ORDERING, and the reason is
-#   narrower than it may look. An arm mutating it (`s/stat -c %Y/stat -f %m/`)
-#   reports a vacuous guard against the TWO CASES BELOW, because their stub answers
-#   unconditionally and ignores its flags by design — deliberately, so both stay
-#   ordering-agnostic.
+#   Fourth arm — the GNU-first ORDERING:
+#   bash ~/.claude/plugins/cache/managed-service/cogni-service/0.0.402/scripts/mutation-check.sh \
+#     --root . \
+#     --file cogni-portfolio/scripts/append-claim.sh \
+#     --expr 's/stat -c %Y/stat -f %m/' \
+#     --test 'bash cogni-portfolio/tests/test-append-claim-lock.sh' \
+#     --case live-lock-not-swept-on-gnu-stat
 #
-#   That is a property of these two cases, NOT a general limit: a flag-aware stub
-#   (`-c` prints an epoch, `-f` prints `%m` and exits 0, simulating GNU) does
-#   discriminate the two orderings, and the ordering is worth pinning on its own
-#   merits — with the floor present but the ordering swapped, a GNU host floors
-#   every contended lock's reading to 0, reads it as ancient, and sweeps a LIVE
-#   peer's lock. Do not read this note as "the ordering cannot be tested".
+#   The expression swaps the chain back to BSD-first while leaving the shape floor
+#   intact, so this arm mutates the ORDERING rather than the floor arms one and two
+#   cover. Under case 3's flag-aware stub the mutated script calls `stat -f %m`
+#   first; the stub answers `%m` and exits 0, so the `||` never falls through, the
+#   floor coerces that non-numeric reading to 0, a LIVE peer's lock reads as ancient
+#   and is swept, and the script appends and exits 0 where case 3 demands exit 1.
+#   That is the whole reason the ordering is worth pinning on its own merits: the
+#   floor makes this failure silent rather than loud, it does not make it safe, and
+#   the host it strikes is exactly the one — Linux — the GNU-first fix was about.
+#
+#   Only case 3 catches this arm. Cases 1 and 2 pass a stub that ignores its flags,
+#   so they answer identically under either ordering and stay ordering-agnostic by
+#   design — which is why this arm names case 3 and not one of them. `stat -c %Y`
+#   occurs exactly once in the script (the comment above the read line names only
+#   `stat -f %m`), so the substitution can never be a no-op, and the expression
+#   carries no `^`/`$` anchor so it needs no `/m` under the harness's `perl -0pi`.
 
 # `set -u` only — `set -e` would abort on the first failing assertion and defeat
-# the per-case failure counter below. Both cases also run a script that is
-# EXPECTED to exit non-zero in one of them.
+# the per-case failure counter below. All cases also run a script that is
+# EXPECTED to exit non-zero in two of them.
 set -u
 
 TESTS_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -128,10 +146,13 @@ fail() { printf 'FAIL: %s %s\n' "$1" "${2:-}" >&2; failures=$((failures + 1)); }
 # file so `date` and `python3` keep resolving to the real binaries — the script
 # calls all three by bare name.
 #
-# The stub ignores its flags and answers unconditionally. That is deliberate: the
-# `||` chain short-circuits on the first exit-0 call, so an unconditional stub is
-# correct under both the pre-fix BSD-first and post-fix GNU-first orderings, and
-# the suite is not coupled to the ordering the fix happens to land with.
+# The helper is body-agnostic — it writes whatever `$2` holds — and the suite uses
+# that in two deliberately different ways. Cases 1 and 2 pass a body that ignores
+# its flags and answers unconditionally: the `||` chain short-circuits on the first
+# exit-0 call, so such a body is correct under both the pre-fix BSD-first and the
+# post-fix GNU-first ordering, which keeps those two cases from being coupled to
+# the ordering the fix happens to land with. Case 3 passes a FLAG-AWARE body and is
+# coupled to the ordering on purpose — that coupling is the thing it exists to pin.
 make_stat_stub() {
   mkdir -p "$1"
   printf '#!/bin/sh\n%s\n' "$2" > "$1/stat"
@@ -181,8 +202,8 @@ seed_contended_project() {
 #
 # The general rule, worth keeping in view when adding a case: assert a FOREIGN
 # tool's output by SHAPE (exit status, stream emptiness, numeric form), and only
-# our OWN scripts' literals by text. Case 2 below greps `Could not acquire lock`
-# precisely because append-claim.sh emits that string itself.
+# our OWN scripts' literals by text. Cases 2 and 3 below grep `Could not acquire
+# lock` precisely because append-claim.sh emits that string itself.
 case1_dir="$(seed_contended_project stale-non-numeric)"
 case1_stub="$TMPROOT/stub-non-numeric"
 make_stat_stub "$case1_stub" 'echo "%m"'
@@ -218,6 +239,55 @@ elif [ ! -d "$case2_dir/cogni-claims/.claims.lock" ]; then
   fail "live-lock-not-swept-on-numeric-stat" "a live peer's lock was swept"
 else
   pass "live-lock-not-swept-on-numeric-stat" "fresh lock left intact, script timed out"
+fi
+
+# --- Case 3: the ordering pin — only a chain that tries `-c` first reads an mtime.
+#
+# Cases 1 and 2 cannot see the ordering at all, and that is by design: their stub
+# answers unconditionally, so the `||` chain's first call succeeds whichever form
+# it is, and both cases stay green under either ordering. The consequence is that
+# nothing above pins the GNU-first chain — reverting it to BSD-first leaves the
+# suite green. This case closes that gap with a FLAG-AWARE stub, which is the
+# minimum needed to tell the two calls apart.
+#
+# The stub simulates GNU coreutils, where `-f` means --file-system rather than a
+# format string: `-c` answers with a real current epoch, `-f` answers with the
+# literal `%m` and — the load-bearing part — exits 0, so a BSD-first chain never
+# falls through to its second call. Against the SHIPPED script this case is
+# behaviourally identical to case 2: `-c` runs first, returns a numeric current
+# epoch, the lock reads as live, and the script times out leaving it intact. The
+# two diverge ONLY when the ordering is swapped, which is exactly what makes this a
+# distinct case rather than a duplicate of case 2 — under the swap the `%m` reading
+# is floored to 0, a live peer's lock reads as ancient and is swept, and the script
+# appends and exits 0.
+#
+# The stub body is SINGLE-quoted so `$1` reaches the written file unexpanded rather
+# than being substituted with this suite's own (empty) `$1` at authoring time, and
+# make_stat_stub passes it as printf's ARGUMENT, so the `%m` inside it is never
+# read as a format specifier — case 1's `echo "%m"` body is the precedent.
+#
+# The stderr grep is of append-claim.sh's OWN literal, which is why it is a text
+# match at all. Anything the shell or coreutils emits is asserted by SHAPE here
+# instead — those diagnostics are gettext-localized, so a text match on one would
+# pass vacuously off an English-locale host.
+case3_dir="$(seed_contended_project live-gnu-ordering)"
+case3_stub="$TMPROOT/stub-gnu-ordering"
+make_stat_stub "$case3_stub" 'case "$1" in
+  -c) date +%s ;;
+  -f) echo "%m" ;;
+  *) exit 1 ;;
+esac'
+PATH="$case3_stub:$PATH" APPEND_CLAIM_MAX_WAIT=3 bash "$SCRIPT" "$case3_dir" '{"id": "claim-3"}' >/dev/null 2>"$TMPROOT/case3.err"
+case3_rc=$?
+
+if [ "$case3_rc" -ne 1 ]; then
+  fail "live-lock-not-swept-on-gnu-stat" "expected exit 1, got $case3_rc — a BSD-first chain would sweep the live lock and append"
+elif ! grep -q 'Could not acquire lock on claims.json after 0.3s' "$TMPROOT/case3.err"; then
+  fail "live-lock-not-swept-on-gnu-stat" "stderr did not carry the timeout error: $(cat "$TMPROOT/case3.err")"
+elif [ ! -d "$case3_dir/cogni-claims/.claims.lock" ]; then
+  fail "live-lock-not-swept-on-gnu-stat" "a live peer's lock was swept"
+else
+  pass "live-lock-not-swept-on-gnu-stat" "GNU-first chain read the true mtime, live lock left intact"
 fi
 
 if [ "$failures" -gt 0 ]; then


### PR DESCRIPTION
Closes #1433.

## Summary

- Add case 3 `live-lock-not-swept-on-gnu-stat` to `cogni-portfolio/tests/test-append-claim-lock.sh`: a flag-aware `stat` stub (`-c` answers with a current epoch, `-f` answers with the literal `%m` and exits 0 — the GNU shape, where `-f` means `--file-system`) against a pre-created contended lock, asserting exit 1, append-claim.sh's own `Could not acquire lock on claims.json after 0.3s` literal, and survival of the peer's `.claims.lock`.
- Record a **fourth mutation arm** in the suite header swapping the chain to BSD-first (`s/stat -c %Y/stat -f %m/`), so the recipe *proves* the new case discriminates rather than asserting it.
- Repair the header prose the third case falsifies — the coverage list, the `Both cases` counts, the derived-literal note, the `set -u` rationale, the `make_stat_stub` paragraph, the own-emitter assertion rule, and the standing "the remaining unrecorded arm is the ORDERING" note, whose surviving true content moves into the fourth arm's preamble.

`cogni-portfolio/scripts/append-claim.sh` is **not touched**. It is correct as shipped; this is a coverage gap, not a behaviour bug.

## Why the ordering is worth pinning on its own merits

Measured against the *fixed* script with the numeric-shape floor present in both arms:

| Ordering | rc | stdout | live peer's lock |
|---|---|---|---|
| GNU-first (shipped) | 1 | none | survived |
| BSD-first (swapped) | 0 | `{"status": "appended", ...}` | **swept** |

With the floor present but the ordering swapped, a GNU host floors every contended lock's reading to 0, reads it as ancient, and sweeps a **live** peer's lock after the timeout — destroying the mutual exclusion case 2 exists to protect, on exactly the platform the GNU-first fix was about. The floor makes that failure silent rather than loud; it does not make it safe.

## Why cases 1 and 2 could not have caught it

Both pass a stub that ignores its flags and answers unconditionally. The `||` chain short-circuits on the first exit-0 call, so such a stub returns the same answer under either ordering — which is exactly why those two cases are ordering-agnostic *by design*, and why case 3 is additive rather than a replacement. Their flag-blind stubs and assertion blocks are unchanged in this PR.

## Scope decisions

- **Included:** only `cogni-portfolio/tests/test-append-claim-lock.sh`. A repo-wide grep for both existing case ids and for `test-append-claim-lock` returns hits inside that file alone.
- **Included:** the header prose repair. Leaving it would ship a file whose own comments assert, falsely, that the ordering is unrecorded and cannot be tested.
- **Excluded:** any edit to `append-claim.sh` — mutating it is the recipe's job, not the diff's.
- **Excluded:** any `plugin.json` / `marketplace.json` version bump — the post-merge workflow owns it.

## Mutation recipe

New fourth arm — the ordering:

```
bash ~/.claude/plugins/cache/managed-service/cogni-service/0.0.402/scripts/mutation-check.sh \
  --root . \
  --file cogni-portfolio/scripts/append-claim.sh \
  --expr 's/stat -c %Y/stat -f %m/' \
  --test 'bash cogni-portfolio/tests/test-append-claim-lock.sh' \
  --case live-lock-not-swept-on-gnu-stat
```

The expression swaps the chain to BSD-first while leaving the shape floor intact. Under case 3's flag-aware stub the mutated script calls `stat -f %m` first, the stub answers `%m` and exits 0, the `||` never falls through, the floor coerces the reading to 0, the live lock reads as ancient and is swept, and the script appends and exits 0 where case 3 demands exit 1. `stat -c %Y` occurs exactly once in the script, so the substitution can never be a no-op; the expression carries no `^`/`$` anchor, so it needs no `/m` under the harness's slurping `perl -0pi`.

### Replay results — all four arms, run on this branch

| Arm | Expression | Case | Verdict |
|---|---|---|---|
| 1 — floor assignment | `s/lock_mtime=0/lock_mtime_unused=0/` | `stale-lock-swept-on-non-numeric-stat` | `guard_verified` |
| 2 — floor condition | `s/\^\[0-9\]\+\$/^NOMATCH\$/` | `live-lock-not-swept-on-numeric-stat` | `guard_verified` |
| 3 — ceiling coupling | `s/APPEND_CLAIM_MAX_WAIT:-30/APPEND_CLAIM_MAX_WAIT_UNUSED:-30/` | `live-lock-not-swept-on-numeric-stat` | `guard_verified` |
| **4 — ordering (new)** | `s/stat -c %Y/stat -f %m/` | `live-lock-not-swept-on-gnu-stat` | `guard_verified` |

Each replayed `mutated: red → restored: green`. Arms 1–3 were re-run rather than assumed: adding a third case changes which cases go red under them.

## Verification

| Check | Result |
|---|---|
| `bash cogni-portfolio/tests/test-append-claim-lock.sh` | exit 0, three `ok:` lines, **1.6s** (base 1.4s, cap 3s) |
| `python3 scripts/run-plugin-tests.py --filter cogni-portfolio` | exit 0 — 7/7 suites, 0 failed |
| `python3 scripts/check-result-line-plainness.py` | exit 0, `summary.total == 0` |
| `python3 scripts/check-breadcrumbs.py` | exit 0, 0 violations |
| `python3 scripts/check-version-bump.py` | `ok` — 9 scanned, 0 touched, 0 violations |
| `git diff --name-only origin/main` | one file only |
| `git diff origin/main -- cogni-portfolio/scripts/append-claim.sh` | empty |

Also confirmed by direct probe that the single-quoted stub body reaches the written `stat` file with `$1` unexpanded and `%m` not format-interpreted (`make_stat_stub` passes the body as printf's *argument*), and that the stub behaves as intended: `-c` → numeric, rc 0; `-f` → `%m`, rc 0; default → rc 1.

## Pre-commit quality pass — what was found and what was done

Four cleanup agents (reuse / simplification / efficiency / altitude) reviewed the diff. Two findings were real but **deliberately not applied**, because in both cases the fix would have broken the acceptance bar it was meant to serve:

1. **The timeout literal `Could not acquire lock on claims.json after 0.3s` now appears twice** (line 236 in case 2, line 285 in case 3) rather than in one shared variable. Extracting it would require editing case 2's assertion block — which this issue's acceptance criteria ("the two existing cases still pass **unchanged**") and the merger contract both put off-limits. The duplication fails loud (grep misses, case reddens), so the cost is one extra edit site, not a silent hole.
2. **The stub's `*) exit 1 ;;` catch-all is unreachable** — `append-claim.sh` only ever passes `-c` or `-f`, and it was measured that deleting it changes neither the green run nor the arm-4 red. It stays because the issue specifies that exact fixture, the contract has an explicit item requiring the default branch to exit non-zero, and it keeps the stub fail-loud if the script ever grows a third `stat` form.

Efficiency returned clean: case 3 carries the `APPEND_CLAIM_MAX_WAIT=3` prefix in the same position as cases 1 and 2, costs ~0.53s (exactly one standard case, no per-case overhead of its own), and that cost is structurally irreducible — the stat chain sits behind the acquire ceiling, so any case reaching it must burn the ceiling first. Altitude returned clean, noting the behavioural route is the *stronger* of the two available depths: a textual assertion on the chain's source goes vacuous the moment it is renamed or refactored, while this one does not.

## Follow-up issues

- #1456 — **cogni-visual: the canvas-lock suite pins the stat ordering textually on a now-falsified premise, and misses the swept_mtime chain entirely.** That suite justifies its source-text grep with "because that floor makes both orders behave identically at runtime, no behavioural case can reach the ordering" — which case 3 here disproves. Removing this suite's copy of that belief leaves the cogni-visual copy as the last surviving instance. Verified before filing: its arm greps `lock_mtime=$(stat ` with `head -1`, so the hook's second chain (`swept_mtime`, `ensure-excalidraw-canvas.sh:155`) is pinned by nothing today.

Out of scope here — fixing it means editing a second plugin's suite in a change the issue scoped to one file.

---

*Token-scope note: pushed on the default `gh auth login` (`gho_`) token, whose scope set is fixed by the GitHub CLI OAuth app and cannot be narrowed. `check-token-scope.sh --strict` exits 1 on it; the sanctioned `--allow-overscoped` opt-out was used.*