### PR TITLE
cogni-knowledge: unique first tokens in scheme-bearing test suites

### DIFF
--- a/cogni-knowledge/tests/test_question_store.sh
+++ b/cogni-knowledge/tests/test_question_store.sh
@@ -127,25 +127,25 @@ echo "$OUT" | python3 -c 'import json,sys; d=json.load(sys.stdin); sys.exit(0 if
 # 1) sq-01 + sq-03 pages exist; sq-02 (no findings) does not.
 SQ1="$WIKI/wiki/questions/records-of-processing-scope.md"
 SQ3="$WIKI/wiki/questions/pflichten-fuer-risikoklassen.md"
-[ -f "$SQ1" ] && green "PASS: sq-01 question page written at slugified theme_label" \
-  || { red "FAIL: missing $SQ1"; errors=$((errors+1)); }
-[ -f "$SQ3" ] && green "PASS: sq-03 page uses transliterated slug (für->fuer)" \
-  || { red "FAIL: missing $SQ3"; errors=$((errors+1)); }
+[ -f "$SQ1" ] && green "PASS: sq-01-1 question page written at slugified theme_label" \
+  || { red "FAIL: sq-01-1 missing $SQ1"; errors=$((errors+1)); }
+[ -f "$SQ3" ] && green "PASS: sq-03-1 page uses transliterated slug (für->fuer)" \
+  || { red "FAIL: sq-03-1 missing $SQ3"; errors=$((errors+1)); }
 [ ! -f "$WIKI/wiki/questions/court-interpretation.md" ] \
-  && green "PASS: sq-02 (zero findings) wrote no page" \
-  || { red "FAIL: sq-02 page should not exist"; errors=$((errors+1)); }
+  && green "PASS: sq-02-1 (zero findings) wrote no page" \
+  || { red "FAIL: sq-02-1 page should not exist"; errors=$((errors+1)); }
 
-echo "$OUT" | grep -q '"sq-02"' && green "PASS: sq-02 reported in skipped_no_findings" \
-  || { red "FAIL: sq-02 not in skipped_no_findings"; errors=$((errors+1)); }
+echo "$OUT" | grep -q '"sq-02"' && green "PASS: sq-02-2 reported in skipped_no_findings" \
+  || { red "FAIL: sq-02-2 not in skipped_no_findings"; errors=$((errors+1)); }
 
 # 2) forward links + frontmatter
-assert_grep 'type: question' "$SQ1" "sq-01 page is type: question"
-assert_grep 'sub_question_id: sq-01' "$SQ1" "sq-01 page carries sub_question_id"
-assert_grep '## Findings' "$SQ1" "sq-01 page has ## Findings section"
+assert_grep 'type: question' "$SQ1" "sq-01-2 page is type: question"
+assert_grep 'sub_question_id: sq-01' "$SQ1" "sq-01-3 page carries sub_question_id"
+assert_grep '## Findings' "$SQ1" "sq-01-4 page has ## Findings section"
 # #931: the question page now emits an H1 + reader-facing type line (it had no body
 # H1 before). Assert the type line and that the order is H1 -> type line -> ## Findings.
-assert_grep '^Type: Question · raw$' "$SQ1" "sq-01 page: Type: Question · raw line"
-python3 - "$SQ1" <<'PY' && green "PASS: sq-01 page renders H1 then 'Type: Question · raw' then ## Findings" || { red "FAIL: question H1/type-line/findings order wrong"; errors=$((errors+1)); }
+assert_grep '^Type: Question · raw$' "$SQ1" "sq-01-5 page: Type: Question · raw line"
+python3 - "$SQ1" <<'PY' && green "PASS: sq-01-6 page renders H1 then 'Type: Question · raw' then ## Findings" || { red "FAIL: sq-01-6 question H1/type-line/findings order wrong"; errors=$((errors+1)); }
 import sys
 lines = [l for l in open(sys.argv[1], encoding="utf-8").read().splitlines()]
 h1 = next(i for i, l in enumerate(lines) if l.startswith("# "))
@@ -156,11 +156,11 @@ fnd = lines.index("## Findings")
 sys.exit(0 if h1 < typ < fnd else 1)
 PY
 # sq-01 is answered by records-scope (sq-01 ref) AND controller-obligations (sq-01+sq-03 ref)
-assert_grep '\[\[records-scope\]\]' "$SQ1" "sq-01 Findings links its source finding"
-assert_grep 'sources_answering: \[records-scope, controller-obligations\]' "$SQ1" "sq-01 sources_answering lists both findings in order"
+assert_grep '\[\[records-scope\]\]' "$SQ1" "sq-01-7 Findings links its source finding"
+assert_grep 'sources_answering: \[records-scope, controller-obligations\]' "$SQ1" "sq-01-8 sources_answering lists both findings in order"
 # sq-03 has two findings (controller-obligations via sq-03 ref + risk-classes)
-assert_grep '\[\[controller-obligations\]\]' "$SQ3" "sq-03 links shared finding controller-obligations"
-assert_grep '\[\[risk-classes\]\]' "$SQ3" "sq-03 links risk-classes finding"
+assert_grep '\[\[controller-obligations\]\]' "$SQ3" "sq-03-2 links shared finding controller-obligations"
+assert_grep '\[\[risk-classes\]\]' "$SQ3" "sq-03-3 links risk-classes finding"
 
 # ===== Idempotency: add a human ## Notes tail, re-run ========================
 printf '\n## Notes\n\nHuman annotation that must survive a re-run.\n' >> "$SQ1"
@@ -199,8 +199,8 @@ OUT3="$(emit)"
 assert_grep 'type: source' "$WIKI/wiki/sources/court-interpretation.md" \
   "pre-existing source page left untouched (still type: source)"
 [ ! -f "$WIKI/wiki/questions/court-interpretation.md" ] \
-  && green "PASS: did not write a question at the colliding bare slug" \
-  || { red "FAIL: question shadowed the source slug"; errors=$((errors+1)); }
+  && green "PASS: did-1 did not write a question at the colliding bare slug" \
+  || { red "FAIL: did-1 question shadowed the source slug"; errors=$((errors+1)); }
 
 # ===== Within-run collision: two DISTINCT sub-questions, identical slug ======
 # Two sub-questions whose theme_label slugifies to the same base must NOT
