### PR TITLE
cogni-workspace: clear the install-mcp move's advisory findings

### DIFF
--- a/cogni-workspace/references/mcp-git-registry.json
+++ b/cogni-workspace/references/mcp-git-registry.json
@@ -38,7 +38,7 @@
       },
       "env": {},
       "provides_tools": ["get_editor_state", "batch_design", "batch_get", "get_guidelines", "open_document", "get_screenshot"],
-      "required_by": ["cogni-visual"],
+      "required_by": ["cogni-visual", "cogni-website"],
       "notes": "Pencil desktop app with bundled MCP server. Must have Pencil.app installed. The MCP binary path is platform-specific."
     }
   }

--- a/cogni-workspace/skills/install-mcp/SKILL.md
+++ b/cogni-workspace/skills/install-mcp/SKILL.md
@@ -1,20 +1,19 @@
 ---
 name: install-mcp
 description: >-
-  End-to-end MCP server installation for the insight-wave ecosystem — clone and
-  build git-based MCPs, configure native app MCPs, and write the server into the
-  user's own config (`~/.claude.json` for Claude Code, `claude_desktop_config.json`
-  for Claude Desktop) so everything works without manual JSON editing. Use this
-  skill whenever the user mentions MCP installation, MCP setup, MCP configuration,
-  "my MCPs aren't working", "set up excalidraw", "install MCP servers", "MCP not
-  found", "excalidraw tools not available", "excalidraw tools missing in Claude
-  Code", "MCP not loaded", "mcpServers missing in ~/.claude.json", "pencil MCP not
-  working", port conflicts with MCP servers (localhost:3000), or any mention of
-  claude_desktop_config.json.
-  Also trigger when manage-workspace needs to handle its MCP installation step
-  (step 5), when workspace-status reports MCP servers as not loaded and the user
-  wants to fix it, or when a rendering skill (story-to-infographic, story-to-web)
-  fails because its MCP dependency is missing.
+  End-to-end MCP server installation for the insight-wave ecosystem — clone and build
+  git-based MCPs, configure native app MCPs, and write the server into the user's own
+  config for Claude Code or Claude Desktop without manual JSON editing. Use this skill
+  whenever the user mentions MCP installation, MCP setup, MCP configuration, "my MCPs
+  aren't working", "set up excalidraw", "install MCP servers", "update MCP servers",
+  "patch desktop config", "MCP not found", "excalidraw tools not available", "excalidraw
+  tools missing in Claude Code", "MCP not loaded", "mcpServers missing in
+  ~/.claude.json", "pencil MCP not working", port conflicts with MCP servers
+  (localhost:3000), or any mention of claude_desktop_config.json. Also trigger when
+  manage-workspace needs to handle its MCP installation step (step 5), when
+  workspace-status reports MCP servers as not loaded and the user wants to fix it, or
+  when a rendering skill (story-to-infographic, story-to-web) fails because its MCP
+  dependency is missing.
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep, AskUserQuestion, ToolSearch
 ---
 
@@ -53,6 +52,10 @@ Determine the user's runtime environment — this affects what needs patching:
    - **Claude Desktop** — needs the git install AND a `--target desktop` write.
    - **Both** — Desktop config exists alongside CLI usage. Use `--target both`.
 
+Record the classification as `MCP_TARGET`, whose only legal values are `cli`, `desktop`
+and `both`. The write step below sets and consumes it in a single shell — each invocation
+gets a fresh environment, so an assignment made here would not survive to reach it.
+
 Report which environment was detected before proceeding.
 
 ## Discover What's Needed
@@ -64,8 +67,8 @@ REGISTRY="${CLAUDE_PLUGIN_ROOT}/references/mcp-git-registry.json"
 cat "$REGISTRY"
 ```
 
-Cross-reference against installed plugins. There are three ways to determine installed plugins,
-in order of preference:
+Cross-reference against installed plugins, determined one of three ways in order of
+preference:
 
 1. **During manage-workspace** — the confirmed plugin list is already available from step 2
    (the user-confirmed list, not step 1's raw discovery output)
@@ -94,12 +97,14 @@ list. Only install servers that have at least one requiring plugin present.
 Present the installation plan to the user before executing:
 
 Name the config that will actually be written, taken from the environment detected
-above — one line per target, so a `both` run shows both:
+above — one line per target, so a `both` run shows both. The block below is illustrative;
+each server's requiring plugins come from its `required_by` in the registry, never from
+this example:
 
 ```
 MCP Installation Plan:
   mcp_excalidraw  git clone + build    needed by: cogni-visual, cogni-portfolio
