### PR TITLE
cogni-portfolio: record append-claim.sh's three guard rationales

### DIFF
--- a/cogni-portfolio/scripts/append-claim.sh
+++ b/cogni-portfolio/scripts/append-claim.sh
@@ -8,6 +8,9 @@
 # Env: APPEND_CLAIM_MAX_WAIT — lock-acquire ceiling in 0.1s ticks. Unset means
 # the production default of 30 ticks (3s); tests set a small value so they can
 # drive the timeout path in fractions of a second.
+# The duration the timeout diagnostic prints is DERIVED from that ceiling and
+# never restates a fixed number, so the message cannot outlive a change to the
+# ceiling it reports on.
 # Exit codes: 0 = success, 1 = error
 set -euo pipefail
 
@@ -32,9 +35,36 @@ MAX_WAIT="${APPEND_CLAIM_MAX_WAIT:-30}"
 # comparison below a hard error mid-loop. Regex unquoted on purpose — a quoted
 # right-hand side matches literally on bash 3.2, which this repo still targets.
 # The `||` form keeps a non-match from tripping `set -e`.
+#
+# The `[1-9]` lead is deliberate and must NOT be harmonised with the plain-digit
+# floor the stale-lock reading further down uses. A value like 08 or 030
+# satisfies a plain-digit pattern, and arithmetic expansion then reads the
+# leading zero as octal — a hard error, which under `set -e` aborts the script
+# outright. The two patterns look inconsistent because they guard different
+# inputs; unifying them reintroduces that abort on the very values this floor
+# exists to reject.
+#
+# Zero is excluded on the same line for its own reason. The loop below sleeps
+# BEFORE its first -ge check, so a ceiling of 0 and a ceiling of 1 both mean
+# exactly one 0.1s poll — 0 buys no fail-immediately semantics, and it would
+# render a misleading `after 0s` for a path that did in fact wait.
 [[ "$MAX_WAIT" =~ ^[1-9][0-9]*$ ]] || MAX_WAIT=30
 # Derive the diagnostic's number from the ceiling rather than restating it, so
 # the message can never claim a wait the loop no longer honours.
+#
+# The arithmetic is written as ASSIGNMENTS, never as a bare `(( ... ))` command.
+# A bare arithmetic command whose expression evaluates to 0 returns exit status
+# 1, and the default ceiling of 30 ticks makes the remainder exactly 0 — so that
+# form aborts under `set -e` on bash 5.x while passing on 3.2. A version-divergent
+# failure on the DEFAULT path, which is the one every production caller takes.
+#
+# The computation sits at TOP LEVEL, before the acquire loop, and that placement
+# is load-bearing rather than incidental. An arithmetic abort *inside* the loop
+# is the failure the stale-lock block's own comment further down documents: the
+# error abandons the loop body AND the loop, so the script resumes after `done`
+# and appends the claim having never held the lock — after which the release trap
+# removes a live peer's lock directory it never owned. Up here the same abort is
+# a clean exit, before any lock is taken and before that trap is installed.
 TIMEOUT_LABEL="$(( MAX_WAIT / 10 )).$(( MAX_WAIT % 10 ))"
 TIMEOUT_LABEL="${TIMEOUT_LABEL%.0}"
 WAITED=0


### PR DESCRIPTION
Closes #1448.

## Summary

Comment-only. Three guards in `cogni-portfolio/scripts/append-claim.sh` were correct but unexplained, so they read as arbitrary and a harmonising "cleanup" was the obvious next edit. This records the reasoning next to each one.

- **The shape floor** now names the octal-abort hazard behind its leading `[1-9]`, states explicitly that it must **not** be harmonised with the plain-digit floor the stale-lock reading further down uses, and records why zero is excluded on the same line (the loop sleeps *before* its first `-ge` check, so a ceiling of 0 and of 1 both mean exactly one 0.1s poll, and 0 would render a misleading `after 0s` for a path that did wait).
- **The label derivation** now names the bare-arithmetic-command hazard: such a command whose expression evaluates to 0 returns exit status 1, and the default ceiling of 30 ticks makes the remainder exactly 0 — so that form aborts under `set -e` on bash 5.x while passing on 3.2, a version-divergent failure on the **default** path every production caller takes.
- **That derivation's top-level placement** now names the in-loop consequence the stale-lock block already documents: an arithmetic abort inside the loop abandons the loop body and the loop, resumes after `done`, appends the claim having never held the lock, and lets the release trap remove a live peer's lock directory. Up top the same abort is a clean exit before any lock is taken.
- **The header** gains the clause an earlier review flagged and the maintainer waived: the duration the timeout diagnostic prints is *derived* from the ceiling and never restates a fixed number.

30 added lines, all comments. Zero executable lines changed, zero lines removed.

## Anchor safety — the load-bearing constraint the issue does not state

`cogni-portfolio/tests/test-append-claim-lock.sh` records six mutation arms, each asserting its expression's anchor occurs **exactly once** in `append-claim.sh`, and the harness substitutes with a whole-file slurp and a **non-global** match — so only the first occurrence top-to-bottom is replaced.

All four edits here sit *earlier* in the file than every anchor site. New prose that reproduced an anchor literal would therefore silently hijack that arm: the real code line survives untouched, the mutated script behaves identically, the named case stays green, and the arm reports as un-caught — while also falsifying the suite's own uniqueness claims. A guard that silently stops guarding, with everything green.

Every cross-reference in the new comments is consequently written **by description** ("the plain-digit floor the stale-lock reading further down uses"), never by reproducing the referenced token. All six anchors still occur exactly once — verified below.

## Verification

- `python3 scripts/run-plugin-tests.py --filter cogni-portfolio` → **7/7 suites pass**, exit 0.
- `bash -n cogni-portfolio/scripts/append-claim.sh` → exit 0.
- Comment-only shape: added non-comment lines **0**, removed lines **0**.
- Anchor uniqueness: each of the six recorded anchors returns **1** on the head file.
- No breadcrumbs: no issue/PR reference in the file.
- No version field touched — the post-merge workflow owns the bump.
- **Mutation replay run, not just described.** The arm this diff sits closest to was replayed verbatim: `mutated_result: red`, `restored_result: green`, `verdict: guard_verified`. The do-not-harmonise prose did not absorb the substitution.

## A note on acceptance criterion 4

AC 4 asks the lock suite to stay "under 2s". The suite's own measured header note records it near four seconds ("measured, not estimated"), so that figure is stale and fails against **unmodified** base code — a comment-only diff can neither hit nor miss it. The bar discharged here is no-regression instead, measured both ways: **3.63s on `origin/main`, 3.63s on this branch**.

This is a defect in the issue's acceptance bar, not in the change — flagged rather than silently satisfied or silently failed.

## Mutation recipe

Runnable as written from the repo root:

```
bash ~/.claude/plugins/cache/managed-service/cogni-service/0.0.402/scripts/mutation-check.sh --root . --file cogni-portfolio/scripts/append-claim.sh --expr 's/\^\[0-9\]\+\$/^NOMATCH\$/' --test 'bash cogni-portfolio/tests/test-append-claim-lock.sh' --case live-lock-not-swept-on-numeric-stat
```

Expected: the case goes red under the mutation and green when restored. If a newer harness version directory exists under the same parent, use it — everything after the path is version-independent.