### PR TITLE
cogni-workspace: confine test-sanitize-theme.sh artifacts to TMPROOT

### DIFF
--- a/cogni-workspace/tests/test-sanitize-theme.sh
+++ b/cogni-workspace/tests/test-sanitize-theme.sh
@@ -333,14 +333,16 @@ assert_json "3g CLI skips empty scalar section" "$TMPROOT/cli-empty.json" \
 
 echo "=== wired renderer end-to-end ==="
 WS="$TMPROOT/ws"; mkdir -p "$WS"
-run_render() { python3 "$RENDERER" "$WS" --design-variables "$1" --output "$WS/out.html" >/tmp/render-out.json 2>/tmp/render-err.txt; }
+# Result sinks live under the per-run temp root rather than a fixed shared path, so two
+# concurrent runs of this suite cannot overwrite each other's documents mid-assertion.
+run_render() { python3 "$RENDERER" "$WS" --design-variables "$1" --output "$WS/out.html" >"$TMPROOT/render-out.json" 2>"$TMPROOT/render-err.txt"; }
 
 # Malicious color value must not reach the output; renderer must still succeed.
 run_render "$TMPROOT/dv-evil.json"
-assert_json "4a malicious render succeeds" /tmp/render-out.json 'd.get("status")=="ok"'
+assert_json "4a malicious render succeeds" "$TMPROOT/render-out.json" 'd.get("status")=="ok"'
 assert_lacks "4b </style><script> not in output" '</style><script>' "$WS/out.html"
 assert_has   "4c built-in background applied instead" '#FAFAF8' "$WS/out.html"
-assert_json "4d rejection surfaced as warning" /tmp/render-out.json 'd.get("theme_warnings")'
+assert_json "4d rejection surfaced as warning" "$TMPROOT/render-out.json" 'd.get("theme_warnings")'
 
 # Safe theme still applies, and the legitimate @import url(...) font path is untouched.
 cat > "$TMPROOT/dv-safe.json" <<'EOF'
@@ -353,16 +355,16 @@ assert_has "4f legitimate @import url() font preserved" "@import url('https://fo
 # A breakout in google_fonts_import lands at the TOP of the <style> block, before
 # :root — the most exposed slot, and the one that was unguarded until font-aware.
 run_render "$TMPROOT/dv-font-evil.json"
-assert_json "4g font-evil render succeeds" /tmp/render-out.json 'd.get("status")=="ok"'
+assert_json "4g font-evil render succeeds" "$TMPROOT/render-out.json" 'd.get("status")=="ok"'
 assert_lacks "4h @import breakout not in output" '<script>alert(1)</script>' "$WS/out.html"
 assert_lacks "4i font declaration injection not in output" 'background-image: url(https://evil.example' "$WS/out.html"
-assert_json "4j font rejection surfaced as warning" /tmp/render-out.json 'd.get("theme_warnings")'
+assert_json "4j font rejection surfaced as warning" "$TMPROOT/render-out.json" 'd.get("theme_warnings")'
 # Legitimate rgba shadow and radius from the same fixture must survive.
 assert_has "4k legitimate rgba shadow preserved" 'rgba(0,0,0,0.04)' "$WS/out.html"
 
 # An empty google_fonts_import means "no import" — a valid theme, so no warning.
 run_render "$TMPROOT/dv-empty-import.json"
-assert_json "4l empty import produces no warning" /tmp/render-out.json 'not d.get("theme_warnings")'
+assert_json "4l empty import produces no warning" "$TMPROOT/render-out.json" 'not d.get("theme_warnings")'
 # ...and "no import" must mean no import, not a silent fall back to DEFAULT_THEME's
 # hard-coded Google Fonts URL. Without this the absence is indistinguishable in
 # the output from the default having been applied.
@@ -375,8 +377,8 @@ cat > "$TMPROOT/dv-font-url-injection.json" <<'EOF'
  "fonts": {"body": "https://a.example/x;background:red;position:fixed"}}
 EOF
 run_render "$TMPROOT/dv-font-url-injection.json"
