### PR TITLE
fix(cogni-portfolio): memoize the append-claim stat form and bound stale-lock sweep re-entry

### DIFF
--- a/cogni-portfolio/scripts/append-claim.sh
+++ b/cogni-portfolio/scripts/append-claim.sh
@@ -38,6 +38,22 @@ MAX_WAIT="${APPEND_CLAIM_MAX_WAIT:-30}"
 TIMEOUT_LABEL="$(( MAX_WAIT / 10 )).$(( MAX_WAIT % 10 ))"
 TIMEOUT_LABEL="${TIMEOUT_LABEL%.0}"
 WAITED=0
+# Stale-sweep budget. A lock we have failed to remove this many times is not
+# going to become removable: the directory is non-empty, or a peer keeps
+# re-taking it inside the same tick. Without a bound the sweep below `continue`s
+# forever and the timeout diagnostic becomes unreachable, because WAITED only
+# ever climbs -- so once the ceiling test is true it stays true on every later
+# pass. The budget is what lets the loop fall through to that diagnostic instead
+# of spinning at 10Hz over a lock it cannot clear.
+MAX_SWEEPS=3
+SWEEPS=0
+# Empty means "the working stat form is not resolved yet". Resolution is
+# deliberately lazy -- deferred to the first stale-block entry rather than done
+# ahead of the loop -- because an uncontended acquire never enters the loop body
+# at all, so probing up front would add a fork to every one of those to save
+# forks on the rare contended path. The lock directory also need not exist yet
+# at this point; it is created only by the loop's own mkdir below.
+STAT_MTIME=""
 while ! mkdir "$LOCK_DIR" 2>/dev/null; do
   sleep 0.1
   WAITED=$((WAITED + 1))
@@ -58,11 +74,34 @@ while ! mkdir "$LOCK_DIR" 2>/dev/null; do
       #
       # Floor on numeric SHAPE, not emptiness — the failure mode is a successful
       # *wrong* answer, which an emptiness test structurally cannot catch.
-      lock_mtime=$(stat -c %Y "$LOCK_DIR" 2>/dev/null || stat -f %m "$LOCK_DIR" 2>/dev/null || echo 0)
+      #
+      # The candidate list is walked once per acquire and the winner memoized in
+      # STAT_MTIME, so only the first entry pays the failing probe; every later
+      # entry costs a single exec. `$stat_form` and `$STAT_MTIME` expand UNQUOTED
+      # on purpose — each holds a command plus its flags and has to word-split
+      # into three words. Both are set from this file's own literals and the
+      # format specifiers carry no glob character, so the split is safe.
+      # The sentinel for "no form worked" is the `false` builtin, which keeps the
+      # memoized path fork-free and lets the tail below absorb its non-zero
+      # status. Both branches always assign lock_mtime, which is what keeps
+      # `set -u` off the floor that follows; the assignment-as-condition form is
+      # what keeps a failing probe from tripping `set -e`.
+      if [ -z "$STAT_MTIME" ]; then
+        STAT_MTIME=false
+        for stat_form in "stat -c %Y" "stat -f %m"; do
+          if lock_mtime=$($stat_form "$LOCK_DIR" 2>/dev/null); then
+            STAT_MTIME="$stat_form"
+            break
+          fi
+        done
+      else
+        lock_mtime=$($STAT_MTIME "$LOCK_DIR" 2>/dev/null || echo 0)
+      fi
       [[ "$lock_mtime" =~ ^[0-9]+$ ]] || lock_mtime=0
       now=$(date +%s)
       lock_age=$(( now - lock_mtime ))
-      if [ "$lock_age" -gt 60 ]; then
+      if [ "$lock_age" -gt 60 ] && [ "$SWEEPS" -lt "$MAX_SWEEPS" ]; then
+        SWEEPS=$((SWEEPS + 1))
         rmdir "$LOCK_DIR" 2>/dev/null || true
         continue
       fi

--- a/cogni-portfolio/scripts/append-claim.sh
+++ b/cogni-portfolio/scripts/append-claim.sh
@@ -54,17 +54,51 @@ SWEEPS=0
 # forks on the rare contended path. The lock directory also need not exist yet
 # at this point; it is created only by the loop's own mkdir below.
 STAT_MTIME=""
