### PR TITLE
cogni-workspace: fixture-pin the store-path green half in the roster guard

### DIFF
--- a/cogni-workspace/references/wiki-tree-reconciliation.md
+++ b/cogni-workspace/references/wiki-tree-reconciliation.md
@@ -355,7 +355,7 @@ the branch that added this section, per `## On the figures in this document`.
 | `cogni-…` tokens across both `index.md` copies, all on-roster | `grep -ohE 'cogni-[a-z0-9-]+[/:]?' wiki/wiki/index.md cogni-workspace/wiki/wiki/index.md \| wc -l` | 318 | this branch |
 | The two `overview.md` copies are byte-identical | `diff wiki/wiki/overview.md cogni-workspace/wiki/wiki/overview.md` | no output | this branch |
 | The preserved `index.md` divergence | `wc -l wiki/wiki/index.md cogni-workspace/wiki/wiki/index.md` | 221 root, 224 bundled | this branch |
-| Bare-name guard, both surfaces | `bash cogni-workspace/tests/test-wiki-bare-name-roster.sh` | exit 0, 22 cases | this branch |
+| Bare-name guard, both surfaces | `bash cogni-workspace/tests/test-wiki-bare-name-roster.sh` | exit 0, 23 cases | this branch |
 | Tree-parity guard | `bash cogni-workspace/tests/test-wiki-tree-parity.sh` | exit 0, 12 cases | this branch |
 
 **Why the guard arm is per tree, not an intersection.** The two `index.md` copies diverge **by

--- a/cogni-workspace/tests/test-wiki-bare-name-roster.sh
+++ b/cogni-workspace/tests/test-wiki-bare-name-roster.sh
@@ -121,6 +121,18 @@
 # returns — stay green. That asymmetry is the point: it shows the arm is
 # falsifiable on its own rather than riding on the shared matcher.
 #
+# For the slash allowance, drive it at the constant: dropping the store token
+# from the allowed set while leaving the org token alone reds B23, which owns
+# that allowance's green half on a fixture of its own. B1 reds alongside it,
+# because the live intersection genuinely carries the path form — but B7 and
+# B22 both stay GREEN, and naming them individually matters because they do not
+# move together: B7's store-token needle is an assert_out_has that the
+# newly-offending slash form also satisfies, and the real tree-level pages B22
+# scans carry no store token at all. That is why the green half needs B23 rather
+# than riding on B1: B1's coverage is incidental on what the live trees happen
+# to contain, so a page retirement or a sweep could remove it with every case
+# still green.
+#
 # Portability: bash 3.2 (stock macOS /bin/bash) — no associative arrays, no
 # mapfile/readarray, no case-modifying expansions, no globstar. Stdlib only:
 # bash, coreutils, and python3 for JSON. No network.
@@ -785,6 +797,24 @@ if [ "$b22_root_ok" -eq 1 ] && assert_rc 0; then
   pass "B22 the real tree-level pages in both trees carry no off-roster plugin names"
 else
   fail "B22 the real tree-level pages in both trees carry no off-roster plugin names"
+fi
+
+# ---------------------------------------------------------------------------
+# B23 — the store path's GREEN half, on a fixture of its own. B7 covers only the
+# red half: scan_file strips the delimiter before emitting, so the path form and
+# the dispatch form of the same token produce byte-identical offender lines, and
+# B7's needle is satisfied by the dispatch form alone even when the path form
+# also offends. This is the case the header's slash-allowance recipe drives.
+# ---------------------------------------------------------------------------
+R23="$TMPROOT/b23"; mk_fixture_repo "$R23"
+mk_both "$R23" "concept-store-path.md" \
+  "Records land in cogni-claims/claims.json under the workspace root."
+run_scan_repo "$R23"
+if assert_rc 0 \
+   && assert_out_lacks "concept-store-path.md: cogni-claims"; then
+  pass "B23 the store path form alone is allowed and emits no offender line"
+else
+  fail "B23 the store path form alone is allowed and emits no offender line"
 fi
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #1468.

## Summary

- Add case **B23** to `cogni-workspace/tests/test-wiki-bare-name-roster.sh`: a fixture page planted in **both** trees via `mk_both`, carrying only the slash form `cogni-claims/claims.json` and never the dispatch form, asserting `rc 0` plus a page-qualified `assert_out_lacks "concept-store-path.md: cogni-claims"`.
- Extend the header's `Mutation recipe` section with a third arm naming the constant-level falsifier and the exact case set it moves.
- Re-measure the `exit 0, 22 cases` figure at `cogni-workspace/references/wiki-tree-reconciliation.md:358` to `23 cases`.

## The defect, and why B7 could not cover it

`scan_file` emits `OFF-ROSTER [$label] $base: $tok` — the basename is in the line, **the delimiter that produced the hit is not**. B7 plants the green slash form and the red dispatch form on one page, so both emit byte-identical text and its `assert_out_has "...: cogni-claims"` is satisfied by the dispatch form alone.

