### PR TITLE
Unique first-token ids for the 8 colliding root test suites

### DIFF
--- a/tests/test_apply_version_bump.sh
+++ b/tests/test_apply_version_bump.sh
@@ -22,6 +22,13 @@
 #  11. Real tree, --dry-run, empty touched set -> clean no-op.
 #
 # bash 3.2 + stdlib python3 only. No git required (the touched set is passed in).
+#
+# Result-line ids: every emitted PASS:/FAIL: line carries a first-token id
+# (avbNN), unique PER EMITTED LINE rather than per logical case, so
+# `mutation-check.sh --case <id>` addresses exactly one assertion. The id is
+# followed by a SPACE, never a colon abutting it — the harness matches the
+# case whole-token, so a colon-abutting id returns case_not_found. A new
+# assertion takes the next free id rather than renumbering its neighbours.
 
 set -eu
 
@@ -130,14 +137,14 @@ python3 "$BUMPER" --root "$R" --changed alpha/file.md beta/file.md gamma/file.md
 MULTI_RC=$?
 set -e
 
-check "case 1/5: multi-plugin run exits 0" "$([ "$MULTI_RC" -eq 0 ] && echo 0 || echo 1)"
-check "case 1: alpha 1.0.70 -> 1.0.71 in both manifests" \
+check "avb01-multi-plugin-exit0 multi-plugin run exits 0" "$([ "$MULTI_RC" -eq 0 ] && echo 0 || echo 1)"
+check "avb02-alpha-mirror alpha 1.0.70 -> 1.0.71 in both manifests" \
   "$([ "$(version_of "$R" alpha)" = "1.0.71|1.0.71" ] && echo 0 || echo 1)"
-check "case 2: beta carry 0.0.9 -> 0.0.10 in both manifests" \
+check "avb03-beta-carry beta carry 0.0.9 -> 0.0.10 in both manifests" \
   "$([ "$(version_of "$R" beta)" = "0.0.10|0.0.10" ] && echo 0 || echo 1)"
-check "case 3: gamma (collides with beta on 0.0.9) -> 0.0.10 in both manifests" \
+check "avb04-gamma-carry-collision gamma (collides with beta on 0.0.9) -> 0.0.10 in both manifests" \
   "$([ "$(version_of "$R" gamma)" = "0.0.10|0.0.10" ] && echo 0 || echo 1)"
-check "case 4: root metadata.version stays 0.0.9" \
+check "avb05-root-metadata-untouched root metadata.version stays 0.0.9" \
   "$([ "$(meta_version_of "$R")" = "0.0.9" ] && echo 0 || echo 1)"
 
 # ---------------------------------------------------------------------------
@@ -149,13 +156,13 @@ cp "$R2/.claude-plugin/marketplace.json" "$WORK/marketplace.before"
 python3 "$BUMPER" --root "$R2" --changed gamma/file.md >/dev/null 2>&1
 DIFF_LINES="$(diff "$WORK/marketplace.before" "$R2/.claude-plugin/marketplace.json" \
   | grep -c '^[<>]' || true)"
-check "case 10: exactly 2 changed lines in marketplace.json (one -, one +)" \
+check "avb06-changed-line-count exactly 2 changed lines in marketplace.json (one -, one +)" \
   "$([ "$DIFF_LINES" -eq 2 ] && echo 0 || echo 1)"
-check "case 10: non-ASCII description preserved verbatim" \
+check "avb07-nonascii-description-verbatim non-ASCII description preserved verbatim" \
   "$(grep -q 'Größe, Prüfung, ä ö ü ß, é è ê ç' "$R2/.claude-plugin/marketplace.json" && echo 0 || echo 1)"
-check "case 10: keywords array untouched" \
+check "avb08-keywords-untouched keywords array untouched" \
   "$(grep -q '"keywords": \["gamma", "incubating"\]' "$R2/.claude-plugin/marketplace.json" && echo 0 || echo 1)"
-check "case 8: untouched alpha still 1.0.70" \
+check "avb09-untouched-alpha-unchanged untouched alpha still 1.0.70" \
   "$([ "$(version_of "$R2" alpha)" = "1.0.70|1.0.70" ] && echo 0 || echo 1)"
 
 # ---------------------------------------------------------------------------
@@ -176,10 +183,10 @@ python3 "$BUMPER" --root "$R3" --changed alpha/file.md > "$WORK/nn.json" 2>/dev/
 NN_RC=$?
 set -e
 NN_SEV="$(python3 -c "import json,sys;d=json.load(open(sys.argv[1]))['data'];print(d['skipped'][0]['severity'] if d['skipped'] else 'NONE')" "$WORK/nn.json")"
-check "case 6: non-numeric tail exits 0" "$([ "$NN_RC" -eq 0 ] && echo 0 || echo 1)"
-check "case 6: non-numeric tail skipped as warning" \
+check "avb10-nonnumeric-exit0 non-numeric tail exits 0" "$([ "$NN_RC" -eq 0 ] && echo 0 || echo 1)"
+check "avb11-nonnumeric-warning-skip non-numeric tail skipped as warning" \
   "$([ "$NN_SEV" = "warning" ] && echo 0 || echo 1)"
-check "case 6: nothing written for the skipped plugin" \
+check "avb12-nonnumeric-nothing-written nothing written for the skipped plugin" \
   "$([ "$(version_of "$R3" alpha)" = "0.1.0-rc1|0.1.0-rc1" ] && echo 0 || echo 1)"
 
 # ---------------------------------------------------------------------------
@@ -199,12 +206,12 @@ python3 "$BUMPER" --root "$R4" --changed alpha/file.md beta/file.md \
 DRIFT_RC=$?
 set -e
 DRIFT_SEV="$(python3 -c "import json,sys;d=json.load(open(sys.argv[1]))['data'];print(d['skipped'][0]['severity'] if d['skipped'] else 'NONE')" "$WORK/drift.json")"
-check "case 7: mirror drift exits 1" "$([ "$DRIFT_RC" -eq 1 ] && echo 0 || echo 1)"
-check "case 7: mirror drift skipped as error" \
+check "avb13-drift-exit1 mirror drift exits 1" "$([ "$DRIFT_RC" -eq 1 ] && echo 0 || echo 1)"
+check "avb14-drift-error-severity mirror drift skipped as error" \
   "$([ "$DRIFT_SEV" = "error" ] && echo 0 || echo 1)"
-check "case 7: drifted alpha left untouched" \
+check "avb15-drift-alpha-untouched drifted alpha left untouched" \
   "$([ "$(version_of "$R4" alpha)" = "1.0.69|1.0.70" ] && echo 0 || echo 1)"
-check "case 7: co-touched healthy beta still bumped" \
+check "avb16-drift-cotouched-beta-bumped co-touched healthy beta still bumped" \
   "$([ "$(version_of "$R4" beta)" = "0.0.10|0.0.10" ] && echo 0 || echo 1)"
 
 # ---------------------------------------------------------------------------
@@ -213,7 +220,7 @@ check "case 7: co-touched healthy beta still bumped" \
 R5="$WORK/dry"
 make_fixture "$R5"
 python3 "$BUMPER" --root "$R5" --changed alpha/file.md --dry-run >/dev/null 2>&1
-check "case 9: --dry-run leaves both manifests untouched" \
+check "avb17-dry-run-untouched --dry-run leaves both manifests untouched" \
   "$([ "$(version_of "$R5" alpha)" = "1.0.70|1.0.70" ] && echo 0 || echo 1)"
 
 # ---------------------------------------------------------------------------
@@ -225,7 +232,7 @@ python3 "$BUMPER" --root "$REPO_ROOT" --changed README.md --dry-run \
 REAL_RC=$?
 set -e
 REAL_N="$(python3 -c "import json,sys;print(len(json.load(open(sys.argv[1]))['data']['bumped']))" "$WORK/real.json")"
-check "case 11: real tree, no plugin touched -> exit 0, zero bumps" \
+check "avb18-real-tree-noop real tree, no plugin touched -> exit 0, zero bumps" \
   "$([ "$REAL_RC" -eq 0 ] && [ "$REAL_N" -eq 0 ] && echo 0 || echo 1)"
 
 echo

--- a/tests/test_apply_version_bump.sh
+++ b/tests/test_apply_version_bump.sh
@@ -5,21 +5,21 @@
 # and that plugin's entry inside the single shared root `.claude-plugin/marketplace.json`.
 # The shared file is the risk: an unscoped regex could rewrite a sibling entry or the
 # root `metadata.version`. Cases:
-#   1. Single-plugin bump -> both manifests advance, together.
-#   2. Digit carry 0.0.9 -> 0.0.10 (the byte-growth case that shifts later spans).
+#   1. Single-plugin bump -> both manifests advance, together.  [avb02]
+#   2. Digit carry 0.0.9 -> 0.0.10 (the byte-growth case that shifts later spans).  [avb03]
 #   3. Version collision -> two plugins share a version string; only the touched
-#      one moves. This is the test an unscoped regex fails.
+#      one moves. This is the test an unscoped regex fails.  [avb04]
 #   4. metadata.version immunity -> root metadata carries the same version string
-#      as a bumped plugin and must not move.
+#      as a bumped plugin and must not move.  [avb05]
 #   5. Multi-plugin merge -> three plugins in one run, spans re-derived after each