-assert_json "4p url-injection render succeeds" /tmp/render-out.json 'd.get("status")=="ok"'
-assert_json "4q url-injection surfaced as warning" /tmp/render-out.json 'd.get("theme_warnings")'
+assert_json "4p url-injection render succeeds" "$TMPROOT/render-out.json" 'd.get("status")=="ok"'
+assert_json "4q url-injection surfaced as warning" "$TMPROOT/render-out.json" 'd.get("theme_warnings")'
 assert_lacks "4r injected declaration not in output" 'a.example' "$WS/out.html"
 assert_has   "4s theming otherwise intact" '#123456' "$WS/out.html"
 
@@ -387,7 +389,7 @@ cat > "$TMPROOT/dv-bare-import.json" <<'EOF'
  "google_fonts_import": "https://fonts.googleapis.com/css2?family=Outfit&display=swap"}
 EOF
 run_render "$TMPROOT/dv-bare-import.json"
-assert_json "4t bare-import render succeeds" /tmp/render-out.json 'd.get("status")=="ok"'
+assert_json "4t bare-import render succeeds" "$TMPROOT/render-out.json" 'd.get("status")=="ok"'
 assert_has "4u bare URL normalized into a terminated @import" \
   "@import url('https://fonts.googleapis.com/css2?family=Outfit&display=swap');" "$WS/out.html"
 assert_has "4v :root not swallowed — theme variable still applied" '#123456' "$WS/out.html"
@@ -397,7 +399,7 @@ cat > "$TMPROOT/dv-partial-fonts.json" <<'EOF'
 {"fonts": {"body": "'Inter', sans-serif"}}
 EOF
 run_render "$TMPROOT/dv-partial-fonts.json"
-assert_json "4m partial fonts override renders" /tmp/render-out.json 'd.get("status")=="ok"'
+assert_json "4m partial fonts override renders" "$TMPROOT/render-out.json" 'd.get("status")=="ok"'
 assert_has "4n header font backfilled from defaults" "'Bricolage Grotesque'" "$WS/out.html"
 assert_has "4o overridden body font still applied" "'Inter', sans-serif" "$WS/out.html"
 
@@ -435,16 +437,17 @@ def sanitize_values(values, defaults, profile="strict"):
 EOF
 LEGACY_RENDERER="$LEGACY/skills/workspace-dashboard/scripts/generate-dashboard.py"
 LWS="$TMPROOT/lws"; mkdir -p "$LWS"
-run_legacy() { python3 "$LEGACY_RENDERER" "$LWS" --design-variables "$1" --output "$LWS/out.html" >/tmp/legacy-out.json 2>/tmp/legacy-err.txt; }
+# Same per-run temp-root discipline as the render helper above.
+run_legacy() { python3 "$LEGACY_RENDERER" "$LWS" --design-variables "$1" --output "$LWS/out.html" >"$TMPROOT/legacy-out.json" 2>"$TMPROOT/legacy-err.txt"; }
 
 run_legacy "$TMPROOT/dv-evil.json"
-assert_json "6a stale guard still renders (no AttributeError)" /tmp/legacy-out.json 'd.get("status")=="ok"'
+assert_json "6a stale guard still renders (no AttributeError)" "$TMPROOT/legacy-out.json" 'd.get("status")=="ok"'
 assert_lacks "6b stale guard still blocks the colour breakout" '</style><script>' "$LWS/out.html"
 assert_has   "6c stale guard falls back to the built-in palette" '#FAFAF8' "$LWS/out.html"
 # render_css indexes fonts[headers|body|mono] directly, so the degraded path must
 # still backfill or the render dies with a KeyError instead of an AttributeError.
 run_legacy "$TMPROOT/dv-partial-fonts.json"
-assert_json "6d stale guard handles a partial fonts override" /tmp/legacy-out.json 'd.get("status")=="ok"'
+assert_json "6d stale guard handles a partial fonts override" "$TMPROOT/legacy-out.json" 'd.get("status")=="ok"'
 assert_has   "6e stale guard backfills the omitted header font" "'Bricolage Grotesque'" "$LWS/out.html"
 
 # And with no guard at all — the unguarded pass-through branch. It must still
@@ -453,7 +456,7 @@ assert_has   "6e stale guard backfills the omitted header font" "'Bricolage Grot
 # in precisely the case the fallback exists to survive.
 rm -f "$LEGACY/scripts/sanitize-theme.py"
 run_legacy "$TMPROOT/dv-partial-fonts.json"