-  pencil          native app check     needed by: cogni-visual
+  pencil          native app check     needed by: cogni-visual, cogni-website
 
   Config write:    ~/.claude.json (Claude Code user scope)
   Config write:    claude_desktop_config.json (Claude Desktop)
@@ -128,9 +133,11 @@ bash "${CLAUDE_PLUGIN_ROOT}/scripts/install-mcp.sh" \
   $WRAPPER_ARG
 ```
 
-The script outputs JSON — parse `success` and `data.action` to report what happened
-(installed / skipped / updated / failed). If any server fails, continue with the rest
-but flag the failure clearly.
+The script outputs JSON. On success, `data.action` is `installed` (fresh clone),
+`updated` (a `--force` refetch), `rebuilt` (already cloned but unbuilt, so the build
+reran) or `skipped` (already built). A failure carries no `action` at all — it reports
+`success: false` with the cause in `data.error` — so branch on `success` before reaching
+for `action`. If any server fails, continue with the rest but flag the failure clearly.
 
 To force-update an already-installed server (e.g. after upstream changes), add `--force`.
 
@@ -149,29 +156,42 @@ Run this **after** the git install succeeds — the writer resolves each server'
 wrapper, and reports `skipped: not installed` rather than writing an entry that points at
 a path which does not exist yet.
 
-Pass `--target` for the environment detected above (`desktop`, `cli`, or `both`), and
-scope every invocation with `--server` so only the servers the plan actually named are
-written — repeating the flag once per server (`--server mcp_excalidraw --server pencil`),
-because it appends rather than splitting a comma-separated value, so a CSV filters on a name
-no registry entry has and the run writes nothing while still reporting success. An unrequested entry is another server spawned at every session or app start,
-which is the condition this whole arrangement exists to avoid — for either target. The
-script's name predates its remit: despite `desktop` in the file name it writes either
-config, selected by `--target`, so a `--target cli` invocation writing `~/.claude.json`
-is correct and not a copy-paste slip. Dry-run first:
+With `MCP_TARGET` set to the environment classified above:
+
+- Pass `--target "${MCP_TARGET}"`.
+- The script's name predates its remit: despite `desktop` in the file name it writes
+  either config, selected by `--target`, so a `--target cli` run writing
+  `~/.claude.json` is correct and not a copy-paste slip.
+- Scope every invocation to the servers the plan named. An unrequested entry is another
+  server spawned at every session or app start, which is what this arrangement exists
+  to avoid — for either target.
+- Repeat `--server` once per server (`--server mcp_excalidraw --server pencil`). The
+  flag appends rather than splitting a comma-separated value, so a CSV is read as one
+  server name, matches no registry entry, and the run exits non-zero with
+  `Unknown server(s) in registry: ...` having written nothing.
+
+Dry-run first:
 
 ```bash
+MCP_TARGET="<cli|desktop|both, as classified above>"
+
 python3 "${CLAUDE_PLUGIN_ROOT}/scripts/patch-desktop-config.py" \
   --registry "${CLAUDE_PLUGIN_ROOT}/references/mcp-git-registry.json" \
