### PR TITLE
cogni-portfolio: assert append-claim error envelopes structurally

### DIFF
--- a/cogni-portfolio/tests/test-append-claim-lock.sh
+++ b/cogni-portfolio/tests/test-append-claim-lock.sh
@@ -1,12 +1,14 @@
 #!/usr/bin/env bash
 # Regression test for cogni-portfolio/scripts/append-claim.sh covering the
 # stale-lock sweep's mtime reading — the BSD-first `stat` chain that returns a
-# successful *wrong* answer on GNU coreutils.
+# successful *wrong* answer on GNU coreutils — and the script's output-envelope
+# contract on every emit path, success and failure alike.
 #
 # Fixtures are built inline under a temp root — no committed blobs to maintain.
-# Each case builds a minimal claims project, pre-creates the lock directory so
-# the acquire loop is genuinely contended, shadows `stat` with a stub on PATH,
-# runs the script, and asserts on the exit code plus both output streams.
+# Most cases build a minimal claims project, pre-create the lock directory so
+# the acquire loop is genuinely contended, shadow `stat` with a stub on PATH,
+# run the script, and assert on the exit code plus both output streams. Cases 7
+# and 8 are the exceptions and build less than that — see the note below.
 #
 # Coverage:
 #   1  stale-lock-swept-on-non-numeric-stat   non-numeric mtime reading is floored
@@ -39,6 +41,11 @@
 #                                             never contends must spawn NO stat at
 #                                             all; this is what forbids resolving
 #                                             the form ahead of the loop
+#   8  no-arguments-emits-usage-envelope      the argument guard — the one failure
+#                                             path that never reaches the acquire
+#                                             loop writes a SINGLE error-envelope
+#                                             object to stderr and exits 1, asserted
+#                                             by shape and not by message alone
 #
 # Every case that CONTENDS drives the acquire loop to its ceiling on purpose, so
 #   each sets APPEND_CLAIM_MAX_WAIT as a per-invocation prefix rather than paying
@@ -47,9 +54,11 @@
 #   than the ~7.3s it cost when the ceiling was a hardcoded constant. Cases 4 and 5
 #   each drive the loop through the full sweep budget, so they carry most of the
 #   ~2.4s this suite grew by; folding them into one invocation that emits two result
-#   lines would recover roughly half of that if the budget ever needs tightening. Case 7 is the deliberate exception
-#   and never contends at all — it exists to prove the UNcontended acquire stays
-#   fork-free, so driving the loop is precisely what it must not do.
+#   lines would recover roughly half of that if the budget ever needs tightening.
+#   Cases 7 and 8 are the deliberate exceptions and never contend at all. Case 7
+#   exists to prove the UNcontended acquire stays fork-free, so driving the loop is
+#   precisely what it must not do; case 8 returns at the argument guard before the
+#   loop is reached at all, so it has no loop to drive.
 #   The prefix is deliberately NOT a suite-level export: run-plugin-tests.py
 #   invokes each suite as a bare `bash <path>`, so each case must carry its own
 #   ceiling.
@@ -206,6 +215,52 @@
 #   assertions stay green and only the envelope assertion discriminates. That is
 #   precisely what makes asserting the whole envelope, rather than the nested status
 #   alone, worth its line in all three.