+# Read the lock's mtime into lock_mtime, resolving the working stat form on first
+# use and reusing it thereafter. This lives in a function rather than inline so
+# the acquire loop's body carries no stat invocation of its own: the loop asks
+# for a reading, and which form produces it is this function's business.
+#
+# GNU form first: on GNU coreutils `-f` means --file-system, so `stat -f %m`
+# yields no mtime yet still exits 0, and a fallback chain would never fall
+# through. BSD has no `-c`, so it errors cleanly and does fall through — only
+# this direction works on both. The candidate list is therefore ordered, not
+# arbitrary, and reversing it is what the ordering mutation arm exists to catch.
+#
+# The winner is memoized in STAT_MTIME, so only the first entry pays the failing
+# probe; every later entry costs a single exec. `$stat_form` and `$STAT_MTIME`
+# expand UNQUOTED on purpose — each holds a command plus its flags and has to
+# word-split into three words. Both are set from this file's own literals and the
+# format specifiers carry no glob character, so the split is safe.
+#
+# The sentinel for "no form worked" is the `false` builtin, which keeps the
+# memoized path fork-free and lets the read's tail absorb its non-zero status.
+# Every path assigns lock_mtime — a failing substitution still assigns the empty
+# string — which is what keeps `set -u` off the shape floor at the call site, and
+# the assignment-as-condition form is what keeps a failing probe from tripping
+# `set -e`. The function itself always returns 0 for the same reason.
+#
+# Both probe calls keep their stderr redirect, so a real BSD host's complaint
+# about the GNU flag never reaches the caller's stderr.
+read_lock_mtime() {
+  if [ -z "$STAT_MTIME" ]; then
+    STAT_MTIME=false
+    for stat_form in "stat -c %Y" "stat -f %m"; do
+      if lock_mtime=$($stat_form "$LOCK_DIR" 2>/dev/null); then
+        STAT_MTIME="$stat_form"
+        return 0
+      fi
+    done
+    return 0
+  fi
+  lock_mtime=$($STAT_MTIME "$LOCK_DIR" 2>/dev/null || echo 0)
+}
 while ! mkdir "$LOCK_DIR" 2>/dev/null; do
   sleep 0.1
   WAITED=$((WAITED + 1))
   if [ "$WAITED" -ge "$MAX_WAIT" ]; then
     # Stale lock detection: remove lock older than 60 seconds
     if [ -d "$LOCK_DIR" ]; then
-      # GNU form first: on GNU coreutils `-f` means --file-system, so `stat -f %m`
-      # yields no mtime yet still exits 0, and the `||` never falls through. BSD
-      # has no `-c`, so it errors cleanly and does fall through — only this
-      # direction works on both.
-      #
       # Resolve the reading into a variable before any arithmetic. A bad
       # substitution nested directly inside $(( )) is a hard bash error, and the
       # damage is worse than an abort: on every bash tested (3.2.57 through
@@ -74,29 +108,7 @@ while ! mkdir "$LOCK_DIR" 2>/dev/null; do
       #
       # Floor on numeric SHAPE, not emptiness — the failure mode is a successful
       # *wrong* answer, which an emptiness test structurally cannot catch.
-      #
-      # The candidate list is walked once per acquire and the winner memoized in
-      # STAT_MTIME, so only the first entry pays the failing probe; every later
-      # entry costs a single exec. `$stat_form` and `$STAT_MTIME` expand UNQUOTED
-      # on purpose — each holds a command plus its flags and has to word-split
-      # into three words. Both are set from this file's own literals and the
-      # format specifiers carry no glob character, so the split is safe.
-      # The sentinel for "no form worked" is the `false` builtin, which keeps the
-      # memoized path fork-free and lets the tail below absorb its non-zero
-      # status. Both branches always assign lock_mtime, which is what keeps
-      # `set -u` off the floor that follows; the assignment-as-condition form is
-      # what keeps a failing probe from tripping `set -e`.
-      if [ -z "$STAT_MTIME" ]; then
-        STAT_MTIME=false
-        for stat_form in "stat -c %Y" "stat -f %m"; do
-          if lock_mtime=$($stat_form "$LOCK_DIR" 2>/dev/null); then
-            STAT_MTIME="$stat_form"
-            break
-          fi
-        done
-      else
-        lock_mtime=$($STAT_MTIME "$LOCK_DIR" 2>/dev/null || echo 0)
-      fi
+      read_lock_mtime
       [[ "$lock_mtime" =~ ^[0-9]+$ ]] || lock_mtime=0
       now=$(date +%s)
       lock_age=$(( now - lock_mtime ))

--- a/cogni-portfolio/tests/test-append-claim-lock.sh
+++ b/cogni-portfolio/tests/test-append-claim-lock.sh
@@ -21,17 +21,42 @@
 #                                             non-mtime, so only a chain that tries
 #                                             `-c` first reads the true mtime and
 #                                             leaves a LIVE peer's lock alone
+#   4  probe-resolved-once-per-acquire        the memo pin — a COUNTING stub on a
+#                                             lock whose rmdir always fails records
+#                                             exactly ONE GNU-form probe across the
+#                                             four stale-block entries, not one per
+#                                             entry
+#   5  stale-sweep-bounded-when-rmdir-fails   the re-entry bound — an unremovable
+#                                             lock reaches the timeout branch and
+#                                             exits, instead of sweeping at 10Hz
+#                                             forever with the diagnostic dead
+#                                             behind an always-firing `continue`
+#   6  no-working-stat-form-still-appends     neither form resolves, so the reading
+#                                             floors to 0 exactly as the old
+#                                             per-read `|| echo 0` tail did, and
+#                                             stderr still stays empty
+#   7  uncontended-acquire-spawns-no-stat     the hot-path guard — an acquire that
+#                                             never contends must spawn NO stat at
+#                                             all; this is what forbids resolving
+#                                             the form ahead of the loop
 #
