### PR TITLE
Unique result-line ids across the colliding suites and the theme harness

### DIFF
--- a/cogni-portfolio/tests/test-dashboard-handoff.sh
+++ b/cogni-portfolio/tests/test-dashboard-handoff.sh
@@ -303,22 +303,28 @@ test_refresher_has_no_skip_path() {
 # --- test_open_browser_optin -----------------------------------------------
 # Two halves: the documented default is the non-opening one, and every call site
 # whose prose promises to open names the opt-in explicitly.
+#
+# Both halves emit a green line on a clean run, so the addressable id names the
+# HALF rather than the case — a single `test_open_browser_optin` token would name
+# two lines and a mutation of either half could be credited by the other. The
+# function name itself is unchanged: ALL_TESTS/run_one and scripts/mutation-check.sh
+# dispatch on it.
 test_open_browser_optin() {
-  agent_surface_ok test_open_browser_optin || return
+  agent_surface_ok test_open_browser_optin-surface || return
 
   # Half 1 — the input contract.
   local contract_line
   contract_line="$(grep -F '`open_browser` (optional' "$AGENT" | head -1)"
   if [ -z "$contract_line" ]; then
-    fail test_open_browser_optin "no open_browser input-contract line in agents/dashboard-refresher.md"
+    fail test_open_browser_optin-contract-default-false "no open_browser input-contract line in agents/dashboard-refresher.md"
   else
     case "$contract_line" in
-      *"default: false"*) pass test_open_browser_optin "input contract documents the non-opening default" ;;
-      *) fail test_open_browser_optin "input-contract line does not document 'default: false': $contract_line" ;;
+      *"default: false"*) pass test_open_browser_optin-contract-default-false "input contract documents the non-opening default" ;;
+      *) fail test_open_browser_optin-contract-default-false "input-contract line does not document 'default: false': $contract_line" ;;
     esac
   fi
   if grep -qF 'default: true' "$AGENT"; then
-    fail test_open_browser_optin "agent contract still documents 'default: true' somewhere"
+    fail test_open_browser_optin-no-default-true "agent contract still documents 'default: true' somewhere"
   fi
 
   # Half 2 — the call-site surface. Three globs: agents/, skills/*/SKILL.md and
@@ -332,7 +338,7 @@ test_open_browser_optin() {
   )"
   scanned="$(printf '%s\n' "$surface" | grep -c . )"
   if [ "$scanned" -eq 0 ]; then
-    fail test_open_browser_optin "scanned no files; scan surface is broken"
+    fail test_open_browser_optin-scan-surface "scanned no files; scan surface is broken"
     return
   fi
 
@@ -350,7 +356,7 @@ test_open_browser_optin() {
   )"
   dispatch_count="$(printf '%s\n' "$dispatch_lines" | grep -c . )"
   if [ "$dispatch_count" -eq 0 ]; then
-    fail test_open_browser_optin "found no dashboard-refresher dispatch lines; scan surface is broken"
+    fail test_open_browser_optin-dispatch-surface "found no dashboard-refresher dispatch lines; scan surface is broken"
     return
   fi
 
@@ -380,9 +386,9 @@ $dispatch_lines
 EOF
 
   if [ -n "$offenders" ]; then
-    fail test_open_browser_optin "call sites promise to open but pass no flag:$offenders"
+    fail test_open_browser_optin-callsite-optin "call sites promise to open but pass no flag:$offenders"
   else
-    pass test_open_browser_optin "all intending call sites name the opt-in ($dispatch_count dispatch lines scanned)"
+    pass test_open_browser_optin-callsite-optin "all intending call sites name the opt-in ($dispatch_count dispatch lines scanned)"
   fi
 }
 

--- a/cogni-workspace/scripts/verify-theme-backcompat.sh
+++ b/cogni-workspace/scripts/verify-theme-backcompat.sh
@@ -18,6 +18,51 @@
 # This harness also runs in CI, via the thin wrapper suite
 # cogni-workspace/tests/test-theme-backcompat.sh that run-plugin-tests.py
 # discovers. Keep it runnable with no arguments and no network access.
+#
+# RESULT-LINE CONTRACT. Every result line is plain, colon-terminated and
+# id-first: `PASS: <case-id> <label>` / `FAIL: <case-id> <label>`. The case id is
+# what the shared mutation harness addresses, and it matches whole-token —
+# `^[ \t]*FAIL:[ \t]+<case>(?:[ \t]|$)` — so no colour, no leading whitespace
+# and no colon may sit between the label and the id, or between the id and the
+# text. Plainness is NOT gated on a capability probe (`[ -t 1 ]`, `$TERM`): that
+# would make parsability depend on where the harness runs, and the colour would
+# come back under a pty.
+#
+# A check's PASS branch and its FAIL branch carry the SAME id, deliberately.
+# The mutation harness returns `guard_verified` only when the mutant is red AND
+# the restore is green under one `--case`, so a check whose two branches carry
+# different ids can never be verified — it degrades to `case_not_found`, which
+# reads as a missing case rather than going red. Several `fail` arms may share
+# one id (the TIERS_PROBE case does): `fail()` exits on the first failure, so at
+# most one FAIL line is ever emitted per run.
+#
+# `c_skip` and `c_info` are deliberately NOT result lines and keep their colour —
+# they must never begin with `PASS:` or `FAIL:`.
+#
+# This file lives under scripts/, one path segment outside
+# scripts/check-result-line-plainness.py's two non-recursive globs
+# (`tests/*.sh`, `*/tests/*.sh`), so that guard does not cover it — before or
+# after this contract was adopted. The plainness above rests on this file, not
+# on CI. Do not "fix" that by moving the harness under tests/: the surviving
+# c_skip/c_info escape literals would then be discovered and turn the guard's
+# hard clean zero red.
+#
+# Mutation recipe — verified, replayable. The wrapper is the only runnable entry
+# point (this harness takes no per-case selector), and because fail() exits on
+# the first failure the mutated file must redden the chosen id before any
+# earlier phase can fail.
+#
+#   M1 -> tbc10-tier0-baseline-match       (verdict: guard_verified)
+#     bash ~/.claude/plugins/cache/managed-service/cogni-service/0.0.402/scripts/mutation-check.sh \
+#       --root . \
+#       --file cogni-workspace/scripts/baselines/_template-tier0-output.json \
+#       --expr 's#"source": "standard"#"source": "mutated"#' \
+#       --test 'bash cogni-workspace/tests/test-theme-backcompat.sh' \
+#       --case tbc10-tier0-baseline-match
+#
+#   Before this contract existed the harness emitted zero addressable lines, so
+#   every invocation of the form above returned case_not_found and no check here
+#   could contribute mutation evidence at all.
 
 set -uo pipefail
 
@@ -44,8 +89,8 @@ trap cleanup EXIT
 # Output helpers
 # --------------------------------------------------------------------------
 
-c_pass() { printf "  \033[32mPASS\033[0m  %s\n" "$1"; }
-c_fail() { printf "  \033[31mFAIL\033[0m  %s\n" "$1"; }
+c_pass() { printf 'PASS: %s\n' "$1"; }
+c_fail() { printf 'FAIL: %s\n' "$1"; }
 c_skip() { printf "  \033[33mSKIP\033[0m  %s\n" "$1"; }
 c_info() { printf "  \033[36mINFO\033[0m  %s\n" "$1"; }
 
@@ -90,29 +135,34 @@ On the first failure, prints a triage line and exits 1.
 
 Failure-mode triage table
 
-  - "tier-0 baseline mismatch" or "tier-0 fixture discover failed":
+  - tbc10-tier0-baseline-match ("tier-0 baseline mismatch") or
+    tbc06-tier0-fixture-discover ("tier-0 fixture discover failed"):
       Likely #126 (cogni-workspace: discover-themes.py reads manifest.json
       with tier-0 fallback). The contract is "no manifest.json => byte-
       identical legacy output"; if discover added a field, this fires.
 
-  - "cogni-work missing tiers.tokens" or "tokens.css absent":
+  - tbc13-cogni-work-tiers-tokens ("cogni-work missing tiers.tokens" or
+    "tokens.css absent"):
       Likely #127 (cogni-workspace: migrate cogni-work theme to tiered
       directory structure as Phase 2 reference implementation) or #128
       (manifest schema). Either the migration regressed or the schema
       stopped accepting the existing manifest.
 