@@ -336,15 +336,15 @@ echo "$OUTL" | grep -q '"action": "merged"' \
   && green "PASS: variant theme_label lineage-merged into the existing node (action=merged)" \
   || { red "FAIL: variant did not merge into the lineage node"; echo "$OUTL"; errors=$((errors+1)); }
 [ ! -f "$WIKI/wiki/questions/scope-of-processing-records.md" ] \
-  && green "PASS: did NOT fork a second node for the variant theme_label" \
-  || { red "FAIL: variant forked a second question node"; errors=$((errors+1)); }
+  && green "PASS: did-2 did NOT fork a second node for the variant theme_label" \
+  || { red "FAIL: did-2 variant forked a second question node"; errors=$((errors+1)); }
 echo "$OUTL" | grep -q '"action": "lineage_reused"' \
   && green "PASS: theme_bindings[] records action=lineage_reused" \
   || { red "FAIL: no lineage_reused theme_binding emitted"; echo "$OUTL"; errors=$((errors+1)); }
 # created: preserved; human ## Notes tail survived; new finding unioned in.
-assert_grep 'created: 2025-12-01' "$WIKI/wiki/questions/$LSLUG.md" "lineage merge preserves created:"
-assert_grep 'Prior-run human note that must survive' "$WIKI/wiki/questions/$LSLUG.md" "lineage merge preserves human ## Notes tail"
-assert_grep '\[\[controller-obligations\]\]' "$WIKI/wiki/questions/$LSLUG.md" "lineage merge unions the new finding"
+assert_grep 'created: 2025-12-01' "$WIKI/wiki/questions/$LSLUG.md" "lineage-1 merge preserves created:"
+assert_grep 'Prior-run human note that must survive' "$WIKI/wiki/questions/$LSLUG.md" "lineage-2 merge preserves human ## Notes tail"
+assert_grep '\[\[controller-obligations\]\]' "$WIKI/wiki/questions/$LSLUG.md" "lineage-3 merge unions the new finding"
 
 # ===== Fail-soft binding read error (#426): degrade to slug-only success ======
 # A corrupt / unreadable --binding must NOT abort emit — lineage is an
@@ -362,14 +362,14 @@ OUTCB="$(python3 "$SCRIPT" emit \
   --ingest-manifest "$PROJ/.metadata/ingest-manifest.json" \
   --binding "$WORK/corrupt-binding.json")"
 echo "$OUTCB" | python3 -c 'import json,sys; d=json.load(sys.stdin); sys.exit(0 if d["success"] and d["data"].get("binding_skipped") else 1)' \
-  && green "PASS: corrupt --binding degrades to success + data.binding_skipped (no abort)" \
-  || { red "FAIL: corrupt --binding did not fail-soft"; echo "$OUTCB"; errors=$((errors+1)); }
+  && green "PASS: corrupt-1 --binding degrades to success + data.binding_skipped (no abort)" \
+  || { red "FAIL: corrupt-1 --binding did not fail-soft"; echo "$OUTCB"; errors=$((errors+1)); }
 # No lineage map -> the variant theme_label falls back to slugify(theme_label)
 # and writes its OWN node (it does NOT route into $LSLUG), proving the degrade
 # to slug-only accumulation actually changed behavior vs the lineage case.
 [ -f "$WIKI/wiki/questions/scope-of-processing-records.md" ] \
-  && green "PASS: corrupt --binding ran slug-only (variant got its own slug node, no lineage routing)" \
-  || { red "FAIL: corrupt --binding did not degrade to slug-only"; errors=$((errors+1)); }
+  && green "PASS: corrupt-2 --binding ran slug-only (variant got its own slug node, no lineage routing)" \
+  || { red "FAIL: corrupt-2 --binding did not degrade to slug-only"; errors=$((errors+1)); }
 
 # -- Unreadable-path arm (OSError) --
 OUTMB="$(python3 "$SCRIPT" emit \

--- a/cogni-knowledge/tests/test_repair_mode.sh
+++ b/cogni-knowledge/tests/test_repair_mode.sh
@@ -107,15 +107,15 @@ cp "$WIKI/wiki/index.md" "$WORK/degraded-index.before"
 
 DRY="$WORK/dry.json"
 python3 "$SCRIPT" --wiki-root "$WIKI" --wiki-scripts-dir "$WSD" --repair > "$DRY"
-assert_grep '"success": true' "$DRY" "AC1 dry-run succeeds"
-assert_grep '"action": "dry_run"' "$DRY" "AC1 dry-run is the default (no --apply)"
-assert_grep '"reason": "repair_pending"' "$DRY" "AC1 dry-run reason is repair_pending"
-assert_grep 'ROOT-LINKS' "$DRY" "AC1 dry-run names the drifted ROOT-LINKS region"
-assert_grep 'root-index-proposed.md' "$DRY" "AC1 dry-run stages the proposed root MAP"
+assert_grep '"success": true' "$DRY" "AC1-1 dry-run succeeds"
+assert_grep '"action": "dry_run"' "$DRY" "AC1-2 dry-run is the default (no --apply)"
+assert_grep '"reason": "repair_pending"' "$DRY" "AC1-3 dry-run reason is repair_pending"
+assert_grep 'ROOT-LINKS' "$DRY" "AC1-4 dry-run names the drifted ROOT-LINKS region"
+assert_grep 'root-index-proposed.md' "$DRY" "AC1-5 dry-run stages the proposed root MAP"
 if cmp -s "$WIKI/wiki/index.md" "$WORK/degraded-index.before"; then
-  green "PASS: AC1 dry-run leaves the live index.md byte-identical"
+  green "PASS: AC1-6 dry-run leaves the live index.md byte-identical"
 else
-  red "FAIL: AC1 dry-run mutated the live index.md"
+  red "FAIL: AC1-6 dry-run mutated the live index.md"
   errors=$((errors + 1))
 fi
 
@@ -124,24 +124,24 @@ fi
 # ===========================================================================
 APPLY="$WORK/apply.json"
 python3 "$SCRIPT" --wiki-root "$WIKI" --wiki-scripts-dir "$WSD" --repair --apply > "$APPLY"
-assert_grep '"success": true' "$APPLY" "AC1 --apply succeeds"
-assert_grep '"action": "repaired"' "$APPLY" "AC1 --apply action is repaired"
+assert_grep '"success": true' "$APPLY" "AC1-7 --apply succeeds"
+assert_grep '"action": "repaired"' "$APPLY" "AC1-8 --apply action is repaired"
 assert_not_grep "$ROOT_LINKS_EMPTY" "$WIKI/wiki/index.md" \