-assert_json "6f absent guard still renders" /tmp/legacy-out.json 'd.get("status")=="ok"'
+assert_json "6f absent guard still renders" "$TMPROOT/legacy-out.json" 'd.get("status")=="ok"'
 assert_has   "6g absent guard backfills the omitted header font" "'Bricolage Grotesque'" "$LWS/out.html"
 assert_has   "6h absent guard still applies the override" "'Inter', sans-serif" "$LWS/out.html"
 


### PR DESCRIPTION
Closes #1480

## Summary

`cogni-workspace/tests/test-sanitize-theme.sh` allocated a private temp root, then wrote every
renderer result to fixed, world-shared absolute temp paths and asserted against them. Any
concurrent writer — including a second run of this same suite, which is exactly what the repo-wide
sweep does — could truncate a document between the render and the assertion that reads it. The
suite then reds with no signal about why, which is the failure mode the issue is about.

Both result helpers now write under the per-run temp root, and all twelve assertions that read them
follow. **16 literals across 14 lines**, one file, no lifecycle change: the temp root is already
allocated and already trap-cleaned.

## Two scope corrections against the issue text

The issue's `## Proposed change` is narrower than its own acceptance criteria, and following it
literally would have failed AC2:

| | Issue says | Actually |
|---|---|---|
| Render assertion sites | eight | **nine** (340, 343, 356, 359, 365, 378, 379, 390, 400) |
| `run_legacy()` (line 438) | not mentioned | **identical defect** — two more literals, asserted at 441, 447, 456 |

AC2 forbids *any* absolute shared temp literal, so both helpers are in scope. A fix scoped to the
Proposed change alone would satisfy the prose and fail the bar.

## AC3 remedy — translate at the harness, not in the repo

`mutation-check.sh` classifies a case RED only on `^FAIL: <case>` and GREEN only on
`^(ok|PASS): <case>`. This suite emits colon-less `OK   ` / `FAIL ` (lines 22-23), so an
untranslated `--case` replay returns `case_not_found` (exit 2) and grades nothing — AC3 is
unsatisfiable as literally written. Two remedies were available; the triage contract permits either.

- **Rejected — relabel the emitters.** The colon-less form is an **11-suite holdout family** across
  three plugins, not a local anomaly, and several sibling suites document this file's label shape by
  name. Converting one member is churn unrelated to the race being fixed, and leaves the other ten.
- **Chosen — a translating `--test` pipeline.** The harness runs `--test` through `eval`, so a `sed`
  stage is a valid value. **Zero repo files change**, and the recipe lives in the PR body, which is
  what AC3 asks for.

The convention question is filed as **#1482** rather than widened into this PR.

## Mutation recipe

Both recipes mutate the **guard under test** (`generate-dashboard.py`), never this suite's own
expected literal — the contract requires proving the assertions still read what the helpers
*actually write at the new path*, which only a guard mutation demonstrates. Both anchors were
verified unique on `origin/main`. Each `--expr` carries `/m` because the harness runs `perl -0pi`,
which slurps the file.

**The harness is not vendored in this repo.** `cogni-service/` does not exist in insight-wave; the
script is plugin-cache-resident via the `cogni-work/managed-service` marketplace. A recipe citing
`cogni-service/scripts/mutation-check.sh` as a repo-relative path resolves to "No such file".

Both recipes are written to be **replayable verbatim** — no command substitution, no shell
metacharacters. Run them with the repository root as your working directory.

### Recipe 1 — warning-append guard, render arm, case `4d`

```bash
bash ~/.claude/plugins/marketplaces/managed-service/cogni-service/scripts/mutation-check.sh \
  --root . \
  --file cogni-workspace/skills/workspace-dashboard/scripts/generate-dashboard.py \
  --expr 's/^        if rejected:$/        if False:/m' \
  --test 'bash cogni-workspace/tests/test-sanitize-theme.sh 2>&1 | sed -e "s/^OK   /PASS: /" -e "s/^FAIL /FAIL: /"' \
  --case 4d
```

Recorded output:

```json
{
  "case": "4d",
  "expr_applied": "s/^        if rejected:$/        if False:/m",
  "mutated_result": "red",
  "restored_result": "green",
  "verdict": "guard_verified",
  "metric_version": "1"
}
```

### Recipe 2 — stale-guard lookup, legacy arm, case `6a`

