### PR TITLE
Sweep retired cogni-visual from the three MCP consumer tables

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,9 +166,9 @@ Use `cogni-docs` skills to manage: `doc-audit` detects drift, `doc-generate` fix
 
 | Server | Plugins | Purpose |
 |--------|---------|---------|
-| excalidraw | cogni-visual, cogni-portfolio, cogni-workspace | Diagram rendering (infographics, concept diagrams, architecture) |
+| excalidraw | cogni-portfolio, cogni-workspace | Diagram rendering (infographics, concept diagrams, architecture) |
 | claude-in-chrome | cogni-website, cogni-workspace | Browser automation (verification, preview, theme extraction) |
-| pencil | cogni-visual, cogni-website, cogni-workspace | Web narrative, storyboard, poster, hero rendering |
+| pencil | cogni-website, cogni-workspace | Web narrative, storyboard, poster, hero rendering |
 
 Managed by `cogni-workspace:install-mcp`, which installs each server on demand and writes it into the user's own config — the top-level `mcpServers` in `~/.claude.json` for Claude Code, `claude_desktop_config.json` for Claude Desktop — pointing at `$HOME/.claude/mcp-servers/{name}/start.sh`.
 

--- a/README.md
+++ b/README.md
@@ -160,9 +160,9 @@ Some plugins extend their capabilities through external [MCP servers](https://do
 
 | MCP Server | Used by | What it enables | Install |
 |------------|---------|-----------------|---------|
-| excalidraw | [cogni-visual](cogni-visual/README.md), [cogni-portfolio](cogni-portfolio/README.md) | Diagram rendering (infographics, concept diagrams, solution architecture, report enrichment) | Auto-installed by `manage-workspace` from [yctimlin/mcp_excalidraw](https://github.com/yctimlin/mcp_excalidraw) (git clone + build). Includes React canvas on localhost:3000. |
+| excalidraw | [cogni-portfolio](cogni-portfolio/README.md), [cogni-workspace](cogni-workspace/README.md) | Diagram rendering (infographics, concept diagrams, solution architecture, report enrichment) | Auto-installed by `manage-workspace` from [yctimlin/mcp_excalidraw](https://github.com/yctimlin/mcp_excalidraw) (git clone + build). Includes React canvas on localhost:3000. |
 | claude-in-chrome | [cogni-website](cogni-website/README.md), [cogni-workspace](cogni-workspace/README.md) | Browser automation — claim verification, website preview, theme extraction | Manual — install [Chrome extension](https://code.claude.com/docs/en/chrome) |
-| pencil | [cogni-visual](cogni-visual/README.md), [cogni-website](cogni-website/README.md) | Web narrative, storyboard, and poster rendering; homepage hero generation | Manual — open [Pencil](https://docs.pencil.dev/getting-started/installation) desktop app |
+| pencil | [cogni-website](cogni-website/README.md), [cogni-workspace](cogni-workspace/README.md) | Web narrative, storyboard, and poster rendering; homepage hero generation | Manual — open [Pencil](https://docs.pencil.dev/getting-started/installation) desktop app |
 
 Plugins that don't use MCP servers work without them — only install what you need.
 

--- a/cogni-workspace/skills/manage-workspace/SKILL.md
+++ b/cogni-workspace/skills/manage-workspace/SKILL.md
@@ -160,8 +160,8 @@ row with the registry server name. The block below is illustrative:
 
 ```
 MCP Servers (installed on demand, written to your config):
-  excalidraw       added      loaded       <- cogni-visual, cogni-portfolio
-  pencil           skipped    not loaded   <- cogni-visual, cogni-website
+  excalidraw       added      loaded       <- cogni-portfolio, cogni-workspace
+  pencil           skipped    not loaded   <- cogni-website, cogni-workspace
 
 Manual install needed:
   claude-in-chrome Chrome extension                  <- cogni-website, cogni-workspace


### PR DESCRIPTION
Closes #1514.

## Summary

- `cogni-workspace/skills/manage-workspace/SKILL.md:163-164` — the illustrative MCP block now reads `<- cogni-portfolio, cogni-workspace` (excalidraw) and `<- cogni-website, cogni-workspace` (pencil). Only the free-form region after the `<-` marker changes, so the block's fixed-column alignment is untouched.
- `README.md:163,165` — the dead `[cogni-visual](cogni-visual/README.md)` link (the directory no longer exists in the tree) is replaced with `[cogni-workspace](cogni-workspace/README.md)`, preserving the table's markdown-link consumer form.
- `CLAUDE.md:169,171` — the superset case: `cogni-visual, ` is **deleted** rather than substituted, because `cogni-workspace` was already listed in both rows. No duplicate consumer entry results.

Each row now matches `cogni-workspace/references/mcp-git-registry.json` `required_by` exactly, with `cogni-workspace` last to match the neighbouring `claude-in-chrome` rows.

| Server | Registry `required_by` | All three tables now read |
|---|---|---|
| excalidraw | `cogni-portfolio`, `cogni-workspace` | `cogni-portfolio, cogni-workspace` |
| pencil | `cogni-website`, `cogni-workspace` | `cogni-website, cogni-workspace` |

## Verification

| Check | Expected | Actual |
|---|---|---|
| `git diff --numstat` | 3 files, `2 2` each | 3 files, `2 2` each |
| Total changed lines | 6 insertions, 6 deletions | 6 insertions, 6 deletions |
| `grep -c cogni-visual README.md` | 4 | 4 |
| `grep -c cogni-visual CLAUDE.md` | 2 | 2 |
| `grep -c cogni-visual …/manage-workspace/SKILL.md` | 0 | 0 |
| `cogni-workspace` per edited `CLAUDE.md` row | exactly 1 | exactly 1 |
| `claude-in-chrome` anchor rows | byte-identical | context-only in the diff, no `+`/`-` line |
| `python3 scripts/run-plugin-tests.py` | exit 0 | **124/124 passed**, exit 0 |
| `python3 scripts/check-breadcrumbs.py` | no new finding | 0 violations |
| `check-frontmatter.sh cogni-workspace` | clean | clean, 52 files scanned |

## Scope decisions

- **In:** exactly six lines, two per file — the excalidraw and pencil rows of the three hand-maintained MCP/consumer tables.
- **Out:** the broader retired-`cogni-visual` prose (`README.md:66`, `:70`, `:198`, `:224`; `CLAUDE.md:101`, `:188`) — that belongs to the roster-drift reconciliation issue, and those six tokens must survive this sweep. The residual counts in the table above are the check that they did.
- **Out:** `cogni-workspace/references/mcp-git-registry.json` — already correct; it is the authority this change conforms to.
- **Out:** `cogni-workspace/skills/workspace-status/references/mcp-registry.md` — pinned to the registry by the sibling MCP PR that merged while this branch was being planned, and already clean of `cogni-visual` at base.
- **Out:** `docs/audit-report.md`, stale pre-retirement but generator-owned and replaced wholesale by a fresh `cogni-docs` audit rather than hand-patched.
- **Out:** any `plugin.json` / `marketplace.json` version field — the post-merge workflow owns the bump.

### Apply hazard worth knowing about

The fragment `[cogni-visual](cogni-visual/README.md)` occurs **four** times in `README.md` — lines 66, 163, 165 and 224. Only 163 and 165 are in scope. A file-wide replace would also have rewritten the line-66 plugin blurb and the line-224 component-table row, driving the residual count to 2 instead of 4. All six edits were therefore applied line-pinned under an exact-match assertion, not by pattern substitution.

## Review notes

Three items surfaced by the pre-commit quality passes, none actioned here because each falls outside the six-line diff this PR is graded against:

1. **Pre-existing progressive-disclosure drift** (`skill-quality-reviewer`, `introduced_by_change: false`, `opt_out: true`, category `preference`): Init step 5 of `manage-workspace/SKILL.md` (lines 142-185) carries ~44 lines of dense row-selection, labelling and error-shape procedure that would fit a `references/` file behind a pointer. Not introduced or worsened by this change; the body sits at 15,147 chars against a 40,500 cap (37%), so there is no size pressure.
2. **Duplicated labelling rationale** (`skill-simplifier`, reported not edited): the `desktop_config_key`-not-server-name rule is stated in full at both Init step 5 (155-159) and Update step 5 (291-294). Worth noting that these are *not* verbatim duplicates — Init governs how to label a displayed row, Update governs which key the user must delete and carries its own consequence — so any future fold must preserve both imperatives at their point of use rather than leaving a bare pointer.
3. **Token-scope preflight** exited 1 with `status: over_scoped` (`extra_scopes: gist, read:org, workflow`). This is the documented `gho_` case: the runner is on a GitHub CLI OAuth token whose scope set is fixed by the CLI's OAuth app and cannot be narrowed, so the run took the sanctioned `--allow-overscoped` opt-out (exit 0). Disclosed rather than silently passed. This diff touches no `.github/workflows/` file.

## Root cause, deliberately not fixed here

The repo already knows `cogni-visual` is retired — `scripts/retired-plugins.json` lists it — but that file's only consumer, `scripts/check-external-dispatch.py`, requires a trailing colon to count a dispatch token, so bare comma-separated plugin names in a doc table never match it. Nothing in CI derives these three tables from `mcp-git-registry.json`, so the identical drift will recur on the next retirement.

That durable fix is **not** carried here: it is a new stdlib checker plus a red-case suite — separable work an order of magnitude larger than a doc sweep — and the issue-time acceptance contract explicitly reserves the "should this guard exist" call for a human. Recorded so the decision is visible without pre-empting it. Recommended shape if taken up: one stdlib checker asserting that each `desktop_config_key` row in these three files lists exactly the registry's `required_by`, with a red case proving it fails on an unswept retirement.

## Guard interaction

No test or guard file is touched, so no mutation recipe applies. `scripts/check-mcp-tool-grant.py` globs `*/agents/*.md` only. `scripts/check-external-dispatch.py` is colon-anchored, so these comma-separated consumer lists never matched it and do not now. No suite asserts on these three files' MCP content — verified before editing.