That makes the issue's first proposed remedy — "add an `assert_out_lacks` to B7 that isolates the slash-form occurrence" — unimplementable as literally worded: no needle confined to `concept-store.md` can distinguish the two. The third option ("assert exactly one offender") is also wrong at baseline, since `mk_both` puts the page in both trees and `scan_repo` scans the root and workspace arms separately, so the dispatch form alone already emits two identical lines. This PR takes the second option's spirit — a separate page — as a standalone case.

## Verification

Baseline before this change: dropping the store token from the allowed set red **exactly one** case, `B1`, the real-tree case. That coverage is incidental on the live intersection happening to carry the path form.

After this change, the same mutation moves the case set as follows:

| Case | Under `SLASH_ALLOWED="$ORG_TOKEN"` | Why |
|---|---|---|
| **B23** | **red** | owns the allowance's green half on a fixture of its own |
| B1 | red | live intersection genuinely carries the path form — expected |
| B7 | green | its needle is an `assert_out_has` the newly-offending slash form also satisfies |
| B22 | green | the real tree-level pages carry no store token at all |

B7 and B22 are named individually because they do not move together.

## Mutation recipe

The harness ships with the cogni-service plugin, not this repo, so `--root` points at this checkout and the command is run from where the harness lives:

```bash
bash "$COGNI_SERVICE_ROOT/scripts/mutation-check.sh" \
  --root <path to this insight-wave checkout> \
  --file cogni-workspace/tests/test-wiki-bare-name-roster.sh \
  --expr 's/^SLASH_ALLOWED="\$ORG_TOKEN \$STORE_TOKEN"/SLASH_ALLOWED="\$ORG_TOKEN"/m' \
  --test 'bash cogni-workspace/tests/test-wiki-bare-name-roster.sh' \
  --case B23
```

Observed: `"mutated_result": "red"`, `"restored_result": "green"`, **`"verdict": "guard_verified"`**.

`--expr` is evaluated by `perl -0pi`, which slurps the whole file, so `/m` is what keeps `^` line-anchored; the `\$` escapes stop perl interpolating `$ORG_TOKEN` / `$STORE_TOKEN` on either side. A sed-style `/.../d` form would hard-error as `expr_no_op`. `--case B23` reproduces the printed label as a whole token — the suite writes `FAIL: B23 <text>` with a single space and no colon after the id.

## Scope decisions

- **B7 is left byte-for-byte untouched.** Its red-half assertions are preserved trivially rather than re-derived.
- **Separate page, not a same-page negative needle.** B14's shape works because its green and red tokens are different strings; here both halves are the same token, so B4's separate-page precedent is the one that transfers.
- **Allowance semantics unchanged.** No token added to `SLASH_ALLOWED`; `scan_file`'s slash branch keeps its `[ "$tok" = "$p" ]` equality; no path-fragment exclusion introduced. `scan_file` still strips the delimiter before emitting — deliberately not changed, since making it emit the delimiter would be a production-behaviour change to fix a test-coverage gap, and would silently alter what every existing needle in the suite matches.
- **No version field touched** — the post-merge workflow owns the bump.
- **Out of scope**, per the issue: the `index.md` / `overview.md` bare-name class and the held one-sided pages.

## Test plan

- [x] `bash cogni-workspace/tests/test-wiki-bare-name-roster.sh` — exit 0, 23 `PASS:` lines, 0 `FAIL:`
- [x] `python3 scripts/run-plugin-tests.py --filter cogni-workspace` — 14/14 suites, `failed == 0`
- [x] `python3 scripts/check-result-line-plainness.py` — 0 violations
- [x] `python3 scripts/check-breadcrumbs.py` — 0 violations
- [x] `grep -n '22 cases' cogni-workspace/references/wiki-tree-reconciliation.md` — no output
- [x] `git diff origin/main --stat -- '*/.claude-plugin/plugin.json' '.claude-plugin/marketplace.json'` — empty
- [x] Mutation harness returns `guard_verified` on `--case B23`

## Reviewer notes

Two quality observations from the pre-commit review pass, both recorded rather than acted on:

1. **`assert_out_lacks` is subsumed by `assert_rc 0`** — any emitted offender forces a non-zero rc, so the negative needle cannot fail while `rc 0` passes. Kept deliberately: it is the house idiom (B12 and B19 carry the identical pairing), and it states the page-scoped claim explicitly for a reader.
2. **Folding B23's page into B7's fixture would save ~47 ms** (~3% of the suite's ~1.7 s). Not taken: it would cost B23's `assert_rc 0` — the stronger claim that the allowed form alone scans *entirely* clean — couple B23 to B7 by physical adjacency through the shared `OUT`/`RC` globals, and break file-order == id-order.

Separately, and **outside this diff**: all 18 `mk_fixture_repo` calls rebuild a byte-identical `marketplace.json` through its own `python3` spawn. Building it once and copying it thereafter measured **1764 ms → 1502 ms (−15%)** on the whole suite — roughly 5× the cost of anything in this PR. Flagged as context for a possible follow-up, not proposed here.