-  - "validate-theme-manifest.py rejects cogni-work":
+  - tbc14-validator-accepts-cogni-work ("validate-theme-manifest.py rejects
+    cogni-work"):
       Likely #128 (manifest schema definition) or #138 (manage-themes deep
       authoring) — schema and authoring surfaces drifted.
 
-  - "render-html-slides theme contract missing":
+  - tbc20-consumer-theme-ref-<plugin>-<skill> ("render-html-slides theme
+    contract missing"):
       Likely #129 (the cogni-visual refactor of render-html-slides to consume
       tier-1 tokens and tier-3 component primitives from cogni-work).
 
-  - "migration guide reference missing":
+  - tbc18-migration-guide-present ("migration guide reference missing"):
       Likely #130 (cogni-workspace: write Theme System v2 migration guide).
 
-  - "consumer SKILL.md reference missing":
+  - tbc20-consumer-theme-ref-<plugin>-<skill> ("consumer SKILL.md reference
+    missing"):
       Cross-cutting drift; could be a SKILL.md regeneration that lost the
       theme reference. File against the affected plugin.
 
@@ -145,29 +195,29 @@ done
 phase "Pre-flight"
 
 if ! command -v python3 >/dev/null 2>&1; then
-  fail "pre-flight" "python3 not found on PATH; the harness needs python3 to run discover-themes.py and to normalize JSON."
+  fail "tbc01-python3-available python3 not found on PATH; the harness needs python3 to run discover-themes.py and to normalize JSON."
 fi
-c_pass "python3 available"
+c_pass "tbc01-python3-available python3 available"
 
 if [[ ! -f "$DISCOVER_SCRIPT" ]]; then
-  fail "pre-flight" "discover-themes.py not at $DISCOVER_SCRIPT (expected under skills/pick-theme/scripts/). Likely #126 moved the script — update DISCOVER_SCRIPT here to match."
+  fail "tbc02-discover-script-present discover-themes.py not at $DISCOVER_SCRIPT (expected under skills/pick-theme/scripts/). Likely #126 moved the script — update DISCOVER_SCRIPT here to match."
 fi
-c_pass "discover-themes.py present"
+c_pass "tbc02-discover-script-present discover-themes.py present"
 
 if [[ ! -f "$VALIDATOR_SCRIPT" ]]; then
-  fail "pre-flight" "validate-theme-manifest.py not at $VALIDATOR_SCRIPT. Likely #128 moved the validator."
+  fail "tbc03-validator-present validate-theme-manifest.py not at $VALIDATOR_SCRIPT. Likely #128 moved the validator."
 fi
-c_pass "validate-theme-manifest.py present"
+c_pass "tbc03-validator-present validate-theme-manifest.py present"
 
 if [[ ! -d "$PLUGIN_ROOT/themes/_template" ]]; then
-  fail "pre-flight" "themes/_template/ not present in $PLUGIN_ROOT — the tier-0 reference theme is missing."
+  fail "tbc04-template-theme-present themes/_template/ not present in $PLUGIN_ROOT — the tier-0 reference theme is missing."
 fi
-c_pass "themes/_template/ present"
+c_pass "tbc04-template-theme-present themes/_template/ present"
 
 if [[ ! -d "$PLUGIN_ROOT/themes/cogni-work" ]]; then
-  fail "pre-flight" "themes/cogni-work/ not present in $PLUGIN_ROOT — the tiered reference theme is missing."
+  fail "tbc05-cogni-work-theme-present themes/cogni-work/ not present in $PLUGIN_ROOT — the tiered reference theme is missing."
 fi
-c_pass "themes/cogni-work/ present"
+c_pass "tbc05-cogni-work-theme-present themes/cogni-work/ present"
 
 # --------------------------------------------------------------------------
 # Helpers — run discover-themes / normalize JSON
@@ -223,32 +273,32 @@ phase "Phase A — discover-themes invariants"
 verbose "Building tier-0 fixture"
 build_tier0_fixture >/dev/null
 TIER0_OUTPUT="$(discover "$TMPDIR" --no-include-tiers 2>/dev/null)" \
-  || fail "tier-0 fixture discover failed" "discover-themes.py exited non-zero against the tier-0 fixture. Likely #126 broke the fallback path."
+  || fail "tbc06-tier0-fixture-discover tier-0 fixture discover failed" "discover-themes.py exited non-zero against the tier-0 fixture. Likely #126 broke the fallback path."
 
 NORMALIZED="$(printf "%s" "$TIER0_OUTPUT" | normalize_for_baseline)" \
-  || fail "tier-0 normalize failed" "JSON normalization failed — output of discover-themes is not valid JSON."
+  || fail "tbc07-tier0-normalize tier-0 normalize failed" "JSON normalization failed — output of discover-themes is not valid JSON."
 
 if [[ "$REGENERATE" -eq 1 ]]; then
   printf "%s\n" "$NORMALIZED" > "$TIER0_BASELINE"
   c_info "Regenerated baseline: $TIER0_BASELINE"
-  c_pass "tier-0 baseline regeneration"
+  c_pass "tbc08-tier0-baseline-regenerated tier-0 baseline regeneration"
 else
   EXPECTED="$(cat "$TIER0_BASELINE")" \
-    || fail "tier-0 baseline read failed" "Cannot read $TIER0_BASELINE. Run with --regenerate-baseline to recreate it."
+    || fail "tbc09-tier0-baseline-read tier-0 baseline read failed" "Cannot read $TIER0_BASELINE. Run with --regenerate-baseline to recreate it."
 
   if [[ "$NORMALIZED" != "$EXPECTED" ]]; then
     if [[ "$VERBOSE" -eq 1 ]]; then
       printf "  --- expected\n%s\n  --- actual\n%s\n" "$EXPECTED" "$NORMALIZED" >&2
     fi
-    fail "tier-0 baseline mismatch" "discover-themes.py output for the tier-0 fixture diverged from $TIER0_BASELINE. Run with -v to see the diff. If the change is intentional, regenerate with --regenerate-baseline."
+    fail "tbc10-tier0-baseline-match tier-0 baseline mismatch" "discover-themes.py output for the tier-0 fixture diverged from $TIER0_BASELINE. Run with -v to see the diff. If the change is intentional, regenerate with --regenerate-baseline."
   fi
-  c_pass "tier-0 baseline matches snapshot"
+  c_pass "tbc10-tier0-baseline-match tier-0 baseline matches snapshot"
 fi
 
 # A2. Tiered cogni-work surfaces tiers.tokens.
 verbose "Running discover against $PLUGIN_ROOT"
 TIERED_OUTPUT="$(discover "$PLUGIN_ROOT" 2>/dev/null)" \
-  || fail "tiered discover failed" "discover-themes.py exited non-zero against the real plugin root."
+  || fail "tbc11-tiered-discover tiered discover failed" "discover-themes.py exited non-zero against the real plugin root."
 
 TIERS_PROBE="$(printf "%s" "$TIERED_OUTPUT" | python3 -c '
 import json, os, sys
@@ -268,16 +318,16 @@ css = os.path.join(tokens, "tokens.css")
 if not os.path.isfile(css):
     print(f"TOKENS_CSS_ABSENT:{css}"); sys.exit(0)
 print("OK")
-')" || fail "tiered probe failed" "JSON parse failed reading discover output."
+')" || fail "tbc12-tiered-probe tiered probe failed" "JSON parse failed reading discover output."
 
 case "$TIERS_PROBE" in
-  OK) c_pass "cogni-work surfaces tiers.tokens with tokens.css" ;;
-  MISSING_THEME) fail "cogni-work missing from discover" "discover-themes.py did not return cogni-work. Likely #127 regressed the migration." ;;
-  MISSING_TIERS) fail "cogni-work missing tiers.tokens" "discover output for cogni-work has no 'tiers' key. Likely #126 (manifest fallback) or #128 (schema). Check $PLUGIN_ROOT/themes/cogni-work/manifest.json." ;;
-  MISSING_TOKENS_KEY) fail "cogni-work tiers.tokens absent" "manifest.json declares no tokens tier. Likely #127/#128 — manifest does not match the v2 schema." ;;
-  TOKENS_DIR_ABSENT:*) fail "cogni-work tokens dir absent" "tiers.tokens resolves to a path that does not exist: ${TIERS_PROBE#TOKENS_DIR_ABSENT:}. Likely #127 dropped the tokens/ dir." ;;
-  TOKENS_CSS_ABSENT:*) fail "cogni-work tokens.css absent" "tokens dir exists but tokens.css is missing: ${TIERS_PROBE#TOKENS_CSS_ABSENT:}. Likely #136 (tier-1 tokens.css) regressed." ;;
-  *) fail "tiered probe unknown response" "Unexpected probe output: $TIERS_PROBE" ;;
+  OK) c_pass "tbc13-cogni-work-tiers-tokens cogni-work surfaces tiers.tokens with tokens.css" ;;
+  MISSING_THEME) fail "tbc13-cogni-work-tiers-tokens cogni-work missing from discover" "discover-themes.py did not return cogni-work. Likely #127 regressed the migration." ;;
+  MISSING_TIERS) fail "tbc13-cogni-work-tiers-tokens cogni-work missing tiers.tokens" "discover output for cogni-work has no 'tiers' key. Likely #126 (manifest fallback) or #128 (schema). Check $PLUGIN_ROOT/themes/cogni-work/manifest.json." ;;
+  MISSING_TOKENS_KEY) fail "tbc13-cogni-work-tiers-tokens cogni-work tiers.tokens absent" "manifest.json declares no tokens tier. Likely #127/#128 — manifest does not match the v2 schema." ;;
+  TOKENS_DIR_ABSENT:*) fail "tbc13-cogni-work-tiers-tokens cogni-work tokens dir absent" "tiers.tokens resolves to a path that does not exist: ${TIERS_PROBE#TOKENS_DIR_ABSENT:}. Likely #127 dropped the tokens/ dir." ;;
+  TOKENS_CSS_ABSENT:*) fail "tbc13-cogni-work-tiers-tokens cogni-work tokens.css absent" "tokens dir exists but tokens.css is missing: ${TIERS_PROBE#TOKENS_CSS_ABSENT:}. Likely #136 (tier-1 tokens.css) regressed." ;;
+  *) fail "tbc13-cogni-work-tiers-tokens tiered probe unknown response" "Unexpected probe output: $TIERS_PROBE" ;;
 esac
 
 # --------------------------------------------------------------------------
