### PR TITLE
Normalise 12 test suites to the mutation-replayable PASS:/FAIL: shape

### DIFF
--- a/cogni-consult/tests/test_assumption_change_frequency.sh
+++ b/cogni-consult/tests/test_assumption_change_frequency.sh
@@ -39,8 +39,8 @@ TMPROOT="$(mktemp -d)"
 trap 'rm -rf "$TMPROOT"' EXIT
 
 failures=0
-pass() { printf 'OK   %s\n' "$1"; }
-fail() { printf 'FAIL %s: %s\n' "$1" "$2" >&2; failures=$((failures + 1)); }
+pass() { printf 'PASS: %s\n' "$1"; }
+fail() { printf 'FAIL: %s - %s\n' "$1" "$2" >&2; failures=$((failures + 1)); }
 
 # Assert the envelope's success flag and (on failure) failed_check.
 # Args: <name> <expected-success> <expected-failed_check-or-empty> <envelope>

--- a/cogni-consult/tests/test_deliverable_graph.sh
+++ b/cogni-consult/tests/test_deliverable_graph.sh
@@ -52,8 +52,8 @@ TMPROOT="$(mktemp -d)"
 trap 'rm -rf "$TMPROOT"' EXIT
 
 failures=0
-pass() { printf 'OK   %s\n' "$1"; }
-fail() { printf 'FAIL %s: %s\n' "$1" "$2" >&2; failures=$((failures + 1)); }
+pass() { printf 'PASS: %s\n' "$1"; }
+fail() { printf 'FAIL: %s - %s\n' "$1" "$2" >&2; failures=$((failures + 1)); }
 
 run() { python3 "$SCRIPT" "$@"; }
 

--- a/cogni-consult/tests/test_discover_extractor.sh
+++ b/cogni-consult/tests/test_discover_extractor.sh
@@ -58,11 +58,12 @@ trap 'rm -rf "$TMPROOT"' EXIT
 
 failures=0
 
-# Label shape deviates from the sibling suites' `OK   <name>` / `FAIL <name>:` on
-# purpose. cogni-service/scripts/mutation-check.sh classifies a case by scanning
+# Label shape is the one every suite in this directory now uses.
+# cogni-service/scripts/mutation-check.sh classifies a case by scanning
 # output for `^[ \t]*FAIL:[ \t]+<case>([ \t]|$)` (RED) and
-# `^[ \t]*(ok|PASS):[ \t]+<case>([ \t]|$)` (GREEN) — the inherited shape matches
-# neither, so a mutation recipe naming a case here would return case_not_found.
+# `^[ \t]*(ok|PASS):[ \t]+<case>([ \t]|$)` (GREEN) — the older `OK   <name>` /
+# `FAIL <name>:` shape matched neither, so a mutation recipe naming such a case
+# returned case_not_found.
 # The match is whole-token, so --case M1 never matches an M10 line — which is
 # also why the detail is separated from the case-id by a SPACE and not a colon:
 # `FAIL: M1: detail` puts a colon where the harness requires whitespace-or-EOL,

--- a/cogni-consult/tests/test_dt_stage_advance.sh
+++ b/cogni-consult/tests/test_dt_stage_advance.sh
@@ -37,8 +37,8 @@ TMPROOT="$(mktemp -d)"
 trap 'rm -rf "$TMPROOT"' EXIT
 
 failures=0
-pass() { printf 'OK   %s\n' "$1"; }
-fail() { printf 'FAIL %s: %s\n' "$1" "$2" >&2; failures=$((failures + 1)); }
+pass() { printf 'PASS: %s\n' "$1"; }
+fail() { printf 'FAIL: %s - %s\n' "$1" "$2" >&2; failures=$((failures + 1)); }
 
 # Build a minimal engagement with one field manifest. Args: <dir> <dt_stage-json-snippet>
 # The snippet is spliced as the deliverable's dt_stage line (or empty to omit it).

--- a/cogni-consult/tests/test_generate_dashboard.sh
+++ b/cogni-consult/tests/test_generate_dashboard.sh
@@ -49,8 +49,8 @@ failures=0
 # case_not_found. The `OK   `/`FAIL ` shape this suite used before matched
 # neither, so a mutation recipe naming one of these cases could not return a
 # verdict at all. (The plugin-local scripts/mutation-check.sh is a different
-# instrument — it takes no --case and reads only exit status.) Suites here are
-# mixed on this today; test_reference_pointers.sh already uses this shape.
+# instrument — it takes no --case and reads only exit status.) Every suite in
+# this directory now uses this shape.
 pass() { printf 'PASS: %s\n' "$1"; }
 fail() { printf 'FAIL: %s - %s\n' "$1" "$2" >&2; failures=$((failures + 1)); }
 

--- a/cogni-consult/tests/test_generate_engagement_readme.sh
+++ b/cogni-consult/tests/test_generate_engagement_readme.sh
@@ -54,8 +54,8 @@ failures=0
 # case_not_found. The `OK   `/`FAIL ` shape this suite used before matched
 # neither, so a mutation recipe naming one of these cases could not return a
 # verdict at all. (The plugin-local scripts/mutation-check.sh is a different
-# instrument — it takes no --case and reads only exit status.) Suites here are
-# mixed on this today; test_reference_pointers.sh already uses this shape.
+# instrument — it takes no --case and reads only exit status.) Every suite in
+# this directory now uses this shape.
 pass() { printf 'PASS: %s\n' "$1"; }
 fail() { printf 'FAIL: %s - %s\n' "$1" "$2" >&2; failures=$((failures + 1)); }
 

--- a/cogni-consult/tests/test_orthography_drift_scan.sh
+++ b/cogni-consult/tests/test_orthography_drift_scan.sh
@@ -45,7 +45,7 @@ PLUGIN_DIR="$(dirname "$TESTS_DIR")"
 SCRIPT="${CONSULT_ORTHOGRAPHY_SCAN:-$PLUGIN_DIR/scripts/orthography-drift-scan.py}"
 
 if [ ! -f "$SCRIPT" ]; then
-  echo "FAIL orthography-drift-scan.py not found at $SCRIPT" >&2
+  echo "FAIL: orthography-drift-scan.py not found at $SCRIPT" >&2
   exit 1
 fi
 
@@ -53,8 +53,8 @@ TMPROOT="$(mktemp -d)"
 trap 'rm -rf "$TMPROOT"' EXIT
 
 failures=0
-pass() { printf 'OK   %s\n' "$1"; }
-fail() { printf 'FAIL %s: %s\n' "$1" "$2" >&2; failures=$((failures + 1)); }
+pass() { printf 'PASS: %s\n' "$1"; }
+fail() { printf 'FAIL: %s - %s\n' "$1" "$2" >&2; failures=$((failures + 1)); }
 
 # Always invoked through python3: this plugin's script mode bits are mixed, and a copied
 # fixture need not keep the executable bit.