-  "AC1 --apply replaced the empty ROOT-LINKS sentinel in the live index.md"
+  "AC1-9 --apply replaced the empty ROOT-LINKS sentinel in the live index.md"
 assert_grep 'Sources (1)' "$WIKI/wiki/index.md" \
-  "AC1 --apply populated the ROOT-LINKS span with the theme-scoped count-link"
+  "AC1-10 --apply populated the ROOT-LINKS span with the theme-scoped count-link"
 assert_grep 'curated-layout repair' "$WIKI/wiki/meta/log.md" \
-  "AC1 --apply appended a repair log line"
+  "AC1-11 --apply appended a repair log line"
 
 # ===========================================================================
 # AC2. Re-running health on the repaired base reports zero structural_drift
 # ===========================================================================
 HOUT="$WORK/health-after-repair.json"
 python3 "$HEALTH" --wiki-root "$WIKI" > "$HOUT"
-assert_grep '"success": true' "$HOUT" "AC2 health succeeds on the repaired base"
+assert_grep '"success": true' "$HOUT" "AC2-1 health succeeds on the repaired base"
 assert_not_grep 'structural_drift' "$HOUT" \
-  "AC2 repaired base fires no structural_drift"
-assert_grep '"errors": 0' "$HOUT" "AC2 repaired base has zero errors"
+  "AC2-2 repaired base fires no structural_drift"
+assert_grep '"errors": 0' "$HOUT" "AC2-3 repaired base has zero errors"
 
 # ===========================================================================
 # AC3. --repair on a clean curated base is a noop; a second --apply too
@@ -150,12 +150,12 @@ CLEAN="$WORK/clean"
 build_curated "$CLEAN" "0.0.9" "$REAL_OVERVIEW" "$POPULATED_LINKS"
 NOOP="$WORK/noop.json"
 python3 "$SCRIPT" --wiki-root "$CLEAN" --wiki-scripts-dir "$WSD" --repair > "$NOOP"
-assert_grep '"action": "noop"' "$NOOP" "AC3 clean base reaches action:noop"
-assert_grep '"reason": "no_drift_detected"' "$NOOP" "AC3 clean base reason is no_drift_detected"
+assert_grep '"action": "noop"' "$NOOP" "AC3-1 clean base reaches action:noop"
+assert_grep '"reason": "no_drift_detected"' "$NOOP" "AC3-2 clean base reason is no_drift_detected"
 
 NOOP2="$WORK/noop2.json"
 python3 "$SCRIPT" --wiki-root "$CLEAN" --wiki-scripts-dir "$WSD" --repair --apply > "$NOOP2"
-assert_grep '"action": "noop"' "$NOOP2" "AC3 second --apply on a clean base is a clean no-op"
+assert_grep '"action": "noop"' "$NOOP2" "AC3-3 second --apply on a clean base is a clean no-op"
 
 # ===========================================================================
 # lag. Schema-lag-only repair: 0.0.8 base with populated links bumps to 0.0.9
@@ -164,10 +164,10 @@ LAG="$WORK/lag"
 build_curated "$LAG" "0.0.8" "$REAL_OVERVIEW" "$POPULATED_LINKS"
 LAGOUT="$WORK/lag.json"
 python3 "$SCRIPT" --wiki-root "$LAG" --wiki-scripts-dir "$WSD" --repair --apply > "$LAGOUT"
-assert_grep '"action": "repaired"' "$LAGOUT" "lag --apply repairs the schema lag"
-assert_grep '"schema_after": "0.0.9"' "$LAGOUT" "lag --apply reports schema_after 0.0.9"
+assert_grep '"action": "repaired"' "$LAGOUT" "lag-1 --apply repairs the schema lag"
+assert_grep '"schema_after": "0.0.9"' "$LAGOUT" "lag-2 --apply reports schema_after 0.0.9"
 assert_grep '"schema_version": "0.0.9"' "$LAG/.cogni-wiki/config.json" \
-  "lag --apply bumped the on-disk schema_version to 0.0.9"
+  "lag-3 --apply bumped the on-disk schema_version to 0.0.9"
 
 # ===========================================================================
 # guard. A pre-0.0.8 base is refused (run --migrate first)
@@ -176,8 +176,8 @@ OLD="$WORK/old"
 build_curated "$OLD" "0.0.7" "$REAL_OVERVIEW" "$ROOT_LINKS_EMPTY"
 GUARD="$WORK/guard.json"
 python3 "$SCRIPT" --wiki-root "$OLD" --wiki-scripts-dir "$WSD" --repair > "$GUARD" || true
-assert_grep '"success": false' "$GUARD" "guard: pre-0.0.8 base is refused"
-assert_grep 'migrate' "$GUARD" "guard: refusal points at the full migration (--migrate)"
+assert_grep '"success": false' "$GUARD" "guard-1 pre-0.0.8 base is refused"
+assert_grep 'migrate' "$GUARD" "guard-2 refusal points at the full migration (--migrate)"
 
 # ---------------------------------------------------------------------------
 if [ "$errors" -eq 0 ]; then

--- a/cogni-knowledge/tests/test_root_index.sh
+++ b/cogni-knowledge/tests/test_root_index.sh
@@ -200,10 +200,10 @@ PROSE=""; BEFORE=""
 # === 1. render → curated MAP ===
 OUT="$(python3 "$ROOT_SCRIPT" render --wiki-root "$WIKI" --wiki-scripts-dir "$WSD")"
 echo "$OUT" | grep -q '"changed": true' \
-  && green "PASS: 1 render reports changed:true" \
-  || { red "FAIL: 1 render not changed:true ($OUT)"; errors=$((errors+1)); }
-assert_grep "MACHINE-OWNED:ROOT-INDEX" "$IDX" "1 ROOT-INDEX ownership marker present"
-assert_grep "Curated map of this knowledge base" "$IDX" "1 curated intro line present"
+  && green "PASS: 1-1 render reports changed:true" \
+  || { red "FAIL: 1-1 render not changed:true ($OUT)"; errors=$((errors+1)); }
+assert_grep "MACHINE-OWNED:ROOT-INDEX" "$IDX" "1-2 ROOT-INDEX ownership marker present"
+assert_grep "Curated map of this knowledge base" "$IDX" "1-3 curated intro line present"
 # AC#3 (no-fabrication half): the source fixture index carried no
 # OVERVIEW-NARRATIVE block, so the renderer must NOT invent a placeholder one.
 assert_not_grep "MACHINE-OWNED:OVERVIEW-NARRATIVE" "$IDX" "1b no narrative span fabricated when none authored"