```bash
bash ~/.claude/plugins/marketplaces/managed-service/cogni-service/scripts/mutation-check.sh \
  --root . \
  --file cogni-workspace/skills/workspace-dashboard/scripts/generate-dashboard.py \
  --expr 's/^        guard_section = getattr\(_THEME_GUARD, "sanitize_section", None\)$/        guard_section = _THEME_GUARD.sanitize_section/m' \
  --test 'bash cogni-workspace/tests/test-sanitize-theme.sh 2>&1 | sed -e "s/^OK   /PASS: /" -e "s/^FAIL /FAIL: /"' \
  --case 6a
```

Recorded output:

```json
{
  "case": "6a",
  "expr_applied": "s/^        guard_section = getattr\\(_THEME_GUARD, \"sanitize_section\", None\\)$/        guard_section = _THEME_GUARD.sanitize_section/m",
  "mutated_result": "red",
  "restored_result": "green",
  "verdict": "guard_verified",
  "metric_version": "1"
}
```

`git status` after both replays shows only `test-sanitize-theme.sh` modified — the harness restored
the mutated guard, and this PR does not edit `generate-dashboard.py`.

## Concurrency check (AC4)

```bash
bash cogni-workspace/tests/test-sanitize-theme.sh >/dev/null 2>&1 & p1=$!
bash cogni-workspace/tests/test-sanitize-theme.sh >/dev/null 2>&1 & p2=$!
wait $p1; rc1=$?
wait $p2; rc2=$?
echo "rc1=$rc1 rc2=$rc2"
```

Recorded output:

```
rc1=0 rc2=0
```

**On falsification:** a concurrent double-run on the *unfixed* tree is not a reliable red — the
collision is timing-dependent, which is the whole complaint. The deterministic falsifier is the
AC1/AC2 grep, not the race. I also deliberately did not race the base tree, because doing so writes
the shared paths and could have reddened a concurrent sweep in another session.

## Verification

| Check | Result |
|---|---|
| AC1 — `grep -n '/tmp/render-'` | **0 lines** |
| AC2 — `grep -c '/tmp/'` | **0** (was 14) |
| Counts — `"$TMPROOT/render-out.json"` | **10** (1 redirect + 9 assertions) |
| Counts — `render-err.txt` / `legacy-out.json` / `legacy-err.txt` | **1 / 4 / 1** |
| `mktemp` occurrences | **1** (unchanged; no new lifecycle) |
| `assert_json` total | **22** (unchanged; no assertion lost or renamed) |
| AC3 green — suite exit | **0**, zero FAIL lines |
| AC3 red — both mutation arms | **`guard_verified`** |
| AC4 — concurrent double-run | **rc1=0 rc2=0** |
| `run-plugin-tests.py` (full repo, post-commit) | **127/127, 0 failed** |
| `run-plugin-tests.py --filter cogni-workspace` | **14/14** |
| `check-breadcrumbs.py` / `check-result-line-plainness.py` | exit 0 / exit 0 |
| `check-version-bump.py` | 9 scanned, **0 touched, 0 violations** |
| `check-frontmatter.sh cogni-workspace` | exit 0 |

## Review notes

- **No version bump**, per the post-merge auto-increment convention.
- **No maintainer breadcrumbs** added. The nine `#123456` / `#111111` hits a naive `#1[0-9]{3}`
  grep finds in this file are **pre-existing hex colour literals** — identical count on
  `origin/main`, none introduced here. `check-breadcrumbs.py` exits 0.
- **The two added comments deliberately avoid the four result-file name tokens**, so the exact
  counts in the table above stay true.
- `/simplify` was not dispatched: the edits live in a separate branch worktree, and the skill
  inspects the session working tree, so it would have read the wrong tree. The diff is a mechanical
  path swap plus two comment lines and was reviewed directly instead.
- **Token scope:** the runner uses the standard `gh auth login` OAuth token, whose scope set is
  fixed by the CLI's OAuth app; `check-token-scope.sh --strict` therefore exits 1 on
  `gist, read:org, workflow`. Pushed under the documented `--allow-overscoped` opt-out (exit 0).

## Follow-up issues

- **#1482** — repo: 11 test suites emit colon-less `FAIL` result lines and are silently unreplayable
  by the mutation harness. Adjacent work found here; the repo-wide convention decision belongs there.