-#      edit so a carry in plugin #1 cannot misplace plugin #3's edit.
-#   6. Non-numeric tail -> skipped as a warning, exit 0, nothing written.
+#      edit so a carry in plugin #1 cannot misplace plugin #3's edit.  [avb01]
+#   6. Non-numeric tail -> skipped as a warning, exit 0, nothing written.  [avb10-avb12]
 #   7. Mirror drift -> skipped as an error, exit 1, that plugin untouched, but a
-#      co-touched healthy plugin still bumps (partial progress, loud failure).
-#   8. Untouched plugin -> never bumped.
-#   9. --dry-run -> computes and verifies, writes nothing.
-#  10. Formatting + non-ASCII preserved byte-for-byte (no json.dump round-trip).
-#  11. Real tree, --dry-run, empty touched set -> clean no-op.
+#      co-touched healthy plugin still bumps (partial progress, loud failure).  [avb13-avb16]
+#   8. Untouched plugin -> never bumped.  [avb09]
+#   9. --dry-run -> computes and verifies, writes nothing.  [avb17]
+#  10. Formatting + non-ASCII preserved byte-for-byte (no json.dump round-trip).  [avb06-avb08]
+#  11. Real tree, --dry-run, empty touched set -> clean no-op.  [avb18]
 #
 # bash 3.2 + stdlib python3 only. No git required (the touched set is passed in).
 #

--- a/tests/test_check_breadcrumbs.sh
+++ b/tests/test_check_breadcrumbs.sh
@@ -12,6 +12,13 @@
 # edit that adds a NEW breadcrumb to a tracked file will (correctly) fail it.
 #
 # bash 3.2 + stdlib python3 only.
+#
+# Result-line ids: every emitted PASS:/FAIL: line carries a first-token id
+# (cbcNN), unique PER EMITTED LINE rather than per logical case, so
+# `mutation-check.sh --case <id>` addresses exactly one assertion. The id is
+# followed by a SPACE, never a colon abutting it — the harness matches the
+# case whole-token, so a colon-abutting id returns case_not_found. A new
+# assertion takes the next free id rather than renumbering its neighbours.
 
 set -eu
 
@@ -72,8 +79,8 @@ OUT=$(python3 "$GUARD" --root "$WORK/clean" --baseline "$EMPTY_BASELINE" \
         "skills/demo/SKILL.md" 2>/dev/null)
 CODE=$?
 set -e
-check "negative controls exit 0" "$([ "$CODE" -eq 0 ] && echo 0 || echo 1)"
-assert_json "negative controls report zero violations" "$OUT" "
+check "cbc01 negative controls exit 0" "$([ "$CODE" -eq 0 ] && echo 0 || echo 1)"
+assert_json "cbc02 negative controls report zero violations" "$OUT" "
 import json,sys
 d=json.load(sys.stdin)
 assert d['success'] is True, d
@@ -96,8 +103,8 @@ OUT=$(python3 "$GUARD" --root "$WORK/dirty" --baseline "$EMPTY_BASELINE" \
         "agents/bad.md" 2>/dev/null)
 CODE=$?
 set -e
-check "breadcrumb fixture exits 1" "$([ "$CODE" -eq 1 ] && echo 0 || echo 1)"
-assert_json "breadcrumb fixture names every token with correct file+line" "$OUT" "
+check "cbc03 breadcrumb fixture exits 1" "$([ "$CODE" -eq 1 ] && echo 0 || echo 1)"
+assert_json "cbc04 breadcrumb fixture names every token with correct file+line" "$OUT" "
 import json,sys
 d=json.load(sys.stdin)
 v=d['data']['violations']
@@ -128,8 +135,8 @@ OUT=$(python3 "$GUARD" --root "$WORK/allow" --baseline "$EMPTY_BASELINE" \
         "agents/ok.md" 2>/dev/null)
 CODE=$?
 set -e
-check "inline-allow line exits 0" "$([ "$CODE" -eq 0 ] && echo 0 || echo 1)"
-assert_json "inline-allow suppresses the M2 match" "$OUT" "
+check "cbc05 inline-allow line exits 0" "$([ "$CODE" -eq 0 ] && echo 0 || echo 1)"
+assert_json "cbc06 inline-allow suppresses the M2 match" "$OUT" "
 import json,sys
 d=json.load(sys.stdin)
 assert d['data']['summary']['total']==0, d['data']['summary']
@@ -142,7 +149,7 @@ set +e
 python3 "$GUARD" >/dev/null 2>&1
 CODE=$?
 set -e
-check "real tree passes against committed baseline" \
+check "cbc07 real tree passes against committed baseline" \
   "$([ "$CODE" -eq 0 ] && echo 0 || echo 1)"
 
 echo ""

--- a/tests/test_check_external_dispatch.sh
+++ b/tests/test_check_external_dispatch.sh
@@ -29,6 +29,13 @@
 # unknown flag, which proves nothing about the load path.
 #
 # bash 3.2 + stdlib python3 only (+ git for the discover-mode exclusion case).
+#
+# Result-line ids: every emitted PASS:/FAIL: line carries a first-token id,
+# unique PER EMITTED LINE rather than per logical case, so
+# `mutation-check.sh --case <id>` addresses exactly one assertion. Cases 1-5
+# use `edNN`; the registry cases use `R<n><letter>`. The whole-token matching
+# rule the ids depend on is stated once, with the regex, above the registry
+# cases below. A new assertion takes the next free id, never a renumbering.
 
 set -eu
 
@@ -82,8 +89,8 @@ set +e
 OUT=$(python3 "$GUARD" --root "$WORK/clean" "cogni-demo/skills/demo/SKILL.md" 2>/dev/null)
 CODE=$?
 set -e
-check "bare-noun negative control exits 0" "$([ "$CODE" -eq 0 ] && echo 0 || echo 1)"
-assert_json "negative control reports zero violations" "$OUT" "
+check "ed01 bare-noun negative control exits 0" "$([ "$CODE" -eq 0 ] && echo 0 || echo 1)"
+assert_json "ed02 negative control reports zero violations" "$OUT" "
 import json,sys
 d=json.load(sys.stdin)
 assert d['success'] is True, d
@@ -103,8 +110,8 @@ set +e
 OUT=$(python3 "$GUARD" --root "$WORK/dirty" "cogni-bad/agents/bad.md" 2>/dev/null)
 CODE=$?
 set -e
-check "dispatch fixture exits 1" "$([ "$CODE" -eq 1 ] && echo 0 || echo 1)"
-assert_json "dispatch fixture names both tokens with correct file+line" "$OUT" "
+check "ed03 dispatch fixture exits 1" "$([ "$CODE" -eq 1 ] && echo 0 || echo 1)"
+assert_json "ed04 dispatch fixture names both tokens with correct file+line" "$OUT" "
 import json,sys
 d=json.load(sys.stdin)
 v=d['data']['violations']
@@ -128,8 +135,8 @@ set +e
 OUT=$(python3 "$GUARD" --root "$WORK/allow" "cogni-x/commands/c.md" 2>/dev/null)
 CODE=$?
 set -e
-check "inline-allow line exits 0" "$([ "$CODE" -eq 0 ] && echo 0 || echo 1)"
-assert_json "inline-allow suppresses the dispatch token" "$OUT" "
+check "ed05 inline-allow line exits 0" "$([ "$CODE" -eq 0 ] && echo 0 || echo 1)"
+assert_json "ed06 inline-allow suppresses the dispatch token" "$OUT" "
 import json,sys
 d=json.load(sys.stdin)
 assert d['data']['summary']['total']==0, d['data']['summary']
@@ -161,9 +168,9 @@ set +e
 OUT=$(python3 "$GUARD" --root "$EXC" 2>/dev/null)
 CODE=$?
 set -e
-check "discover-mode exclusions pass (cogni-knowledge/ + */wiki/ skipped)" \
+check "ed07 discover-mode exclusions pass (cogni-knowledge/ + */wiki/ skipped)" \
   "$([ "$CODE" -eq 0 ] && echo 0 || echo 1)"
-assert_json "exclusions report zero violations" "$OUT" "
+assert_json "ed08 exclusions report zero violations" "$OUT" "
 import json,sys
 d=json.load(sys.stdin)
 assert d['success'] is True, d
@@ -177,7 +184,7 @@ set +e
 python3 "$GUARD" >/dev/null 2>&1
 CODE=$?
 set -e
-check "real tree passes clean-zero" "$([ "$CODE" -eq 0 ] && echo 0 || echo 1)"
+check "ed09 real tree passes clean-zero" "$([ "$CODE" -eq 0 ] && echo 0 || echo 1)"
 
 # ===========================================================================
 # Registry-loading cases (R1-R6).
@@ -185,7 +192,7 @@ check "real tree passes clean-zero" "$([ "$CODE" -eq 0 ] && echo 0 || echo 1)"
 # Case labels below are `<id> <description>` — an id token followed by a SPACE,
 # never a colon abutting the id. The mutation harness matches
 # `^[[:space:]]*FAIL:[[:space:]]+<case>([[:space:]]|$)` (and the ok|PASS twin)
-# whole-token, so `--case R3` matches `FAIL: R3 empty ...` while `--case 'R3:'`
+# whole-token, so `--case R3a` matches `FAIL: R3a empty ...` while `--case 'R3a:'`
 # would match neither line and return case_not_found instead of a verdict.
 # ===========================================================================
 