@@ -211,74 +211,74 @@ assert_not_grep "MACHINE-OWNED:OVERVIEW-NARRATIVE" "$IDX" "1b no narrative span 
 # === 1c. the 5W1H intent spine is a PRIMARY front-door entry (R8) ===
 # Promoted from a secondary italic "_See also:_" line to a bold primary
 # wayfinding entry leading with the intent spine.
-assert_grep "Start here — browse by intent:" "$IDX" "1c intent spine promoted to a primary front-door line (R8)"
-assert_grep "Perspectives (5W1H) →](perspectives.md)" "$IDX" "1c spine links the 5W1H perspectives overlay (R8)"
-assert_not_grep "_See also: \[Perspectives (5W1H)\](perspectives.md)" "$IDX" "1c old secondary 'See also' framing is gone (R8)"
+assert_grep "Start here — browse by intent:" "$IDX" "1c-1 intent spine promoted to a primary front-door line (R8)"
+assert_grep "Perspectives (5W1H) →](perspectives.md)" "$IDX" "1c-2 spine links the 5W1H perspectives overlay (R8)"
+assert_not_grep "_See also: \[Perspectives (5W1H)\](perspectives.md)" "$IDX" "1c-3 old secondary 'See also' framing is gone (R8)"
 # === 1d. secondary-view labels (R10) + overview-stub signpost (R11) ===
-assert_grep "Other views:" "$IDX" "1d secondary-view labels render on the root portal (R10)"
-assert_grep "\[Recent syntheses\](overview.md)" "$IDX" "1d overview stub signposted from the spine — Recent syntheses (R11)"
+assert_grep "Other views:" "$IDX" "1d-1 secondary-view labels render on the root portal (R10)"
+assert_grep "\[Recent syntheses\](overview.md)" "$IDX" "1d-2 overview stub signposted from the spine — Recent syntheses (R11)"
 
 # === 2. per-theme count-links with counts AND theme-scoped deep-link anchors ===
 # The link now deep-links into the theme's `## <theme>` section of each
 # sub-index (`<type>/index.md#<anchor>`), not the bare unfiltered sub-index.
 # Obsidian resolves a heading link by the heading's literal text: the anchor
 # preserves case (theme "Scope" → `## Scope` → #Scope), spaces → %20.
-assert_grep "Sources (2)](sources/index.md#Scope)" "$IDX" "2 Sources (2) deep-link to #Scope"
-assert_grep "Concepts (1)](concepts/index.md#Scope)" "$IDX" "2 Concepts (1) deep-link to #Scope"
-assert_grep "Questions (1)](questions/index.md#Scope)" "$IDX" "2 Questions (1) deep-link to #Scope"
-assert_grep "Syntheses (1)](syntheses/index.md#Scope)" "$IDX" "2 Syntheses (1) deep-link to #Scope (folded into theme)"
+assert_grep "Sources (2)](sources/index.md#Scope)" "$IDX" "2-1 Sources (2) deep-link to #Scope"
+assert_grep "Concepts (1)](concepts/index.md#Scope)" "$IDX" "2-2 Concepts (1) deep-link to #Scope"
+assert_grep "Questions (1)](questions/index.md#Scope)" "$IDX" "2-3 Questions (1) deep-link to #Scope"
+assert_grep "Syntheses (1)](syntheses/index.md#Scope)" "$IDX" "2-4 Syntheses (1) deep-link to #Scope (folded into theme)"
 
 # === 2b. distinct per-theme anchors + non-ASCII heading-anchor (Obsidian convention) ===
-assert_grep '^## KI Bußgelder' "$IDX" "2b non-ASCII theme heading kept verbatim"
+assert_grep '^## KI Bußgelder' "$IDX" "2b-1 non-ASCII theme heading kept verbatim"
 # The deep link is the Obsidian heading-text anchor for `## KI Bußgelder`:
 # literal text, space → %20, case + ß preserved verbatim (#KI%20Bußgelder) —
 # distinct from the Scope theme's #Scope (so per-theme Explore lines differ).
-assert_grep "Sources (1)](sources/index.md#KI%20Bußgelder)" "$IDX" "2b non-ASCII theme deep-links to #KI%20Bußgelder"
+assert_grep "Sources (1)](sources/index.md#KI%20Bußgelder)" "$IDX" "2b-2 non-ASCII theme deep-links to #KI%20Bußgelder"
 # Regression: NOT the GFM slug form, and NOT slugify's transliterated form
 # (neither resolves to the heading in Obsidian).
-assert_not_grep "sources/index.md#ki-bußgelder)" "$IDX" "2b anchor is NOT the GFM slug form #ki-bußgelder"
-assert_not_grep "sources/index.md#ki-bussgelder)" "$IDX" "2b anchor is NOT the transliterated slugify form #ki-bussgelder"
+assert_not_grep "sources/index.md#ki-bußgelder)" "$IDX" "2b-3 anchor is NOT the GFM slug form #ki-bußgelder"
+assert_not_grep "sources/index.md#ki-bussgelder)" "$IDX" "2b-4 anchor is NOT the transliterated slugify form #ki-bussgelder"
 
 # === 2c. A1 false-filtering fix (#933): theme-label whitespace is normalized so
 #         the rendered `## <theme>` heading and the count-link anchor AGREE. ===
 # The fixture theme_label is "AI  Liability " (double internal space + trailing).
 # The producer-site _collapse normalizes it to "AI Liability", so the heading is
 # single-space and the anchor is the matching single-%20 fragment.
-assert_grep '^## AI Liability' "$IDX" "2c double-space theme heading collapsed to single space"
-assert_not_grep '^## AI  Liability' "$IDX" "2c heading does NOT keep the double space (the drift)"
-assert_grep "Sources (1)](sources/index.md#AI%20Liability)" "$IDX" "2c count-link anchors to the single-%20 fragment that matches the heading"
+assert_grep '^## AI Liability' "$IDX" "2c-1 double-space theme heading collapsed to single space"
+assert_not_grep '^## AI  Liability' "$IDX" "2c-2 heading does NOT keep the double space (the drift)"
+assert_grep "Sources (1)](sources/index.md#AI%20Liability)" "$IDX" "2c-3 count-link anchors to the single-%20 fragment that matches the heading"
 # Regression: the heading↔anchor MUST agree — the drift would have rendered the
 # double-space heading while the anchor collapsed, landing the click at page top.