-# Every case drives the acquire loop to its ceiling on purpose, so each sets
-#   APPEND_CLAIM_MAX_WAIT=3 as a per-invocation prefix — 0.3s each instead of the
-#   production 3s, which is what keeps the whole suite around a second rather than
-#   the ~7.3s it cost when the ceiling was a hardcoded constant. The prefix is
-#   deliberately NOT a suite-level export: run-plugin-tests.py invokes each suite
-#   as a bare `bash <path>`, so each case must carry its own ceiling.
-#   Cases 2 and 3 assert the DERIVED form of that ceiling in their stderr literal
-#   (`after 0.3s`), not a fixed string — change the ceiling and the literal moves
-#   with it. That coupling is the point: it is what stops the message from
-#   drifting back into restating a number the loop no longer honours.
+# Every case that CONTENDS drives the acquire loop to its ceiling on purpose, so
+#   each sets APPEND_CLAIM_MAX_WAIT as a per-invocation prefix rather than paying
+#   the production 3s: cases 1-3 use 3 (0.3s) and cases 4-6 use 1 (0.1s). That is
+#   what keeps the whole suite near four seconds — measured, not estimated — rather
+#   than the ~7.3s it cost when the ceiling was a hardcoded constant. Cases 4 and 5
+#   each drive the loop through the full sweep budget, so they carry most of the
+#   ~2.4s this suite grew by; folding them into one invocation that emits two result
+#   lines would recover roughly half of that if the budget ever needs tightening. Case 7 is the deliberate exception
+#   and never contends at all — it exists to prove the UNcontended acquire stays
+#   fork-free, so driving the loop is precisely what it must not do.
+#   The prefix is deliberately NOT a suite-level export: run-plugin-tests.py
+#   invokes each suite as a bare `bash <path>`, so each case must carry its own
+#   ceiling.
+#   Cases 2, 3 and 5 assert the DERIVED form of that ceiling in their stderr
+#   literal (`after 0.3s`, `after 0.1s`), not a fixed string — change a ceiling and
+#   the literal moves with it. That coupling is the point: it is what stops the
+#   message from drifting back into restating a number the loop no longer honours.
 #
 # Usage: bash cogni-portfolio/tests/test-append-claim-lock.sh
 # Exits non-zero on any assertion failure.
@@ -53,8 +78,9 @@
 #
 #   The expression redirects the shape floor's assignment to a dead variable, so
 #   the non-numeric reading survives into the arithmetic. `lock_mtime=0` occurs
-#   exactly once in the fixed script (the read line is `lock_mtime=$(stat ...`,
-#   which does not contain it), so the substitution can never be a no-op.
+#   exactly once in the fixed script — BOTH read paths of the memoizing probe
+#   spell the assignment as a command substitution and neither contains that
+#   literal — so the substitution can never be a no-op.
 #
 #   Second arm — the shape floor, case 2's side of it:
 #   bash ~/.claude/plugins/cache/managed-service/cogni-service/0.0.402/scripts/mutation-check.sh \
@@ -114,9 +140,47 @@
 #   Only case 3 catches this arm. Cases 1 and 2 pass a stub that ignores its flags,
 #   so they answer identically under either ordering and stay ordering-agnostic by
 #   design — which is why this arm names case 3 and not one of them. `stat -c %Y`