@@ -241,9 +248,9 @@ PLANTED_REL="cogni-demo/agents/planted.md"
 # Also proves the default registry path follows __file__ and not --root: --root
 # points at REG_TREE, which has no registry, and the staged dir has none either.
 run_reg r1 NONE "$CLEAN_REL"
-check "R1 missing registry exits 2 (base exits 0 here)" \
+check "R1a missing registry exits 2 (base exits 0 here)" \
   "$([ "$CODE" -eq 2 ] && echo 0 || echo 1)"
-assert_json "R1 missing registry reports success:false and names the path" "$OUT" "
+assert_json "R1b missing registry reports success:false and names the path" "$OUT" "
 import json,sys
 d=json.load(sys.stdin)
 assert d['success'] is False, d
@@ -253,9 +260,9 @@ assert 'retired-plugins.json' in d['error'], d['error']
 
 # --- R2: malformed JSON -> exit 2 ------------------------------------------
 run_reg r2 '{"retired_prefixes": ["cogni-wiki",' "$CLEAN_REL"
-check "R2 malformed registry JSON exits 2 (base exits 0 here)" \
+check "R2a malformed registry JSON exits 2 (base exits 0 here)" \
   "$([ "$CODE" -eq 2 ] && echo 0 || echo 1)"
-assert_json "R2 malformed registry reports success:false with a non-empty error" "$OUT" "
+assert_json "R2b malformed registry reports success:false with a non-empty error" "$OUT" "
 import json,sys
 d=json.load(sys.stdin)
 assert d['success'] is False, d
@@ -264,9 +271,9 @@ assert d['error'], d
 
 # --- R3: empty prefix list -> exit 2 ---------------------------------------
 # Kept as its own case rather than folded into R4's table: the recorded mutation
-# recipe targets `--case R3`, which needs a separately-labelled line.
+# recipe targets `--case R3a`, which needs a separately-labelled line.
 run_reg r3 '{"retired_prefixes": []}' "$CLEAN_REL"
-check "R3 empty registry exits 2 and never 0 (base exits 0 here)" \
+check "R3a empty registry exits 2 and never 0 (base exits 0 here)" \
   "$([ "$CODE" -eq 2 ] && echo 0 || echo 1)"
 
 # --- R4: wrong type / non-string / blank / padded / colon-bearing -> exit 2 -
@@ -289,15 +296,15 @@ do
   run_reg "r4_$R4_N" "$BAD" "$CLEAN_REL"
   [ "$CODE" -eq 2 ] || R4_FAILED=1
 done
-check "R4 degenerate registry entries all exit 2 ($R4_N variants)" "$R4_FAILED"
+check "R4a degenerate registry entries all exit 2 ($R4_N variants)" "$R4_FAILED"
 
 # --- R5: a prefix added to the registry makes a planted dispatch fire -------
 # The data-driven proof: base's hardcoded regex knows nothing of cogni-demo.
 run_reg r5 '{"retired_prefixes": ["cogni-wiki", "cogni-research", "cogni-demo"]}' \
   "$PLANTED_REL"
-check "R5 registry-added prefix fires on a planted dispatch (exit 1)" \
+check "R5a registry-added prefix fires on a planted dispatch (exit 1)" \
   "$([ "$CODE" -eq 1 ] && echo 0 || echo 1)"
-assert_json "R5 registry-added prefix reports match cogni-demo: with file+line" "$OUT" "
+assert_json "R5b registry-added prefix reports match cogni-demo: with file+line" "$OUT" "
 import json,sys
 d=json.load(sys.stdin)
 v=d['data']['violations']
@@ -314,9 +321,9 @@ printf '%s' '{"retired_prefixes": ["cogni-wiki", "cogni-research"]}' \
   > "$WORK/r6/override.json"
 run_reg r6 '{"retired_prefixes": ["cogni-wiki", "cogni-research", "cogni-demo"]}' \
   "$PLANTED_REL" --registry "$WORK/r6/override.json"
-check "R6 --registry replaces the default set rather than unioning (exit 0)" \
+check "R6a --registry replaces the default set rather than unioning (exit 0)" \
   "$([ "$CODE" -eq 0 ] && echo 0 || echo 1)"
-assert_json "R6 override set reports zero violations on the planted file" "$OUT" "
+assert_json "R6b override set reports zero violations on the planted file" "$OUT" "
 import json,sys
 d=json.load(sys.stdin)
 assert d['success'] is True, d

--- a/tests/test_check_plugin_inventory.sh
+++ b/tests/test_check_plugin_inventory.sh
@@ -14,6 +14,13 @@
 #   6. Real repo at branch head -> exit 0.
 #
 # bash 3.2 + stdlib python3 only. No arguments, no network.
+#
+# Result-line ids: every emitted PASS:/FAIL: line carries a first-token id
+# (cpiNN), unique PER EMITTED LINE rather than per logical case, so
+# `mutation-check.sh --case <id>` addresses exactly one assertion. The id is
+# followed by a SPACE, never a colon abutting it — the harness matches the
+# case whole-token, so a colon-abutting id returns case_not_found. A new
+# assertion takes the next free id rather than renumbering its neighbours.
 
 set -eu
 
@@ -82,8 +89,8 @@ make_plugin "$CONSISTENT" cogni-alpha
 make_plugin "$CONSISTENT" cogni-beta
 make_marketplace "$CONSISTENT" cogni-alpha cogni-beta
 run_guard "$CONSISTENT"
-check "consistent inventory exits 0" "$([ "$CODE" -eq 0 ] && echo 0 || echo 1)"
-assert_json "consistent inventory reports zero violations" "$OUT" "
+check "cpi01 consistent inventory exits 0" "$([ "$CODE" -eq 0 ] && echo 0 || echo 1)"
+assert_json "cpi02 consistent inventory reports zero violations" "$OUT" "
 import json,sys
 d=json.load(sys.stdin)
 assert d['success'] is True, d
@@ -97,8 +104,8 @@ NODIR="$WORK/entry-without-dir"
 make_plugin "$NODIR" cogni-alpha
 make_marketplace "$NODIR" cogni-alpha cogni-ghost
 run_guard "$NODIR"
-check "marketplace entry with no directory exits non-zero" "$([ "$CODE" -eq 1 ] && echo 0 || echo 1)"
-assert_json "entry with no directory reports source-missing naming the plugin" "$OUT" "
+check "cpi03 marketplace entry with no directory exits non-zero" "$([ "$CODE" -eq 1 ] && echo 0 || echo 1)"
+assert_json "cpi04 entry with no directory reports source-missing naming the plugin" "$OUT" "
 import json,sys
 d=json.load(sys.stdin)
 assert d['success'] is False, d
@@ -114,8 +121,8 @@ make_plugin "$UNLISTED" cogni-alpha
 make_plugin "$UNLISTED" cogni-orphan
 make_marketplace "$UNLISTED" cogni-alpha
 run_guard "$UNLISTED"
-check "unlisted plugin directory exits non-zero" "$([ "$CODE" -eq 1 ] && echo 0 || echo 1)"
-assert_json "unlisted directory reports plugin-unlisted naming the directory" "$OUT" "
+check "cpi05 unlisted plugin directory exits non-zero" "$([ "$CODE" -eq 1 ] && echo 0 || echo 1)"
+assert_json "cpi06 unlisted directory reports plugin-unlisted naming the directory" "$OUT" "
 import json,sys
 d=json.load(sys.stdin)
 assert d['success'] is False, d
@@ -133,8 +140,8 @@ mkdir -p "$NESTED/.claude/worktrees/wt-1/cogni-stale/.claude-plugin"
 printf '{"name":"cogni-stale","version":"9.9.9"}\n' \
   > "$NESTED/.claude/worktrees/wt-1/cogni-stale/.claude-plugin/plugin.json"
 run_guard "$NESTED"
-check "stale manifest under .claude/worktrees is ignored" "$([ "$CODE" -eq 0 ] && echo 0 || echo 1)"
-assert_json "nested manifest does not register as a plugin directory" "$OUT" "
+check "cpi07 stale manifest under .claude/worktrees is ignored" "$([ "$CODE" -eq 0 ] && echo 0 || echo 1)"
+assert_json "cpi08 nested manifest does not register as a plugin directory" "$OUT" "
 import json,sys
 d=json.load(sys.stdin)
 assert d['success'] is True, d
@@ -147,8 +154,8 @@ make_plugin "$BROKEN" cogni-alpha
 mkdir -p "$BROKEN/.claude-plugin"
 printf '{ not json\n' > "$BROKEN/.claude-plugin/marketplace.json"
 run_guard "$BROKEN"
-check "malformed marketplace exits 2, not 1" "$([ "$CODE" -eq 2 ] && echo 0 || echo 1)"
-assert_json "malformed marketplace reports the error in the envelope" "$OUT" "
+check "cpi09 malformed marketplace exits 2, not 1" "$([ "$CODE" -eq 2 ] && echo 0 || echo 1)"
+assert_json "cpi10 malformed marketplace reports the error in the envelope" "$OUT" "
 import json,sys
 d=json.load(sys.stdin)
 assert d['success'] is False, d
