### PR TITLE
cogni-workspace: repair the layering-guard survivor inventory citations

### DIFF
--- a/cogni-workspace/references/absorption-roadmap.md
+++ b/cogni-workspace/references/absorption-roadmap.md
@@ -370,8 +370,8 @@ would fail on arrival.
 **Decision.** The "Phrase-level survivors" inventory in the header of
 `cogni-workspace/tests/test-layering-claim-reconciled.sh` **may only name files
 that exist in the current tree**. Three of its entries quoted course and workflow
-prose from a plugin retired into its adopting plugin; all three are **dropped,
-not repointed**. The historical inventory tables under
+prose from `cogni-help`, retired into its adopting plugin; all three are
+**dropped, not repointed**. The historical inventory tables under
 `## Known remaining contradictions — reconciled` keep their retired paths intact
 and are not touched.
 

--- a/cogni-workspace/references/absorption-roadmap.md
+++ b/cogni-workspace/references/absorption-roadmap.md
@@ -364,3 +364,41 @@ state: a forbidden-literal scan over the paths above, plus per-page byte-parity
 between the two wiki trees. Parity is asserted **per touched page**, never
 tree-wide — the trees legitimately differ by one page, so a tree-wide assertion
 would fail on arrival.
+
+## Decision 8 — retired-plugin phrasing leaves a live survivor inventory but stays in the historical tables
+
+**Decision.** The "Phrase-level survivors" inventory in the header of
+`cogni-workspace/tests/test-layering-claim-reconciled.sh` **may only name files
+that exist in the current tree**. Three of its entries quoted course and workflow
+prose from a plugin retired into its adopting plugin; all three are **dropped,
+not repointed**. The historical inventory tables under
+`## Known remaining contradictions — reconciled` keep their retired paths intact
+and are not touched.
+
+**Why the two surfaces diverge.** The discriminator is what each surface asserts.
+A survivor inventory is a **live claim about what is standing right now** — it
+exists to explain why a forbidden literal is worded the way it is, and a reader
+who follows one of its citations expects to land on a line the scan deliberately
+leaves alone. The reconciled-contradictions tables assert something else
+entirely: they are an audit record of the pre-reconciliation state, which is why
+that section says the table is kept as the historical inventory rather than
+deleted, so the set stays auditable. Rewriting a dated record to reach a cosmetic
+zero falsifies history — the failure Decision 7 already rejects. Dropping a live
+citation that resolves to nothing does the opposite: it removes a claim that is
+no longer true.
+
+**Why dropped rather than repointed.** There is no successor to point at. The
+three files named — a full-onboarding module, an install-to-infographic tour, and
+a canonical-workflows page — are absent from the tree, and each phrase they
+quoted ("the workspace provides the foundation", "builds on this foundation",
+"the workspace + theme + MCP foundation") occurs nowhere else in the repo. The
+bundled wiki carries a similarly-named workflow page, but it contains none of
+that prose, so repointing there would swap a dead citation for a false one — the
+worse of the two, because a false citation reads as verified.
+
+**The two surviving entries are de-numbered rather than corrected.** Both had
+drifted by one line as the files above them grew. Correcting the numbers would
+have restored the citations only until the next edit; quoting the distinctive
+text instead makes the quote the locator, which cannot drift. This follows the
+same reasoning the block already applies to the `index.md` bullet it identifies
+by wikilink because the two wiki trees number it differently.

--- a/cogni-workspace/tests/test-layering-claim-reconciled.sh
+++ b/cogni-workspace/tests/test-layering-claim-reconciled.sh
@@ -6,8 +6,9 @@
 # LAYERING claim (cogni-workspace is the layer everything depends on) with a
 # SCOPE claim (it is the horizontal layer; each vertical business plugin keeps
 # its own project lifecycle). The claim was asserted in 19 places across docs/,
-# both wiki trees, cogni-help and cogni-workspace, and reconciling them by hand
-# is only durable if something notices when one comes back. Nothing did:
+# both wiki trees, a since-retired plugin and cogni-workspace, and reconciling
+# them by hand is only durable if something notices when one comes back. Nothing
+# did:
 # test-wiki-namespace-sync.sh checks filename stems against the marketplace
 # roster and never reads page prose, and no suite anywhere compares the two wiki
 # trees against each other. A regenerated doc or a re-imported wiki page could
@@ -45,17 +46,24 @@
 # Phrase-level survivors. These lines keep foundation vocabulary on purpose and
 # must NOT be caught. Each says something about the workspace *state* other
 # plugins read, never about the plugin's position in a dependency order, so none