-  --target desktop --server mcp_excalidraw \
+  --target "${MCP_TARGET}" --server mcp_excalidraw \
   --dry-run
 ```
+
+Substitute the classified value for the placeholder; carried through as written, argparse
+rejects it rather than silently writing the wrong host's config. Keep the assignment in the
+same invocation as the command — a separate one starts a fresh shell and `${MCP_TARGET}`
+expands empty.
 
 Show the user what would change. If they confirm (or if running non-interactively from
 manage-workspace), run again without `--dry-run`.
 
-For a Claude Code CLI environment, use the same command with `--target cli` — dry-run first,
-then confirm, exactly as above — which writes the user-scope entry in `~/.claude.json`. Use
-`--target both` to write both configs in one run.
+The same command covers every environment, because `MCP_TARGET` carries the detection:
+`cli` writes the user-scope entry in `~/.claude.json`, `desktop` writes
+`claude_desktop_config.json`, and `both` writes each in turn.
 
 **Reading the result depends on the target.** A single-target run reports a flat
 `data.action` and `data.config_path`. `--target both` reports neither at the top level —
@@ -179,9 +199,11 @@ it returns `data.targets[]`, one `{target, action, config_path, actions}` object
 config. Branch on the target before reading the envelope, or a `both` run parses as
 though nothing happened.
 
-In both shapes the **per-server** detail is `actions[]` — `{server, action: added | updated
-| skipped, reason}` — while the target-level `action` is `patched`, `noop` (nothing needed)
-or `dry_run`. Build the Summary rows below from `actions[]`, not from the target-level
+In both shapes the **per-server** detail is `actions[]`. Every entry carries `server` and
+`action` (`added`, `updated` or `skipped`); an `added` or `updated` entry also carries
+`config_key`, and only a `skipped` entry carries `reason` — so do not expect `reason` on
+every entry. The target-level `action` is `patched`, `noop` (nothing needed) or
+`dry_run`. Build the Summary rows below from `actions[]`, not from the target-level
 verb, or every server collapses into one row and a `noop` reads as a failure.
 
 The script:
@@ -199,19 +221,13 @@ that wrote them.
 
 ## Verify Installation
 
-After installation and patching, verify that MCP servers are actually available in the
-current session. Use ToolSearch to probe for MCP tool prefixes:
+After installation and patching, verify that MCP servers are available in the current
+session. For each server just installed, use ToolSearch to probe for its tool prefix:
 
 | Server | Probe Tool |
 |--------|-----------|
 | excalidraw | `mcp__excalidraw__describe_scene` |
 | pencil | `mcp__pencil__get_editor_state` |
-
-For each server that was just installed:
-
-```
-Use ToolSearch to search for the probe tool.
-```
 
 Report status:
 - **Loaded** — tools found, server is active
@@ -226,15 +242,17 @@ described above.
 Present a compact result:
 
 Name the config actually written, and follow the target for the restart line — a CLI
-write needs a new Claude Code session, not a Claude Desktop restart:
+write needs a new Claude Code session, not a Claude Desktop restart. The Action cell is
+the `action` verb taken verbatim from that target's `actions[]` (`added`, `updated` or
+`skipped`), never a label composed here:
 
 ```
 MCP Installation Complete:
 
   Server            Action          Config Written    Status
   ────────────────  ──────────────  ────────────────  ──────────
-  mcp_excalidraw    installed       ~/.claude.json    loaded
-  pencil            binary found    ~/.claude.json    loaded
+  mcp_excalidraw    added           ~/.claude.json    not loaded
+  pencil            added           ~/.claude.json    not loaded
 
   Backup: ~/.claude.backup-20260409T...json
   Next: start a new Claude Code session if any servers show "not loaded"