@@ -157,8 +164,8 @@ assert d['error'], d
 
 # ---------------------------------------------------------------- case 6
 run_guard "$REPO_ROOT"
-check "real repo inventory is consistent" "$([ "$CODE" -eq 0 ] && echo 0 || echo 1)"
-assert_json "real repo: marketplace count equals directory count" "$OUT" "
+check "cpi11 real repo inventory is consistent" "$([ "$CODE" -eq 0 ] && echo 0 || echo 1)"
+assert_json "cpi12 real repo: marketplace count equals directory count" "$OUT" "
 import json,sys
 d=json.load(sys.stdin)
 assert d['success'] is True, d

--- a/tests/test_check_version_bump.sh
+++ b/tests/test_check_version_bump.sh
@@ -5,20 +5,20 @@
 # version == its marketplace.json entry version) and a git-anchored TOUCH check
 # (pr mode: untouched vs the fork point / post-merge mode: strictly greater).
 # Cases:
-#   1. pr, plugin touched but version untouched -> clean, exit 0.
-#   2. pr, version touched -> version-touched, exit 1.
+#   1. pr, plugin touched but version untouched -> clean, exit 0.  [cvb01]
+#   2. pr, version touched -> version-touched, exit 1.  [cvb02]
 #   3. pr, stale-below-main -> CLEAN. The branch never touched the version but
 #      main advanced past it after the fork. This is the merge-base-anchoring
 #      regression test: a base-TIP anchor would false-flag this, and since main's
-#      version now advances on every merge it would false-flag most real PRs.
-#   4. pr, ^bump/ branch -> exempt, clean.
-#   5. post-merge, incremented -> clean, exit 0.
-#   6. post-merge, not incremented -> version-not-incremented, exit 1.
-#   7. post-merge, regressed -> version-regressed, exit 1.
-#   8. mirror drift -> version-mirror-desync in BOTH modes.
+#      version now advances on every merge it would false-flag most real PRs.  [cvb06]
+#   4. pr, ^bump/ branch -> exempt, clean.  [cvb07]
+#   5. post-merge, incremented -> clean, exit 0.  [cvb03]
+#   6. post-merge, not incremented -> version-not-incremented, exit 1.  [cvb04]
+#   7. post-merge, regressed -> version-regressed, exit 1.  [cvb05]
+#   8. mirror drift -> version-mirror-desync in BOTH modes.  [cvb08, cvb09]
 #   9. degraded (no origin/main) -> status degraded, exit 0 — and a mirror
-#      violation is STILL reported, proving the mirror half needs no git.
-#  10. Real tree -> clean (the repo is in sync today).
+#      violation is STILL reported, proving the mirror half needs no git.  [cvb10, cvb11]
+#  10. Real tree -> clean (the repo is in sync today).  [cvb12]
 #
 # bash 3.2 + stdlib python3 + git.
 #

--- a/tests/test_check_version_bump.sh
+++ b/tests/test_check_version_bump.sh
@@ -21,6 +21,13 @@
 #  10. Real tree -> clean (the repo is in sync today).
 #
 # bash 3.2 + stdlib python3 + git.
+#
+# Result-line ids: every emitted PASS:/FAIL: line carries a first-token id
+# (cvbNN), unique PER EMITTED LINE rather than per logical case, so
+# `mutation-check.sh --case <id>` addresses exactly one assertion. The id is
+# followed by a SPACE, never a colon abutting it — the harness matches the
+# case whole-token, so a colon-abutting id returns case_not_found. A new
+# assertion takes the next free id rather than renumbering its neighbours.
 
 set -eu
 
@@ -126,25 +133,25 @@ PY
 # --- case 1: touched, version untouched ------------------------------------
 R1="$WORK/r1"; make_repo "$R1"
 (cd "$R1" && echo x >> alpha/file.md && $GIT commit -aqm touch)
-check "case 1: pr, touched but version untouched -> clean" \
+check "cvb01-touched-version-untouched pr, touched but version untouched -> clean" \
   "$([ "$(run_gate "$R1")" = "0|ok|EMPTY" ] && echo 0 || echo 1)"
 
 # --- case 2: version touched ------------------------------------------------
 set_version "$R1" alpha 1.0.70 1.0.71 both
 (cd "$R1" && $GIT commit -aqm bump)
-check "case 2: pr, version touched -> version-touched, exit 1" \
+check "cvb02-version-touched pr, version touched -> version-touched, exit 1" \
   "$([ "$(run_gate "$R1")" = "1|ok|version-touched" ] && echo 0 || echo 1)"
 
 # --- case 5/6/7: post-merge polarity ----------------------------------------
-check "case 5: post-merge, incremented -> clean" \
+check "cvb03-postmerge-incremented post-merge, incremented -> clean" \
   "$([ "$(run_gate "$R1" --mode post-merge)" = "0|ok|EMPTY" ] && echo 0 || echo 1)"
 set_version "$R1" alpha 1.0.71 1.0.70 both
 (cd "$R1" && $GIT commit -aqm revert)
-check "case 6: post-merge, not incremented -> version-not-incremented" \
+check "cvb04-postmerge-not-incremented post-merge, not incremented -> version-not-incremented" \
   "$([ "$(run_gate "$R1" --mode post-merge)" = "1|ok|version-not-incremented" ] && echo 0 || echo 1)"
 set_version "$R1" alpha 1.0.70 1.0.69 both
 (cd "$R1" && $GIT commit -aqm regress)
-check "case 7: post-merge, regressed -> version-regressed" \
+check "cvb05-postmerge-regressed post-merge, regressed -> version-regressed" \
   "$([ "$(run_gate "$R1" --mode post-merge)" = "1|ok|version-regressed" ] && echo 0 || echo 1)"
 
 # --- case 3: stale-below-main (merge-base anchoring regression test) --------
@@ -160,7 +167,7 @@ BASE="$(cd "$R3" && $GIT rev-parse HEAD)"
 set_version "$R3" alpha 1.0.70 1.0.71 both
 (cd "$R3" && $GIT commit -aqm "bump(alpha): v1.0.71" \
    && $GIT update-ref refs/remotes/origin/main HEAD && $GIT checkout -q feature)
-check "case 3: pr, stale-below-main -> clean (merge-base anchored)" \
+check "cvb06-stale-below-main pr, stale-below-main -> clean (merge-base anchored)" \
   "$([ "$(run_gate "$R3")" = "0|ok|EMPTY" ] && echo 0 || echo 1)"
 
 # --- case 4: ^bump/ exemption ----------------------------------------------
@@ -168,7 +175,7 @@ R4="$WORK/r4"; make_repo "$R4"
 (cd "$R4" && $GIT checkout -q -b bump/auto-abc123 && echo x >> alpha/file.md)
 set_version "$R4" alpha 1.0.70 1.0.71 both
 (cd "$R4" && $GIT commit -aqm "bump(alpha)")
-check "case 4: pr, ^bump/ branch -> exempt, clean" \
+check "cvb07-bump-branch-exempt pr, ^bump/ branch -> exempt, clean" \
   "$([ "$(run_gate "$R4")" = "0|ok|EMPTY" ] && echo 0 || echo 1)"
 
 # --- case 8/9: mirror drift, and drift surviving the degraded path ----------
@@ -178,15 +185,15 @@ set_version "$R8" alpha 1.0.70 1.0.71 plugin-only
 # Bumping only plugin.json trips BOTH halves: the touch check sees the version
 # move vs the fork point, and the mirror check sees the pair disagree. Both are
 # correct and both must be reported.
-check "case 8: pr, mirror drift -> desync AND touched" \
+check "cvb08-mirror-drift-pr pr, mirror drift -> desync AND touched" \
   "$([ "$(run_gate "$R8")" = "1|ok|version-mirror-desync,version-touched" ] && echo 0 || echo 1)"
-check "case 8: post-merge, mirror drift also reported" \
+check "cvb09-mirror-drift-postmerge post-merge, mirror drift also reported" \
   "$(run_gate "$R8" --mode post-merge | grep -q 'version-mirror-desync' && echo 0 || echo 1)"
-check "case 9: degraded base ref -> status degraded, drift STILL reported" \
+check "cvb10-degraded-base-drift-reported degraded base ref -> status degraded, drift STILL reported" \
   "$([ "$(run_gate "$R8" --base-ref origin/nope)" = "1|degraded|version-mirror-desync" ] && echo 0 || echo 1)"
 
 R9="$WORK/r9"; make_repo "$R9"
-check "case 9: degraded base ref, tree in sync -> clean, exit 0" \
+check "cvb11-degraded-base-in-sync degraded base ref, tree in sync -> clean, exit 0" \
   "$([ "$(run_gate "$R9" --base-ref origin/nope)" = "0|degraded|EMPTY" ] && echo 0 || echo 1)"
 
 # --- case 10: the real tree -------------------------------------------------
@@ -195,7 +202,7 @@ python3 "$GATE" --root "$REPO_ROOT" > "$WORK/real.json" 2>/dev/null
 REAL_RC=$?
 set -e
 REAL_CLEAN="$(python3 -c "import json,sys;print(json.load(open(sys.argv[1]))['data']['clean'])" "$WORK/real.json")"
-check "case 10: real tree -> clean, exit 0" \
+check "cvb12-real-tree-clean real tree -> clean, exit 0" \
   "$([ "$REAL_RC" -eq 0 ] && [ "$REAL_CLEAN" = "True" ] && echo 0 || echo 1)"
 
 echo