-# is falsified by the scope claim:
+# is falsified by the scope claim. Each is cited by its quoted text rather than
+# by a line number: the quote is the locator, so an edit above it cannot rot the
+# citation the way a number does.
 #
-#   - manage-workspace/SKILL.md:23 — "An insight-wave workspace is the shared
+#   - manage-workspace/SKILL.md — "An insight-wave workspace is the shared
 #     foundation that all marketplace plugins depend on" (subject is the
 #     workspace, not cogni-workspace)
-#   - workspace-dashboard/SKILL.md:24 — "the foundation that every other plugin
+#   - workspace-dashboard/SKILL.md — "the foundation that every other plugin
 #     reads from" (reads from, not depends on)
-#   - cogni-help full-onboarding.md:26 — "the workspace provides the foundation"
-#   - cogni-help tour-install-to-infographic.md — "builds on this foundation" /
-#     "the workspace + theme + MCP foundation" (bootstrap ordering among
-#     workflows, which the scope claim permits)
+#
+# Two further entries once sat in this list, and a third such citation in the
+# paragraph below, quoting course and workflow prose from a plugin since retired
+# from the marketplace roster. All three are dropped rather than repointed: the
+# files they named are gone from the tree, and the phrases they quoted survive
+# nowhere else, so no page is left to point at. This inventory is a claim about
+# what is standing in the current tree, so it may only name things that exist —
+# the retired paths stay recorded in the historical tables of
+# references/absorption-roadmap.md, whose Decision 8 states the reasoning.
 #
 # This list is why the shared-foundation literal below is prefixed with the
 # plugin name: the bare "is the shared foundation" also matches the first entry,
@@ -69,8 +77,7 @@
 # the cogni-workspace skills heading of each wiki tree's index.md (identified
 # by wikilink rather than line number: the two trees number that bullet
 # differently, so no single line number is right for both), and into both
-# skill-cogni-workspace-manage-workspace.md:16; cogni-help
-# canonical-workflows.md:11 has its own. Those are
+# skill-cogni-workspace-manage-workspace.md:16. Those are
 # all the same compatible claim about workspace state, and no literal here
 # targets them. Grepping "foundation" will surface hits this block does not
 # account for; that is expected, and the test is whether the sentence asserts a


### PR DESCRIPTION
Closes #1462.

## Summary

- **De-number the two live survivor citations** in the `test-layering-claim-reconciled.sh` header block (`manage-workspace/SKILL.md`, `workspace-dashboard/SKILL.md`). Both were off by one — `:23`/`:24` cited, `:22`/`:23` actual. The verbatim quote becomes the locator, so they cannot drift again.
- **Drop the three clauses citing a retired plugin's** `full-onboarding.md`, `tour-install-to-infographic.md` and `canonical-workflows.md`. None of those files exists at `origin/main`, and the phrases they quoted (`the workspace provides the foundation`, `builds on this foundation`, `the workspace + theme + MCP foundation`) appear nowhere else in the tree — there is no repoint target.
- **Reword the one remaining retired-plugin mention** in the "Why this exists" paragraph so the header names no plugin that has left the 9-plugin roster. The count of 19 and the fact that a retired plugin carried some of those assertions both survive.
- **Record the decision as `## Decision 8`** in `cogni-workspace/references/absorption-roadmap.md`: retired-plugin phrasing is dropped from a live survivor inventory but kept in the historical tables, because a live inventory is a claim about the current tree while the tables are an audit record of a past one.

Plan record: https://github.com/cogni-work/insight-wave/issues/1462#issuecomment-5323253787

## Scope decisions