-#   occurs exactly once in the script (the comment above the read line names only
-#   `stat -f %m`), so the substitution can never be a no-op, and the expression
-#   carries no `^`/`$` anchor so it needs no `/m` under the harness's `perl -0pi`.
+#   occurs exactly once in the script — it is the FIRST entry of the memoizing
+#   probe's candidate list, and no comment restates it — so the substitution can
+#   never be a no-op, and the expression carries no `^`/`$` anchor so it needs no
+#   `/m` under the harness's `perl -0pi`.
+#
+#   Fifth arm — the MEMO (the probe is resolved once per acquire, not per pass):
+#   bash ~/.claude/plugins/cache/managed-service/cogni-service/0.0.402/scripts/mutation-check.sh \
+#     --root . \
+#     --file cogni-portfolio/scripts/append-claim.sh \
+#     --expr 's/STAT_MTIME="\$stat_form"/STAT_MTIME=""/' \
+#     --test 'bash cogni-portfolio/tests/test-append-claim-lock.sh' \
+#     --case probe-resolved-once-per-acquire
+#
+#   The expression stops the winning form from ever being recorded, so the sentinel
+#   test at the top of the block stays true and EVERY stale-block entry re-probes
+#   from the start of the candidate list. Case 4's counting stub then records one
+#   GNU-form call per entry instead of one per acquire, and its exact-count
+#   assertion goes red. `STAT_MTIME="$stat_form"` occurs exactly once (the
+#   initialiser spells `STAT_MTIME=""` and the memoized read spells
+#   `$STAT_MTIME`), so the substitution can never be a no-op, and the expression
+#   carries no `^`/`$` anchor so it needs no `/m`.
+#
+#   Sixth arm — the RE-ENTRY BOUND:
+#   bash ~/.claude/plugins/cache/managed-service/cogni-service/0.0.402/scripts/mutation-check.sh \
+#     --root . \
+#     --file cogni-portfolio/scripts/append-claim.sh \
+#     --expr 's/MAX_SWEEPS=3/MAX_SWEEPS=9/' \
+#     --test 'bash cogni-portfolio/tests/test-append-claim-lock.sh' \
+#     --case stale-sweep-bounded-when-rmdir-fails
+#
+#   The expression WIDENS the sweep budget rather than removing it, so the bounded
+#   case sees more sweeps than it allows and goes red. `MAX_SWEEPS=3` occurs
+#   exactly once, and the expression carries no `^`/`$` anchor so it needs no `/m`.
+#
+#   STANDING RULE for any future arm on this bound: widen it, never delete it.
+#   Removing `MAX_SWEEPS` — or dropping the `SWEEPS` increment, which leaves the
+#   counter at 0 forever — makes the MUTATED script non-terminating on case 5's
+#   unremovable-lock fixture. The harness would then HANG rather than report red,
+#   and because this suite has no per-case selector the harness runs every case, so
+#   one hanging case hangs the entire replay. A widening reproduces the same defect
+#   observably and terminates.
 
 # `set -u` only — `set -e` would abort on the first failing assertion and defeat
 # the per-case failure counter below. All cases also run a script that is
@@ -168,6 +232,50 @@ seed_contended_project() {
   mkdir -p "$pdir/cogni-claims"
   mkdir "$pdir/cogni-claims/.claims.lock"
   printf '%s' "$pdir"
+}
+
+# Two fixtures the seeder above structurally cannot produce, each needed by a case
+# below. The blocker variant puts a FILE inside the lock directory, which is what
+# makes `rmdir` fail with ENOTEMPTY permanently — the script swallows that failure
+# (`2>/dev/null || true`), so without a sweep budget the loop would re-enter every
+# 100ms forever. The uncontended variant creates no lock at all, so the acquire
+# succeeds on the loop's first condition test and the body never runs.
+seed_blocked_project() {
+  local pdir="$TMPROOT/$1"
+  mkdir -p "$pdir/cogni-claims/.claims.lock"
+  : > "$pdir/cogni-claims/.claims.lock/blocker"
+  printf '%s' "$pdir"
+}
+
+seed_uncontended_project() {
+  local pdir="$TMPROOT/$1"
+  mkdir -p "$pdir/cogni-claims"
+  printf '%s' "$pdir"
+}
+
+# A counting variant of make_stat_stub: the stub records its FIRST ARGUMENT — the
+# flag it was called with — one per line, then runs the caller's behaviour. That
+# is what lets a case assert a spawn count by measurement rather than by argument.
+#
+# The counter path is baked into the stub body at authoring time because the stub
+# is a SEPARATE PROCESS: a bare `$TMPROOT` left for the stub's own shell to expand
+# would resolve to nothing. `$1` is left unexpanded on purpose so it means the
+# stub's argument, not this suite's.
+#
+# The counter must NOT live in the stub directory. That directory holds exactly one
+# file so `date` and `python3` keep resolving to the real binaries (see
+# make_stat_stub above); a second file there would erode the invariant the whole
+# stubbing scheme rests on. Each caller also passes its OWN counter path — the stub
+# appends, so a shared counter would bleed counts between cases and make both
+# assertions meaningless.
+make_counting_stat_stub() {
+  mkdir -p "$1"
+  {
+    printf '#!/bin/sh\n'
+    printf 'printf "%%s\\n" "$1" >> "%s"\n' "$2"
+    printf '%s\n' "$3"
+  } > "$1/stat"
+  chmod +x "$1/stat"
 }
 
 # --- Case 1: a non-numeric mtime reading must be floored, not fed to arithmetic.
@@ -288,6 +396,147 @@ elif [ ! -d "$case3_dir/cogni-claims/.claims.lock" ]; then
   fail "live-lock-not-swept-on-gnu-stat" "a live peer's lock was swept"
 else
   pass "live-lock-not-swept-on-gnu-stat" "GNU-first chain read the true mtime, live lock left intact"