@@ -288,40 +338,40 @@ phase "Phase B — pick-theme, manage-themes"
 
 # B1. validate-theme-manifest accepts cogni-work.
 if python3 "$VALIDATOR_SCRIPT" "$PLUGIN_ROOT/themes/cogni-work" >/dev/null 2>&1; then
-  c_pass "validate-theme-manifest accepts cogni-work"
+  c_pass "tbc14-validator-accepts-cogni-work validate-theme-manifest accepts cogni-work"
 else
-  fail "validate-theme-manifest rejects cogni-work" "Run \`python3 $VALIDATOR_SCRIPT $PLUGIN_ROOT/themes/cogni-work\` for the error. Likely #128 (schema) or #138 (manage-themes authoring drift)."
+  fail "tbc14-validator-accepts-cogni-work validate-theme-manifest rejects cogni-work" "Run \`python3 $VALIDATOR_SCRIPT $PLUGIN_ROOT/themes/cogni-work\` for the error. Likely #128 (schema) or #138 (manage-themes authoring drift)."
 fi
 
 # B2. discover-themes returns cogni-work in default invocation (tier-aware).
 if printf "%s" "$TIERED_OUTPUT" | python3 -c 'import json,sys; sys.exit(0 if any(t.get("slug")=="cogni-work" for t in json.load(sys.stdin)) else 1)'; then
-  c_pass "discover returns cogni-work"
+  c_pass "tbc15-discover-returns-cogni-work discover returns cogni-work"
 else
-  fail "discover does not return cogni-work" "Already failed Phase A; pick-theme would not surface the theme to the user."
+  fail "tbc15-discover-returns-cogni-work discover does not return cogni-work" "Already failed Phase A; pick-theme would not surface the theme to the user."
 fi
 
 # B3. pick-theme SKILL.md still references discover-themes.py.
 PICK_SKILL="$PLUGIN_ROOT/skills/pick-theme/SKILL.md"
 if [[ -f "$PICK_SKILL" ]] && grep -q "discover-themes" "$PICK_SKILL"; then
-  c_pass "pick-theme SKILL.md references discover-themes"
+  c_pass "tbc16-pick-theme-references-discover pick-theme SKILL.md references discover-themes"
 else
-  fail "pick-theme SKILL.md theme reference missing" "$PICK_SKILL no longer mentions discover-themes. Likely a SKILL.md drift."
+  fail "tbc16-pick-theme-references-discover pick-theme SKILL.md theme reference missing" "$PICK_SKILL no longer mentions discover-themes. Likely a SKILL.md drift."
 fi
 
 # B4. manage-themes SKILL.md still references manifest.json.
 MANAGE_SKILL="$PLUGIN_ROOT/skills/manage-themes/SKILL.md"
 if [[ -f "$MANAGE_SKILL" ]] && grep -q "manifest\.json" "$MANAGE_SKILL"; then
-  c_pass "manage-themes SKILL.md references manifest.json"
+  c_pass "tbc17-manage-themes-references-manifest manage-themes SKILL.md references manifest.json"
 else
-  fail "manage-themes SKILL.md manifest reference missing" "$MANAGE_SKILL no longer mentions manifest.json. Likely #138 regressed the deep-authoring documentation."
+  fail "tbc17-manage-themes-references-manifest manage-themes SKILL.md manifest reference missing" "$MANAGE_SKILL no longer mentions manifest.json. Likely #138 regressed the deep-authoring documentation."
 fi
 
 # B5. Migration guide present.
 MIGRATION_GUIDE="$PLUGIN_ROOT/docs/theme-system-v2-migration.md"
 if [[ -f "$MIGRATION_GUIDE" ]]; then
-  c_pass "theme-system-v2 migration guide present"
+  c_pass "tbc18-migration-guide-present theme-system-v2 migration guide present"
 else
-  fail "migration guide reference missing" "$MIGRATION_GUIDE not found. Likely #130 was reverted or the path moved."
+  fail "tbc18-migration-guide-present migration guide reference missing" "$MIGRATION_GUIDE not found. Likely #130 was reverted or the path moved."
 fi
 
 # --------------------------------------------------------------------------