@@ -205,15 +205,15 @@ DRIFT_DIGEST_BEFORE="$(digest_tree "$DRIFT")"
 # --- 1  clean ---------------------------------------------------------------
 
 env_clean="$(scan "$CLEAN")"
-assert_envelope "clean: envelope" true "" "$env_clean"
+assert_envelope "clean - envelope" true "" "$env_clean"
 if [ "$(total_findings "$env_clean")" = "0" ]; then
-  pass "clean: dass/muss/Prozess/Masse/Busse report nothing"
+  pass "clean - dass/muss/Prozess/Masse/Busse report nothing"
 else
   fail "clean" "expected 0 findings, got $(total_findings "$env_clean")"
 fi
 
 env_drift="$(scan "$DRIFT")"
-assert_envelope "drift: envelope is success (drift is a successful scan)" true "" "$env_drift"
+assert_envelope "drift - envelope is success (drift is a successful scan)" true "" "$env_drift"
 # Pinned to the exact seeded count, not merely -gt 0: a non-zero check passes just as
 # happily on 1 as on 8, so it cannot see a regression that silently loses most findings.
 # The eight, by file: scope/key-question.md carries grösse (in Messgrösse), heisst,
@@ -221,7 +221,7 @@ assert_envelope "drift: envelope is success (drift is a successful scan)" true "
 # .metadata/decision-log.json's rationale carries Strasse and gemäss; the marker-less
 # sources/README.md carries Strasse. The two marker-bearing echoes contribute nothing.
 if [ "$(total_findings "$env_drift")" = "8" ]; then
-  pass "drift: reports exactly the 8 seeded findings"
+  pass "drift - reports exactly the 8 seeded findings"
 else
   fail "drift" "expected exactly 8 findings, got $(total_findings "$env_drift")"
 fi
@@ -252,7 +252,7 @@ else:
     print("")
 ')"
 if [ -z "$shape" ]; then
-  pass "markdown-finding: path + line + form + suggestion"
+  pass "markdown-finding - path + line + form + suggestion"
 else
   fail "markdown-finding" "$shape"
 fi
@@ -277,7 +277,7 @@ else:
     print("")
 ')"
 if [ -z "$breakdown" ]; then
-  pass "markdown-finding: per-file breakdown matches the findings list and sums to the total"
+  pass "markdown-finding - per-file breakdown matches the findings list and sums to the total"
 else
   fail "markdown-finding/by_file" "$breakdown"
 fi
@@ -285,7 +285,7 @@ fi
 # --- 3  stem-match ----------------------------------------------------------
 
 if [ "$(count_form 'grösse' "$env_drift")" = "1" ]; then
-  pass "stem-match: Messgrösse reported from the bare Grösse entry"
+  pass "stem-match - Messgrösse reported from the bare Grösse entry"
 else
   fail "stem-match" "expected 1 lowercase grösse finding (from Messgrösse), got $(count_form 'grösse' "$env_drift")"
 fi
@@ -293,7 +293,7 @@ fi
 # --- 4  case-variance -------------------------------------------------------
 
 if [ "$(count_form 'heisst' "$env_drift")" -ge 1 ] && [ "$(count_form 'Heisst' "$env_drift")" -ge 1 ]; then
-  pass "case-variance: heisst and sentence-initial Heisst both report"
+  pass "case-variance - heisst and sentence-initial Heisst both report"
 else
   fail "case-variance" "heisst=$(count_form 'heisst' "$env_drift") Heisst=$(count_form 'Heisst' "$env_drift"), want both >= 1"
 fi
@@ -301,7 +301,7 @@ fi
 # --- 5  homographs ----------------------------------------------------------
 
 if [ "$(count_form 'Masse' "$env_drift")" = "0" ] && [ "$(count_form 'Busse' "$env_drift")" = "0" ]; then
-  pass "homographs: Masse and Busse are not entries"
+  pass "homographs - Masse and Busse are not entries"
 else
   fail "homographs" "Masse and Busse must never be reported — spelling cannot disambiguate them"
 fi
@@ -328,7 +328,7 @@ else:
     print("")
 ')"
 if [ -z "$json_verdict" ]; then
-  pass "json-prose-key: framing reports, the non-prose deliverable slug does not"
+  pass "json-prose-key - framing reports, the non-prose deliverable slug does not"
 else
   fail "json-prose-key" "$json_verdict"
 fi
@@ -350,7 +350,7 @@ else:
     print("")
 ')"
 if [ -z "$dot_verdict" ]; then
-  pass "dot-directory: .metadata/decision-log.json rationale reports"
+  pass "dot-directory - .metadata/decision-log.json rationale reports"
 else
   fail "dot-directory" "$dot_verdict"
 fi
@@ -374,7 +374,7 @@ else:
     print("")
 ')"
 if [ -z "$echo_verdict" ]; then
-  pass "generated-echo: marker-bearing echoes excluded, a marker-less file still scanned"
+  pass "generated-echo - marker-bearing echoes excluded, a marker-less file still scanned"
 else
   fail "generated-echo" "$echo_verdict"
 fi
@@ -393,16 +393,16 @@ else:
     print("")
 ')"
 if [ -z "$esc_verdict" ]; then
-  pass "escaped-json: \\uXXXX-escaped values are decoded before matching"
+  pass "escaped-json - \\uXXXX-escaped values are decoded before matching"
 else
   fail "escaped-json" "$esc_verdict"
 fi
 
 # --- 9  failure-paths ------------------------------------------------------
 
-assert_envelope "failure-paths: missing engagement" false "engagement_missing" "$(scan "$TMPROOT/does-not-exist")"
-assert_envelope "failure-paths: not a directory" false "not_a_directory" "$(scan "$DRIFT/scope/key-question.md")"
-assert_envelope "failure-paths: no argument" false "usage" "$(scan)"
+assert_envelope "failure-paths - missing engagement" false "engagement_missing" "$(scan "$TMPROOT/does-not-exist")"
+assert_envelope "failure-paths - not a directory" false "not_a_directory" "$(scan "$DRIFT/scope/key-question.md")"
+assert_envelope "failure-paths - no argument" false "usage" "$(scan)"
 
 # --- 10  envelope-shape ----------------------------------------------------
 
@@ -413,7 +413,7 @@ for envelope in "$env_clean" "$env_drift" "$(scan "$TMPROOT/does-not-exist")" "$
   fi
 done
 if [ "$lines_ok" -eq 1 ]; then
-  pass "envelope-shape: exactly one stdout line on every exit path"
+  pass "envelope-shape - exactly one stdout line on every exit path"
 else
   fail "envelope-shape" "an exit path emitted a preamble line before the JSON"
 fi
@@ -421,7 +421,7 @@ fi
 if printf '%s' "$env_drift" | grep -qF 'Grösse' \
   && printf '%s' "$env_drift" | grep -qF 'Größe' \
   && ! printf '%s' "$env_drift" | grep -q 'u00df'; then