+fi
+
+# --- Case 4: the stat form is resolved ONCE per acquire, not once per pass.
+#
+# This is the MEASURED criterion, and it is measured rather than argued because the
+# mechanism lives in an executable script, so a count is obtainable. The stub
+# simulates a BSD host — the GNU form fails, the BSD form answers a numeric epoch 0
+# — and records every flag it is called with.
+#
+# The fixture's lock carries a blocker file, so `rmdir` can never succeed and the
+# loop is driven through the full sweep budget: four stale-block entries (three
+# sweeps, then one pass where the budget is spent). A memoizing probe pays the
+# failing GNU form on the FIRST entry only, so the tally is exactly one `-c` and
+# four `-f`. An un-memoized chain re-probes on every entry and records four of each
+# — which is what the fifth mutation arm above reproduces.
+#
+# The counts are asserted by SHAPE (a line count over the recorded flags), never by
+# reading any stat diagnostic: the stub is ours, but `rmdir`'s ENOTEMPTY is not,
+# and that one is gettext-localized.
+case4_dir="$(seed_blocked_project probe-memo)"
+case4_stub="$TMPROOT/stub-counting-bsd"
+case4_counter="$TMPROOT/case4.count"
+: > "$case4_counter"
+make_counting_stat_stub "$case4_stub" "$case4_counter" 'case "$1" in
+  -c) exit 1 ;;
+  -f) echo 0 ;;
+  *) exit 1 ;;
+esac'
+PATH="$case4_stub:$PATH" APPEND_CLAIM_MAX_WAIT=1 bash "$SCRIPT" "$case4_dir" '{"id": "claim-4"}' >/dev/null 2>"$TMPROOT/case4.err"
+case4_rc=$?
+case4_c=$(grep -c '^-c$' "$case4_counter" || true)
+case4_f=$(grep -c '^-f$' "$case4_counter" || true)
+
+if [ "$case4_rc" -ne 1 ]; then
+  fail "probe-resolved-once-per-acquire" "expected exit 1 once the sweep budget is spent, got $case4_rc"
+elif [ "$case4_c" -ne 1 ]; then
+  fail "probe-resolved-once-per-acquire" "expected exactly 1 GNU-form probe across 4 stale-block entries, got $case4_c (the form is being re-probed per pass)"
+elif [ "$case4_f" -ne 4 ]; then
+  fail "probe-resolved-once-per-acquire" "expected 4 memoized reads, got $case4_f"
+else
+  pass "probe-resolved-once-per-acquire" "1 probe + 4 memoized reads across 4 entries"
+fi
+
+# --- Case 5: stale-sweep re-entry is BOUNDED, so an unremovable lock terminates.
+#
+# Against the pre-fix script this fixture never returns at all. `WAITED` only ever
+# climbs, so once the ceiling test is true it stays true; the sweep `continue`s
+# before the timeout branch can be reached, and a lock whose `rmdir` keeps failing
+# is swept at 10Hz indefinitely. That is why this case and the bound ship together:
+# there is no version of it that is both deterministic and writable against the
+# unbounded script.
+#
+# The assertion is deliberately NOT a timeout wrapper. The bound makes termination
+# a property of the script, so the case asserts the real contract — the script's own
+# timeout diagnostic and exit 1 — with no race, no background process and no timing
+# dependence. It also asserts the lock and its blocker SURVIVE: the sweep genuinely
+# could not remove them, which is what distinguishes a bounded sweep from a
+# successful one.
+case5_dir="$(seed_blocked_project sweep-bounded)"
+case5_stub="$TMPROOT/stub-counting-bounded"
+case5_counter="$TMPROOT/case5.count"
+: > "$case5_counter"
+make_counting_stat_stub "$case5_stub" "$case5_counter" 'case "$1" in
+  -c) exit 1 ;;
+  -f) echo 0 ;;
+  *) exit 1 ;;
+esac'
+PATH="$case5_stub:$PATH" APPEND_CLAIM_MAX_WAIT=1 bash "$SCRIPT" "$case5_dir" '{"id": "claim-5"}' >/dev/null 2>"$TMPROOT/case5.err"
+case5_rc=$?
+case5_f=$(grep -c '^-f$' "$case5_counter" || true)
+
+if [ "$case5_rc" -ne 1 ]; then
+  fail "stale-sweep-bounded-when-rmdir-fails" "expected exit 1, got $case5_rc"
+elif ! grep -q 'Could not acquire lock on claims.json after 0.1s' "$TMPROOT/case5.err"; then
+  fail "stale-sweep-bounded-when-rmdir-fails" "stderr did not carry the timeout error: $(cat "$TMPROOT/case5.err")"
+elif [ ! -f "$case5_dir/cogni-claims/.claims.lock/blocker" ]; then
+  fail "stale-sweep-bounded-when-rmdir-fails" "the blocker vanished — the fixture no longer makes rmdir fail"
+elif [ ! -d "$case5_dir/cogni-claims/.claims.lock" ]; then
+  fail "stale-sweep-bounded-when-rmdir-fails" "an unremovable lock was reported swept"
+elif [ "$case5_f" -gt 4 ]; then
+  fail "stale-sweep-bounded-when-rmdir-fails" "sweep re-entered $case5_f times, past the budget — the bound is not holding"
+else
+  pass "stale-sweep-bounded-when-rmdir-fails" "unremovable lock reached the timeout branch in $case5_f reads"
+fi
+
+# --- Case 6: when NEITHER form resolves, the old per-read fallback's semantics hold.
+#
+# The pre-fix chain ended in `|| echo 0`, so a host where both forms fail floored the
+# reading to 0 on every read. Memoizing the form has to reproduce that, and the way
+# it does is the `false` builtin as the no-form sentinel — non-empty, so it memoizes,
+# and fork-free, with its non-zero status absorbed by the read's tail.
+#
+# stderr EMPTINESS is the load-bearing assertion here, and it is what pins that BOTH
+# probe calls keep their `2>/dev/null`. Drop either redirect and a real BSD host's
+# `stat: illegal option -- c` reaches stderr — a diagnostic this case would catch by
+# shape without ever matching its wording, which it must not do, because that
+# wording is gettext-localized and would pass vacuously off an English-locale host.
+case6_dir="$(seed_contended_project no-working-form)"
+case6_stub="$TMPROOT/stub-no-form"
+make_stat_stub "$case6_stub" 'exit 1'
+case6_out="$(PATH="$case6_stub:$PATH" APPEND_CLAIM_MAX_WAIT=1 bash "$SCRIPT" "$case6_dir" '{"id": "claim-6"}' 2>"$TMPROOT/case6.err")"
+case6_rc=$?
+
+if [ "$case6_rc" -ne 0 ]; then
+  fail "no-working-stat-form-still-appends" "expected exit 0, got $case6_rc (stderr: $(cat "$TMPROOT/case6.err"))"
+elif [ -s "$TMPROOT/case6.err" ]; then
+  fail "no-working-stat-form-still-appends" "expected silence on stderr, got: $(cat "$TMPROOT/case6.err")"
+elif ! printf '%s' "$case6_out" | python3 -c 'import json,sys; sys.exit(0 if json.load(sys.stdin).get("status") == "appended" else 1)' 2>/dev/null; then
+  fail "no-working-stat-form-still-appends" "stdout did not parse as JSON with status=appended: $case6_out"
+else
+  pass "no-working-stat-form-still-appends" "no form resolved, reading floored to 0, ancient lock swept"
+fi
+
+# --- Case 7: an UNCONTENDED acquire must spawn no stat at all.
+#
+# This is the hot-path guard, and it is the case that forbids the obvious reading of
+# "resolve the form once before the loop". An uncontended acquire never enters the
+# loop body — the `while` condition's own mkdir succeeds — so it costs exactly one
+# fork today. Resolving the form ahead of the loop would add one or two more to
+# every such call, which is the overwhelmingly common one, in order to save forks on
+# the rare contended path. Lazy resolution is what keeps this counter empty.
+#
+# The counter is pre-created empty so the assertion distinguishes "the stub never
+# ran" from "the stub was never installed" — an emptiness test on a file that does
+# not exist would pass for the wrong reason.
+case7_dir="$(seed_uncontended_project uncontended)"
+case7_stub="$TMPROOT/stub-counting-uncontended"
+case7_counter="$TMPROOT/case7.count"
+: > "$case7_counter"
+make_counting_stat_stub "$case7_stub" "$case7_counter" 'echo 0'
+case7_out="$(PATH="$case7_stub:$PATH" bash "$SCRIPT" "$case7_dir" '{"id": "claim-7"}' 2>"$TMPROOT/case7.err")"
+case7_rc=$?
+
+if [ "$case7_rc" -ne 0 ]; then
+  fail "uncontended-acquire-spawns-no-stat" "expected exit 0, got $case7_rc (stderr: $(cat "$TMPROOT/case7.err"))"
+elif ! printf '%s' "$case7_out" | python3 -c 'import json,sys; sys.exit(0 if json.load(sys.stdin).get("status") == "appended" else 1)' 2>/dev/null; then
+  fail "uncontended-acquire-spawns-no-stat" "stdout did not parse as JSON with status=appended: $case7_out"
+elif [ -s "$case7_counter" ]; then
+  fail "uncontended-acquire-spawns-no-stat" "an uncontended acquire spawned stat $(wc -l < "$case7_counter" | tr -d ' ') time(s) — the probe is no longer lazy"
+else
+  pass "uncontended-acquire-spawns-no-stat" "no stat spawned on the uncontended path"
 fi
 
 if [ "$failures" -gt 0 ]; then