+#
+#   Eighth arm — the TIMEOUT envelope's SHAPE, as distinct from its message:
+#   bash ~/.claude/plugins/cache/managed-service/cogni-service/0.0.402/scripts/mutation-check.sh \
+#     --root . \
+#     --file cogni-portfolio/scripts/append-claim.sh \
+#     --expr 's/\\"data\\": null, //' \
+#     --test 'bash cogni-portfolio/tests/test-append-claim-lock.sh' \
+#     --case live-lock-not-swept-on-numeric-stat
+#
+#   The expression drops the `data` key from the timeout envelope. It matches the
+#   ESCAPED spelling exactly once — the bash-side emit inside the acquire loop's
+#   double-quoted string; the two unescaped spellings in the SCRIPT, in its own
+#   header comment documenting the envelope and in the argument guard's
+#   single-quoted literal, cannot match it. It carries no `^`/`$` anchor, so it
+#   needs no `/m` under the harness's `perl -0pi`.
+#
+#   Cases 2 and 3 both catch this arm — both reach the timeout emit and both now
+#   assert its shape. Case 5 reaches the SAME envelope but asserts only the message
+#   grep, so it stays green under the mutation and is deliberately not a catcher.
+#   The arm names case 2 only because `--case` takes one name.
+#
+#   Under the mutation the script still exits 1, still writes one line to stderr,
+#   and that line still carries the timeout message and still parses as JSON — so
+#   the exit-code assertion and the message grep both stay green, and only the
+#   structural check discriminates. That is what makes the structural check evidence
+#   rather than decoration, and it is why the grep was kept alongside it rather than
+#   replaced by it: the two pin different things.
+#
+#   Ninth arm — the USAGE envelope's shape:
+#   bash ~/.claude/plugins/cache/managed-service/cogni-service/0.0.402/scripts/mutation-check.sh \
+#     --root . \
+#     --file cogni-portfolio/scripts/append-claim.sh \
+#     --expr 's/"data": null, "error": "Usage/"error": "Usage/' \
+#     --test 'bash cogni-portfolio/tests/test-append-claim-lock.sh' \
+#     --case no-arguments-emits-usage-envelope
+#
+#   The expression drops the `data` key from the argument guard's envelope. It
+#   matches exactly once — the guard's own emit; the SCRIPT's header comment spells
+#   the surrounding text differently and cannot match. It carries no `^`/`$` anchor,
+#   so it too needs no `/m`.
+#
+#   Case 8 is the only catcher, because it is the only case that runs the script
+#   with no arguments. Under the mutation the guard still exits 1, still writes one
+#   line to stderr, and that line still carries the `Usage:` literal — so every
+#   assertion in case 8 except the structural one stays green. A case that asserted
+#   the usage path by message alone would not have caught this.
 
 # `set -u` only — `set -e` would abort on the first failing assertion and defeat
 # the per-case failure counter below. All cases also run a script that is
@@ -368,6 +423,8 @@ if [ "$case2_rc" -ne 1 ]; then
   fail "live-lock-not-swept-on-numeric-stat" "expected exit 1, got $case2_rc"
 elif ! grep -q 'Could not acquire lock on claims.json after 0.3s' "$TMPROOT/case2.err"; then
   fail "live-lock-not-swept-on-numeric-stat" "stderr did not carry the timeout error: $(cat "$TMPROOT/case2.err")"
+elif ! python3 -c 'import json,sys; d=json.load(sys.stdin); sys.exit(0 if d["success"] is False and d["data"] is None else 1)' < "$TMPROOT/case2.err" 2>/dev/null; then
+  fail "live-lock-not-swept-on-numeric-stat" "stderr did not parse as a {success,data,error} object with success=false and data=null: $(cat "$TMPROOT/case2.err")"
 elif [ ! -d "$case2_dir/cogni-claims/.claims.lock" ]; then
   fail "live-lock-not-swept-on-numeric-stat" "a live peer's lock was swept"
 else
@@ -417,6 +474,8 @@ if [ "$case3_rc" -ne 1 ]; then
   fail "live-lock-not-swept-on-gnu-stat" "expected exit 1, got $case3_rc — a BSD-first chain would sweep the live lock and append"
 elif ! grep -q 'Could not acquire lock on claims.json after 0.3s' "$TMPROOT/case3.err"; then
   fail "live-lock-not-swept-on-gnu-stat" "stderr did not carry the timeout error: $(cat "$TMPROOT/case3.err")"