-assert_not_grep "sources/index.md#AI%20%20Liability)" "$IDX" "2c anchor is NOT the un-collapsed double-%20 form"
+assert_not_grep "sources/index.md#AI%20%20Liability)" "$IDX" "2c-4 anchor is NOT the un-collapsed double-%20 form"
 
 # === 3. no per-page source bullets remain on the root ===
-assert_not_grep '^- \[\[src-a\]\]' "$IDX" "3 per-page src-a bullet dropped from root"
-assert_not_grep '^- \[\[scope-synth\]\]' "$IDX" "3 per-page synthesis bullet dropped from root"
+assert_not_grep '^- \[\[src-a\]\]' "$IDX" "3-1 per-page src-a bullet dropped from root"
+assert_not_grep '^- \[\[scope-synth\]\]' "$IDX" "3-2 per-page synthesis bullet dropped from root"
 
 # === 4. carried PORTAL-LEADIN span (verbatim, date intact) ===
-assert_grep "refreshed:2026-06-01 bullets:3" "$IDX" "4 PORTAL-LEADIN carried with original date"
-assert_grep "Framing for the scope theme." "$IDX" "4 PORTAL-LEADIN inner prose carried"
+assert_grep "refreshed:2026-06-01 bullets:3" "$IDX" "4-1 PORTAL-LEADIN carried with original date"
+assert_grep "Framing for the scope theme." "$IDX" "4-2 PORTAL-LEADIN inner prose carried"
 
 # === 4b. seeded default lead-in for a theme that carries none (#946) ===
 # KI Bußgelder has NO authored lead-in in the legacy root, so the renderer seeds a
 # deterministic engine-owned PORTAL-LEADIN span that names the theme — the
 # legibility default, mirroring the perspectives facet defaults. AC1.
-assert_grep "grouped under the \*\*KI Bußgelder\*\* theme" "$IDX" "4b no-lead-in theme seeded a default PORTAL-LEADIN one-liner"
+assert_grep "grouped under the \*\*KI Bußgelder\*\* theme" "$IDX" "4b-1 no-lead-in theme seeded a default PORTAL-LEADIN one-liner"
 # AC2 (no clobber): the Scope theme's authored span is NOT replaced by the default.
-assert_not_grep "grouped under the \*\*Scope\*\* theme" "$IDX" "4b authored lead-in not clobbered by the seeded default"
+assert_not_grep "grouped under the \*\*Scope\*\* theme" "$IDX" "4b-2 authored lead-in not clobbered by the seeded default"
 
 # === 5. container headings dropped ===
-assert_not_grep '^## Categories' "$IDX" "5 ## Categories container heading dropped"
-assert_not_grep '^## Syntheses' "$IDX" "5 ## Syntheses fixed heading dropped (folded per-theme)"
-assert_grep '^## Scope' "$IDX" "5 real theme heading kept"
+assert_not_grep '^## Categories' "$IDX" "5-1 ## Categories container heading dropped"
+assert_not_grep '^## Syntheses' "$IDX" "5-2 ## Syntheses fixed heading dropped (folded per-theme)"
+assert_grep '^## Scope' "$IDX" "5-3 real theme heading kept"
 
 # === 6. OVERVIEW-NARRATIVE fold carried into intro ===
 PROSE="$(mktemp)"; printf 'This base maps scope for SMEs.' > "$PROSE"
 python3 "$OVR_SCRIPT" narrative-splice --wiki-root "$WIKI" --prose-file "$PROSE" \
   --target-file index.md --wiki-scripts-dir "$WSD" >/dev/null
 python3 "$ROOT_SCRIPT" render --wiki-root "$WIKI" --wiki-scripts-dir "$WSD" >/dev/null
-assert_grep "MACHINE-OWNED:OVERVIEW-NARRATIVE" "$IDX" "6 OVERVIEW-NARRATIVE block in index.md"
-assert_grep "This base maps scope for SMEs." "$IDX" "6 overview narrative prose in intro"
+assert_grep "MACHINE-OWNED:OVERVIEW-NARRATIVE" "$IDX" "6-1 OVERVIEW-NARRATIVE block in index.md"
+assert_grep "This base maps scope for SMEs." "$IDX" "6-2 overview narrative prose in intro"
 
 # === 7. idempotent re-render ===
 OUT2="$(python3 "$ROOT_SCRIPT" render --wiki-root "$WIKI" --wiki-scripts-dir "$WSD")"
@@ -297,14 +297,14 @@ BEFORE="$(mktemp)"; cp "$IDX" "$BEFORE"
 python3 "$WSD/wiki_index_update.py" --wiki-root "$WIKI" --reflow-only >/dev/null 2>&1 || true
 python3 "$WSD/wiki_index_update.py" --wiki-root "$WIKI" --collapse-only >/dev/null 2>&1 || true
 if diff -q "$BEFORE" "$IDX" >/dev/null 2>&1; then
-  green "PASS: 8 curated MAP byte-stable under reflow-only + collapse-only"
+  green "PASS: 8-1 curated MAP byte-stable under reflow-only + collapse-only"
 else
-  red "FAIL: 8 curated MAP drifted under reflow/collapse"; diff "$BEFORE" "$IDX" || true; errors=$((errors+1))
+  red "FAIL: 8-1 curated MAP drifted under reflow/collapse"; diff "$BEFORE" "$IDX" || true; errors=$((errors+1))
 fi
 OUT3="$(python3 "$ROOT_SCRIPT" render --wiki-root "$WIKI" --wiki-scripts-dir "$WSD")"
 echo "$OUT3" | grep -q '"changed": false' \
-  && green "PASS: 8 re-render after reflow/collapse stays changed:false" \
-  || { red "FAIL: 8 re-render after fixers not idempotent ($OUT3)"; errors=$((errors+1)); }
+  && green "PASS: 8-2 re-render after reflow/collapse stays changed:false" \
+  || { red "FAIL: 8-2 re-render after fixers not idempotent ($OUT3)"; errors=$((errors+1)); }
 
 # === 9. transient bullets: a freshly re-filed bullet is dropped next render ===
 python3 - "$IDX" <<'PY'