@@ -246,8 +264,8 @@ Under `--target both`, give each config its own row per server (reading each ent
 ```
   Server            Action          Config Written               Status
   ────────────────  ──────────────  ───────────────────────────  ──────────
-  mcp_excalidraw    installed       ~/.claude.json               loaded
-  mcp_excalidraw    installed       claude_desktop_config.json   not loaded
+  mcp_excalidraw    added           ~/.claude.json               loaded
+  mcp_excalidraw    added           claude_desktop_config.json   not loaded
 
   Backup: ~/.claude.backup-20260409T...json
   Backup: claude_desktop_config.backup-20260409T...json
@@ -257,8 +275,8 @@ Under `--target both`, give each config its own row per server (reading each ent
 
 ## When Called from manage-workspace
 
-manage-workspace delegates its MCP step (Init and Update mode step 5) to this skill. When invoked as
-part of workspace init or update:
+manage-workspace delegates its MCP step (Init and Update mode step 5) to this skill.
+When invoked that way:
 
 - Skip the plugin discovery step (use the confirmed plugin list from manage-workspace)
 - Skip the user confirmation of the plan (manage-workspace already has user consent)

--- a/cogni-workspace/skills/install-mcp/evals/evals.json
+++ b/cogni-workspace/skills/install-mcp/evals/evals.json
@@ -16,7 +16,7 @@
     {
       "id": 3,
       "prompt": "I want to update all my MCP servers to their latest versions. The excalidraw canvas has been buggy.",
-      "expected_output": "Should run install-mcp.sh with --force to pull latest and rebuild, then re-patch Desktop config if needed. Should verify the updated server loads correctly.",
+      "expected_output": "Should run install-mcp.sh with --force to pull latest and rebuild, then re-run patch-desktop-config.py against the environment detected in this session \u2014 the --target follows that detection rather than assuming Desktop \u2014 scoping the write with --server repeated once per server, never a comma-separated value. Should verify the updated server loads correctly and follow the target for the restart advice.",
       "files": []
     },
     {

--- a/cogni-workspace/skills/manage-workspace/SKILL.md
+++ b/cogni-workspace/skills/manage-workspace/SKILL.md
@@ -142,21 +142,26 @@ when called from here (no extra user confirmations needed).
 After install-mcp completes, read
 `${CLAUDE_PLUGIN_ROOT}/references/mcp-git-registry.json` — anchored because at this point
 in the flow the working directory is the user's workspace target, not the plugin root —
-for the installable server set, and present a combined summary. The registry covers only
-the servers install-mcp can write (`mcp_excalidraw`, `pencil`); claude-in-chrome is a
-Chrome extension the user installs themselves and has no registry entry. Show a row only
+for the installable server set, and present a combined summary. The registry is what says
+which servers install-mcp can write, so read the set from it rather than assuming a fixed
+pair — a server added there is installable without touching this skill. claude-in-chrome
+is the one ecosystem MCP with no registry entry: a Chrome extension the user installs
+themselves. Show a row only
 for a registry server whose `required_by` intersects the plugin list confirmed in step 2 —
 install-mcp installs nothing for an absent plugin — and take each row's action and status
-verbatim from install-mcp's returned summary rather than from the registry. Label each row
-with the entry's `desktop_config_key` — `excalidraw` for the registry server
-`mcp_excalidraw`, `pencil` for `pencil` — because that key is what lands in the user's
-config and what the `mcp__<key>__*` tool names derive from; do not label the row with the
-registry server name. The block below is illustrative:
+verbatim from install-mcp's returned summary rather than from the registry. The Action
+cell is the per-server `action` verb exactly as `actions[]` carries it — `added`,
+`updated` or `skipped` — never a label composed here; composing one reports a write for a
+server the writer may have skipped. Label each row
+with the entry's `desktop_config_key` as the registry gives it (the server
+`mcp_excalidraw` labels as `excalidraw`, for example), because that key is what lands in
+the user's config and what the `mcp__<key>__*` tool names derive from; do not label the
+row with the registry server name. The block below is illustrative:
 
 ```
 MCP Servers (installed on demand, written to your config):
-  excalidraw       git-installed + config written    <- cogni-visual, cogni-portfolio
-  pencil           native app + config written       <- cogni-visual
+  excalidraw       added      loaded       <- cogni-visual, cogni-portfolio
+  pencil           skipped    not loaded   <- cogni-visual, cogni-website
 
 Manual install needed:
   claude-in-chrome Chrome extension                  <- cogni-website, cogni-workspace
@@ -166,6 +171,15 @@ The row-selection rule above covers registry servers only. Show the `Manual inst
 row when the plugin list confirmed in step 2 includes `cogni-website` or `cogni-workspace`;
 that pairing is fixed here rather than read from the registry, since `claude-in-chrome` has
 no registry entry to supply it.
+
+install-mcp does not always return per-server rows, and there is nothing to render when it
+does not. Two shapes produce that: a `--target both` run that fails on its first target
+returns `success: false` carrying `error` and `target` but no `targets[]`/`actions[]`, and
+a config whose backup cannot be created exits with no JSON envelope at all. In either
+case, render no rows rather than inventing them: report the affected servers as not
+configured, surface the raw error and the target it names when there is one, and send the
+user to `/cogni-workspace:install-mcp` to finish the write before treating workspace setup
+as complete.
 
 Newly written servers load only after a session restart — relay install-mcp's restart
 reminder in the summary rather than presenting "config written" as a finished state.

--- a/cogni-workspace/skills/workspace-status/SKILL.md
+++ b/cogni-workspace/skills/workspace-status/SKILL.md
@@ -179,7 +179,7 @@ means it is not available. The **Install** column decides how a missing server i
 |------------|-----------|-----------|---------|
 | `excalidraw` | `mcp__excalidraw__describe_scene` | cogni-visual, cogni-portfolio | install-mcp |
 | `claude-in-chrome` | `mcp__claude-in-chrome__tabs_context_mcp` | cogni-website, cogni-workspace | manual (Chrome extension) |
-| `pencil` | `mcp__pencil__get_editor_state` | cogni-visual | manual (Pencil desktop app) |
+| `pencil` | `mcp__pencil__get_editor_state` | cogni-visual, cogni-website | manual (Pencil desktop app) |
 
 **Report format**:
 
@@ -188,12 +188,16 @@ means it is not available. The **Install** column decides how a missing server i
   alone cannot say why — it returns the same no-match in every case — and the install is
   two independent steps, so read two pieces of state before advising:
   - the **config entry** — the server's `desktop_config_key` (`excalidraw` for the registry
-    server `mcp_excalidraw`) under the top-level `mcpServers` in `~/.claude.json`, and/or the
-    same key in `claude_desktop_config.json` for Claude Desktop
+    server `mcp_excalidraw`) in the config of the host **this session runs in**: the
+    top-level `mcpServers` in `~/.claude.json` under Claude Code, or the same key in
+    `claude_desktop_config.json` under Claude Desktop. Only that host's config feeds the
+    table below — an entry present solely in the *other* host's config leaves this one
+    unconfigured, and counting it lands on the restart row for a write that never happened
+    here
   - the **install directory** — `$HOME/.claude/mcp-servers/mcp_excalidraw/start.sh`, named
     for the registry **server name**, not the config key
 
-  | Config entry | `start.sh` | State | Advise |
+  | Config entry (this host) | `start.sh` | State | Advise |
   |---|---|---|---|
   | absent | absent | never installed | route to `/cogni-workspace:install-mcp` |
   | absent | present | built but not configured | re-run the config write — `/cogni-workspace:install-mcp` |
@@ -203,8 +207,10 @@ means it is not available. The **Install** column decides how a missing server i
   A restart *on its own* only fixes the configured-but-not-loaded row: `install-mcp.sh` clones
   and builds, and nothing is configured until `patch-desktop-config.py` runs — so wherever a
   step is missing the write or the build comes first and the new session follows it, never
-  instead of it. If a restart does not clear it, treat the server as a failed spawn (a broken
-  build or a port conflict) rather than a configuration gap. Both steps are documented in the
+  instead of it. If a restart does not clear it, first re-check that the entry is in *this*
+  host's config — a server written only with `--target desktop` is absent from
+  `~/.claude.json` and needs a `--target cli` write, not a restart — and only then treat it
+  as a failed spawn (a broken build or a port conflict). Both steps are documented in the
   `mcp-registry.md` read at the top of this check
 - **Manual**: The MCP is a manual install — the Claude-in-Chrome browser extension or the
   Pencil desktop app. Name what to fetch and inform the user, but don't flag as an error;
@@ -212,8 +218,10 @@ means it is not available. The **Install** column decides how a missing server i
   matters: `claude-in-chrome` has no registry entry and so no config entry at all, whereas
   `pencil` is a registry `native` server whose `pencil` config entry `install-mcp` still
   writes. So if Pencil is installed and running and its tools are still missing, check for the
-  `pencil` key in `~/.claude.json` and run `/cogni-workspace:install-mcp` if it is absent,
-  before telling the user to open the app
+  `pencil` key in the config of the host this session runs in — `~/.claude.json` under
+  Claude Code, `claude_desktop_config.json` under Claude Desktop — and run
+  `/cogni-workspace:install-mcp` for that target if it is absent, before telling the user to
+  open the app
 
 Only check MCPs for plugins that are actually installed (cross-reference with the plugin
 registry from Check 3).
@@ -259,7 +267,7 @@ Themes:       WARNING  | 2 themes available, 1 tiered, 1 drift advisory
   -> Run `manage-themes` to refresh the workspace copy (overwrites local edits)
 
 MCP Servers:  WARNING  | 1/3 loaded (2 manual)
-  excalidraw   built but not configured — start.sh present, no `excalidraw` key in ~/.claude.json
+  excalidraw   built but not configured — start.sh present, no `excalidraw` key in this host's config (`~/.claude.json`, Claude Code)
     -> Run /cogni-workspace:install-mcp to write the config entry, then start a new session
   pencil       manual install — Pencil desktop app not running
     -> Open Pencil (https://pencil.dev); informational, not an error

--- a/cogni-workspace/skills/workspace-status/references/mcp-registry.md
+++ b/cogni-workspace/skills/workspace-status/references/mcp-registry.md
@@ -69,6 +69,7 @@ These MCPs are not written by install-mcp and require user action.
 
 ### pencil
 
+- **Needed by:** cogni-visual, cogni-website
 - **Type:** Desktop app with bundled MCP server
 - **Install:** Download from https://pencil.dev, open the app — MCP auto-starts
 - **Probe tool:** `mcp__pencil__get_editor_state`

--- a/cogni-workspace/tests/test-mcp-declaration-hygiene.sh
+++ b/cogni-workspace/tests/test-mcp-declaration-hygiene.sh
@@ -22,7 +22,9 @@
 # or a hook matcher string.
 #
 # Contract under test:
-#   - no cogni-*/.mcp.json exists anywhere in the tree
+#   - no cogni-*/.mcp.json exists at any plugin root — the only depth a
+#     client loads a plugin-level declaration from, so a file nested deeper
+#     is out of scope by glob depth rather than by exclusion
 #   - mcp-git-registry.json still maps mcp_excalidraw to the desktop key
 #     "excalidraw" — MCP tool names derive from that key, so renaming it breaks
 #     every mcp__excalidraw__* tool and both hook matchers at once, silently


### PR DESCRIPTION
Closes #1429.

Clears the advisory findings deferred from the move of the excalidraw MCP declaration out of per-plugin `.mcp.json` files and into `cogni-workspace:install-mcp`. Documentation and fixture changes only — `cogni-workspace/scripts/patch-desktop-config.py` is the ground truth these findings are measured against and is deliberately untouched. Changing the script would invert two of the findings.

## What changed

**`install-mcp/SKILL.md`**
- The write section claimed a comma-separated `--server` value "filters on a name no registry entry has and the run writes nothing while still reporting success". The script does the opposite — an unrecognised name yields a `success: false` envelope carrying `Unknown server(s) in registry: ...` and exits non-zero. The instruction it justified (repeat the flag per server) was already correct; only the false rationale is replaced.
- The four instructions previously fused by em-dashes are now bullets, grouped by subject, and the 157-column line is gone. The file's over-92 line count drops from 16 to 11, and no line added by this PR exceeds 92.
- `MCP_TARGET` now carries the detected target so the section's only literal command stops contradicting the prose above it. **The assignment sits inside the same fence as the command that consumes it**: each Bash invocation gets a fresh shell, so an assignment made back in Detect Environment would not survive to reach the write and `${MCP_TARGET}` would expand empty. The value is a placeholder rather than a concrete default — `argparse`'s `choices` rejects it loudly instead of silently writing the wrong host's config, which a copyable `"cli"` or `"desktop"` would not.
- Frontmatter restores the `update MCP servers` and `patch desktop config` triggers, paid for by trimming a config-path parenthetical whose two literals still appear later in the trigger list. Resolved description: **1022 → 998 of the 1024 cap**, so headroom is restored rather than consumed.
- The `actions[]` shape is documented as emitted: `config_key` on `added`/`updated`, `reason` only on `skipped`.
- The fence wrapping a single English sentence is now prose.
- Summary examples use the real `added` verb instead of composed labels, and name that the Action cell is taken verbatim from `actions[]`.
- The plan block is marked illustrative, with the requiring plugins sourced from the registry rather than the example — so that value cannot silently re-rot.

**`install-mcp/evals/evals.json`** — case 3's `expected_output` no longer pins Desktop for a prompt carrying no Desktop framing, and now requires the repeated `--server` scoping. Prompt, id and files unchanged; four unique ids preserved.

**`manage-workspace/SKILL.md`** — the closed-server-set assertion yields to the registry it already points at; Action cells use install-mcp's real `added | updated | skipped` vocabulary; and the previously uninstructed no-summary case is covered for **both** shapes that produce it (a `--target both` run failing on its first target returns `success: false` with `error` and `target` but no `targets[]`/`actions[]`; a config whose backup cannot be created exits with no JSON envelope at all).

**`workspace-status/SKILL.md`** — the not-loaded triage input is explicit about which host's config it reads, and the failed-spawn conclusion is gated on that check. A user who ran only `--target desktop` and diagnoses from a Claude Code session is now routed to a `--target cli` write rather than a restart that cannot help. The same ambiguity was restated in the Manual bullet and in the Status Report worked example; both follow.

**Registry + restatements** — `pencil.required_by` gains `cogni-website`, and the four surfaces restating that set follow it, including `workspace-status/references/mcp-registry.md`, whose `### pencil` block was stale by *omission* (no `Needed by:` line at all).

**`tests/test-mcp-declaration-hygiene.sh`** — header comment only. It claimed `.mcp.json` absence "anywhere in the tree" while the arm globs plugin roots one level deep. Reworded to the real scope and why that depth is correct. No executable line, case label, emitter or mutation-recipe block is touched.

## Verified, not edited

The repo-root `CLAUDE.md` MCP table and **both** `concept-mcp-server-map.md` wiki copies already read `cogni-visual, cogni-website` for pencil. The two wiki copies are pinned byte-identical by case `D1`, so a one-sided edit would turn the suite red for no benefit. They were checked, not changed.

## Corrections to the issue as filed

Two of the issue's own line citations were wrong, and a fix trusting them would have edited the wrong lines. The real restatements are `manage-workspace/SKILL.md:159` (issue said 147-148) and `workspace-status/SKILL.md:182` (issue said 172); the cited lines hold unrelated prose. `install-mcp/SKILL.md:102` was correct.

The issue's title says twelve findings; the body enumerates **thirteen**. All thirteen are addressed.

The issue states "no CI gate in this repo catches" the description cap. Accurate for this repo's own `lint.yml`, but incomplete: `cogni-service/scripts/check-frontmatter.sh` enforces `DESC_CAP = 1024` as a block-on-failure pre-gate, so every PR the service pipeline authors is already gated on exactly that cap.

## Adjacent correction, surfaced by the pre-commit quality gate

`install-mcp/SKILL.md` documented `install-mcp.sh`'s `data.action` vocabulary as `installed / skipped / updated / failed`. Verified against the script: `failed` is **never** emitted — a build failure returns `success: false` with the cause in `data.error` and no `action` key at all — while `rebuilt` (emitted when the repo is present but unbuilt) was missing entirely. A model branching on `action == "failed"` never matches and a `rebuilt` run falls through unhandled. This is pre-existing and was not among the thirteen, but it is the identical class of defect this PR exists to clear, one script over, in a file already open. Corrected here rather than deferred; flagged explicitly so the scope addition is visible rather than smuggled.

## Deliberately not included

**A description-length guard.** The issue raises it as worth considering. Declined, with the reasoning recorded so it is auditable: the `check-frontmatter.sh` pre-gate above already blocks every pipeline-authored PR at exactly this cap, and this PR restores 26 characters of headroom. A second in-repo copy of a platform constant would itself be a second source of truth — the defect class this PR exists to close. The residual gap is real but narrow: a human editing a `SKILL.md` and pushing outside the pipeline. Knowingly accepted, not overlooked.

**A registry-restatement guard.** A census run during review found pencil's requiring-set restated in **nine** places repo-wide, and the five this PR did not touch were *already correct* — the registry, the declared single source of truth, was the last file to be fixed. That is direct evidence the invariant is not self-enforcing. A broad prose-parsing guard across nine sites in two wiki trees is the brittle-checker class this repo warns against. But a **narrow** arm is cheaper than it first appears: `tests/test-mcp-declaration-hygiene.sh` already parses the registry with `python3` (case `A2`) and already asserts byte-identity across two markdown copies (case `D1`), so asserting that each server's `required_by` appears in its `Needed by:` line in `mcp-registry.md` is roughly ten lines in a suite CI already runs. Left out to keep this PR's scope settled; raised here so the call belongs to a reviewer rather than to the diff.

## Review notes (annotated, not actioned)

- `manage-workspace/SKILL.md` §Error Handling says to read `data.error`. Only some of this plugin's scripts nest it there; the repo-standard envelope puts `error` at top level. **Pre-existing**, in a section this diff does not touch.
- `manage-workspace/SKILL.md`'s MCP step now carries six rules in running prose; a reviewer suggested lifting them into a bulleted list. A `preference`-category readability change to a section already verified against the acceptance contract — left for a separate pass.
- `install-mcp/SKILL.md` is ~2.9k words with no skill-level `references/`. The offloadable material is presentational (the four-platform config-path table, the two Summary templates); the envelope-parsing rules are wrong-without-them and belong inline. Annotation-grade, well inside the soft cap.

## Test plan

- [x] `python3 scripts/run-plugin-tests.py --filter cogni-workspace` — 11/11 suites pass
- [x] `bash cogni-workspace/tests/test-mcp-declaration-hygiene.sh` — 9/9 (`L0`-`L3`, `A1`-`A3`, `D1`, `M1`)
- [x] `python3 scripts/check-breadcrumbs.py` — clean
- [x] `python3 scripts/check-version-bump.py` — 9 plugins scanned, 0 touched, 0 violations
- [x] `python3 scripts/check-result-line-plainness.py` — clean
- [x] `check-frontmatter.sh cogni-workspace` — clean, 26 files scanned, 0 offenders
- [x] Both edited JSON files parse; `evals.json` keeps its `skill_name` + four unique ids
- [x] `patch-desktop-config.py` unmodified
- [x] No line added by this PR to `install-mcp/SKILL.md` exceeds 92 columns

## Mutation recipe

The suite's own recipe, unchanged by this diff — the header edit is a comment above the contract list and leaves case `A2` and every label intact. Run from the repo root:

```bash
bash "$HOME/.claude/plugins/marketplaces/managed-service/cogni-service/scripts/mutation-check.sh" --root . --file cogni-workspace/references/mcp-git-registry.json --expr 's/"desktop_config_key": "excalidraw"/"desktop_config_key": "sketchpad"/' --test 'bash cogni-workspace/tests/test-mcp-declaration-hygiene.sh' --case A2
```

Expected verdict: `guard_verified`. The search literal occurs exactly once and the replacement does not contain it, so the mutant cannot re-satisfy the pattern and stay green. Use the cogni-service harness, not the differently-shaped `scripts/mutation-check.sh` that cogni-consult and cogni-portfolio each ship.

## Follow-up filed

#1469 — `cogni-website/agents/hero-renderer.md` documents rendering through Pencil MCP, but its frontmatter grants `tools: ["Read","Write","Glob","Bash"]` with no `mcp__pencil__*`, so it can never invoke Pencil and always takes its own CSS-only fallback. Found while verifying who actually drives Pencil for the registry correction. It is a functional defect in a different plugin and is tracked on its own rather than folded in here — adding `cogni-website` to `required_by` makes the registry's claim accurate, but does not make the agent able to act on it.