- **Comment-only in the guard.** Every added and removed line in the test file begins with `#`. `FORBIDDEN`, `EXCLUDED`, `PAGE_PARITY`, the L1–L9 case bodies and the `l2_n -lt 14` count floor are byte-identical; nothing from `set -u` onward is touched.
- **De-numbered rather than re-pointed to `:22`/`:23`.** The same block already de-numbers the `index.md` wikilink bullet for exactly this reason. Correcting the numbers would restore the citations only until the next edit above them. Quotes are kept verbatim and untruncated, since a de-numbered citation is only durable while the quote is the locator.
- **Dropped rather than re-pointed for the retired-plugin clauses.** The bundled wiki's `workflow-full-onboarding.md` resembles one of the filenames but carries none of the quoted prose, so re-pointing there would swap a dead citation for a false one — the worse failure, because a false citation reads as verified.
- **The plugin-prefix rationale survives unchanged** and its referent still resolves: `manage-workspace` is still the first survivor entry, so "the bare `is the shared foundation` also matches the first entry" remains true. That sentence is load-bearing — losing it invites a later editor to un-prefix the FORBIDDEN literal and turn L1 red against a line that is deliberately standing.
- **The ILLUSTRATIVE paragraph keeps a non-empty enumeration** — the manage-workspace frontmatter (`:4`, `:10`), the wikilink-identified `index.md` bullet, and both copies of `skill-cogni-workspace-manage-workspace.md:16` — so its closing "Those are all the same compatible claim" still has a referent.
- **One edit sits outside the two ranges the issue names:** the retired-plugin mention in the opening paragraph. It is inside the same leading comment block and is required for the header to stop naming a plugin that does not exist. Calling it out here rather than letting it read as scope creep.
- **`Decision 8` is appended, never interleaved** — that leaves the reconciled-contradictions section unshifted, so no existing citation into that file rots. It cites that section **by heading and by phrase, not by line number**, since this PR exists to remove rotten line citations and a fresh `301-302` citation would reintroduce the same class.
- **Deliberately out of scope:** editing `manage-workspace/SKILL.md` or `workspace-dashboard/SKILL.md` to move a sentence onto a cited line (that inverts the fix); rewriting the roadmap's historical inventory tables; any version or manifest change.

## Verification run

All measured on this branch:

- `bash cogni-workspace/tests/test-layering-claim-reconciled.sh` → exit 0, nine `PASS:` lines (L1–L9), no `FAIL:`
- `python3 scripts/run-plugin-tests.py --filter cogni-workspace` → exit 0
- `python3 scripts/check-result-line-plainness.py` → exit 0, 0 violations across 122 discovered suites
- `python3 scripts/check-breadcrumbs.py` → exit 0
- `python3 scripts/check-version-bump.py` → exit 0, 0 plugins touched
- `grep -c 'cogni-help' cogni-workspace/tests/test-layering-claim-reconciled.sh` → `0`
- `grep -n 'manage-workspace/SKILL.md:23'` and `grep -n 'workspace-dashboard/SKILL.md:24'` → no output
- `git diff -U0 -- <test file> | grep -E '^[+-][^+-]' | grep -v '^[+-]#'` → empty (every changed line is a comment)
- `git diff --numstat -- cogni-workspace/references/absorption-roadmap.md` → `38 0` (additions only)
- Both surviving citations resolve: the quotes sit at `manage-workspace/SKILL.md:22` and `workspace-dashboard/SKILL.md:23`

## Mutation recipe

```bash
bash ~/.claude/plugins/marketplaces/managed-service/cogni-service/scripts/mutation-check.sh --root . --file cogni-workspace/tests/test-layering-claim-reconciled.sh --expr 's/^foundation layer\n//m' --test 'bash cogni-workspace/tests/test-layering-claim-reconciled.sh' --case 'L2'
```

Replayed on this branch before opening the PR: `verdict: guard_verified` (`mutated_result: red`, `restored_result: green`).

Removing the `foundation layer` entry from `FORBIDDEN` takes `l2_n` to 13, under the `-lt 14` floor, so case L2 turns red — proving the count floor this PR must not disturb is still live. The expression anchors at line start with `/m` (`perl -0pi` slurps the file) and matches **exactly one** line — 149, the `FORBIDDEN` entry. The other four occurrences of the phrase are non-matching by construction: line 3 is `# foundation layer` (comment-prefixed), and lines 361/465/481 are indented fixture `printf`s. The arm is therefore not vacuous.

## Pipeline notes

- **`/simplify` (Step 6.4) was skipped, with reason, not silently passed.** Its remit is code-only, and this diff contains no code — the comment-only assertion above is mechanical proof, and the only other change is 38 added markdown lines. The prose-simplify pass (6.4b) and the skill-quality gate (6.5) are genuine no-ops here: no `SKILL.md` and no `agents/*.md` is touched.
- **The token-scope preflight is over-scoped, not clean.** `check-token-scope.sh --strict` exits 1 on `gist, read:org, workflow`; the runner is on a `gho_` token whose scope set the GitHub CLI OAuth app fixes and which cannot be narrowed. The push proceeded under the script's own documented `--allow-overscoped` opt-out (exit 0). Flagging it rather than letting the green exit code imply a clean posture.