### PR TITLE
cogni-website: cogni-visual dependency row no longer frames Pencil as indirect

### DIFF
--- a/cogni-website/CLAUDE.md
+++ b/cogni-website/CLAUDE.md
@@ -63,7 +63,7 @@ Any page entry in `website-plan.json` carrying an `arc_id` is rendered through t
 | cogni-marketing | No | Blog posts, articles, whitepapers |
 | cogni-trends | No | Trend reports, investment themes for insights page |
 | cogni-knowledge | No | Research syntheses for resources page |
-| cogni-visual (Pencil MCP) | No | AI-generated hero image via hero-renderer agent |
+| cogni-visual | No | Arc taxonomy and story-to-web decomposition references (website-plan); image-prompt conventions (hero-renderer) |
 
 ## Output
 

--- a/cogni-website/README.md
+++ b/cogni-website/README.md
@@ -221,7 +221,7 @@ cogni-website/
 | cogni-marketing | No | Blog posts, demand-generation articles, lead-generation landing pages |
 | cogni-trends | No | Trend report with investment themes for an Insights page |
 | cogni-knowledge | No | Research syntheses as whitepapers for a Resources page |
-| cogni-visual | No | Pencil MCP access for AI-generated hero imagery (indirect — via hero-renderer agent) |
+| cogni-visual | No | Arc taxonomy (element → block mapping) and story-to-web section-architecture and copywriting references read by website-plan; image-prompt conventions for the hero-renderer agent |
 
 ## Custom development
 


### PR DESCRIPTION
Closes #1473.

## Summary

- `cogni-website/README.md:224` — the `cogni-visual` Dependencies row no longer describes Pencil access as "indirect — via hero-renderer agent". Its Purpose now derives from the plugin's five real cogni-visual reference contexts.
- `cogni-website/CLAUDE.md:66` — the hand-written mirror row is corrected to match, and the `(Pencil MCP)` qualifier is dropped from the Plugin cell: that qualifier *was* the mediated framing.

Two changed lines, two files. No row added, none removed.

## The issue's premise, re-verified against `main`

The issue gates itself on "**Once #1469 lands**". That gate turned out to be **already satisfied — by a different PR**, so this work was not blocked on the still-stuck #1469:

- `cogni-workspace/references/mcp-git-registry.json` already carries pencil `"required_by": ["cogni-visual", "cogni-website"]`. That landed in **a0e0d6a2 (#1471)**, not #1469.
- The issue's *other* premise — that `agents/hero-renderer.md` "holds its own `mcp__pencil__*` grants" — is **false on base**: it is still `tools: ["Read", "Write", "Glob", "Bash"]`. #1469 is open. **Nothing in this diff claims that grant exists.**

#1469 governs whether hero-renderer can *invoke* Pencil; #1471 already settled *whose dependency it is*. These rows describe the latter.

## Why the row was wrong — deeper than the word "indirect"

`doc-generate` builds `## Dependencies` by scanning `cogni-*` references under `skills/`/`agents/`/`commands/` and taking each Purpose "from the context where the dependency is referenced", under an explicit rule: **only `cogni-*` plugin references, not external tools** (`doc-generate/references/section-templates.md` → "Dependencies Table").

Pencil is an external MCP server. So using the cogni-visual row's Purpose cell to describe Pencil access **at all** — indirect *or* direct — is off-contract. Swapping "indirect" for "direct" would have corrected the adverb and left the category error in place.

The five real cogni-visual reference contexts are all file-content reads:

| Context | What is consumed |
|---|---|
| `skills/website-plan/SKILL.md:188` | arc-taxonomy element → block mapping (visual-type column) |
| `skills/website-plan/SKILL.md:190`, `:192` | story-to-web decomposition rules, section-architecture decision tree |
| `skills/website-plan/SKILL.md:193` | story-to-web section-copywriting rules |
| `agents/hero-renderer.md:34` | image-prompt conventions |

That is what the Purpose cells now say.

The genuine direct-Pencil fact already has a correct home and needed no new row: the root `README.md` MCP-servers table lists `| pencil | cogni-visual, cogni-website | … |`.

## Provenance of the README row — what was and was not run

**No `doc-generate` run produced this row, and this PR does not claim one did.**

The Dependencies table is stage-gated. `doc-generate/references/section-templates.md` → "Stage-gated section behavior" maps **Incubating → Skip (dependencies still fluid)**, and cogni-website is **v0.0.8** → Incubating. So the generator declines this section for this plugin. That decline is read from the generator's published gate table, not from an executed run — a reviewer can confirm it either by reading that table or by running `/doc-generate cogni-website --section=dependencies --dry-run` and observing no diff for the section.

The row was therefore written to **conform to the generator's own derivation rules**, with the reasoning recorded here rather than left to editorial taste: Purpose derived from the reference context, Required `Yes`/`No`, required rows sorted before optional, only `cogni-*` references. Conformance is checkable against those published rules, which is the durability the acceptance criterion is actually asking for — a regenerated section and a correct hand edit are byte-identical, so provenance can only be graded as conformance-plus-recorded-reasoning.

**A side effect worth recording:** the same stage gate disproves the issue's stated reason for deferring this fix ("correcting it by hand … would be overwritten by the next `doc-generate` run"). While cogni-website is Incubating, it would not be. The deferral was still the right call — it just made the work cheaper, not blocked.

## Two hazards found while planning, both avoided

1. **An unscoped regeneration would flip the licence.** `doc-generate`'s standard License template is `[AGPL-3.0](LICENSE)`, while cogni-website is **Apache-2.0** (`README.md:232`, `plugin.json`). A `--section=all` run would have silently relicensed the docs. Filed upstream as **cogni-work/managed-service#921**.
2. **A worktree-launched run would have produced an empty diff.** The *tracked* `.claude/cogni-docs.local.md` pins `insight_wave_repo:` to the main checkout, so a writing `doc-generate` run started from a branch worktree edits the main clone and leaves the branch untouched.

## Scope decisions

- The `cogni-visual` row **stays** — the dependency is genuine (five reference contexts above); deleting it would trade a wrong Purpose for a missing dependency and a doc-audit Check 4 undocumented-dependency finding.
- **No Pencil/MCP row added** to either per-plugin table — the generator excludes external tools and would erase it.
- `cogni-website/agents/hero-renderer.md` is **not touched**: its `tools:` frontmatter belongs to open #1469, and its line-34 `cogni-visual:` token is claimed by #1451.
- `CLAUDE.md` is hand-edited deliberately — that table is hand-written developer documentation, not `doc-generate` output, and `doc-claude` regenerates the whole guide.
- **No version bump** — the post-merge workflow owns it.
- **On linking:** the one deferred item (hazard 1) is a cross-repo cogni-docs defect discovered during planning, not withheld scope of this issue, so it does not make this PR partial. All three of the issue's acceptance criteria are satisfied here, hence `Closes` rather than `Refs`.

## Test plan

- [x] Diff touches exactly two files; no manifest or version file appears in it.
- [x] The README diff is a single changed line, 224 (`gh pr diff` renders it as `@@ -221,7 +221,7 @@` with context); `README.md:232` still reads `[Apache-2.0](LICENSE)`; `CLAUDE.md` lines 19 and 73 unchanged; `agents/hero-renderer.md` absent from the diff.
- [x] Added lines contain zero occurrences of `indirect`, `via cogni-visual`, `Pencil`, `mcp__pencil__`.
- [x] Each file still has exactly one `cogni-visual` row, Required `No`, last in its table; both tables still have 6 data rows, matching base.
- [x] Both changed rows have balanced pipes (4 each) and the required-first order holds (`Yes, Yes, No, No, No, No`).
- [x] The two Purpose cells name the same consumers (`website-plan`, `hero-renderer`) and the same reference families (arc taxonomy, story-to-web decomposition, image-prompt conventions) — the CLAUDE.md cell is the condensed mirror, never a divergent claim.
- [x] Full `python3 scripts/run-plugin-tests.py` sweep run **post-commit** on the branch tree: **126/126 suites passed**, exit code 0. Run post-commit deliberately — a pre-commit sweep cannot see tracked-only guards.
- [ ] **For the reviewer:** `cogni-docs:doc-audit` for cogni-website. Not executed here. Check 4 grades row presence and Required-status, both unchanged by this diff, so no new finding is expected — but that is a static argument, not an observed run.

## Follow-up issues

- **cogni-work/managed-service#921** — `doc-generate` hardcodes `[AGPL-3.0](LICENSE)`, silently relicensing Apache-2.0 plugins on regeneration.