--- a/tests/test_check_workflow_yaml.sh
+++ b/tests/test_check_workflow_yaml.sh
@@ -28,6 +28,13 @@
 # Fixtures always drive the real guard through --root rather than a vendored
 # copy of its logic, so the suite cannot keep passing against a frozen snapshot
 # while the guard itself drifts.
+#
+# Result-line ids: every emitted PASS:/FAIL: line carries a first-token id
+# (WY<n><letter>), unique PER EMITTED LINE rather than per logical case, so
+# `mutation-check.sh --case <id>` addresses exactly one assertion. The id is
+# followed by a SPACE, never a colon abutting it — the harness matches the
+# case whole-token, so a colon-abutting id returns case_not_found. A new
+# assertion takes the next free id rather than renumbering its neighbours.
 
 set -eu
 
@@ -78,8 +85,8 @@ set +e
 OUT1=$(python3 "$GUARD" 2>/dev/null)
 CODE1=$?
 set -e
-check_eq "WY1 real tree scans clean (exit 0)" 0 "$CODE1"
-assert_json "WY1 real tree reports success with no violations" "$OUT1" "
+check_eq "WY1a real tree scans clean (exit 0)" 0 "$CODE1"
+assert_json "WY1b real tree reports success with no violations" "$OUT1" "
 import json,sys
 d=json.load(sys.stdin)
 assert d['success'] is True, d
@@ -88,7 +95,7 @@ assert d['data']['summary']['files_scanned']>=3, d
 "
 
 # --- WY2: the defect shape is flagged ----------------------------------------
-# The exact shape that took every gate job in one file offline. This is the case
+# The exact shape that took every gate job in one file offline. This is the case (WY2a)
 # the mutation recipe pins.
 
 mkdir -p "$WORK/red/.github/workflows"
@@ -108,8 +115,8 @@ set +e
 OUT2=$(python3 "$GUARD" --root "$WORK/red" 2>/dev/null)
 CODE2=$?
 set -e
-check_eq "WY2 unquoted plain-scalar colon-space exits 1" 1 "$CODE2"
-assert_json "WY2 violation names the file, the 1-based line and the kind" "$OUT2" "
+check_eq "WY2a unquoted plain-scalar colon-space exits 1" 1 "$CODE2"
+assert_json "WY2b violation names the file, the 1-based line and the kind" "$OUT2" "
 import json,sys
 d=json.load(sys.stdin)
 assert d['success'] is False, d
@@ -141,7 +148,7 @@ set +e
 python3 "$GUARD" --root "$WORK/quoted" >/dev/null 2>&1
 CODE3=$?
 set -e
-check_eq "WY3 quoted value is accepted (exit 0)" 0 "$CODE3"
+check_eq "WY3a quoted value is accepted (exit 0)" 0 "$CODE3"
 
 # --- WY4: block-scalar body skipped, dedented line re-processed ---------------
 # Modelled on the live shape at .github/workflows/cla.yml — an `if: |` opener at
@@ -172,8 +179,8 @@ set +e
 OUT4=$(python3 "$GUARD" --root "$WORK/dedent" 2>/dev/null)
 CODE4=$?
 set -e
-check_eq "WY4 block body skipped and dedented line re-processed (exit 1)" 1 "$CODE4"
-assert_json "WY4 flags only the line after the dedent, never the block body" "$OUT4" "
+check_eq "WY4a block body skipped and dedented line re-processed (exit 1)" 1 "$CODE4"
+assert_json "WY4b flags only the line after the dedent, never the block body" "$OUT4" "
 import json,sys
 d=json.load(sys.stdin)
 v=[x for x in d['data']['violations'] if x['kind']=='plain_scalar_colon_space']
@@ -191,8 +198,8 @@ set +e
 OUT5=$(python3 "$GUARD" --root "$WORK/empty" 2>/dev/null)
 CODE5=$?
 set -e
-check_eq "WY5 empty workflows directory exits 1" 1 "$CODE5"
-assert_json "WY5 empty directory reports success:false and a non-empty error" "$OUT5" "
+check_eq "WY5a empty workflows directory exits 1" 1 "$CODE5"
+assert_json "WY5b empty directory reports success:false and a non-empty error" "$OUT5" "
 import json,sys
 d=json.load(sys.stdin)
 assert d['success'] is False, d
@@ -210,8 +217,8 @@ set +e
 OUT6=$(python3 "$GUARD" --root "$WORK/nogithub" 2>/dev/null)
 CODE6=$?
 set -e
-check_eq "WY6 missing .github directory exits 1" 1 "$CODE6"
-assert_json "WY6 missing directory reports success:false and a non-empty error" "$OUT6" "
+check_eq "WY6a missing .github directory exits 1" 1 "$CODE6"
+assert_json "WY6b missing directory reports success:false and a non-empty error" "$OUT6" "
 import json,sys
 d=json.load(sys.stdin)
 assert d['success'] is False, d
@@ -242,8 +249,8 @@ set +e
 OUT7=$(python3 "$GUARD" --root "$WORK/jobless" 2>/dev/null)
 CODE7=$?
 set -e
-check_eq "WY7 jobless workflows exit 1" 1 "$CODE7"
-assert_json "WY7 childless jobs reports its line, absent jobs reports null" "$OUT7" "
+check_eq "WY7a jobless workflows exit 1" 1 "$CODE7"
+assert_json "WY7b childless jobs reports its line, absent jobs reports null" "$OUT7" "
 import json,sys
 d=json.load(sys.stdin)
 v={x['file']: x for x in d['data']['violations'] if x['kind']=='no_jobs'}
@@ -274,8 +281,8 @@ set +e
 OUT8=$(python3 "$GUARD" --root "$WORK/ext" 2>/dev/null)
 CODE8=$?
 set -e
-check_eq "WY8 .yaml extension is discovered and scanned (exit 1)" 1 "$CODE8"
-assert_json "WY8 the .yaml file is scanned and the .txt is not" "$OUT8" "
+check_eq "WY8a .yaml extension is discovered and scanned (exit 1)" 1 "$CODE8"
+assert_json "WY8b the .yaml file is scanned and the .txt is not" "$OUT8" "
 import json,sys
 d=json.load(sys.stdin)
 assert d['data']['scanned']==['.github/workflows/broken.yaml'], d['data']['scanned']
@@ -290,8 +297,8 @@ set +e
 OUT9=$(python3 "$GUARD" --root "$WORK/binary" 2>"$WORK/stderr9")
 CODE9=$?
 set -e
-check_eq "WY9 undecodable file exits 2" 2 "$CODE9"
-assert_json "WY9 error envelope carries empty data and a non-empty error" "$OUT9" "
+check_eq "WY9a undecodable file exits 2" 2 "$CODE9"
+assert_json "WY9b error envelope carries empty data and a non-empty error" "$OUT9" "
 import json,sys
 d=json.load(sys.stdin)
 assert d['success'] is False, d
@@ -302,7 +309,7 @@ set +e
 grep -q 'Traceback' "$WORK/stderr9"
 GREP9=$?
 set -e
-check "WY9 no traceback reaches stderr" "$([ "$GREP9" -ne 0 ] && echo 0 || echo 1)"
+check "WY9c no traceback reaches stderr" "$([ "$GREP9" -ne 0 ] && echo 0 || echo 1)"
 
 # --- WY10: a comment carrying a colon-space is not flagged --------------------
 # The live shape in .github/workflows/lint.yml, which WY1 already depends on.
@@ -328,7 +335,7 @@ set +e
 python3 "$GUARD" --root "$WORK/comment" >/dev/null 2>&1
 CODE10=$?
 set -e
-check_eq "WY10 comments carrying a colon-space are not flagged (exit 0)" 0 "$CODE10"
+check_eq "WY10a comments carrying a colon-space are not flagged (exit 0)" 0 "$CODE10"
 
 echo ""
 if [ "$FAILED" -eq 0 ]; then

--- a/tests/test_release_bundle_wiki.sh
+++ b/tests/test_release_bundle_wiki.sh
@@ -2,17 +2,19 @@
 #
 # Self-test for scripts/release-bundle-wiki.sh's pre-sync destruction gate.
 #
-# Cases:
-#   RBW1  a bundle-only page makes a bare sync refuse, and writes no bytes
-#   RBW2  the refusal is one JSON object naming the path in data.would_delete
-#   RBW3  a bundled copy holding lines the source lacks is refused as would_overwrite
-#   RBW4  a bundle that is a strict subset of source still syncs bare (no over-refusal)
-#   RBW5  an already-identical bundle still syncs bare (the empty-count regression)
-#   RBW6  --force performs the destructive sync the bare run refused
-#   RBW7  --help prints the whole header and nothing below it
-#   RBW8  an unknown argument still yields the error envelope and exit 1
+# Cases: the bracketed id range after each entry is what the suite actually
+# emits as the result line's first token, and is the addressable `--case`
+# value; the RBWn stems group them and are never emitted on their own.
+#   RBW1  a bundle-only page makes a bare sync refuse, and writes no bytes  [RBW1a-RBW1d]
+#   RBW2  the refusal is one JSON object naming the path in data.would_delete  [RBW2a-RBW2e]
+#   RBW3  a bundled copy holding lines the source lacks is refused as would_overwrite  [RBW3a-RBW3d]
+#   RBW4  a bundle that is a strict subset of source still syncs bare (no over-refusal)  [RBW4a-RBW4c]
+#   RBW5  an already-identical bundle still syncs bare (the empty-count regression)  [RBW5a-RBW5b]
+#   RBW6  --force performs the destructive sync the bare run refused  [RBW6a-RBW6d]
+#   RBW7  --help prints the whole header and nothing below it  [RBW7a-RBW7e]
+#   RBW8  an unknown argument still yields the error envelope and exit 1  [RBW8a-RBW8c]
 #   RBW9  a bundled tree that is absent, or present but holding no pages, still