--- a/cogni-portfolio/tests/test-append-claim-lock.sh
+++ b/cogni-portfolio/tests/test-append-claim-lock.sh
@@ -521,12 +521,18 @@ fi
 # The counter is pre-created empty so the assertion distinguishes "the stub never
 # ran" from "the stub was never installed" — an emptiness test on a file that does
 # not exist would pass for the wrong reason.
+#
+# The ceiling prefix is behaviourally inert here — this case never enters the
+# acquire loop, which is the whole point of it — and is carried anyway so every
+# case states its own ceiling rather than inheriting the production default by
+# omission. A reader should not have to know a case never contends to know what
+# ceiling it would run under.
 case7_dir="$(seed_uncontended_project uncontended)"
 case7_stub="$TMPROOT/stub-counting-uncontended"
 case7_counter="$TMPROOT/case7.count"
 : > "$case7_counter"
 make_counting_stat_stub "$case7_stub" "$case7_counter" 'echo 0'
-case7_out="$(PATH="$case7_stub:$PATH" bash "$SCRIPT" "$case7_dir" '{"id": "claim-7"}' 2>"$TMPROOT/case7.err")"
+case7_out="$(PATH="$case7_stub:$PATH" APPEND_CLAIM_MAX_WAIT=1 bash "$SCRIPT" "$case7_dir" '{"id": "claim-7"}' 2>"$TMPROOT/case7.err")"
 case7_rc=$?
 
 if [ "$case7_rc" -ne 0 ]; then