-  pass "envelope-shape: literal ß bytes, no ASCII substitutes and no \\u escapes"
+  pass "envelope-shape - literal ß bytes, no ASCII substitutes and no \\u escapes"
 else
   fail "envelope-shape" "reported forms must be the literal bytes Grösse / Größe"
 fi
@@ -434,21 +434,21 @@ import json, sys
 print(repr(json.loads(sys.stdin.read())["error"]))
 ')"
 if [ "$error_repr" = "''" ]; then
-  pass "envelope-shape: the success envelope's error is the empty string, not null"
+  pass "envelope-shape - the success envelope's error is the empty string, not null"
 else
   fail "envelope-shape" "success envelope error is $error_repr, want ''"
 fi
 
 # --- 11  read-only-flag ----------------------------------------------------
 
-assert_envelope "read-only-flag: --fix rejected" false "unexpected_argument" "$(scan "$DRIFT" --fix)"
+assert_envelope "read-only-flag - --fix rejected" false "unexpected_argument" "$(scan "$DRIFT" --fix)"
 
 # --- 12  read-only-tree ----------------------------------------------------
 
 scan "$DRIFT" >/dev/null
 after="$(digest_tree "$DRIFT")"
 if [ "$DRIFT_DIGEST_BEFORE" = "$after" ]; then
-  pass "read-only-tree: fixture tree byte-identical across a drift-reporting scan"
+  pass "read-only-tree - fixture tree byte-identical across a drift-reporting scan"
 else
   fail "read-only-tree" "the scan modified the corpus it was asked to inspect"
 fi
@@ -466,7 +466,7 @@ import json, sys
 print(json.dumps(json.loads(sys.stdin.read())["data"]["by_file"]))
 ')"
   if [ "$clean_by_file" = "{}" ]; then
-    pass "scoping: a sibling engagement's Swiss text contributes zero findings"
+    pass "scoping - a sibling engagement's Swiss text contributes zero findings"
   else
     fail "scoping" "the clean scan reached outside its engagement: by_file=$clean_by_file"
   fi
@@ -487,10 +487,10 @@ if [ "$(id -u)" -ne 0 ]; then
   unreadable_envelope="$(scan "$unreadable")"
   # Restored immediately so the EXIT trap's rm -rf can still remove the fixture.
   chmod 755 "$unreadable"
-  assert_envelope "fail-loud: an unreadable engagement root" false "engagement_unreadable" \
+  assert_envelope "fail-loud - an unreadable engagement root" false "engagement_unreadable" \
     "$unreadable_envelope"
 else
-  pass "fail-loud: an unreadable engagement root (skipped as root)"
+  pass "fail-loud - an unreadable engagement root (skipped as root)"
 fi
 
 # --- 13  goes-red ----------------------------------------------------------
@@ -539,7 +539,7 @@ if mutate "$TMPROOT/mutant_empty.py" empty-pairs; then
   env_mut="$(mutant_findings "$TMPROOT/mutant_empty.py")"
   got="$(total_findings "$env_mut" 2>/dev/null || echo unparseable)"
   if [ "$got" = "0" ]; then
-    pass "goes-red: emptying SWISS_PAIRS drops every finding (detection has teeth)"
+    pass "goes-red - emptying SWISS_PAIRS drops every finding (detection has teeth)"
   else
     fail "goes-red/empty-pairs" "mutant still reported $got findings — the pair list is not what drives detection"
   fi
@@ -552,7 +552,7 @@ if mutate "$TMPROOT/mutant_anchored.py" anchor-whole-word; then
   env_mut="$(mutant_findings "$TMPROOT/mutant_anchored.py")"
   if printf '%s' "$env_mut" | python3 -c 'import json,sys; sys.exit(0 if json.loads(sys.stdin.read()).get("success") is True else 1)'; then
     if [ "$(count_form 'grösse' "$env_mut")" = "0" ]; then
-      pass "goes-red: anchoring the matcher whole-word loses Messgrösse (stem matching is load-bearing)"
+      pass "goes-red - anchoring the matcher whole-word loses Messgrösse (stem matching is load-bearing)"
     else
       fail "goes-red/anchored" "the anchored mutant still reported Messgrösse — matching is not stem-based"
     fi

--- a/cogni-consult/tests/test_reference_pointers.sh
+++ b/cogni-consult/tests/test_reference_pointers.sh
@@ -2,7 +2,7 @@
 # Guard: every absolute reference pointer in cogni-consult resolves, the extracted
 # rendering contracts stay extracted, and neither can be silently re-inlined.
 #
-# Label vocabulary is deliberately NOT the sibling suites' `OK   ` shape. The
+# Label vocabulary is the shape every suite in this directory now carries. The
 # shared mutation harness classifies a case by matching `FAIL: <case>` (red) and
 # `ok: <case>` / `PASS: <case>` (green), each requiring whitespace or end-of-line
 # immediately after the case token. So a case id is a single whitespace-free

--- a/cogni-consult/tests/test_register_generator.sh
+++ b/cogni-consult/tests/test_register_generator.sh
@@ -36,8 +36,8 @@ TMPROOT="$(mktemp -d)"
 trap 'rm -rf "$TMPROOT"' EXIT
 
 failures=0