-#         syncs bare — there is nothing there to destroy
+#         syncs bare — there is nothing there to destroy  [RBW9a-RBW9f]
 #
 # Satisfies the runner's three-property contract: it exits non-zero on failure
 # and zero otherwise, runs as `bash <path>` with no arguments from any working
@@ -32,7 +34,7 @@
 # `dirname $0/..`, so running the copy from <fixture>/scripts/ is what makes
 # both roots resolve inside the fixture; there is no path-override flag.
 #
-# Mutation recipe (proves RBW1's refusal assertion can go red):
+# Mutation recipe (proves RBW1a's refusal assertion can go red):
 #
 #   bash cogni-service/scripts/mutation-check.sh \
 #     --root "$REPO_ROOT" \

--- a/tests/test_release_bundle_wiki.sh
+++ b/tests/test_release_bundle_wiki.sh
@@ -39,17 +39,24 @@
 #     --file scripts/release-bundle-wiki.sh \
 #     --expr 's/DESTRUCTIVE_COUNT" -gt 0/DESTRUCTIVE_COUNT" -lt 0/' \
 #     --test 'bash tests/test_release_bundle_wiki.sh' \
-#     --case RBW1
+#     --case RBW1a
 #
 # DESTRUCTIVE_COUNT is a sum of two non-negative counts, so `-lt 0` is
 # unconditionally false: the gate can never fire, the bare run proceeds to the
-# real rsync --delete, and RBW1 goes red on both of its assertions. The
+# real rsync --delete, and RBW1a goes red. The
 # replacement shares no substring with the matched literal, so it cannot be a
 # no-op. Note the harness applies --expr through `perl -0pi` in slurp mode with
 # no /g, so it rewrites only the FIRST occurrence in the file — the literal
 # `DESTRUCTIVE_COUNT" -gt 0` must therefore appear exactly once in the script,
 # on the `if` line. A comment restating the comparison would absorb the mutation
 # and leave the guard intact, reporting a false green.
+#
+# Result-line ids: every emitted PASS:/FAIL: line carries a first-token id
+# (RBW<n><letter>), unique PER EMITTED LINE rather than per logical case, so
+# `mutation-check.sh --case <id>` addresses exactly one assertion. The id is
+# followed by a SPACE, never a colon abutting it — the harness matches the
+# case whole-token, so a colon-abutting id returns case_not_found. A new
+# assertion takes the next free id rather than renumbering its neighbours.
 
 set -eu
 
@@ -140,21 +147,21 @@ BEFORE=$(bundle_manifest rbw1)
 run_fixture rbw1
 AFTER=$(bundle_manifest rbw1)
 
-check_eq "RBW1 a bundle-only page makes a bare sync exit non-zero" "1" "$CODE"
-[ "$BEFORE" = "$AFTER" ]; check "RBW1 the refusal writes no bytes to the bundled tree" "$?"
+check_eq "RBW1a a bundle-only page makes a bare sync exit non-zero" "1" "$CODE"
+[ "$BEFORE" = "$AFTER" ]; check "RBW1b the refusal writes no bytes to the bundled tree" "$?"
 [ -f "$WORK/rbw1/cogni-workspace/wiki/wiki/pages/bundle-only.md" ]
-check "RBW1 the bundle-only page survives the refusal" "$?"
+check "RBW1c the bundle-only page survives the refusal" "$?"
 [ ! -f "$WORK/rbw1/cogni-workspace/wiki/wiki/pages/source-only.md" ]
-check "RBW1 no source-only page was added by the refused run" "$?"
+check "RBW1d no source-only page was added by the refused run" "$?"
 
 printf '%s' "$OUT" | python3 -c 'import json,sys; json.load(sys.stdin)' >/dev/null 2>&1
-check "RBW2 the whole refusal stdout parses as one JSON object" "$?"
-check_eq "RBW2 refusal reports success false" "False" "$(json_field "$OUT" 'd["success"]')"
-check_eq "RBW2 would_delete names the bundle-only page" "wiki/pages/bundle-only.md" \
+check "RBW2a the whole refusal stdout parses as one JSON object" "$?"
+check_eq "RBW2b refusal reports success false" "False" "$(json_field "$OUT" 'd["success"]')"
+check_eq "RBW2c would_delete names the bundle-only page" "wiki/pages/bundle-only.md" \
   "$(json_field "$OUT" 'd["data"]["would_delete"][0]')"
-check_eq "RBW2 destructive_path_count counts it" "1" \
+check_eq "RBW2d destructive_path_count counts it" "1" \
   "$(json_field "$OUT" 'd["data"]["destructive_path_count"]')"
-check_eq "RBW2 the error names the override flag" "True" \
+check_eq "RBW2e the error names the override flag" "True" \
   "$(json_field "$OUT" '"--force" in d["error"]')"
 
 # ---------------------------------------------------------------------- RBW3
@@ -168,11 +175,11 @@ BEFORE=$(bundle_manifest rbw3)
 run_fixture rbw3
 AFTER=$(bundle_manifest rbw3)
 
-check_eq "RBW3 a bundled superset makes a bare sync exit non-zero" "1" "$CODE"
-[ "$BEFORE" = "$AFTER" ]; check "RBW3 the overwrite refusal writes no bytes" "$?"
-check_eq "RBW3 would_overwrite names the shared page" "wiki/pages/shared.md" \
+check_eq "RBW3a a bundled superset makes a bare sync exit non-zero" "1" "$CODE"
+[ "$BEFORE" = "$AFTER" ]; check "RBW3b the overwrite refusal writes no bytes" "$?"
+check_eq "RBW3c would_overwrite names the shared page" "wiki/pages/shared.md" \
   "$(json_field "$OUT" 'd["data"]["would_overwrite"][0]')"
-check_eq "RBW3 would_delete stays empty for the overwrite class" "0" \
+check_eq "RBW3d would_delete stays empty for the overwrite class" "0" \
   "$(json_field "$OUT" 'len(d["data"]["would_delete"])')"
 
 # ---------------------------------------------------------------------- RBW4
@@ -183,10 +190,10 @@ make_fixture rbw4
 printf 'shared page\nnew line from source\n' > "$WORK/rbw4/wiki/wiki/pages/shared.md"
 run_fixture rbw4
 
-check_eq "RBW4 a source-enriched bundle syncs bare, without --force" "0" "$CODE"
-check_eq "RBW4 that sync reports success" "True" "$(json_field "$OUT" 'd["success"]')"
+check_eq "RBW4a a source-enriched bundle syncs bare, without --force" "0" "$CODE"
+check_eq "RBW4b that sync reports success" "True" "$(json_field "$OUT" 'd["success"]')"
 grep -q 'new line from source' "$WORK/rbw4/cogni-workspace/wiki/wiki/pages/shared.md"
-check "RBW4 the source content reached the bundle" "$?"
+check "RBW4c the source content reached the bundle" "$?"
 
 # ---------------------------------------------------------------------- RBW5
 # Regression guard. Deriving the counts with `wc -l` reports 1 for an empty
@@ -195,8 +202,8 @@ check "RBW4 the source content reached the bundle" "$?"
 make_fixture rbw5
 run_fixture rbw5
 
-check_eq "RBW5 an already-identical bundle syncs bare" "0" "$CODE"
-check_eq "RBW5 that sync reports success" "True" "$(json_field "$OUT" 'd["success"]')"
+check_eq "RBW5a an already-identical bundle syncs bare" "0" "$CODE"
+check_eq "RBW5b that sync reports success" "True" "$(json_field "$OUT" 'd["success"]')"
 
 # ---------------------------------------------------------------------- RBW6
 # The opt-in must be a real override, not a no-op.
@@ -205,12 +212,12 @@ printf 'only in the bundle\n' > "$WORK/rbw6/cogni-workspace/wiki/wiki/pages/bund
 printf 'only in the source\n' > "$WORK/rbw6/wiki/wiki/pages/source-only.md"
 run_fixture rbw6 --force
 
-check_eq "RBW6 --force performs the sync the bare run refused" "0" "$CODE"
-check_eq "RBW6 the forced sync reports success" "True" "$(json_field "$OUT" 'd["success"]')"
+check_eq "RBW6a --force performs the sync the bare run refused" "0" "$CODE"
+check_eq "RBW6b the forced sync reports success" "True" "$(json_field "$OUT" 'd["success"]')"
 [ ! -f "$WORK/rbw6/cogni-workspace/wiki/wiki/pages/bundle-only.md" ]
-check "RBW6 --force really deleted the bundle-only page" "$?"
+check "RBW6c --force really deleted the bundle-only page" "$?"
 [ -f "$WORK/rbw6/cogni-workspace/wiki/wiki/pages/source-only.md" ]