+elif ! python3 -c 'import json,sys; d=json.load(sys.stdin); sys.exit(0 if d["success"] is False and d["data"] is None else 1)' < "$TMPROOT/case3.err" 2>/dev/null; then
+  fail "live-lock-not-swept-on-gnu-stat" "stderr did not parse as a {success,data,error} object with success=false and data=null: $(cat "$TMPROOT/case3.err")"
 elif [ ! -d "$case3_dir/cogni-claims/.claims.lock" ]; then
   fail "live-lock-not-swept-on-gnu-stat" "a live peer's lock was swept"
 else
@@ -568,6 +627,52 @@ elif [ -s "$case7_counter" ]; then
   fail "uncontended-acquire-spawns-no-stat" "an uncontended acquire spawned stat $(wc -l < "$case7_counter" | tr -d ' ') time(s) — the probe is no longer lazy"
 else
   pass "uncontended-acquire-spawns-no-stat" "no stat spawned on the uncontended path"
+fi
+
+# --- Case 8: the argument guard emits the full error envelope, not a bare message.
+#
+# This is the script's one failure path that never reaches the acquire loop, so no
+# case above exercises it at all — it returns at the argument check before the lock
+# directory is ever created, which is also why this case needs no seeder and no stub
+# and leaves nothing behind to clean up.
+#
+# The STRUCTURAL assertion is the discriminator, not the message match. A guard that
+# regressed to emitting a bare `{"error": ...}` would keep the same message text, so
+# a grep alone stays green while the envelope around it rots — which is precisely
+# what the ninth mutation arm in the header above demonstrates.
+#
+# `Usage: append-claim.sh` is append-claim.sh's OWN literal, which is what makes a
+# text match legitimate here. Everything the shell or coreutils could emit is
+# asserted by SHAPE instead — the exit status, stdout emptiness, and a line COUNT —
+# because those diagnostics are gettext-localized and a text match on one would pass
+# vacuously off an English-locale host. Case 3's comment states the same rule.
+#
+# The line count is a genuine assertion rather than a formality: the guard's
+# `${1:-}` defaults are what keep `set -u` from adding a second line here, so a
+# regression to bare `$1` would show up as a count of 2 rather than as a message
+# change. `wc -l` reads from a REDIRECT, never a filename argument — the argument
+# form appends the filename to wc's output, which `tr -d ' '` does not strip, and
+# the numeric comparison then dies on a non-numeric operand. Case 7 above is the
+# precedent.
+#
+# The ceiling prefix is behaviourally inert here for the same reason it is on case
+# 7 — the guard returns before the ceiling is ever read — and is carried anyway so
+# every case states its own ceiling rather than inheriting the production default.
+case8_out="$(APPEND_CLAIM_MAX_WAIT=1 bash "$SCRIPT" 2>"$TMPROOT/case8.err")"
+case8_rc=$?
+
+if [ "$case8_rc" -ne 1 ]; then
+  fail "no-arguments-emits-usage-envelope" "expected exit 1, got $case8_rc (stderr: $(cat "$TMPROOT/case8.err"))"
+elif [ -n "$case8_out" ]; then
+  fail "no-arguments-emits-usage-envelope" "expected nothing on stdout, got: $case8_out"
+elif [ "$(wc -l < "$TMPROOT/case8.err" | tr -d ' ')" -ne 1 ]; then
+  fail "no-arguments-emits-usage-envelope" "expected exactly one newline-terminated line on stderr, got $(wc -l < "$TMPROOT/case8.err" | tr -d ' '): $(cat "$TMPROOT/case8.err")"
+elif ! python3 -c 'import json,sys; d=json.load(sys.stdin); sys.exit(0 if d["success"] is False and d["data"] is None and isinstance(d["error"], str) and d["error"] else 1)' < "$TMPROOT/case8.err" 2>/dev/null; then
+  fail "no-arguments-emits-usage-envelope" "stderr did not parse as a {success,data,error} object with success=false, data=null and a non-empty error: $(cat "$TMPROOT/case8.err")"
+elif ! grep -q 'Usage: append-claim.sh' "$TMPROOT/case8.err"; then
+  fail "no-arguments-emits-usage-envelope" "stderr did not carry the usage message: $(cat "$TMPROOT/case8.err")"
+else
+  pass "no-arguments-emits-usage-envelope" "argument guard emitted the full error envelope on stderr"
 fi
 
 if [ "$failures" -gt 0 ]; then