@@ -315,9 +315,9 @@ t = open(p, encoding="utf-8").read()
 t = t.replace("## Scope\n", "## Scope\n\n- [[src-c]] — a freshly ingested source\n", 1)
 open(p, "w", encoding="utf-8").write(t)
 PY
-assert_grep '\[\[src-c\]\]' "$IDX" "9 transient bullet present before render"
+assert_grep '\[\[src-c\]\]' "$IDX" "9-1 transient bullet present before render"
 python3 "$ROOT_SCRIPT" render --wiki-root "$WIKI" --wiki-scripts-dir "$WSD" >/dev/null
-assert_not_grep '\[\[src-c\]\]' "$IDX" "9 transient bullet dropped on next render"
+assert_not_grep '\[\[src-c\]\]' "$IDX" "9-2 transient bullet dropped on next render"
 
 # === 10. counts subcommand ===
 CNT="$(python3 "$SUB_SCRIPT" counts --type sources --wiki-root "$WIKI")"
@@ -337,20 +337,20 @@ HWIKI="$(mktemp -d)"; mkdir -p "$HWIKI/wiki/sources" "$HWIKI/.cogni-wiki"
 printf '# My hand-written portal\n\nJust prose, no headings, no markers.\n' > "$HWIKI/wiki/index.md"
 HOUT="$(python3 "$ROOT_SCRIPT" render --wiki-root "$HWIKI" --wiki-scripts-dir "$WSD")"
 echo "$HOUT" | grep -q '"skipped_human_page": true' \
-  && green "PASS: 12 hand-authored portal skipped" \
-  || { red "FAIL: 12 human page not skipped ($HOUT)"; errors=$((errors+1)); }
+  && green "PASS: 12-1 hand-authored portal skipped" \
+  || { red "FAIL: 12-1 human page not skipped ($HOUT)"; errors=$((errors+1)); }
 grep -q "hand-written portal" "$HWIKI/wiki/index.md" \
-  && green "PASS: 12 hand-authored portal left untouched" \
-  || { red "FAIL: 12 human page clobbered"; errors=$((errors+1)); }
+  && green "PASS: 12-2 hand-authored portal left untouched" \
+  || { red "FAIL: 12-2 human page clobbered"; errors=$((errors+1)); }
 rm -rf "$HWIKI"
 
 # === 13. python3.9 floor ===
 grep -q "from __future__ import annotations" "$ROOT_SCRIPT" \
-  && green "PASS: 13 root_index.py carries __future__ annotations" \
-  || { red "FAIL: 13 missing __future__ annotations"; errors=$((errors+1)); }
+  && green "PASS: 13-1 root_index.py carries __future__ annotations" \
+  || { red "FAIL: 13-1 missing __future__ annotations"; errors=$((errors+1)); }
 python3 -c "import ast,sys; ast.parse(open(sys.argv[1]).read())" "$ROOT_SCRIPT" \
-  && green "PASS: 13 root_index.py parses under ast" \
-  || { red "FAIL: 13 ast.parse failed"; errors=$((errors+1)); }
+  && green "PASS: 13-2 root_index.py parses under ast" \
+  || { red "FAIL: 13-2 ast.parse failed"; errors=$((errors+1)); }
 
 # === 14. render stamps last_rendered_engine_version into config.json (#947) ===
 # A live render records the producing engine version so health.py can flag a

--- a/cogni-knowledge/tests/test_structural_drift_health.sh
+++ b/cogni-knowledge/tests/test_structural_drift_health.sh
@@ -103,22 +103,22 @@ WIKI="$WORK/overview-placeholder"
 build_curated "$WIKI" "0.0.9" "$OVERVIEW_PLACEHOLDER" "$POPULATED_LINKS"
 OUT="$WORK/overview-placeholder.json"
 python3 "$HEALTH" --wiki-root "$WIKI" > "$OUT"
-assert_grep '"success": true' "$OUT" "AC1a: health succeeds on degraded base"
+assert_grep '"success": true' "$OUT" "AC1a-1 health succeeds on degraded base"
 assert_grep 'structural_drift' "$OUT" \
-  "AC1a: placeholder OVERVIEW-NARRATIVE fires structural_drift"
-assert_grep '"errors": 0' "$OUT" "AC1a: structural drift is a warning, errors stay 0"
+  "AC1a-2 placeholder OVERVIEW-NARRATIVE fires structural_drift"
+assert_grep '"errors": 0' "$OUT" "AC1a-3 structural drift is a warning, errors stay 0"
 if grep -q 'schema_version_lag' "$OUT"; then
-  red "FAIL: AC1a 0.0.9 base wrongly fired schema_version_lag"
+  red "FAIL: AC1a-4 0.0.9 base wrongly fired schema_version_lag"
   errors=$((errors + 1))
 else
-  green "PASS: AC1a current-schema base fires no schema_version_lag"
+  green "PASS: AC1a-4 current-schema base fires no schema_version_lag"
 fi
 # verdict no longer bare OK: at least one warning present
 if grep -q '"warnings": 0' "$OUT"; then
-  red "FAIL: AC1a degraded base reported zero warnings (verdict still bare OK)"
+  red "FAIL: AC1a-5 degraded base reported zero warnings (verdict still bare OK)"
   errors=$((errors + 1))
 else
-  green "PASS: AC1a degraded base reports warnings (verdict no longer bare OK)"
+  green "PASS: AC1a-5 degraded base reports warnings (verdict no longer bare OK)"
 fi
 
 # ---------------------------------------------------------------------------
@@ -129,8 +129,8 @@ build_curated "$WIKI" "0.0.9" "$REAL_OVERVIEW" "$ROOT_LINKS_EMPTY"
 OUT="$WORK/rootlinks-empty.json"
 python3 "$HEALTH" --wiki-root "$WIKI" > "$OUT"
 assert_grep 'structural_drift' "$OUT" \
-  "AC1b: empty ROOT-LINKS span fires structural_drift"
-assert_grep '"errors": 0' "$OUT" "AC1b: structural drift is a warning, errors stay 0"
+  "AC1b-1 empty ROOT-LINKS span fires structural_drift"
+assert_grep '"errors": 0' "$OUT" "AC1b-2 structural drift is a warning, errors stay 0"
 
 # ---------------------------------------------------------------------------
 # AC2. Correctly-finalized base (0.0.9): real overview + populated root-links