-check "RBW6 --force really added the source-only page" "$?"
+check "RBW6d --force really added the source-only page" "$?"
 
 # ---------------------------------------------------------------------- RBW7
 # The help range is a hand-maintained line number and the header just grew, so
@@ -219,25 +226,25 @@ check "RBW6 --force really added the source-only page" "$?"
 make_fixture rbw7
 run_fixture rbw7 --help
 
-check_eq "RBW7 --help exits 0" "0" "$CODE"
+check_eq "RBW7a --help exits 0" "0" "$CODE"
 printf '%s' "$OUT" | grep -q -- '--force'
-check "RBW7 --help documents the --force opt-in" "$?"
+check "RBW7b --help documents the --force opt-in" "$?"
 printf '%s' "$OUT" | grep -q -- '--check'
-check "RBW7 --help still documents --check" "$?"
+check "RBW7c --help still documents --check" "$?"
 printf '%s' "$OUT" | grep -q 'error'
-check "RBW7 --help reaches the last header line" "$?"
+check "RBW7d --help reaches the last header line" "$?"
 ! printf '%s' "$OUT" | grep -q 'set -eu'
-check "RBW7 --help does not run past the header into the code" "$?"
+check "RBW7e --help does not run past the header into the code" "$?"
 
 # ---------------------------------------------------------------------- RBW8
 # The new arms must sit before the catch-all, or every flag becomes "unknown".
 make_fixture rbw8
 run_fixture rbw8 --definitely-not-a-flag
 
-check_eq "RBW8 an unknown argument exits 1" "1" "$CODE"
-check_eq "RBW8 an unknown argument reports success false" "False" \
+check_eq "RBW8a an unknown argument exits 1" "1" "$CODE"
+check_eq "RBW8b an unknown argument reports success false" "False" \
   "$(json_field "$OUT" 'd["success"]')"
-check_eq "RBW8 the error names the offending argument" "True" \
+check_eq "RBW8c the error names the offending argument" "True" \
   "$(json_field "$OUT" '"--definitely-not-a-flag" in d["error"]')"
 
 # ---------------------------------------------------------------------------- RBW9
@@ -249,19 +256,19 @@ make_fixture rbw9a
 rm -rf "$WORK/rbw9a/cogni-workspace/wiki"
 run_fixture rbw9a
 
-check_eq "RBW9 an absent bundled tree syncs bare" "0" "$CODE"
-check_eq "RBW9 that bootstrap sync reports success" "True" "$(json_field "$OUT" 'd["success"]')"
+check_eq "RBW9a an absent bundled tree syncs bare" "0" "$CODE"
+check_eq "RBW9b that bootstrap sync reports success" "True" "$(json_field "$OUT" 'd["success"]')"
 [ -f "$WORK/rbw9a/cogni-workspace/wiki/wiki/pages/shared.md" ]
-check "RBW9 the bootstrap sync populated the bundled tree" "$?"
+check "RBW9c the bootstrap sync populated the bundled tree" "$?"
 
 make_fixture rbw9b
 rm -f "$WORK/rbw9b/cogni-workspace/wiki/wiki/pages/shared.md"
 run_fixture rbw9b
 
-check_eq "RBW9 an empty bundled page set syncs bare" "0" "$CODE"
-check_eq "RBW9 that sync reports success" "True" "$(json_field "$OUT" 'd["success"]')"
+check_eq "RBW9d an empty bundled page set syncs bare" "0" "$CODE"
+check_eq "RBW9e that sync reports success" "True" "$(json_field "$OUT" 'd["success"]')"
 [ -f "$WORK/rbw9b/cogni-workspace/wiki/wiki/pages/shared.md" ]
-check "RBW9 the empty bundled tree was populated" "$?"
+check "RBW9f the empty bundled tree was populated" "$?"
 
 # ----------------------------------------------------------------------------
 if [ "$FAILED" -eq 0 ]; then

--- a/tests/test_run_plugin_tests.sh
+++ b/tests/test_run_plugin_tests.sh
@@ -25,6 +25,13 @@
 # recurses into the full sweep.
 #
 # bash 3.2 + stdlib python3 only.
+#
+# Result-line ids: every emitted PASS:/FAIL: line carries a first-token id
+# (rptNN), unique PER EMITTED LINE rather than per logical case, so
+# `mutation-check.sh --case <id>` addresses exactly one assertion. The id is
+# followed by a SPACE, never a colon abutting it — the harness matches the
+# case whole-token, so a colon-abutting id returns case_not_found. A new
+# assertion takes the next free id rather than renumbering its neighbours.
 
 set -eu
 
@@ -77,8 +84,8 @@ set +e
 OUT1="$(python3 "$RUNNER" --root "$FIX1" 2>/dev/null)"
 CODE1=$?
 set -e
-check "all-passing tree exits 0" "$([ "$CODE1" -eq 0 ] && echo 0 || echo 1)"
-assert_json "all-passing tree reports 3 passed, 0 failed" "$OUT1" "
+check "rpt01 all-passing tree exits 0" "$([ "$CODE1" -eq 0 ] && echo 0 || echo 1)"
+assert_json "rpt02 all-passing tree reports 3 passed, 0 failed" "$OUT1" "
 import json,sys
 d=json.load(sys.stdin)
 assert d['success'] is True, d
@@ -98,8 +105,8 @@ set +e
 OUT2="$(python3 "$RUNNER" --root "$FIX2" 2>/dev/null)"
 CODE2=$?
 set -e
-check "failing suite exits 1" "$([ "$CODE2" -eq 1 ] && echo 0 || echo 1)"
-assert_json "failing suite is named in failed_suites" "$OUT2" "
+check "rpt03 failing suite exits 1" "$([ "$CODE2" -eq 1 ] && echo 0 || echo 1)"
+assert_json "rpt04 failing suite is named in failed_suites" "$OUT2" "
 import json,sys
 d=json.load(sys.stdin)
 assert d['success'] is False, d
@@ -123,8 +130,8 @@ set +e
 OUT3="$(python3 "$RUNNER" --root "$FIX3" --timeout 1 2>/dev/null)"
 CODE3=$?
 set -e
-check "timed-out suite exits 1" "$([ "$CODE3" -eq 1 ] && echo 0 || echo 1)"
-assert_json "timed-out suite is flagged timed_out" "$OUT3" "
+check "rpt05 timed-out suite exits 1" "$([ "$CODE3" -eq 1 ] && echo 0 || echo 1)"
+assert_json "rpt06 timed-out suite is flagged timed_out" "$OUT3" "
 import json,sys
 d=json.load(sys.stdin)
 assert d['data']['failed']==1, d['data']
@@ -146,7 +153,7 @@ printf 'helper_fn() { :; }\n' > "$FIX4/cogni-alpha/tests/fixtures/test_helpers.s
 set +e
 LIST4="$(python3 "$RUNNER" --root "$FIX4" --list 2>/dev/null)"
 set -e
-assert_json "_archive and fixtures paths are not discovered" "$LIST4" "
+assert_json "rpt07 _archive and fixtures paths are not discovered" "$LIST4" "
 import json,sys
 d=json.load(sys.stdin)['data']
 assert d['suites']==['cogni-alpha/tests/test_live.sh'], d['suites']
@@ -156,9 +163,9 @@ set +e
 OUT4="$(python3 "$RUNNER" --root "$FIX4" 2>/dev/null)"
 CODE4=$?
 set -e
-check "non-executable suite with a shebang still runs and passes" \
+check "rpt08 non-executable suite with a shebang still runs and passes" \
   "$([ "$CODE4" -eq 0 ] && echo 0 || echo 1)"
-assert_json "only the live suite ran" "$OUT4" "
+assert_json "rpt09 only the live suite ran" "$OUT4" "
 import json,sys
 d=json.load(sys.stdin)['data']
 assert d['total']==1, d
@@ -172,8 +179,8 @@ set +e
 LIST7="$(python3 "$RUNNER" --root "$REPO_ROOT" --list 2>/dev/null)"
 CODE7=$?
 set -e
-check "real-tree --list exits 0" "$([ "$CODE7" -eq 0 ] && echo 0 || echo 1)"
-assert_json "real tree discovers suites, none under _archive or fixtures" "$LIST7" "
+check "rpt10 real-tree --list exits 0" "$([ "$CODE7" -eq 0 ] && echo 0 || echo 1)"
+assert_json "rpt11 real tree discovers suites, none under _archive or fixtures" "$LIST7" "
 import json,sys
 d=json.load(sys.stdin)['data']
 assert d['total'] > 0, 'discovery found nothing — the globs stopped matching'
@@ -194,9 +201,9 @@ set +e
 OUT8="$(python3 "$RUNNER" --root "$FIX8" 2>/dev/null)"
 CODE8=$?
 set -e
-check "empty root exits 1 rather than reporting a vacuous pass" \
+check "rpt12 empty root exits 1 rather than reporting a vacuous pass" \
   "$([ "$CODE8" -eq 1 ] && echo 0 || echo 1)"
-assert_json "empty root reports success:false, total 0, and a non-empty error" "$OUT8" "
+assert_json "rpt13 empty root reports success:false, total 0, and a non-empty error" "$OUT8" "
 import json,sys
 d=json.load(sys.stdin)
 assert d['success'] is False, d