@@ -349,14 +399,18 @@ VISUAL_CONSUMERS=(
 for entry in "${VISUAL_CONSUMERS[@]}"; do
   plugin="${entry%%:*}"
   skill="${entry#*:}"
+  # Case ids carry a per-iteration slug or every consumer would share one token.
+  # Parameter expansion, not `tr` — and the colon has to go: the shared mutation
+  # harness needs whitespace or end-of-line straight after the case token.
+  entry_slug="${entry//:/-}"
   skill_md="$REPO_ROOT/$plugin/skills/$skill/SKILL.md"
   if [[ ! -f "$skill_md" ]]; then
-    fail "$entry SKILL.md not present at expected path" "$skill_md is missing. A listed visual consumer lost its SKILL.md — either the skill was renamed or removed (update VISUAL_CONSUMERS) or a regeneration dropped the file."
+    fail "tbc19-consumer-skill-present-$entry_slug SKILL.md not present at expected path" "$skill_md is missing. A listed visual consumer lost its SKILL.md — either the skill was renamed or removed (update VISUAL_CONSUMERS) or a regeneration dropped the file."
   fi
   if grep -qE 'theme\.md|theme_slug|pick-theme|themes/' "$skill_md"; then
-    c_pass "$entry references the theme contract"
+    c_pass "tbc20-consumer-theme-ref-$entry_slug references the theme contract"
   else
-    fail "$entry SKILL.md theme reference missing" "$skill_md no longer mentions the theme contract. Likely a SKILL.md regeneration dropped the reference."
+    fail "tbc20-consumer-theme-ref-$entry_slug SKILL.md theme reference missing" "$skill_md no longer mentions the theme contract. Likely a SKILL.md regeneration dropped the reference."
   fi
 done
 
@@ -381,9 +435,9 @@ VOICE_HEADER='## Voice & Copy Guidelines'
 for theme in _template cogni-work; do
   theme_file="$PLUGIN_ROOT/themes/$theme/theme.md"
   if grep -qF "$VOICE_HEADER" "$theme_file"; then
-    c_pass "themes/$theme/theme.md has Voice & Copy Guidelines section"
+    c_pass "tbc21-voice-section-$theme themes/$theme/theme.md has Voice & Copy Guidelines section"
   else
-    fail "voice section missing in themes/$theme/theme.md" "Voice consumers (${VOICE_PLUGINS[*]}) include this section in prompts; without it, copy generation drifts. Likely #127 (cogni-work migration) or a tier-0 template regression."
+    fail "tbc21-voice-section-$theme voice section missing in themes/$theme/theme.md" "Voice consumers (${VOICE_PLUGINS[*]}) include this section in prompts; without it, copy generation drifts. Likely #127 (cogni-work migration) or a tier-0 template regression."
   fi
 done
 
@@ -392,7 +446,7 @@ for plugin in "${VOICE_PLUGINS[@]}"; do
     c_skip "$plugin — plugin directory not present in $REPO_ROOT"
     continue
   fi
-  c_pass "$plugin present (voice section verified above is the contract for this plugin)"
+  c_pass "tbc22-voice-plugin-present-$plugin $plugin present (voice section verified above is the contract for this plugin)"
 done
 
 # --------------------------------------------------------------------------
@@ -407,10 +461,11 @@ phase "Phase E — external consumers (informational)"
 for ext in "document-skills:pptx" "document-skills:docx"; do
   plugin="${ext%%:*}"
   skill="${ext#*:}"
+  ext_slug="${ext//:/-}"
   skill_md="$REPO_ROOT/$plugin/skills/$skill/SKILL.md"
   if [[ -f "$skill_md" ]]; then
     if grep -qE 'theme\.md|theme_slug|pick-theme|themes/' "$skill_md"; then
-      c_pass "$ext references the theme contract"
+      c_pass "tbc23-external-theme-ref-$ext_slug $ext references the theme contract"
     else
       c_info "$ext present but does not reference the theme contract — informational only"
     fi

--- a/cogni-workspace/tests/test-check-skill-names.sh
+++ b/cogni-workspace/tests/test-check-skill-names.sh
@@ -35,6 +35,14 @@ failures=0
 pass() { printf 'PASS: %s\n' "$1"; }
 fail() { printf 'FAIL: %s\n' "$1"; failures=$((failures + 1)); }
 
+# Slug an interpreter path into a case-id discriminator: /bin/bash -> bin-bash,
+# /opt/homebrew/bin/bash -> opt-homebrew-bin-bash. The discriminator has to come
+# from the FULL PATH, never `basename` — every interpreter in the matrix is named
+# `bash`, so a basename-derived slug is constant and the ids still collide.
+# Parameter expansion, not `tr -c 'A-Za-z0-9' '-'`: that form turns the leading
+# `/` and the trailing newline into dashes and yields `-bin-bash-`.
+bin_slug() { local _p="${1#/}"; printf '%s' "${_p//\//-}"; }
+
 # Assert the script under test exists before anything reads it. Without this the
 # static guard (Case 4) would sed/grep a missing file, match nothing, and report a
 # spurious PASS — and on Linux/CI, where no bash 3.x exists, Case 4 is the only
@@ -102,10 +110,11 @@ CLEAN="$TMPROOT/clean"
 mk_skill "$CLEAN" cogni-alpha alpha-setup alpha-setup
 mk_skill "$CLEAN" cogni-beta beta-dashboard beta-dashboard
 for BIN in $INTERPRETERS; do
+  BIN_SLUG="$(bin_slug "$BIN")"
   run_check "$CLEAN" "$BIN"
-  assert_rc 0 "1a clean tree exits 0 ($BIN)"
-  assert_out_has "OK: All skill names follow the naming convention." "1b clean tree reports OK ($BIN)"
-  assert_no_bash4_error "1c clean tree free of bash-4 runtime error ($BIN)"
+  assert_rc 0 "1a-$BIN_SLUG clean tree exits 0 ($BIN)"
+  assert_out_has "OK: All skill names follow the naming convention." "1b-$BIN_SLUG clean tree reports OK ($BIN)"
+  assert_no_bash4_error "1c-$BIN_SLUG clean tree free of bash-4 runtime error ($BIN)"
 done
 
 # --- Case 2: duplicate name across two plugins -> ERROR, exit 1 ---
@@ -116,21 +125,23 @@ DUP="$TMPROOT/dup"
 mk_skill "$DUP" cogni-alpha alpha-x iw-shared
 mk_skill "$DUP" cogni-beta beta-y iw-shared
 for BIN in $INTERPRETERS; do
+  BIN_SLUG="$(bin_slug "$BIN")"
   run_check "$DUP" "$BIN"
-  assert_rc 1 "2a duplicate exits 1 ($BIN)"
-  assert_out_has "ERROR: Duplicate skill name 'iw-shared' in:" "2b duplicate ERROR line ($BIN)"
-  assert_out_has "FAIL: 1 naming violation(s) found." "2c duplicate FAIL summary ($BIN)"
-  assert_no_bash4_error "2d duplicate free of bash-4 runtime error ($BIN)"
+  assert_rc 1 "2a-$BIN_SLUG duplicate exits 1 ($BIN)"
+  assert_out_has "ERROR: Duplicate skill name 'iw-shared' in:" "2b-$BIN_SLUG duplicate ERROR line ($BIN)"
+  assert_out_has "FAIL: 1 naming violation(s) found." "2c-$BIN_SLUG duplicate FAIL summary ($BIN)"
+  assert_no_bash4_error "2d-$BIN_SLUG duplicate free of bash-4 runtime error ($BIN)"
 done
 
 # --- Case 3: generic name without a domain prefix -> ERROR, exit 1 ---
 GEN="$TMPROOT/gen"
 mk_skill "$GEN" cogni-alpha the-dash dashboard
 for BIN in $INTERPRETERS; do
+  BIN_SLUG="$(bin_slug "$BIN")"
   run_check "$GEN" "$BIN"
-  assert_rc 1 "3a generic exits 1 ($BIN)"
-  assert_out_has "ERROR: Generic skill name 'dashboard' requires a domain prefix" "3b generic ERROR line ($BIN)"
-  assert_no_bash4_error "3c generic free of bash-4 runtime error ($BIN)"
+  assert_rc 1 "3a-$BIN_SLUG generic exits 1 ($BIN)"
+  assert_out_has "ERROR: Generic skill name 'dashboard' requires a domain prefix" "3b-$BIN_SLUG generic ERROR line ($BIN)"
+  assert_no_bash4_error "3c-$BIN_SLUG generic free of bash-4 runtime error ($BIN)"
 done
 
 # --- Case 4: portability — no bash-4-only construct may reach the script ---
@@ -171,10 +182,11 @@ TABF="$TMPROOT/tabname"
 mk_skill "$TABF" cogni-alpha alpha-tab "$(printf 'foo\tbar')"
 mk_skill "$TABF" cogni-beta beta-foo foo
 for BIN in $INTERPRETERS; do
+  BIN_SLUG="$(bin_slug "$BIN")"
   run_check "$TABF" "$BIN"
-  assert_rc 0 "5a tabbed name exits 0 ($BIN)"
-  assert_out_lacks "ERROR: Duplicate skill name 'foo'" "5b tabbed name reports no phantom duplicate ($BIN)"
-  assert_no_bash4_error "5c tabbed name free of bash-4 runtime error ($BIN)"
+  assert_rc 0 "5a-$BIN_SLUG tabbed name exits 0 ($BIN)"
+  assert_out_lacks "ERROR: Duplicate skill name 'foo'" "5b-$BIN_SLUG tabbed name reports no phantom duplicate ($BIN)"
+  assert_no_bash4_error "5c-$BIN_SLUG tabbed name free of bash-4 runtime error ($BIN)"
 done
 
 if [ "$failures" -gt 0 ]; then

--- a/cogni-workspace/tests/test-excalidraw-canvas-lock.sh
+++ b/cogni-workspace/tests/test-excalidraw-canvas-lock.sh
@@ -24,13 +24,26 @@
 #   written, from the repo root. If that version directory is gone, use the
 #   newest under the same parent; everything after the path is version-independent.
 #
+#   The case id names the ASSERTION, not the case function, and every id inside
+#   a loop over EXCALIDRAW_HOOKS also carries the owning plugin directory. That
+#   is why each --case below is spelled out rather than being the same string as
+#   the --test selector: one function emits several result lines, and before the
+#   ids were split a mutation of one line could be credited by a sibling line
+#   going red. --test still names the bare shell function, because ALL_TESTS and
+#   run_one dispatch on the function name — those are unchanged.
+#
+#   The harness matches a case whole-token, so a stale --case does not go red:
+#   it returns case_not_found, which reads as a missing case rather than a
+#   surviving mutant. Re-key every recipe here in the same change that re-ids a
+#   line, and replay it.
+#
 #   M1 -> test_cold_start_spawns_exactly_one_server
 #   bash ~/.claude/plugins/cache/managed-service/cogni-service/0.0.402/scripts/mutation-check.sh \
 #     --root . \
 #     --file cogni-workspace/hooks/ensure-excalidraw-canvas.sh \
 #     --expr 's#mkdir "\$LOCK_DIR" 2>/dev/null#mkdir -p "\$LOCK_DIR" 2>/dev/null#' \
 #     --test 'bash cogni-workspace/tests/test-excalidraw-canvas-lock.sh test_cold_start_spawns_exactly_one_server' \
-#     --case test_cold_start_spawns_exactly_one_server
+#     --case test_cold_start_spawns_exactly_one_server-spawn-count
 #   `mkdir -p` succeeds against an existing directory, so both racers believe
 #   they won and both spawn — exactly the pre-fix behaviour. The searched
 #   literal occurs once (the two other `mkdir` mentions are prose), the
@@ -40,27 +53,32 @@
 #
 #   M2 -> test_stale_lock_does_not_deadlock
 #     --expr 's#LOCK_STALE_SECS=60#LOCK_STALE_SECS=999999999#'
+#     --case test_stale_lock_does_not_deadlock-swept
 #   The aged claim is never swept, so no spawn happens. Occurs once as the
 #   declaration; every use is "$LOCK_STALE_SECS".
 #
 #   M3 -> test_release_is_trapped_for_signals
 #     --expr 's#trap release_start_claim EXIT INT TERM#trap release_start_claim EXIT#'
+#     --case test_release_is_trapped_for_signals-trap-signals-cogni-workspace
 #   Still valid bash, so nothing aborts — only the signal-coverage case reddens.
 #
 #   M4 -> test_hook_copies_are_identical
 #     --file cogni-portfolio/hooks/ensure-excalidraw-canvas.sh
 #     --expr 's#LOCK_STALE_SECS=60#LOCK_STALE_SECS=61#'
+#     --case test_hook_copies_are_identical-hooks-identical
 #   Mutates the other copy so the pair diverges. Run against the cogni-workspace
 #   suite, which reads both copies, so a drift introduced on either side reddens.
 #
 #   M5 -> test_stale_lock_survives_divergent_stat
 #     --expr 's#\[\[ "\$lock_mtime" =~ \^\[0-9\]\+\$ \]\]#[[ -n "\$lock_mtime" ]]#'
+#     --case test_stale_lock_survives_divergent_stat-swept
 #   Reverts the mtime floor to the emptiness test, which structurally cannot see
 #   a successful wrong answer: the stub's non-numeric reading survives it,
 #   reaches the arithmetic, and aborts the hook. Occurs once.
 #
 #   M6 -> test_stale_lock_survives_divergent_stat
 #     --expr 's#stat -c %Y "\$LOCK_DIR"#stat -f %m "\$LOCK_DIR"#'
+#     --case test_stale_lock_survives_divergent_stat-gnu-first-cogni-workspace
 #   Puts the BSD form first, leaving the GNU arm unreachable on the platform
 #   that needs it. Reddens the ordering arm, which reads the chain out of the
 #   hook's source. M8 replays this same substitution against the behavioural
@@ -70,6 +88,7 @@
 #
 #   M7 -> test_concurrent_stale_claim_spawns_exactly_one_server
 #     --expr 's#\$swept_mtime" -eq "\$lock_mtime#\$swept_mtime" -ne "\$lock_mtime#'
+#     --case test_concurrent_stale_claim_spawns_exactly_one_server-spawn-count
 #   Inverts the identity test the sweep turns on, so the invocation that really
 #   did carry the aged claim aside declines to claim and the one that did not
 #   finds nothing left to carry: no spawn at all. Chosen over reverting the
@@ -79,6 +98,7 @@
 #
 #   M8 -> test_live_claim_survives_flag_aware_stat
 #     --expr 's#stat -c %Y "\$LOCK_DIR"#stat -f %m "\$LOCK_DIR"#'
+#     --case test_live_claim_survives_flag_aware_stat-claim-survived
 #   The same substitution M6 makes, replayed against the behavioural case — the
 #   duplication is the point, not a copy error, so do not fold the two arms
 #   together. Under the flag-aware stub a BSD-first chain answers first for a
@@ -89,6 +109,7 @@
 #
 #   M9 -> test_stale_lock_survives_divergent_stat
 #     --expr 's#stat -c %Y "\$swept"#stat -f %m "\$swept"#'
+#     --case test_stale_lock_survives_divergent_stat-gnu-first-cogni-workspace
 #   The sweep's own chain, which no arm reached before. It reddens through the
 #   ordering arm only: under the flag-agnostic stub both forms answer the same
 #   non-numeric value, so reverting this chain leaves every behavioural case
@@ -102,6 +123,12 @@
 #   Mutating a hook copy is required: these cases assert hook behaviour, so
 #   mutating this suite or a docs file would prove nothing. All nine recipes
 #   were replayed against the shared harness and each returned guard_verified.
+#
+#   M3, M6 and M9 mutate the cogni-workspace copy only, so their --case carries
+#   the cogni-workspace slug and the cogni-portfolio sibling id stays GREEN in
+#   the same run. That asymmetry is the point of the per-hook discriminator:
+#   before it existed both iterations shared one token, so a defect introduced
+#   in one copy could be credited by the other copy's line going red.
 
 set -u
 
@@ -118,6 +145,16 @@ MATCHER='mcp__excalidraw__.*'
 # The surviving pair that ships this hook. Stated once: the next change to this
 # population edits one line, so it cannot half-land across the sites below.
 EXCALIDRAW_HOOKS=("$PORTFOLIO_HOOK" "$WORKSPACE_HOOK")
+
+# Slug a hook path down to its owning plugin directory: .../cogni-portfolio/hooks/
+# ensure-excalidraw-canvas.sh -> cogni-portfolio. The discriminator has to come
+# from the DIRECTORY, never `basename` — both copies are named
+# ensure-excalidraw-canvas.sh, so a basename-derived slug is constant and the
+# per-iteration ids would still collide. Parameter expansion, no fork.
+hook_slug() { local _d="${1%/hooks/*}"; printf '%s' "${_d##*/}"; }
+# Same idea for the four-path existence loop, which also covers the hooks.json
+# pair — there the file name does vary, so both parts are kept.
+path_slug() { local _r="${1#"$REPO_ROOT/"}"; printf '%s' "${_r//\//-}"; }
 
 # One reader of the PreToolUse surface, used by both arms below. Both modes are
 # scoped to hooks.PreToolUse, never to the file as a whole: cogni-workspace's
@@ -330,15 +367,15 @@ test_cold_start_spawns_exactly_one_server() {
 
   n="$(spawn_count "$c")"
   if [ "$n" = "1" ]; then
-    pass test_cold_start_spawns_exactly_one_server "exactly one spawn"
+    pass test_cold_start_spawns_exactly_one_server-spawn-count "exactly one spawn"
   else
-    fail test_cold_start_spawns_exactly_one_server "expected 1 spawn, got $n"
+    fail test_cold_start_spawns_exactly_one_server-spawn-count "expected 1 spawn, got $n"
   fi
 
   if [ "$rca" = "0" ] && [ "$rcb" = "0" ]; then
-    pass test_cold_start_spawns_exactly_one_server "both invocations exited 0"
+    pass test_cold_start_spawns_exactly_one_server-exit-codes "both invocations exited 0"
   else
-    fail test_cold_start_spawns_exactly_one_server "exit codes were $rca and $rcb"
+    fail test_cold_start_spawns_exactly_one_server-exit-codes "exit codes were $rca and $rcb"
   fi
 
   pidfile="$TMPROOT/$c/mcp/canvas.pid"
@@ -346,18 +383,18 @@ test_cold_start_spawns_exactly_one_server() {
     livepid="$(cat "$pidfile")"
     STARTED_PIDS="$STARTED_PIDS $livepid"
     if kill -0 "$livepid" 2>/dev/null; then
-      pass test_cold_start_spawns_exactly_one_server "canvas.pid names a live process"
+      pass test_cold_start_spawns_exactly_one_server-canvas-pid "canvas.pid names a live process"
     else
-      fail test_cold_start_spawns_exactly_one_server "canvas.pid $livepid is not live"
+      fail test_cold_start_spawns_exactly_one_server-canvas-pid "canvas.pid $livepid is not live"
     fi
   else
-    fail test_cold_start_spawns_exactly_one_server "canvas.pid was never written"
+    fail test_cold_start_spawns_exactly_one_server-canvas-pid "canvas.pid was never written"
   fi
 
   if [ -d "$TMPROOT/$c/mcp/canvas-start.lock" ]; then
-    fail test_cold_start_spawns_exactly_one_server "claim was not released"
+    fail test_cold_start_spawns_exactly_one_server-claim-released "claim was not released"
   else
-    pass test_cold_start_spawns_exactly_one_server "claim released"
+    pass test_cold_start_spawns_exactly_one_server-claim-released "claim released"
   fi
 }
 
@@ -380,9 +417,9 @@ assert_stale_claim_swept() {
 
   _n="$(spawn_count "$_c")"
   if [ "$_n" = "1" ] && [ "$_rc" = "0" ]; then
-    pass "$_case" "$_label"
+    pass "$_case-swept" "$_label"
   else
-    fail "$_case" "expected 1 spawn and rc 0, got $_n and $_rc"
+    fail "$_case-swept" "expected 1 spawn and rc 0, got $_n and $_rc"
   fi
 
   _pidfile="$TMPROOT/$_c/mcp/canvas.pid"
@@ -391,9 +428,9 @@ assert_stale_claim_swept() {
   fi
 
   if [ -d "$TMPROOT/$_c/mcp/canvas-start.lock" ]; then
-    fail "$_case" "claim was not released"
+    fail "$_case-claim-released" "claim was not released"
   else
-    pass "$_case" "claim released"
+    pass "$_case-claim-released" "claim released"
   fi
 }
 
@@ -443,21 +480,21 @@ test_concurrent_stale_claim_spawns_exactly_one_server() {
 
   n="$(spawn_count "$c")"
   if [ "$n" = "1" ]; then
-    pass test_concurrent_stale_claim_spawns_exactly_one_server "exactly one spawn against a contested stale claim"
+    pass test_concurrent_stale_claim_spawns_exactly_one_server-spawn-count "exactly one spawn against a contested stale claim"
   else
-    fail test_concurrent_stale_claim_spawns_exactly_one_server "expected 1 spawn, got $n"
+    fail test_concurrent_stale_claim_spawns_exactly_one_server-spawn-count "expected 1 spawn, got $n"
   fi
 
   if [ "$rca" = "0" ] && [ "$rcb" = "0" ]; then
-    pass test_concurrent_stale_claim_spawns_exactly_one_server "both invocations exited 0"
+    pass test_concurrent_stale_claim_spawns_exactly_one_server-exit-codes "both invocations exited 0"
   else
-    fail test_concurrent_stale_claim_spawns_exactly_one_server "exit codes were $rca and $rcb"
+    fail test_concurrent_stale_claim_spawns_exactly_one_server-exit-codes "exit codes were $rca and $rcb"
   fi
 
   if [ -d "$TMPROOT/$c/mcp/canvas-start.lock" ]; then
-    fail test_concurrent_stale_claim_spawns_exactly_one_server "claim was not released"
+    fail test_concurrent_stale_claim_spawns_exactly_one_server-claim-released "claim was not released"
   else
-    pass test_concurrent_stale_claim_spawns_exactly_one_server "claim released"
+    pass test_concurrent_stale_claim_spawns_exactly_one_server-claim-released "claim released"
   fi
 }
 
@@ -494,10 +531,11 @@ test_stale_lock_survives_divergent_stat() {
   # a second grep keeps one selector: two would have to be kept in step by hand,
   # and the arm would pass over a different population than the floor counts.
   for h in "${EXCALIDRAW_HOOKS[@]}"; do
+    hslug="$(hook_slug "$h")"
     chains="$(hook_code "$h" | grep -E 'stat ')"
     n_chains="$(printf '%s\n' "$chains" | grep -c .)"
     if [ "$n_chains" != "2" ]; then
-      fail test_stale_lock_survives_divergent_stat "expected 2 stat chains in $h, found $n_chains"
+      fail test_stale_lock_survives_divergent_stat-chain-count-$hslug "expected 2 stat chains in $h, found $n_chains"
       continue
     fi
     bad=0
@@ -508,13 +546,13 @@ test_stale_lock_survives_divergent_stat() {
         *"stat -c "*"stat -f "*) ;;
         *)
           bad=1
-          fail test_stale_lock_survives_divergent_stat "chain is not GNU-first in $h: $chain" ;;
+          fail test_stale_lock_survives_divergent_stat-gnu-first-$hslug "chain is not GNU-first in $h: $chain" ;;
       esac
     done <<EOF
 $chains
 EOF
     if [ "$bad" = "0" ]; then
-      pass test_stale_lock_survives_divergent_stat "both stat chains are GNU-first in $h"
+      pass test_stale_lock_survives_divergent_stat-gnu-first-$hslug "both stat chains are GNU-first in $h"
     fi
   done
 
@@ -558,24 +596,24 @@ test_live_claim_survives_flag_aware_stat() {
   run_hook "$c" a; rc=$?
 
   if [ -d "$TMPROOT/$c/mcp/canvas-start.lock" ]; then
-    pass test_live_claim_survives_flag_aware_stat "a live peer's claim survived the sweep decision"
+    pass test_live_claim_survives_flag_aware_stat-claim-survived "a live peer's claim survived the sweep decision"
   else
-    fail test_live_claim_survives_flag_aware_stat "a live peer's claim was swept"
+    fail test_live_claim_survives_flag_aware_stat-claim-survived "a live peer's claim was swept"
   fi
 
   if [ "$rc" = "0" ]; then
-    pass test_live_claim_survives_flag_aware_stat "hook exited 0"
+    pass test_live_claim_survives_flag_aware_stat-exit-code "hook exited 0"
   else
-    fail test_live_claim_survives_flag_aware_stat "expected rc 0, got $rc"
+    fail test_live_claim_survives_flag_aware_stat-exit-code "expected rc 0, got $rc"
   fi
 
   # Non-vacuity floor: only the stub writes this marker, so its absence means
   # the run never reached a stat chain and the assertions above passed without
   # exercising anything.
   if [ -f "$TMPROOT/$c/stat.called" ]; then
-    pass test_live_claim_survives_flag_aware_stat "the sweep decision read the stubbed stat"
+    pass test_live_claim_survives_flag_aware_stat-stat-called "the sweep decision read the stubbed stat"
   else
-    fail test_live_claim_survives_flag_aware_stat "the stubbed stat was never called — the case never reached the chain"
+    fail test_live_claim_survives_flag_aware_stat-stat-called "the stubbed stat was never called — the case never reached the chain"
   fi
 }
 
@@ -586,15 +624,15 @@ test_live_claim_survives_flag_aware_stat() {
 test_hook_copies_are_identical() {
   for f in "$PORTFOLIO_HOOK" "$WORKSPACE_HOOK" "$PORTFOLIO_HOOKS_JSON" "$WORKSPACE_HOOKS_JSON"; do
     if [ ! -s "$f" ]; then
-      fail test_hook_copies_are_identical "missing or empty: $f"
+      fail test_hook_copies_are_identical-surface-$(path_slug "$f") "missing or empty: $f"
       return
     fi
   done
 
   if cmp -s "$PORTFOLIO_HOOK" "$WORKSPACE_HOOK"; then
-    pass test_hook_copies_are_identical "hook copies are byte-identical"
+    pass test_hook_copies_are_identical-hooks-identical "hook copies are byte-identical"
   else
-    fail test_hook_copies_are_identical "hook copies have diverged"
+    fail test_hook_copies_are_identical-hooks-identical "hook copies have diverged"
   fi
 
   # The two survivors' hooks.json can no longer be compared byte-for-byte:
@@ -607,11 +645,11 @@ test_hook_copies_are_identical() {
   # The emptiness guard is load-bearing: without it two unreadable files would
   # both yield "", compare equal, and green the arm without reading a matcher.
   if [ -z "$portfolio_pre" ] || [ -z "$workspace_pre" ]; then
-    fail test_hook_copies_are_identical "a PreToolUse block could not be read"
+    fail test_hook_copies_are_identical-pretooluse-block "a PreToolUse block could not be read"
   elif [ "$portfolio_pre" = "$workspace_pre" ]; then
-    pass test_hook_copies_are_identical "PreToolUse blocks are equivalent"
+    pass test_hook_copies_are_identical-pretooluse-block "PreToolUse blocks are equivalent"
   else
-    fail test_hook_copies_are_identical "PreToolUse blocks have diverged"
+    fail test_hook_copies_are_identical-pretooluse-block "PreToolUse blocks have diverged"
   fi
 }
 
@@ -620,32 +658,33 @@ test_hook_copies_are_identical() {
 # the harness kills the hook at its declared timeout.
 test_release_is_trapped_for_signals() {
   for h in "${EXCALIDRAW_HOOKS[@]}"; do
+    hslug="$(hook_slug "$h")"
     code="$(hook_code "$h")"
 
     traps="$(printf '%s\n' "$code" | grep -cE '^[[:space:]]*trap ')"
     if [ "$traps" != "1" ]; then
-      fail test_release_is_trapped_for_signals "expected exactly 1 trap line in $h, got $traps"
+      fail test_release_is_trapped_for_signals-trap-count-$hslug "expected exactly 1 trap line in $h, got $traps"
       continue
     fi
 
     trapline="$(printf '%s\n' "$code" | grep -E '^[[:space:]]*trap ')"
     case "$trapline" in
-      *EXIT*INT*TERM*) pass test_release_is_trapped_for_signals "release trapped for EXIT INT TERM" ;;
-      *) fail test_release_is_trapped_for_signals "trap does not cover INT/TERM: $trapline" ;;
+      *EXIT*INT*TERM*) pass test_release_is_trapped_for_signals-trap-signals-$hslug "release trapped for EXIT INT TERM" ;;
+      *) fail test_release_is_trapped_for_signals-trap-signals-$hslug "trap does not cover INT/TERM: $trapline" ;;
     esac
 
     if printf '%s\n' "$code" | grep -q 'mkdir -p'; then
-      fail test_release_is_trapped_for_signals "claim uses mkdir -p, which cannot tell winner from loser"
+      fail test_release_is_trapped_for_signals-bare-mkdir-$hslug "claim uses mkdir -p, which cannot tell winner from loser"
     else
-      pass test_release_is_trapped_for_signals "claim is a bare mkdir"
+      pass test_release_is_trapped_for_signals-bare-mkdir-$hslug "claim is a bare mkdir"
     fi
 
     # The release must be guarded by the claim flag, or a loser deletes the
     # winner's claim on its way out through the shared wait-loop exits.
     if printf '%s\n' "$code" | grep -A 3 'release_start_claim()' | grep -q 'SPAWN_CLAIMED'; then
-      pass test_release_is_trapped_for_signals "release is guarded by the claim flag"
+      pass test_release_is_trapped_for_signals-release-guarded-$hslug "release is guarded by the claim flag"
     else
-      fail test_release_is_trapped_for_signals "release is not guarded by the claim flag in $h"
+      fail test_release_is_trapped_for_signals-release-guarded-$hslug "release is not guarded by the claim flag in $h"
     fi
 
     # No claim machinery may sit above the fast path: an already-warm canvas
@@ -655,12 +694,12 @@ test_release_is_trapped_for_signals() {
     if [ -n "$fastline" ]; then
       above="$(printf '%s\n' "$code" | sed -n "1,${fastline}p" | grep -cE 'LOCK_DIR|LOCK_STALE_SECS|SPAWN_CLAIMED|canvas-start.lock|_claim')"
       if [ "$above" = "0" ]; then
-        pass test_release_is_trapped_for_signals "fast path carries no claim machinery"
+        pass test_release_is_trapped_for_signals-fast-path-$hslug "fast path carries no claim machinery"
       else
-        fail test_release_is_trapped_for_signals "$above claim token(s) above the fast path in $h"
+        fail test_release_is_trapped_for_signals-fast-path-$hslug "$above claim token(s) above the fast path in $h"
       fi
     else
-      fail test_release_is_trapped_for_signals "could not locate the fast path in $h"
+      fail test_release_is_trapped_for_signals-fast-path-$hslug "could not locate the fast path in $h"
     fi
 
     # The staleness sweep must outlast the hook's own declared timeout, or a
@@ -669,9 +708,9 @@ test_release_is_trapped_for_signals() {
     hooks_json="$(dirname "$h")/hooks.json"
     timeout="$(pretooluse_field "$hooks_json" timeout)"
     if [ -n "$secs" ] && [ -n "$timeout" ] && [ "$secs" -gt "$timeout" ]; then
-      pass test_release_is_trapped_for_signals "staleness $secs s outlasts the $timeout s hook timeout"
+      pass test_release_is_trapped_for_signals-staleness-outlasts-timeout-$hslug "staleness $secs s outlasts the $timeout s hook timeout"
     else
-      fail test_release_is_trapped_for_signals "staleness ($secs) does not outlast the hook timeout ($timeout)"
+      fail test_release_is_trapped_for_signals-staleness-outlasts-timeout-$hslug "staleness ($secs) does not outlast the hook timeout ($timeout)"
     fi
   done
 }


### PR DESCRIPTION
Closes #1493.

## Summary

Three suites emitted result lines whose addressable first token named a case **scope**, while the scope emitted several lines — so the shared mutation harness could not tell those lines apart. A fourth emitted no addressable line at all.

| File | Before | After |
|---|---|---|
| `cogni-workspace/tests/test-check-skill-names.sh` | 9 colliding ids, 18 of 23 lines | 23 lines, 23 ids |
| `cogni-workspace/tests/test-excalidraw-canvas-lock.sh` | 7 ids for **28 of 28** lines | 28 lines, 28 ids |
| `cogni-portfolio/tests/test-dashboard-handoff.sh` | 1 colliding id, 2 of 13 lines | 13 lines, 13 ids |
| `cogni-workspace/scripts/verify-theme-backcompat.sh` | **0 addressable lines** | 22 addressable lines across 5 phases |

No behavioural assertion changes, no wrapper change, no version change.

## Three corrections to the issue's premises

The issue was filed before `cogni-visual` was retired, and generalises one mechanism to a suite that has a different one. All three were established by *running* the suites, not by reading the source — which matters, because these labels are runtime-interpolated and a source scan cannot see them.

1. **`cogni-visual/` no longer exists.** The issue names `cogni-visual/tests/test-excalidraw-canvas-lock.sh` as a target and says "both copies". Only the cogni-workspace copy survives; cogni-portfolio ships the *hook* that suite tests, not a copy of the suite. The real population is **3 colliding suites / 48 instances**, not "4 suites / 52 instances". The surviving byte-identity arm already compares cogni-portfolio ↔ cogni-workspace and holds no `cogni-visual` reference, so nothing needed repairing there.
2. **The canvas-lock mechanism is not the loop.** Only 2 of its 7 functions loop over `EXCALIDRAW_HOOKS`; the other 5 collide purely from calling `pass`/`fail` several times inside one body (`test_release_is_trapped_for_signals` alone emitted 10 lines under one id). A loop-variable slug — which is what the issue's worked example generalises to — would have left most of this suite colliding while the diff read as though it had addressed it.
3. **The issue's own worked example is the one label that did not collide.** `1c`/`2d`/`3c`/`5c` emit once per run, because `assert_no_bash4_error` returns early unless the interpreter is the bash-3.x one. Converting only `1c` and `2c` (the two strings the issue quotes verbatim) would have left all nine real collisions in place. All 13 matrix labels are converted.

## Two traps the implementation had to avoid

- **`basename` discriminates neither pair.** Both interpreters are named `bash` — the issue says so. Both hook copies are named `ensure-excalidraw-canvas.sh` — the same trap, one level over, which the issue does not mention. The interpreter slug comes from the full path, the hook slug from the owning plugin directory.
- **`tr -c 'A-Za-z0-9' '-'` does not produce the slug it looks like it produces.** Measured on this host under **both** `/bin/bash` 3.2.57 and `/opt/homebrew/bin/bash` 5.3.9: `echo "$BIN" | tr -c 'A-Za-z0-9' '-'` yields `-bin-bash-` — the leading `/` and the trailing newline each become a dash. Every helper here uses parameter expansion instead.

## Green/red id parity is load-bearing, not cosmetic

The mutation harness returns `guard_verified` only when the mutant is red **and** the restore is green under one `--case`. A check whose PASS branch and FAIL branch carry different ids can therefore never be verified — it degrades to `case_not_found`, which reads as a *missing case* rather than a surviving mutant. So every check's two branches share an id. In the theme harness this replaced the literal id `pre-flight`, which five distinct `fail` sites shared.

## Mutation recipe

Both arms the issue's acceptance criteria ask for, replayed and recorded.

**Arm A — the bash-3.2 property the interpreter matrix exists to protect.**

```bash
bash ~/.claude/plugins/cache/managed-service/cogni-service/0.0.402/scripts/mutation-check.sh \
  --root . \
  --file cogni-workspace/scripts/check-skill-names.sh \
  --expr 's#^violations=0$#declare -A skill_map\nviolations=0#m' \
  --test 'bash cogni-workspace/tests/test-check-skill-names.sh' \
  --case 1c-bin-bash
```

`guard_verified`. The expression reintroduces the `declare -A` that `check-skill-names.sh:6-9` documents avoiding; `^violations=0$` matches exactly once (the other two are `$((…))` forms), so it cannot be a silent no-op, and `/m` is required under the harness's `perl -0pi`.

**Arm A′ — the discrimination itself, on a genuinely-colliding pair.** Acceptance criterion 4 asks for `1c-bin-bash` and for its homebrew sibling to be absent from the FAIL lines — but `1c` has no homebrew sibling at all, so that demand is satisfied by construction rather than by the collision being removed. Under the *same* mutant:

| `--case` | verdict |
|---|---|
| `2c-bin-bash` | `guard_verified` — red under mutation |
| `2c-opt-homebrew-bin-bash` | `vacuous_guard` — **green** under the same mutation |

That asymmetry is the defect being fixed. Before this change both lines carried the token `2c`, so the bash-5 arm going red would have credited a mutation only the bash-3.2 arm can detect — the arm that exists precisely because a bash-4-ism is invisible under bash 5.

**Arm B — the theme-backcompat harness, which could not contribute mutation evidence at all before this change.**

```bash
bash ~/.claude/plugins/cache/managed-service/cogni-service/0.0.402/scripts/mutation-check.sh \
  --root . \
  --file cogni-workspace/scripts/baselines/_template-tier0-output.json \
  --expr 's#"source": "standard"#"source": "mutated"#' \
  --test 'bash cogni-workspace/tests/test-theme-backcompat.sh' \
  --case tbc10-tier0-baseline-match
```

`guard_verified`. Recorded in that file's header.

**The nine recorded recipes M1–M9** in `test-excalidraw-canvas-lock.sh` are re-keyed to the specific sub-id each `--expr` reddens and **all nine replay to `guard_verified`** — the header asserts exactly that, and a stale `--case` would have degraded silently to `case_not_found`. M3, M6 and M9 mutate the cogni-workspace copy only; graded against the cogni-portfolio sibling id, M3's mutant returns `vacuous_guard` (green), which is the per-hook discrimination working.

## Verification

- [x] `python3 scripts/run-plugin-tests.py` — `total=124 passed=124 failed=0`, identical to base.
- [x] Uniqueness **by execution**, per suite: emitted `PASS:`/`ok:`/`FAIL:` lines grouped by first token, `uniq -d` empty for all four surfaces.
- [x] The loop discriminator genuinely differs per iteration: `1a-bin-bash` / `1a-opt-homebrew-bin-bash`, and `…-cogni-workspace` / `…-cogni-portfolio`.
- [x] The wrapper emits ≥1 `PASS: tbc…` line in each of the harness's five contract phases, with no escape byte before any label (`cat -v | grep -c '\^\['` → 0). Phase E is the informational one the harness excludes from its own "5 phases" count and has no `fail` counterpart, so it is not given a synthetic green.
- [x] Wrapper pass-through intact: with the baseline mutated, harness `rc=1` and wrapper `rc=1`; restored, both `0`.
- [x] `scripts/check-result-line-plainness.py` — 0 findings, 124 files discovered, unchanged. That guard's non-recursive globs do not reach `scripts/verify-theme-backcompat.sh` before or after this change, so the harness's plainness rests on the file, not on CI; the header now says so.
- [x] Only the four intended paths changed; no `version` value moved; the `cogni-visual:` token pinned by `test-relocated-skill-hygiene.sh:138` is not reintroduced.

## Disclosures

- **Token-scope preflight was run under `--allow-overscoped`.** `check-token-scope.sh --strict` exits 1 on this runner because the token is a `gho_` token from `gh auth login`, whose scope set is fixed by the GitHub CLI OAuth app and cannot be narrowed. That is the opt-out the script's own guidance names for this case; flagging it rather than passing it over.
- **The Step 6.4 `/simplify` pass was performed as a direct diff review, not via the harness skill.** That pass reads the session working tree, and this work was done in an isolated resolve worktree, so pointing it at the session tree would have reviewed an empty diff. Reviewed for reuse and duplication by hand: the three slug helpers are structurally similar but live in different self-contained suites, and folding them would require a shared test library this repo does not have — which would be scope-widening.
- **`verify-theme-backcompat.sh` carries pre-existing `#126`–`#138` issue refs** in its triage prose. They are outside `check-breadcrumbs.py`'s globs and outside the handoff preflight's breadcrumb arm (which fires only on touched `SKILL.md` / `agents/*.md`), and they are left exactly as they were.
- **The `--help` triage table's pre-existing quote drift was not repaired.** Two of its six rows quote labels that no longer match the emitted text (`:104` says `.py` where the label does not; `:108`/`:115` predate the current interpolated label). The rows gained their case ids, but correcting the stale quotes is a separate defect and out of scope here.

## Blocked

The handoff preflight (`check-preflight.sh`) exits 1 on its `mutation-recipe` instrument, so this PR is **not** handed off to the merger — it carries no `svc:needs-review`.

The instrument searches the suite named by `--test`, whole-file and comment-excluded, for the literal `--case` value. The recorded `1c-bin-bash` is assembled at run time from the interpreter path (`"1c-$BIN_SLUG …"`), so it exists in no source line — the same blind spot #1493 names as its central constraint. Replay contradicts the instrument's prediction: the recipe returns `guard_verified`, not `case_not_found`.

Every other gating instrument is clean (`run-tests` pass, `version-bump` pass, four `not_applicable` skips). Full detail, the replay table, and three options for a ruling are in the [preflight comment](https://github.com/cogni-work/insight-wave/pull/1507#issuecomment-5333504387). Needs a human ruling; the instrument itself ships in `cogni-service`, so any fix belongs in `cogni-work/managed-service`.