-pass() { printf 'OK   %s\n' "$1"; }
-fail() { printf 'FAIL %s: %s\n' "$1" "$2" >&2; failures=$((failures + 1)); }
+pass() { printf 'PASS: %s\n' "$1"; }
+fail() { printf 'FAIL: %s - %s\n' "$1" "$2" >&2; failures=$((failures + 1)); }
 
 # Assert the envelope's success flag. Args: <name> <expected-success> <envelope>
 assert_success() {

--- a/cogni-consult/tests/test_resolve_assumptions.sh
+++ b/cogni-consult/tests/test_resolve_assumptions.sh
@@ -63,8 +63,8 @@ TMPROOT="$(mktemp -d)"
 trap 'rm -rf "$TMPROOT"' EXIT
 
 failures=0
-pass() { printf 'OK   %s\n' "$1"; }
-fail() { printf 'FAIL %s: %s\n' "$1" "$2" >&2; failures=$((failures + 1)); }
+pass() { printf 'PASS: %s\n' "$1"; }
+fail() { printf 'FAIL: %s - %s\n' "$1" "$2" >&2; failures=$((failures + 1)); }
 
 # Assert the envelope's success flag and (on failure envelopes) failed_check.
 # Args: <name> <expected-success> <expected-failed_check-or-empty> <envelope>

--- a/cogni-consult/tests/test_step0_register_block.sh
+++ b/cogni-consult/tests/test_step0_register_block.sh
@@ -67,8 +67,8 @@ Discover cogni-consult engagements
 Laufende Engagements holen'
 
 failures=0
-pass() { printf 'OK   %s\n' "$1"; }
-fail() { printf 'FAIL %s: %s\n' "$1" "$2" >&2; failures=$((failures + 1)); }
+pass() { printf 'PASS: %s\n' "$1"; }
+fail() { printf 'FAIL: %s - %s\n' "$1" "$2" >&2; failures=$((failures + 1)); }
 
 # Extract the paragraph starting at the line matching $2, from file $1.
 # A paragraph ends at the first blank line, which is what makes the comparison
@@ -85,7 +85,7 @@ for f in "$PLUGIN_DIR"/skills/consult-*/SKILL.md; do
 done
 
 if [ "${#skills[@]}" -eq 9 ]; then
-  pass "glob-count: 9 consult-* SKILL.md found"
+  pass "glob-count - 9 consult-* SKILL.md found"
 else
   fail "glob-count" "expected 9 consult-*/SKILL.md, found ${#skills[@]}"
 fi
@@ -104,7 +104,7 @@ for f in "${skills[@]}"; do
     anchor="${pair#*:}"
     n="$(grep -c "$anchor" "$f")"
     if [ "$n" -eq 1 ]; then
-      pass "anchor-once: $name $label"
+      pass "anchor-once - $name $label"
     else
       fail "anchor-once" "$name has $n $label anchors, expected 1"
     fi
@@ -131,7 +131,7 @@ check_identical() {
       continue
     fi
     if [ "$block" = "$reference" ]; then
-      pass "$label: $name matches $reference_name"
+      pass "$label - $name matches $reference_name"
     else
       fail "$label" "$name diverges from $reference_name"
     fi
@@ -153,7 +153,7 @@ while IFS= read -r needle; do
     grep -qF "$needle" "$f" || missing="$missing $(basename "$(dirname "$f")")"
   done
   if [ -z "$missing" ]; then
-    pass "specifics-inline: '$needle' present in all 9"
+    pass "specifics-inline - '$needle' present in all 9"
   else
     fail "specifics-inline" "'$needle' missing from:$missing"
   fi
@@ -168,7 +168,7 @@ if [ ! -f "$OWNER" ]; then
 else
   for needle in '## (f) Tool-call descriptions' '6 words' 'Discover cogni-consult engagements'; do
     if grep -qF "$needle" "$OWNER"; then
-      pass "owner-present: '$needle'"
+      pass "owner-present - '$needle'"
     else
       fail "owner-present" "'$needle' missing from user-facing-output.md"
     fi
@@ -201,7 +201,7 @@ if [ "$NESTED" -eq 0 ]; then
     if bash "$0" --root "$drifted" >/dev/null 2>&1; then
       fail "goes-red" "a drifted register paragraph did not fail the guard"
     else
-      pass "goes-red: a drifted register paragraph fails the guard"
+      pass "goes-red - a drifted register paragraph fails the guard"
     fi
   else
     fail "goes-red" "could not build the drifted fixture"
@@ -216,7 +216,7 @@ if [ "$NESTED" -eq 0 ]; then
     if bash "$0" --root "$thinned" >/dev/null 2>&1; then
       fail "goes-red" "a thinned specific did not fail the guard"
     else
-      pass "goes-red: a thinned specific fails the guard"
+      pass "goes-red - a thinned specific fails the guard"
     fi
   else
     fail "goes-red" "could not build the thinned fixture"

--- a/cogni-consult/tests/test_subagent_start_hook.sh
+++ b/cogni-consult/tests/test_subagent_start_hook.sh
@@ -51,8 +51,8 @@ TMPROOT="$(mktemp -d)"
 trap 'rm -rf "$TMPROOT"' EXIT
 
 failures=0
-pass() { printf 'OK   %s\n' "$1"; }
-fail() { printf 'FAIL %s: %s\n' "$1" "$2" >&2; failures=$((failures + 1)); }
+pass() { printf 'PASS: %s\n' "$1"; }
+fail() { printf 'FAIL: %s - %s\n' "$1" "$2" >&2; failures=$((failures + 1)); }
 
 # Derived from disk, never hardcoded: a fifth consult-* agent added to both
 # agents/ and the matcher would keep the drift guard green while loops 2 and 3
@@ -78,11 +78,11 @@ if inner[0].get("type") != "command":
     sys.exit("hook type must be command, got %r" % inner[0].get("type"))
 if "on-subagent-start.sh" not in (inner[0].get("command") or ""):
     sys.exit("command does not point at on-subagent-start.sh: %r" % inner[0].get("command"))
-' && pass "declaration: one command-type SubagentStart entry" \
+' && pass "declaration - one command-type SubagentStart entry" \
   || fail "declaration" "hooks.json shape wrong (see above)"
 
 if [ -f "$HOOK_SCRIPT" ] && [ -x "$HOOK_SCRIPT" ]; then
-  pass "declaration: hook script present and executable"
+  pass "declaration - hook script present and executable"
 else
   fail "declaration" "hook script missing or not executable: $HOOK_SCRIPT"
 fi
@@ -112,12 +112,12 @@ sys.exit(0 if got == os.environ["WANT"] else 1)
 # with the alternation's optional prefix — unlike block 3, they pin no known
 # behaviour.
 for a in $AGENTS; do
-  assert_match "bare: $a" "$a" yes
+  assert_match "bare - $a" "$a" yes
 done
 
 # 3 plugin-qualified names — the regression this test exists for
 for a in $AGENTS; do
-  assert_match "qualified: cogni-consult:$a" "cogni-consult:$a" yes
+  assert_match "qualified - cogni-consult:$a" "cogni-consult:$a" yes
 done
 
 # 4 near-misses.
@@ -153,13 +153,13 @@ alts.append(m[start:])
 loose = [a for a in alts if not (a.startswith("^") and a.endswith("$"))]
 if loose:
     sys.exit("top-level alternative(s) not anchored at both ends: %r" % loose)
-' && pass "anchoring: every top-level alternative is anchored" \
+' && pass "anchoring - every top-level alternative is anchored" \
   || fail "anchoring" "matcher=$MATCHER (see above)"
 
-assert_match "reject: foreign qualification" "cogni-portfolio:consult-persona-challenger" no
-assert_match "reject: suffix near-miss" "consult-dashboard-refresherX" no
-assert_match "reject: prefix affix" "xconsult-empathy-mapper" no
-assert_match "reject: prefix alone" "cogni-consult:" no
+assert_match "reject - foreign qualification" "cogni-portfolio:consult-persona-challenger" no
+assert_match "reject - suffix near-miss" "consult-dashboard-refresherX" no
+assert_match "reject - prefix affix" "xconsult-empathy-mapper" no
+assert_match "reject - prefix alone" "cogni-consult:" no
 
 # 5 drift guard — the alternation and agents/ agree in both directions.
 # The agent-name group is the LAST alternation group, not the first: the matcher
@@ -180,7 +180,7 @@ missing_matcher = sorted(n for n in on_disk if n not in names)
 if missing_file or missing_matcher:
     sys.exit("in matcher but no agent file: %r; agent file but not matched: %r"
              % (missing_file, missing_matcher))
-' && pass "drift guard: matcher alternation matches agents/" \
+' && pass "drift guard - matcher alternation matches agents/" \
   || fail "drift guard" "matcher and agents/ disagree (see above)"
 
 # 6 envelope — run the hook the way Claude Code does.
@@ -211,7 +211,7 @@ for heading in ("# Interaction language and output register",
                 "## Register"):
     if heading not in ctx:
         sys.exit("additionalContext missing %r" % heading)
-' && pass "envelope: valid SubagentStart payload with language block and contract" \
+' && pass "envelope - valid SubagentStart payload with language block and contract" \
   || fail "envelope" "hook output wrong (see above)"
 
 if [ "$failures" -gt 0 ]; then

--- a/cogni-trends/tests/test-agent-frontmatter-names.sh
+++ b/cogni-trends/tests/test-agent-frontmatter-names.sh
@@ -20,9 +20,9 @@
 #     regex validates kebab-case SHAPE alone; a well-formed but wrong name passes.
 # Both were green on the broken tree.
 #
-# Case-label shape deviates from the sibling suites on purpose.
-# test-project-status.sh and test-stale-detection.sh print "OK   <label>"; this
-# suite prints "PASS: <label>" / "FAIL: <label>" because the cogni-service
+# Case-label shape is "PASS: <label>" / "FAIL: <label>", the shape every
+# discovered suite in this repo now carries — test-project-status.sh and
+# test-stale-detection.sh included. The cogni-service
 # mutation harness classifies a case GREEN only on
 # ^[[:space:]]*(ok|PASS):[[:space:]]+<case> and RED on the matching FAIL: form.
 # Neither "OK   " nor "OK:" is in that vocabulary, so a mutation replay against
@@ -31,7 +31,7 @@
 # reports case_not_found on a genuinely red case. Case ids are A-prefixed and
 # never bare numerals, which keeps the final summary line
 # ("FAIL: <n> agent-frontmatter-name test(s) failed.") from being read as a
-# case's RED line. Do not "fix" these labels back to the house style.
+# case's RED line — a hazard the colon form creates and every suite must answer.
 #
 # This file deliberately never spells the pre-fix bare agent name as one
 # contiguous token: the repo-wide falsifier for issue #1388 is an unfiltered

--- a/cogni-trends/tests/test-project-status.sh
+++ b/cogni-trends/tests/test-project-status.sh
@@ -71,9 +71,9 @@ failures = []
 
 def check(label, actual, expected):
     if actual == expected:
-        print(f"OK   {label}: {actual}")
+        print(f"PASS: {label} - {actual}")
     else:
-        print(f"FAIL {label}: got {actual!r}, expected {expected!r}")
+        print(f"FAIL: {label} - got {actual!r}, expected {expected!r}")
         failures.append(label)
 
 check("counts.investment_themes", counts.get("investment_themes"), 5)
@@ -96,17 +96,17 @@ expected_stage_names = [
 for offset, expected_name in enumerate(expected_stage_names):
     idx = 4 + offset
     if idx >= len(stages):
-        print(f"FAIL stages[{idx}] missing — only {len(stages)} stages emitted")
-        failures.append(f"stages[{idx}]")
+        print(f"FAIL: stages-{idx} - missing, only {len(stages)} stages emitted")
+        failures.append(f"stages-{idx}")
         continue
     s = stages[idx]
     name_ok = s.get("name") == expected_name
     status_ok = s.get("status") == "done"
     if name_ok and status_ok:
-        print(f"OK   stages[{idx}] {s['name']!r} status=done")
+        print(f"PASS: stages-{idx} - {s['name']!r} status=done")
     else:
-        print(f"FAIL stages[{idx}] name={s.get('name')!r} status={s.get('status')!r} (expected {expected_name!r}/done)")
-        failures.append(f"stages[{idx}]")
+        print(f"FAIL: stages-{idx} - name={s.get('name')!r} status={s.get('status')!r} (expected {expected_name!r}/done)")
+        failures.append(f"stages-{idx}")
 
 if failures:
     print(f"\n{len(failures)} assertion(s) failed", file=sys.stderr)

--- a/cogni-trends/tests/test-research-manifest-sections.sh
+++ b/cogni-trends/tests/test-research-manifest-sections.sh
@@ -30,17 +30,17 @@
 # cannot drift apart again" property this suite owes the issue. Every dimension is
 # therefore asserted individually, off a parsed map rather than a text match.
 #
-# Case-label shape deviates from two of the sibling suites on purpose.
-# test-project-status.sh and test-stale-detection.sh print "OK   <label>"; this
-# suite prints "PASS: <label>" / "FAIL: <label>" — matching
-# test-agent-frontmatter-names.sh — because the cogni-service mutation harness
+# Case-label shape is "PASS: <label>" / "FAIL: <label>" — matching
+# test-agent-frontmatter-names.sh, and the shape every discovered suite in this
+# repo now carries, test-project-status.sh and test-stale-detection.sh included.
+# It is what it is because the cogni-service mutation harness
 # classifies a case GREEN only on ^[[:space:]]*(ok|PASS):[[:space:]]+<case> and
 # RED on the matching FAIL: form. Neither "OK   " nor "OK:" is in that vocabulary.
 # The detail after a case id is separated by a SPACE and never a colon —
 # "FAIL: A2: detail" also reports case_not_found on a genuinely red case. Case ids
 # are A-prefixed and never bare numerals, which keeps the final summary line
 # ("FAIL: <n> research-manifest-sections test(s) failed.") from being read as a
-# case's RED line. Do not "fix" these labels back to the house style.
+# case's RED line — a hazard the colon form creates and every suite must answer.
 #
 # This file deliberately never spells the pre-fix section path as one contiguous
 # token. The repo-wide falsifier for issue #1389 is an unfiltered scan under

--- a/cogni-trends/tests/test-stale-detection.sh
+++ b/cogni-trends/tests/test-stale-detection.sh
@@ -170,8 +170,8 @@ run_health() {
 }
 
 FAIL_COUNT=0
-fail() { echo "FAIL $1" >&2; FAIL_COUNT=$((FAIL_COUNT + 1)); }
-ok()   { echo "OK   $1"; }
+fail() { printf 'FAIL: %s\n' "$1" >&2; FAIL_COUNT=$((FAIL_COUNT + 1)); }
+ok()   { printf 'PASS: %s\n' "$1"; }
 
 # ---------------------------------------------------------------------------
 # Case 1: Mirroring is not drift.
@@ -187,9 +187,9 @@ touch "$P1/.metadata/trend-scout-output.json"
 OUT="$(run_health "$P1" | extract)"
 HAS_STALE="$(echo "$OUT" | python3 -c 'import json,sys; w=json.load(sys.stdin)["warnings"]; print(any(x.get("type")=="stale_report" for x in w))')"
 if [ "$HAS_STALE" = "False" ]; then
-  ok "case 1 — mirroring did not fire stale_report"
+  ok "S1 — mirroring did not fire stale_report"
 else
-  fail "case 1 — stale_report fired even though candidate content is unchanged"
+  fail "S1 — stale_report fired even though candidate content is unchanged"
   echo "$OUT" >&2
 fi
 
@@ -233,29 +233,35 @@ print(json.dumps({
 python3 - "$SUMMARY" <<'PYEOF'
 import json, sys
 s = json.loads(sys.argv[1])
-problems = []
+problems_a = []
+problems_b = []
 if s["stale_count"] < 1:
-    problems.append("stale_report did not fire on real drift")
+    problems_a.append("stale_report did not fire on real drift")
 if s["subtype"] != "scout_drift":
-    problems.append(f"subtype={s['subtype']!r} (expected 'scout_drift')")
+    problems_a.append(f"subtype={s['subtype']!r} (expected 'scout_drift')")
 if "t-003" not in (s["added"] or []):
-    problems.append(f"added={s['added']!r} (expected to contain 't-003')")
+    problems_a.append(f"added={s['added']!r} (expected to contain 't-003')")
 if "t-001" not in (s["changed"] or []):
-    problems.append(f"changed={s['changed']!r} (expected to contain 't-001')")
+    problems_a.append(f"changed={s['changed']!r} (expected to contain 't-001')")
 if s["first_action_skill"] != "cogni-trends:trend-research":
-    problems.append(f"first action skill={s['first_action_skill']!r} (expected cogni-trends:trend-research)")
+    problems_b.append(f"first action skill={s['first_action_skill']!r} (expected cogni-trends:trend-research)")
 reason = s["first_action_reason"] or ""
 # Both halves of the post-split refresh path are part of the contract: the
 # research pass regathers the drifted candidates, the synthesis pass rebuilds
 # the report from them. Naming only one would let a half-updated injector pass.
 for fragment in ("1 added", "1 changed", "/trend-research", "/trend-synthesis"):
     if fragment not in reason:
-        problems.append(f"first action reason missing fragment {fragment!r}: {reason!r}")
-if problems:
-    print("\n".join("FAIL case 2 — " + p for p in problems), file=sys.stderr)
+        problems_b.append(f"first action reason missing fragment {fragment!r}: {reason!r}")
+if problems_a:
+    print("\n".join("FAIL: S2a - " + p for p in problems_a), file=sys.stderr)
+else:
+    print("PASS: S2a — drift fired with subtype=scout_drift, added={t-003}, changed={t-001}")
+if problems_b:
+    print("\n".join("FAIL: S2b - " + p for p in problems_b), file=sys.stderr)
+else:
+    print("PASS: S2b — concrete cogni-trends:trend-research action prepended naming the diff")
+if problems_a or problems_b:
     sys.exit(1)
-print("OK   case 2 — drift fired with subtype=scout_drift, added={t-003}, changed={t-001}")
-print("OK   case 2 — concrete cogni-trends:trend-research action prepended naming the diff")
 PYEOF
 RC=$?
 if [ $RC -ne 0 ]; then FAIL_COUNT=$((FAIL_COUNT + 1)); fi
@@ -281,9 +287,9 @@ touch "$P3/.metadata/trend-scout-output.json"
 OUT="$(run_health "$P3" | extract)"
 HAS_STALE="$(echo "$OUT" | python3 -c 'import json,sys; w=json.load(sys.stdin)["warnings"]; print(any(x.get("type")=="stale_report" for x in w))')"
 if [ "$HAS_STALE" = "False" ]; then
-  ok "case 3 — legacy project (no anchor) stayed silent"
+  ok "S3 — legacy project (no anchor) stayed silent"
 else
-  fail "case 3 — stale_report fired on a legacy project (no hash anchor present)"
+  fail "S3 — stale_report fired on a legacy project (no hash anchor present)"
   echo "$OUT" >&2
 fi
 

--- a/cogni-visual/tests/test-arc-taxonomy-sync.sh
+++ b/cogni-visual/tests/test-arc-taxonomy-sync.sh
@@ -28,10 +28,10 @@
 #   intended trade: adding an arc without a visual mapping is an incomplete change, and a
 #   loud failure in the wrong place beats a silent one in the right place.
 #
-# CASE LABEL SHAPE: `ok: <id>` / `FAIL: <id>` — NOT the `OK   ` / `FAIL ` shape carried by most
-#   of this repo's older per-case verdict helpers. This IS a departure from the more common
-#   shape, and it is deliberate: it is forced by the machinery that has to read this output,
-#   not chosen as a matter of style. Two facts carry it.
+# CASE LABEL SHAPE: `ok: <id>` / `FAIL: <id>` — the shape every discovered suite in this repo
+#   now carries, no longer a departure from an older `OK   ` / `FAIL ` form. It is forced by
+#   the machinery that has to read this output, not chosen as a matter of style. Two facts
+#   carry it.
 #
 #   READ THIS BEFORE CHECKING THEM: neither cited file is at an insight-wave path. Both live in
 #   the INSTALLED cogni-service plugin (quoted here from v0.0.383), which a reviewer scoped to an

--- a/cogni-workspace/tests/test-arc-taxonomy-sync.sh
+++ b/cogni-workspace/tests/test-arc-taxonomy-sync.sh
@@ -28,10 +28,10 @@
 #   intended trade: adding an arc without a visual mapping is an incomplete change, and a
 #   loud failure in the wrong place beats a silent one in the right place.
 #
-# CASE LABEL SHAPE: `ok: <id>` / `FAIL: <id>` — NOT the `OK   ` / `FAIL ` shape carried by most
-#   of this repo's older per-case verdict helpers. This IS a departure from the more common
-#   shape, and it is deliberate: it is forced by the machinery that has to read this output,
-#   not chosen as a matter of style. Two facts carry it.
+# CASE LABEL SHAPE: `ok: <id>` / `FAIL: <id>` — the shape every discovered suite in this repo
+#   now carries, no longer a departure from an older `OK   ` / `FAIL ` form. It is forced by
+#   the machinery that has to read this output, not chosen as a matter of style. Two facts
+#   carry it.
 #
 #   READ THIS BEFORE CHECKING THEM: neither cited file is at an insight-wave path. Both live in
 #   the INSTALLED cogni-service plugin (quoted here from v0.0.383), which a reviewer scoped to an

--- a/cogni-workspace/tests/test-check-skill-names.sh
+++ b/cogni-workspace/tests/test-check-skill-names.sh
@@ -32,14 +32,14 @@ TMPROOT="$(mktemp -d)"
 trap 'rm -rf "$TMPROOT"' EXIT
 
 failures=0
-pass() { echo "OK   $1"; }
-fail() { echo "FAIL $1"; failures=$((failures + 1)); }
+pass() { printf 'PASS: %s\n' "$1"; }
+fail() { printf 'FAIL: %s\n' "$1"; failures=$((failures + 1)); }
 
 # Assert the script under test exists before anything reads it. Without this the
 # static guard (Case 4) would sed/grep a missing file, match nothing, and report a
 # spurious PASS — and on Linux/CI, where no bash 3.x exists, Case 4 is the only
 # portability assertion left standing.
-[ -f "$CHECK" ] || { fail "0 script under test not found at $CHECK"; exit 1; }
+[ -f "$CHECK" ] || { fail "C0 script under test not found at $CHECK"; exit 1; }
 
 # Interpreter matrix, derived once. Only *distinct* binaries are listed: on a
 # stock macOS with no homebrew bash, PATH `bash` already IS /bin/bash 3.2.57, and

--- a/cogni-workspace/tests/test-layering-claim-reconciled.sh
+++ b/cogni-workspace/tests/test-layering-claim-reconciled.sh
@@ -124,8 +124,7 @@
 # / "FAIL: <case>", because the cogni-service mutation harness classifies a case
 # GREEN only on ^[[:space:]]*(ok|PASS):[[:space:]]+<case> and RED on the matching
 # FAIL: form. Case ids are L-prefixed and never bare numerals, so the summary line
-# is not read as a case's RED line. Do not "fix" these back to the house
-# "OK   <label>" style.
+# is not read as a case's RED line.
 #
 # bash-3.2 portable (stock macOS /bin/bash is 3.2.57): no declare -A, no mapfile,
 # no ${var^^}. stdlib-only: bash + coreutils, no pip deps, no network.

--- a/cogni-workspace/tests/test-sanitize-theme.sh
+++ b/cogni-workspace/tests/test-sanitize-theme.sh
@@ -19,8 +19,8 @@ TMPROOT="$(mktemp -d)"
 trap 'rm -rf "$TMPROOT"' EXIT
 
 failures=0
-pass() { echo "OK   $1"; }
-fail() { echo "FAIL $1"; failures=$((failures + 1)); }
+pass() { printf 'PASS: %s\n' "$1"; }
+fail() { printf 'FAIL: %s\n' "$1"; failures=$((failures + 1)); }
 
 # assert_py "<label>" "<python expr, True to pass>" — the guard is bound as `g`
 # and the renderer as `r`, so an assertion can check the guard against the real

--- a/cogni-workspace/tests/test-wiki-namespace-sync.sh
+++ b/cogni-workspace/tests/test-wiki-namespace-sync.sh
@@ -49,15 +49,14 @@
 # policy, not dead config. Silence here would have been a latent wrong answer the
 # first time someone wrote such a page.
 #
-# Case-label shape deviates from the sibling suites on purpose. test-check-skill-names.sh
-# and test-sanitize-theme.sh print "OK   <label>"; this suite prints "PASS: <label>"
-# / "FAIL: <label>" because the cogni-service mutation harness classifies a case
+# Case-label shape is "PASS: <label>" / "FAIL: <label>", the shape every discovered
+# suite in this repo now carries. The cogni-service mutation harness classifies a case
 # GREEN only on ^[[:space:]]*(ok|PASS):[[:space:]]+<case> and RED on the matching
 # FAIL: form. Neither "OK   " nor "OK:" is in that vocabulary, so a mutation replay
-# against this suite would report case_not_found instead of a verdict. Case ids are
+# against a suite using them reports case_not_found instead of a verdict. Case ids are
 # C-prefixed and never bare numerals, which is what keeps the final summary line
 # ("FAIL: <n> wiki-namespace-sync test(s) failed.") from being read as a case's RED
-# line. Do not "fix" these labels back to the house style.
+# line — a hazard the colon form creates and every suite here has to answer.
 #
 # bash-3.2 portable (stock macOS /bin/bash is 3.2.57): no declare -A / typeset -A,
 # no mapfile / readarray, no ${var^^} / ${var,,}. The roster is carried as a


### PR DESCRIPTION
Closes #1482.

Adopts **option 1 (normalise the emitters)**; option 2 is rejected rather than merely deprioritised. `scripts/check-result-line-plainness.py`'s own docstring holds that *an exemption someone must remember to delete is the bandaid this guard replaces* — documenting a translating-pipeline workaround is that bandaid with extra steps.

## Summary

- **12 suites' emitters** normalised to `PASS: <case>` / `FAIL: <case>`, the shape the harness classifies and that previously-migrated suites already use.
- **Both arms, not just `fail()`.** Every one of the 12 paired its broken `fail()` with a `pass()`/`ok()` emitting `OK   <case>`, which the GREEN pattern also rejects. A fail-only fix would have left every mutation recipe's green baseline at `case_not_found`.
- **44 glued-colon call-site labels** de-glued to a ` - ` separator: 26 in `test_orthography_drift_scan.sh`, 11 in `test_subagent_start_hook.sh`, 7 in `test_step0_register_block.sh`.
- **`test-stale-detection.sh` case ids made unique** — `S1` / `S2a` / `S2b` / `S3`.
- **10 sibling-suite header blocks** updated, each carrying a claim this change falsifies.

## Roster re-derived at pickup: 12, not 11

`cogni-trends/tests/test-project-status.sh` is a **named, justified delta**. It carries the identical defect but emits from Python (`print(f"OK   {label}: {actual}")`), so a `pass()`/`fail()`-keyed grep cannot see it — which is why the issue's own derivation missed it, and why my first census attempt did too. Two sibling headers already named it alongside `test-stale-detection.sh` as carrying the old shape, so omitting it would have shipped a false header. The other 11 match the issue exactly.

**Correcting a number I got wrong at triage.** I reported 130 discovered suites. The true figure is **127** (9 root + 118 per-plugin, confirmed by `run-plugin-tests.py`'s own envelope). My `find` used `-path './*/tests/*.sh'`, where `*` matches `/`, so it was broader than the non-recursive globs the runner actually uses and pulled in `cogni-knowledge/_archive/tests/…` — a suite parked one path segment deeper and out of scope by glob depth. The issue's own "128 / 117" figures were likewise off. The roster of affected suites was never in doubt; only the denominator.

## Two corrections to the issue's analysis

**1. The stderr wrinkle is false — this de-risked the whole change.** The issue warns that nine of eleven write to stderr and that "fixing only the colon would not necessarily make those replayable — that needs checking, not assuming". Checked: `mutation-check.sh:378` runs the suite as

```
( cd "$ROOT_ABS" && eval "$TEST_CMD" ) >"$1" 2>&1 &
```

stderr is merged into the classified stream. The colon was the only obstacle. Accordingly **no `>&2` is removed and none added** — changing a stream would be unrelated behaviour churn.

**2. The defect was wider than the issue framed it.** Fixing `fail()` alone would have produced a PR that looked complete and left every green baseline unreadable. The mutation evidence below is what makes this checkable rather than assertable.

## The near-miss this had to avoid

The eight cogni-consult suites emit `printf 'FAIL %s: %s\n'`. Naively inserting the colon yields `FAIL: <case>: <detail>` — which **still** fails, because the harness requires whitespace-or-end-of-line immediately after the case token. `test_discover_extractor.sh` documents this exact trap. Hence the ` - ` separator, matching `test_generate_dashboard.sh`, and hence the 44 de-glued call-site labels: 13 of them reach the emitter through the `assert_envelope` / `assert_match` helpers, so a count taken from direct `pass "…"` sites alone would have missed them and shipped the very malformed line this PR removes.

## Scope decisions

**`scripts/check-result-line-plainness.py` is untouched, and no new guard script is added.** Its docstring explicitly rejects enforcing one blessed emitter body shape and treats `ok:`/`PASS:` diversity as legitimate; a plain `printf` trips neither arm. A *new* guard was considered and rejected on its own merits: labels arrive as runtime-interpolated arguments (`pass "$label"`), so the contract is not statically decidable from source, and result lines emitted from Python inside a heredoc are invisible to a source-level scan — exactly where the twelfth carrier hid. A guard covering only literal bash call sites would ship green while blind to the carrier that actually bit.

**Three grep false positives deliberately untouched**, none of which reaches stdout: `test_deliverable_graph.sh:67` (`print('PASS' if … else 'FAIL')`, captured into `$verdict`), `test_dt_stage_advance.sh:129` (captured into `$LOG_OK`), and the Python locals named `ok` in `test_resolve_assumptions.sh`.

**Three header blocks checked and left alone** — `test-wiki-tree-parity.sh` and both `test-de-ascii-orthography.sh` blocks phrase the point generically ("the older no-colon shape") without naming a normalised sibling, so they stay true.

**One straggler normalised beyond the roster:** `test_orthography_drift_scan.sh:48`'s preflight abort was the only one in the tree missing its colon, inconsistent with every sibling preflight.

**No version bump** — the post-merge workflow owns it.

## Ordering

The emitter swap and the de-glueing are not independently sufficient and land together: an emitter swapped without de-glueing emits `PASS: clean: dass/…` (no whitespace after the token — still `case_not_found`), and a de-glued label under the old emitter emits `OK   clean - …` (wrong prefix — still `case_not_found`). Single commit; there is no intermediate green state worth preserving.

## Mutation recipe

```
mutation-check.sh --root "$PWD" \
  --file cogni-workspace/scripts/sanitize-theme.py \
  --expr 's/name if name in _PROFILES else DEFAULT_PROFILE/name if name in _PROFILES else "font-aware"/m' \
  --test 'bash cogni-workspace/tests/test-sanitize-theme.sh' \
  --case '1h'
```

Run on this branch:

```json
{ "case": "1h", "mutated_result": "red", "restored_result": "green",
  "verdict": "guard_verified", "metric_version": "1" }
```

`restored_result: green` is the load-bearing half: it is the leg only a **both-arms** fix can produce. A fail-only normalisation would still return `case_not_found` there. On the pre-change tree the same invocation returns `case_not_found`, exit 2 — the defect this PR closes.

The mutation makes an unknown profile name fall back to the permissive `font-aware` record instead of `strict`; case `1h` asserts `is_safe_value("rgba(0,0,0,0.1)", "nope") is False`, and `font-aware`'s denylist omits the parentheses `strict` carries. The match target occurs exactly once in the file, so the non-global `perl -0pi` cannot hit an unintended site.

## Per-suite RED-line collision arm

A suite's own summary or preflight line must not be readable as a case going red. Two arms close that hazard; per suite, this is which one applies.

| Suite | Arm | Basis |
|---|---|---|
| `test-check-skill-names.sh` | **(a)** no bare-numeral case id | its summary *does* begin `FAIL: $failures …`, so arm (a) is load-bearing here — the `0` → `C0` rename is what secures it |
| `test_dt_stage_advance.sh` | **(b)** summary does not begin `FAIL:` | this suite's case ids **are** bare numerals (`1`…`9`); it is protected instead by its summary at `:141` reading `echo "$failures dt-stage-advance test(s) failed."` — no `FAIL:` prefix |
| `test-sanitize-theme.sh`, `test-stale-detection.sh`, `test-project-status.sh`, `test_assumption_change_frequency.sh`, `test_deliverable_graph.sh`, `test_orthography_drift_scan.sh`, `test_register_generator.sh`, `test_resolve_assumptions.sh`, `test_step0_register_block.sh`, `test_subagent_start_hook.sh` | **(a)** no bare-numeral case id | verified by extracting the first token of every emitted result line and testing it against `^[0-9]+$` — zero hits in each |

Preflight aborts were checked separately: each begins with a script filename (e.g. `FAIL: dt-stage-advance.sh not found at $SCRIPT`), and no case in any suite is named after a filename, so none can collide.

Method: for each suite, run it and extract `^(PASS|FAIL|ok): <token>`, then test each token against `^[0-9]+$`; separately grep the suite for a summary line matching `"FAIL: $`.

## Verification

| Check | Result |
|---|---|
| `python3 scripts/run-plugin-tests.py` (post-commit) | **127/127 passed**, exit 0 |
| `python3 scripts/check-result-line-plainness.py` | exit 0, clean zero |
| `python3 scripts/check-breadcrumbs.py` | exit 0 |
| `python3 scripts/check-version-bump.py` | exit 0 — 9 plugins scanned, 0 touched |
| `python3 scripts/check-workflow-yaml.py` | exit 0 |
| `bash cogni-consult/scripts/mutation-check.sh` | `All mutations caught.` |
| Mutation recipe above | `guard_verified` |
| Colon-less result line remaining anywhere | none |

The sweep was run **after** committing — a pre-commit sweep hides tracked-only guards.

## Disclosed gap

**The `/simplify` quality pass was not run.** The edits live in a detached `git worktree`, while this session's shell resets to a different worktree on every call — so `/simplify` would have inspected a tree with an empty diff and reported "nothing to fix" without having seen the change. Recording that as a pass would have been a vacuous green. The diff is 22 mechanical emitter swaps and comment rewrites with no logic to simplify, so I judged the honest skip better than a misleading pass. Flagging it so a reviewer can run it if they disagree.

## Follow-up

#1484 — *distinct test cases share a first token, so `--case` can name the wrong case*.

A **separate defect** found while censusing at pickup. This issue's colon-less shape yields `case_not_found`, an honest error; a first-token collision yields a verdict for the *wrong* case — a mutation aimed at case A can red sibling B and still record `guard_verified`. It is worst in `test_step0_register_block.sh` (`anchor-once` 18-way) and `test_resolve_assumptions.sh` (`link-mode` 7-way).

Filed standalone rather than as deferred scope: #1482's contract scopes the uniqueness requirement to `test-stale-detection.sh` (item 5), which **is** fixed here — that suite had zero addressable cases and so could not have demonstrated the fix at all. Folding in the rest would roughly triple this diff and hold #1482 open pending work its own contract does not ask for.