@@ -140,18 +140,18 @@ build_curated "$WIKI" "0.0.9" "$REAL_OVERVIEW" "$POPULATED_LINKS"
 OUT="$WORK/clean-finalized.json"
 python3 "$HEALTH" --wiki-root "$WIKI" > "$OUT"
 if grep -q 'structural_drift' "$OUT"; then
-  red "FAIL: AC2 finalized base wrongly fired structural_drift"
+  red "FAIL: AC2-1 finalized base wrongly fired structural_drift"
   errors=$((errors + 1))
 else
-  green "PASS: AC2 finalized base fires no structural_drift"
+  green "PASS: AC2-1 finalized base fires no structural_drift"
 fi
 if grep -q 'schema_version_lag' "$OUT"; then
-  red "FAIL: AC2 current-schema base wrongly fired schema_version_lag"
+  red "FAIL: AC2-2 current-schema base wrongly fired schema_version_lag"
   errors=$((errors + 1))
 else
-  green "PASS: AC2 current-schema base fires no schema_version_lag"
+  green "PASS: AC2-2 current-schema base fires no schema_version_lag"
 fi
-assert_grep '"errors": 0' "$OUT" "AC2: finalized base has zero errors"
+assert_grep '"errors": 0' "$OUT" "AC2-3 finalized base has zero errors"
 
 # ---------------------------------------------------------------------------
 # lag. Curated base at 0.0.8 (behind engine 0.0.9) fires schema_version_lag
@@ -161,8 +161,8 @@ build_curated "$WIKI" "0.0.8" "$REAL_OVERVIEW" "$POPULATED_LINKS"
 OUT="$WORK/schema-lag.json"
 python3 "$HEALTH" --wiki-root "$WIKI" > "$OUT"
 assert_grep 'schema_version_lag' "$OUT" \
-  "lag: a 0.0.8 base behind the engine fires schema_version_lag"
-assert_grep '"errors": 0' "$OUT" "lag: schema_version_lag is a warning, errors stay 0"
+  "lag-1 a 0.0.8 base behind the engine fires schema_version_lag"
+assert_grep '"errors": 0' "$OUT" "lag-2 schema_version_lag is a warning, errors stay 0"
 
 # ---------------------------------------------------------------------------
 # AC3. Pre-0.0.8 base (0.0.7): structural-drift assertions stay silent
@@ -200,8 +200,8 @@ build_curated "$WIKI" "0.0.9" "$REAL_OVERVIEW" "$POPULATED_LINKS"
 set_stamp "$WIKI/.cogni-wiki/config.json" ""
 OUT="$WORK/rel-absent.json"
 python3 "$HEALTH" --wiki-root "$WIKI" > "$OUT"
-assert_grep 'render_engine_lag' "$OUT" "REL1: absent stamp fires render_engine_lag"
-assert_grep '"errors": 0' "$OUT" "REL1: render_engine_lag is a warning, errors stay 0"
+assert_grep 'render_engine_lag' "$OUT" "REL1-1 absent stamp fires render_engine_lag"
+assert_grep '"errors": 0' "$OUT" "REL1-2 render_engine_lag is a warning, errors stay 0"
 
 # REL2. Stamp trails the installed engine → render_engine_lag (lag).
 WIKI="$WORK/rel-trails"
@@ -209,8 +209,8 @@ build_curated "$WIKI" "0.0.9" "$REAL_OVERVIEW" "$POPULATED_LINKS"
 set_stamp "$WIKI/.cogni-wiki/config.json" "1.0.40"
 OUT="$WORK/rel-trails.json"
 python3 "$HEALTH" --wiki-root "$WIKI" > "$OUT"
-assert_grep 'render_engine_lag' "$OUT" "REL2: trailing stamp fires render_engine_lag"
-assert_grep '"errors": 0' "$OUT" "REL2: render_engine_lag is a warning, errors stay 0"
+assert_grep 'render_engine_lag' "$OUT" "REL2-1 trailing stamp fires render_engine_lag"
+assert_grep '"errors": 0' "$OUT" "REL2-2 render_engine_lag is a warning, errors stay 0"
 
 # REL3. Stamp == installed engine → silent.
 WIKI="$WORK/rel-current"


### PR DESCRIPTION
Refs #1494

## Summary

Four `cogni-knowledge` suites already carried a case-id scheme in their result labels, but the ids were not unique: **39 cases shared a first token with a sibling**. `mutation-check.sh` addresses a case by matching `^[[:space:]]*FAIL:[[:space:]]+<case>`, so a colliding id cannot be pointed at unambiguously — a mutation meant to red case A can be credited by sibling case B, recording `guard_verified` for a guard that was never exercised.

This PR hyphenates a discriminator into the id each line already led with (`4b` → `4b-1`/`4b-2`, `AC1` → `AC1-1`…`AC1-11`, `sq-01` → `sq-01-1`…`sq-01-8`, `guard:` → `guard-1`/`guard-2`), dropping every colliding group to size 1.

**Labels and ids only.** No assertion, grep pattern, fixture, path, control flow, or emitter changed. The diff is 1:1 — 118 label edits, equal insertions and deletions.

## How scope was decided — by EXECUTION

All **77** `cogni-knowledge/tests/*.sh` suites were **run** at base `4c49114a` (exit-code histogram `{0: 77}`, a real clean baseline — neither `timeout` nor `gtimeout` exists on the host, so no wrapper could have produced a false clean) and the first whitespace-delimited token of every emitted result line was grouped per suite. No scope decision came from a source grep.

15 suites are already clean, 1 emits no result line at all, **61 collide**. The 61 split **three** ways — not the two the issue's classification names:

| Class | Count | Disposition |
|---|---|---|
| Colliding **and** carrying an extendable case-id stem | **4** | fixed here |
| Colliding, every line a namespace prefix (`knowledge-verify:`, `wiki-composer:`) | 15 | out of scope — the namespace children |
| Colliding on ordinary descriptive words, **no stem to extend** | 42 | deferred to the scheme child |
| Emits no result line at all (`test_portal_store.sh`) | 1 | already claimed by the scheme child |

### The named set, with the executed evidence each was classified on