### PR DESCRIPTION
Closes #1459.

## Summary

`append-claim.sh` documents a single output contract — `{"success", "data", "error"}` on both streams — but the lock suite only ever asserted that contract on the SUCCESS path. Both failure paths were pinned by message text alone, so the envelope around the message could regress to the bare `{"error": ...}` shape with the suite fully green.

- **Cases 2 and 3** gain a structural stderr check alongside their existing timeout-message grep: the captured stderr must parse as an object with `success=false` and `data=null`. The grep is kept **verbatim, not replaced** — it pins the DERIVED ceiling label (`after 0.3s`), a separate coupling and the one the third mutation arm rides on.
- **New case 8** (`no-arguments-emits-usage-envelope`) covers the argument guard — the script's only failure path that never reaches the acquire loop, and which no case previously exercised. It asserts exit 1, empty stdout, exactly one newline-terminated stderr line, the full `{success:false, data:null, non-empty error}` shape, and the script's own `Usage: append-claim.sh` literal.
- **Two mutation arms** (eighth and ninth) are recorded that make the added checks evidence rather than decoration.
- Header prose that a second non-contending case falsifies is de-staled in the same pass (the "Each case builds a minimal claims project" preamble and the "Case 7 is the deliberate exception" note).

`cogni-portfolio/scripts/append-claim.sh` is **not edited**. All seven pre-existing arms target that file, so their exactly-once match counts cannot move.

## Why the greps were joined, not replaced

The issue's first acceptance criterion is falsified by either check *replacing* the grep. They pin different things: the grep pins the ceiling-to-message derivation, the new check pins the envelope keys. The eighth arm below demonstrates the gap concretely — under it the message still matches and only the structural check reds.

## Foreign vs own-emitter assertions

`Usage: append-claim.sh` is this repo's own script's literal, which is what makes a text match legitimate at all. Everything the shell or coreutils could emit is asserted by SHAPE — exit status, stdout emptiness, a line count — because those diagnostics are gettext-localized and a text match on one would pass vacuously off an English-locale host. No `LC_ALL` pin was added; none is needed, and the repo forbids one as a remedy.

The line count is a real assertion, not a formality: the guard's `${1:-}` defaults are what keep `set -u` from adding a second line, so a regression to bare `$1` surfaces as a count of 2. `wc -l` reads from a **redirect**, never a filename argument — the argument form appends the filename to wc's output, which `tr -d ' '` does not strip, and the numeric comparison then dies on a non-numeric operand. Case 7 is the precedent.

## Mutation recipe

Both new arms are recorded in the suite's own header alongside arms 1-7 and reproduced here. **Every arm below was replayed, not asserted.**

```
# Eighth arm — the TIMEOUT envelope's SHAPE, as distinct from its message:
bash ~/.claude/plugins/cache/managed-service/cogni-service/0.0.402/scripts/mutation-check.sh \
  --root . \
  --file cogni-portfolio/scripts/append-claim.sh \
  --expr 's/\\"data\\": null, //' \
  --test 'bash cogni-portfolio/tests/test-append-claim-lock.sh' \
  --case live-lock-not-swept-on-numeric-stat

# Ninth arm — the USAGE envelope's shape:
bash ~/.claude/plugins/cache/managed-service/cogni-service/0.0.402/scripts/mutation-check.sh \
  --root . \
  --file cogni-portfolio/scripts/append-claim.sh \
  --expr 's/"data": null, "error": "Usage/"error": "Usage/' \
  --test 'bash cogni-portfolio/tests/test-append-claim-lock.sh' \
  --case no-arguments-emits-usage-envelope
```