### PR DESCRIPTION
Closes #1432.

## Summary

- `append-claim.sh` re-ran the whole `stat -c %Y || stat -f %m || echo 0` chain on **every** stale-block entry. The read now lives in a `read_lock_mtime()` helper defined before the acquire loop, which resolves the working form on first use and memoizes it in `STAT_MTIME` — so only the first entry pays the failing GNU-form exec on a BSD host, and every later entry costs a single exec. The acquire loop's body contains no `stat` invocation at all.
- The GNU-first ordering is unchanged and still the fix (`-c %Y` before `-f %m`), both probe calls keep `2>/dev/null`, and the numeric-shape floor is byte-identical and still sits between the read and the arithmetic.
- Stale-sweep re-entry is bounded by a `MAX_SWEEPS` budget, so a lock whose `rmdir` cannot succeed now reaches the existing timeout diagnostic and `exit 1` instead of sweeping forever.
- Four new suite cases, two new mutation arms; all four existing arms replayed.

## Scope decisions

**1 — Lazy memoization, not an unconditional pre-loop probe.** The issue says "resolve the working `stat` form once **before** the `while` loop". Implemented literally that regresses the hot path: when `mkdir` succeeds on the first condition test the loop body never runs, so an uncontended acquire costs exactly **one** fork and **zero** `stat`/`date` execs today. A pre-loop probe would add 1-2 forks to every one of those — the overwhelmingly common case — to save forks on a rare contended one, and would also `stat` `$LOCK_DIR`, which is not guaranteed to exist at that point (it is created only by the loop's own `mkdir`). The issue's own framing says both costs are contended-path-only, so resolving lazily on first stale-block entry delivers its intent without the regression. Case `uncontended-acquire-spawns-no-stat` pins this: an uncontended acquire must spawn zero `stat` calls.

**2 — The rmdir-fails path now terminates.** The issue left this open ("optionally reset `WAITED`, or re-check staleness every Nth iteration"). Verified against `origin/main`: the shipped script does not merely spin cheaply on that fixture, it **never returns**. `WAITED` only ever climbs, so once the ceiling test is true it stays true; the sweep's `continue` fires before the timeout branch can be reached, and an ancient lock's age only grows — so `echo … exit 1` is unreachable dead code. A `MAX_SWEEPS` budget was chosen over resetting `WAITED` because resetting merely extends the acquire budget on every sweep, leaving the loop non-terminating at a slower rate.

This **restores** the enumerated semantics rather than breaking them. The 60s threshold, the `rmdir`-then-`continue`, the timeout JSON and `exit 1` all survive textually and in the same relative order; the timeout branch becomes reachable again. The only observable change lands on a fixture that today never returns at all.

**Not changed.** The identical `stat` chains in `cogni-portfolio/hooks/ensure-excalidraw-canvas.sh` and `cogni-visual/hooks/ensure-excalidraw-canvas.sh` sit in one-shot conditionals with an atomic `mv` recovery and no enclosing retry loop, so neither shares the re-entry defect. No version bump in-branch — the post-merge workflow owns it (`check-version-bump.py`: 0 touched, 0 violations).

## Mutation recipe

All six arms **replayed** against this head (re-run, not assumed); each returned `data.verdict == guard_verified`. Run from the repo root:

```bash
bash ~/.claude/plugins/cache/managed-service/cogni-service/0.0.402/scripts/mutation-check.sh --root . --file cogni-portfolio/scripts/append-claim.sh --expr 's/STAT_MTIME="\$stat_form"/STAT_MTIME=""/' --test 'bash cogni-portfolio/tests/test-append-claim-lock.sh' --case probe-resolved-once-per-acquire
```

| # | `--expr` | `--case` | verdict |
|---|---|---|---|
| 1 | `s/lock_mtime=0/lock_mtime_unused=0/` | `stale-lock-swept-on-non-numeric-stat` | `guard_verified` |
| 2 | `s/\^\[0-9\]\+\$/^NOMATCH\$/` | `live-lock-not-swept-on-numeric-stat` | `guard_verified` |
| 3 | `s/APPEND_CLAIM_MAX_WAIT:-30/APPEND_CLAIM_MAX_WAIT_UNUSED:-30/` | `live-lock-not-swept-on-numeric-stat` | `guard_verified` |
| 4 | `s/stat -c %Y/stat -f %m/` | `live-lock-not-swept-on-gnu-stat` | `guard_verified` |
| 5 | `s/STAT_MTIME="\$stat_form"/STAT_MTIME=""/` | `probe-resolved-once-per-acquire` | `guard_verified` |
| 6 | `s/MAX_SWEEPS=3/MAX_SWEEPS=9/` | `stale-sweep-bounded-when-rmdir-fails` | `guard_verified` |

**Target uniqueness re-verified after the rewrite** — the harness's `perl -0pi` is first-occurrence-only, so a second occurrence would silently relocate an arm and let it report green while guarding nothing. `grep -c` on the post-fix script returns **1** for each of `lock_mtime=0`, `stat -c %Y`, `^[0-9]+$`, `APPEND_CLAIM_MAX_WAIT:-30`, `MAX_SWEEPS=3`, `STAT_MTIME="$stat_form"`. The extended in-script comment deliberately restates none of them.

**Arm 6 widens the bound rather than removing it,** and the suite header records that as a standing rule. Deleting `MAX_SWEEPS` — or dropping the `SWEEPS` increment — makes the *mutated* script non-terminating on case 5's fixture, so the harness would hang rather than report red; and because this suite has no per-case selector, one hanging case hangs the whole replay.

## Verification

| Check | Result |
|---|---|
| `bash cogni-portfolio/tests/test-append-claim-lock.sh` | exit 0, 7/7 cases |
| `python3 scripts/run-plugin-tests.py --filter cogni-portfolio` | exit 0, 7/7 suites |
| `python3 scripts/check-result-line-plainness.py` | exit 0 |
| `python3 scripts/check-breadcrumbs.py` | exit 0 |
| `python3 scripts/check-version-bump.py` | exit 0 — 0 touched |
| `/bin/bash -n` (3.2.57) and bash 5.3.9 `-n`, both files | exit 0 |

**Measured, not asserted** (acceptance criterion 1). Case `probe-resolved-once-per-acquire` installs a counting `stat` stub on a lock whose `rmdir` always fails, driving the full sweep budget — four stale-block entries. It records exactly **1** GNU-form call and **4** BSD-form reads. An un-memoized chain records 4 of each, which is what arm 5 reproduces. The counter lives under `$TMPROOT`, never in the stub directory, whose one-file invariant is what keeps `date` and `python3` resolving to the real binaries; each case carries its own counter so counts cannot bleed between them.

**Suite runtime** grew from ~1.6s to ~4.0s (measured via `run-plugin-tests.py`, and the header prose was re-measured to match rather than left claiming "around a second"). Still well under the ~7.3s this suite cost before the ceiling became overridable. Cases 4 and 5 carry most of the increase; the header records that folding them into one invocation would recover about half if the budget ever needs tightening.

**Foreign output is asserted by shape throughout** — exit status, `[ -s ]` stream emptiness, numeric counts. Only `append-claim.sh`'s own literals (`Could not acquire lock on claims.json after 0.1s`) are text-matched, since bash and coreutils diagnostics are gettext-localized and an English grep passes vacuously off an English-locale host.

## Note on the token-scope preflight

`check-token-scope.sh --strict` exits 1 on this runner: the token is the `gho_` token from `gh auth login`, whose scope set is fixed by the GitHub CLI OAuth app and cannot be narrowed (extra scopes `gist`, `read:org`, `workflow`). The push proceeded under the documented `--allow-overscoped` opt-out, so this branch was **not** pushed under the least-privilege posture.

## Self-grade against the issue-time contract

The branch was graded against the 22-item acceptance contract committed on #1432 at triage time (`derivedAt 2026-08-17T23:21:51Z`, before any branch was cut). 20 items came back satisfied on the first pass; two were violated and both were fixed in `812b8a9d`:

- **The loop body must hold exactly one `stat` invocation, or none if the read is delegated to a helper.** The first pass left two call sites inline — the first-use probe and the memoized read — meeting neither count. The read moved wholesale into `read_lock_mtime()`; the loop body's non-comment `stat` count is now **0**. A relocation, not a behaviour change: same candidate list, same GNU-first order, same memo, same `false` sentinel, same stderr redirects.
- **Every new case must carry its own `APPEND_CLAIM_MAX_WAIT` prefix.** The uncontended case had none. It now carries one, with a comment recording that the prefix is behaviourally inert there (that case never enters the acquire loop) and is present so no case inherits the production default by omission.

All six mutation arms were **re-replayed after the move**, since it relocates the literals two of them target; each still returns `guard_verified`, and every target still occurs exactly once.

No item was graded `unclear`, so nothing is left residual for the merger.

## Open questions

None.