| Suite | Colliding multiset (measured by running it) | Why mechanical, not a namespace prefix |
|---|---|---|
| `test_root_index.sh` | `2`×4, `2b`×4, `2c`×4, `1`×3, `1c`×3, `5`×3, `1d`×2, `3`×2, `4`×2, `4b`×2, `6`×2, `8`×2, `9`×2, `12`×2, `13`×2 | Numbered section ids (`1`, `1b`, `2c`, `7b`, `14`) — an id scheme, carried by *some* lines, not one prefix on every line. |
| `test_repair_mode.sh` | `AC1`×11, `AC2`×3, `AC3`×3, `lag`×3, `guard:`×2 | Acceptance-criterion ids plus two named scenario stems from the suite's own header. |
| `test_question_store.sh` | `sq-01`×8, `sq-03`×3, `sq-02`×2, `lineage`×3, `did`×2, `corrupt`×2 | Sub-question ids (`sq-NN`) already present; the three prose stems are extended the same way rather than re-schemed. |
| `test_structural_drift_health.sh` | `AC1a:`×3, `AC1a`×2, `AC1b:`×2, `AC2`×2, `lag:`×2, `REL1:`×2, `REL2:`×2 | `AC`/`REL` ids already present. Note `AC1a:` and `AC1a` are two tokens today purely by punctuation. |

Every one of those tokens is converted — the bar is max group size 1 for each suite in the named set, not just for the numbered ids.

### The 42-suite gap, stated explicitly

The issue's acceptance criterion asks each changed suite be classified on a **binary** — "mechanical rather than a namespace prefix". The executed census does not partition that way: **42 colliding suites are neither.** They collide on ordinary English words (`merge`, `dry-run`, `store`, `page`, `init`) with no case-id stem to extend, and they are not "a namespace prefix carried by every line" either.

They are **not** touched here, because giving them addressable ids means inventing a convention, which this issue explicitly forbids. They belong with the scheme-design child, alongside `test_portal_store.sh`. Recording it so the rollout does not silently skip them.

## Decisions worth reviewing

1. **Hyphen-digit discriminator, not letter suffixes.** `test_root_index.sh` already uses `1b`, `1c`, `1d`, `2b`, `2c`, `4b`, `7b` as *real, unrelated* tests. Splitting `1` into `1a`/`1b`/`1c` would have silently aliased onto them. Safe because the matcher is right-anchored (`re.escape(case_id)` then `(?:[ \t]|$)`), so `AC1` and `AC1-11` can never mis-resolve.
2. **Converted ids carry no trailing colon.** The `AC1a` family spans both a colon group and a colon-free group; keeping the colon would leave one visually identical family needing two different `--case` spellings. This also took `AC2:` → `AC2-3` in `test_structural_drift_health.sh` — the last colon-form id in that suite. It was not itself colliding; converting it keeps the AC2 family on one spelling and removes the copy-template that would re-collide.
3. **Both arms carry one id.** Five pairs in `test_question_store.sh` had a FAIL arm leading with a *different* token than its PASS arm (`sq-01`/`missing`, `sq-01`/`question`, `did`/`question`, `did`/`variant`). The harness reads RED off the `FAIL:` line, so a split pair returns `case_not_found` — or worse, reports GREEN for a case that went red. Both arms now match, which incidentally collapses the FAIL-side groups `missing`, `question` and `variant` too.

## Known-incomplete, tracked not silent

- **#1517** — seven further split PASS/FAIL pairs remain in `test_question_store.sh`, three of whose FAIL arms collide on `expected`. A green-run census only sees the PASS side, so this class is invisible to the measurement this issue specifies. Filed rather than folded in.
- **#1518** — the case-id convention is undocumented in `cogni-knowledge/tests/README.md`, so the next suite author re-collides by default.

## Verification

- `python3 scripts/run-plugin-tests.py --filter cogni-knowledge` → **exit 0**, 77/77.
- `python3 scripts/run-plugin-tests.py` (full unfiltered sweep, 124 suites) → **exit 0**.
- Per-suite uniqueness, by running each and grouping emitted first tokens — **max group size 1 in all four** (`test_root_index` 45 lines, `test_repair_mode` 22, `test_question_store` 37, `test_structural_drift_health` 20; zero duplicates).
- No colon-terminated first token remains in `test_structural_drift_health.sh`.
- `python3 scripts/check-result-line-plainness.py` → exit 0 (97 emitter definitions inspected).
- `python3 scripts/check-breadcrumbs.py` → exit 0.
- `git diff --name-only` lists only the four `cogni-knowledge/tests/` paths. `fixtures/test_helpers.sh` is untouched — it is shared by all 77 suites.
- Fixture data byte-identical: the `plan.json` sub-question ids, every `sub_question_refs`, the `sq-09.md` path, and the `assert_grep` pattern `'sub_question_id: sq-01'` at `test_question_store.sh:143` are unchanged; only that call's third argument moved.
- No version value moved.

## Mutation recipe

Two converted suites. Run from a `cogni-work/managed-service` checkout, `--root` pointing at this branch's checkout.

```sh
bash cogni-service/scripts/mutation-check.sh --root <insight-wave-checkout> \
  --file cogni-knowledge/scripts/root_index.py \
  --expr 's/grouped under the/grouped beneath the/g' \
  --test 'bash cogni-knowledge/tests/test_root_index.sh' \
  --case 4b-1
```

`grouped under the` occurs exactly once in `root_index.py`, so the substitution can never be a no-op. Only `4b-1` (`:266`) greps that phrase; its sibling `4b-2` (`:268`) is an `assert_not_grep` for a *different* theme and stays green under the mutation. Expect exactly `FAIL: 4b-1`.

```sh
bash cogni-service/scripts/mutation-check.sh --root <insight-wave-checkout> \
  --file cogni-knowledge/scripts/migrate-layout.py \
  --expr 's/curated-layout repair/curated-layout mend/g' \
  --test 'bash cogni-knowledge/tests/test_repair_mode.sh' \
  --case AC1-11
```

The `/g` is load-bearing: under the harness's slurping `perl -0pi` a non-global substitution would hit only the first occurrence and leave the emitted log line intact, producing a false green. Only `AC1-11` (`:133-134`) reads that log text. Expect exactly `FAIL: AC1-11`.

Both `--case` values appear verbatim in the suite sources and carry no trailing colon, so they replay as written.

## Follow-up issues

- #1517 — PASS and FAIL arms of the same case lead with different first tokens, so a red case can report green (seven pairs remain in `test_question_store.sh`).
- #1518 — the result-line case-id convention is undocumented, so new suites re-collide by default.