### PR DESCRIPTION
Closes #1492

## Summary

Eight suites under the repo-root `tests/` directory emitted result lines whose first whitespace-delimited token was shared, so `mutation-check.sh --case <id>` could not address a single assertion. With all 18 labels in `tests/test_apply_version_bump.sh` beginning with the bare word `case`, a mutation aimed at one assertion was credited by a red on any of the other 17, and `guard_verified` was recorded for an unexercised guard. These two suites are the enforcement arm of the repo's version discipline, so an unfalsifiable green there is expensive.

Every emitted result line in the eight suites now carries a first token unique within its own suite. The prose after each id is preserved verbatim, so CI output loses nothing.

## Id scheme, per suite

| Suite | Lines | Scheme | Example |
|---|---|---|---|
| `tests/test_apply_version_bump.sh` | 18 | `avbNN-<slug>` replaces the `case N:` prefix | `avb02-alpha-mirror` |
| `tests/test_check_version_bump.sh` | 12 | `cvbNN-<slug>` replaces the `case N:` prefix | `cvb07-bump-branch-exempt` |
| `tests/test_release_bundle_wiki.sh` | 36 | existing `RBWn` stem + per-line letter | `RBW9f` |
| `tests/test_check_workflow_yaml.sh` | 19 | existing `WYn` stem + per-line letter | `WY9c` |
| `tests/test_check_external_dispatch.sh` | 19 | `edNN` for the 9 previously un-idded lines; `R<n><letter>` for the registry family | `ed04`, `R3a` |
| `tests/test_check_plugin_inventory.sh` | 12 | `cpiNN` prefix | `cpi07` |
| `tests/test_run_plugin_tests.sh` | 13 | `rptNN` prefix | `rpt13` |
| `tests/test_check_breadcrumbs.sh` | 7 | `cbcNN` prefix | `cbc07` |

`tests/test_check_mcp_tool_grant.sh` (53 lines) and `tests/test_check_result_line_plainness.sh` (14 lines) already satisfied the property and are the in-repo reference implementations. They are deliberately untouched, which also keeps them usable as a before/after control.

## Scope decisions

**Space, never a colon.** The id is followed by a SPACE. This is the convention already documented in-tree at `tests/test_check_external_dispatch.sh` and `tests/test_check_result_line_plainness.sh`, and it is load-bearing rather than stylistic: the harness matches the case whole-token, so an id spelled `avb02-alpha-mirror:` makes the first token `avb02-alpha-mirror:` and `--case avb02-alpha-mirror` returns `case_not_found`.

The issue's illustrative strings use the colon form, which contradicts its own acceptance criterion 4. Demonstrated:

```
--case avb02-alpha-mirror  vs  colon-form label  -> matches=0 (case_not_found)
--case avb02-alpha-mirror  vs  space-form label  -> matches=1 (resolves)
```

**Ordinals are per emitted line, not per case number.** Criterion 4 pins `avb02-alpha-mirror` to the alpha-mirror assertion, which is the *second emitted line* while sitting inside narrative case 1. So the issue's other illustration (`avb10a/b/c` for the three former `case 10:` lines) cannot also hold; those land as `avb06-changed-line-count`, `avb07-nonascii-description-verbatim` and `avb08-keywords-untouched`, with the discriminators preserved exactly as the issue named them.

The per-line trap is wider than the issue states. Beyond the named `case 10` triple, `test_apply_version_bump.sh` also had `case 6`×3 and `case 7`×4, and `test_check_version_bump.sh` had `case 8`×2 and `case 9`×2 — nine further lines a case-number-keyed rename would have left colliding.

**`RBW7` stem preserved.** `scripts/release-bundle-wiki.sh` carries the repo's only reference to a case id outside `tests/` (`case RBW7 pins both directions`). It names the *case*, so preserving the stem leaves it correct and keeps the whole diff inside acceptance criterion 6's `tests/`-only bound, with no disclosed exception needed.

**Disclosed inconsistency.** Only `avb`/`cvb` carry a `-<slug>`; the other six suites use a bare address. A cleanup review flagged this and recommended converging all eight on the bare form. Not done: criterion 4 pins the literal string `avb02-alpha-mirror`, and dropping the slug would make that id `case_not_found` — the criterion's own named falsifier. Worth revisiting if that pin is ever restated.

## Verification — by execution, never by grepping call sites

All 10 root suites were run before and after. Base was re-derived after `main` moved mid-branch (the cogni-visual retirement landed and removed three suites), so these are new-base numbers.

| Check | Result |
|---|---|
| Max first-token group size, all 10 suites | **1** (base: up to 18) |
| Emitted line counts per suite | 18 / 12 / 36 / 19 / 19 / 12 / 13 / 7 — **unchanged from base** |
| `python3 scripts/run-plugin-tests.py` | exit 0, `data.total` 124, passed 124, failed 0 — unchanged |
| `check-result-line-plainness.py` | exit 0 |
| `check-breadcrumbs.py`, `check-external-dispatch.py`, `check-workflow-yaml.py`, `check-plugin-inventory.py`, `check-mcp-tool-grant.py` | exit 0 |
| Paths outside `tests/` | 0 |
| `"version"` lines touched | 0 |

**Criterion 3 (both arms carry the same id)** is structural — every suite emits `PASS: $1` / `FAIL: $1` from one label argument — and is demonstrated rather than asserted: inverting the emitter predicate in a scratch copy of each suite drives every assertion down its FAIL branch, and the resulting FAIL first-token set is identical to the clean run's PASS set in all eight suites (136/136 ids).

**Label-only property, mechanically confirmed:** normalising every file by dropping comment lines and replacing the first string-literal argument of each `check` / `check_eq` / `assert_json` call with a placeholder leaves all eight byte-identical to base. No condition, expected value, `$([ ... ])` expression, fixture heredoc or variable capture moved.

## Mutation recipe

All three arms were **executed**, not recorded from reading. Each matched literal was confirmed to occur exactly once in its target file, so the harness's `perl -0pi` slurp mode with no `/g` cannot land elsewhere; neither replacement shares a substring with its match, so neither can register as `expr_no_op`.

Arm 1 — the id acceptance criterion 4 pins. Truncating the patch component to its first digit breaks only the two-digit bump (alpha `1.0.70`), leaving the single-digit carries (`0.0.9 -> 0.0.10`) correct:

```
bash cogni-service/scripts/mutation-check.sh \
  --root "$REPO_ROOT" \
  --file scripts/apply-version-bump.py \
  --expr 's/int\(comps\[-1\]\) \+ 1/int(comps[-1][0]) + 1/' \
  --test 'bash tests/test_apply_version_bump.sh' \
  --case avb02-alpha-mirror
```

→ `guard_verified` (mutated red, restored green). **Observed red set: `avb02-alpha-mirror` alone — no sibling red.**

Arm 2 — the repeat criterion 4 asks for. Reverting the `^bump/` branch exemption:

```
bash cogni-service/scripts/mutation-check.sh \
  --root "$REPO_ROOT" \
  --file scripts/check-version-bump.py \
  --expr 's/branch\.startswith\("bump\/"\)/branch.startswith("nope\/")/' \
  --test 'bash tests/test_check_version_bump.sh' \
  --case cvb07-bump-branch-exempt
```

→ `guard_verified`. **Observed red set: `cvb07-bump-branch-exempt` alone.**

Arm 3 — re-verification of the pre-existing in-file recipe this PR repoints (was `--case RBW1`):

```
bash cogni-service/scripts/mutation-check.sh \
  --root "$REPO_ROOT" \
  --file scripts/release-bundle-wiki.sh \
  --expr 's/DESTRUCTIVE_COUNT" -gt 0/DESTRUCTIVE_COUNT" -lt 0/' \
  --test 'bash tests/test_release_bundle_wiki.sh' \
  --case RBW1a
```

→ `guard_verified`. **Observed red set: `RBW1a` alone.** The recipe's own prose claimed "RBW1 goes red on both of its assertions"; that was already stale at base (RBW1 spanned four lines), and the per-line ids now make the recipe isolate exactly one. The sentence is corrected in this PR.

Both `--case R3` (external dispatch) and `--case RBW1` now match **zero** lines, which is why the two in-file pointers had to move rather than being left as prose drift.

## Open questions

- **Criterion 4's "no sibling red" clause is not satisfiable by the mutation the criterion itself suggests.** The parenthetical example — "let the mirror write skip `marketplace.json`" — necessarily reds `avb02-alpha-mirror` together with every other case asserting the same paired-write property, because alpha, beta and gamma travel one code path. The narrower patch-tail truncation used above *does* satisfy the clause exactly. Flagging so a reviewer can confirm the substituted mutation is acceptable evidence.
- **The issue illustrates two mutually inconsistent id families** (per-line ordinals `avb01`/`avb02` versus case-number-plus-letter `avb10a/b/c`). This PR adopts the per-line ordinal family because it is the one criterion 4 is satisfiable under. Confirm this reading before merge.
- **Enforcement is deliberately not in this PR.** A CI guard asserting per-suite id uniqueness would have to live in `scripts/` + `.github/workflows/`, outside criterion 6's bound, and #1499 is the open issue that owns that decision. The per-file header notes added here are documentation, not enforcement, and give #1499 a written contract to point a guard at.