Each arm drops the `data` key from one envelope, leaving valid JSON, an untouched message, unchanged exit status and unchanged stream routing — so only the new structural check sees it.

### Replay results (measured on this branch)

| Arm | Case | Verdict |
|---|---|---|
| 1 | `stale-lock-swept-on-non-numeric-stat` | `guard_verified` |
| 2 | `live-lock-not-swept-on-numeric-stat` | `guard_verified` |
| 3 | `live-lock-not-swept-on-numeric-stat` | `guard_verified` |
| 4 | `live-lock-not-swept-on-gnu-stat` | `guard_verified` |
| 5 | `probe-resolved-once-per-acquire` | `guard_verified` |
| 6 | `stale-sweep-bounded-when-rmdir-fails` | `guard_verified` |
| 7 | `stale-lock-swept-on-non-numeric-stat` | `guard_verified` |
| **8** | `live-lock-not-swept-on-numeric-stat` | **`guard_verified`** |
| **8** | `live-lock-not-swept-on-gnu-stat` (co-catcher) | **`guard_verified`** |
| **8** | `stale-sweep-bounded-when-rmdir-fails` (declared NON-catcher) | `vacuous_guard` — as documented |
| **9** | `no-arguments-emits-usage-envelope` | **`guard_verified`** |

**Non-vacuity proof.** Both new arms were also replayed against the **base-ref suite** in a separate detached worktree at `origin/main`: arm 8 returns `vacuous_guard` and arm 9 returns `case_not_found`. The new assertions are therefore what discriminate, not something already covered.

**Match counts.** All nine `--expr` patterns match **exactly once** in `append-claim.sh`, counted with the same regex engine the harness uses (`perl -0777`). Neither new expression carries a `^`/`$` anchor, so neither needs `/m` under the harness's `perl -0pi`.

## Test plan

- [x] `bash cogni-portfolio/tests/test-append-claim-lock.sh` — 8/8 `ok`, exits 0, 3.35s (header's "near four seconds" claim still holds)
- [x] `python3 scripts/run-plugin-tests.py --filter cogni-portfolio` — 7/7 passed, exits 0
- [x] Full repo sweep **post-commit** — 127/127 passed, 0 failed
- [x] All nine mutation arms replay to `guard_verified`; declared catcher and non-catcher sets confirmed by execution
- [x] Both new arms are `vacuous_guard` / `case_not_found` against the base ref
- [x] `python3 scripts/check-result-line-plainness.py` — 0 violations (the `pass`/`fail` emitters are untouched plain `printf`)
- [x] `python3 scripts/check-breadcrumbs.py` — 0 new breadcrumbs
- [x] No version line touched in any `plugin.json` or `marketplace.json` — the patch bump is applied post-merge

## Scope decisions

- **Case 5 deliberately does not get the structural check.** It reaches the same timeout envelope but is the sweep-budget bound, its assertions are about re-entry, and it already carries five branches; the envelope is pinned twice over by cases 2 and 3. This is recorded explicitly in the suite because it means case 5 is not a catcher for the eighth arm — and the replay above confirms it.
- **`append-claim.sh` is not edited** — the envelope already landed there on all four emit paths.
- **No success-path assertion was touched** — cases 1, 6 and 7 already carry the full-envelope idiom, as the maintainer's scope correction on the issue noted.

## Notes for the reviewer

- The issue body's line references (236, 285) were stale at pick time; the real anchors were 369 and 418.
- The `python3 -c` JSON-parse one-liner is now duplicated three times in the added code. That matches the suite's existing convention — it already carried three copies of the sibling success-shape idiom — so no helper was extracted; doing so would have touched six call sites outside this diff.
- The runner token is over-scoped (`gist`, `read:org`, `workflow`) because it is a `gh auth login` token whose scope set is fixed by the GitHub CLI OAuth app. The scope preflight was cleared with the documented `--allow-overscoped` opt-out rather than silently.