### PR TITLE
cogni-knowledge: document the result-line case-id convention

### DIFF
--- a/cogni-knowledge/tests/README.md
+++ b/cogni-knowledge/tests/README.md
@@ -48,6 +48,84 @@ via `trap rm -rf "$WORK" EXIT`.
   script-level assertions.
 - Fixtures are minimal — only the files the test actually exercises.
 
+## Case ids on result lines
+
+The plain `PASS:`/`FAIL:` label above is what keeps a result line *parsable*.
+What makes one *addressable* is the token after it.
+
+The **case id is the first whitespace-delimited token following the label** —
+not the first token of the line. In `PASS: init bootstraps fetch-cache/
+directory` the id is `init`, and that is what `mutation-check.sh --case <id>`
+points at when it checks that a guard actually fires. That harness ships with
+the cogni-service managed-service tooling and lives outside this repo; the
+same-named `cogni-portfolio/scripts/mutation-check.sh` and
+`cogni-consult/scripts/mutation-check.sh` are different, bespoke scripts and are
+not this harness.
+
+Five rules follow from how it matches:
+
+1. **An id is unique within its suite.** Two cases sharing one id cannot be told
+   apart, so neither is addressable.
+
+2. **Extend a stem with a hyphenated discriminator; never re-use a bare stem.**
+   `test_binding_project_path.sh` shows the defect as it stands today — three
+   cases open with the bare stem `init`:
+
+   ```
+   PASS: init writes schema_version 0.1.5
+   PASS: init bootstraps fetch-cache/ directory
+   PASS: init writes curator_defaults; omits derivable/unused fields
+   ```
+
+   No `--case init` addresses any one of them. As `init-schema-version`,
+   `init-fetch-cache` and `init-curator-defaults` each becomes reachable while
+   the shared stem still groups them by eye. The same suite also collides
+   two-way on `append-project` and `legacy` — a class, not a one-off.
+
+3. **No trailing colon on an id, and nothing before the label.** The id is
+   right-anchored on whitespace-or-end-of-line, so a colon glued to it makes the
+   token `init-fetch-cache:`, and a recipe passing `--case init-fetch-cache`
+   gets `case_not_found` with no hint why. Only whitespace may precede the
+   label — the same reason the plain-emitter rule above exists.
+
+4. **Both arms of one case carry the same id.** The discriminator belongs in the
+   id, never only in the human-readable message:
+
+   ```sh
+   green "PASS: init-fetch-cache bootstraps the fetch-cache/ directory"
+   red   "FAIL: init-fetch-cache bootstraps the fetch-cache/ directory"
+   ```
+
+   Breaking this is worse than it looks. `test_binding_project_path.sh` pairs
+   `PASS: init writes schema_version 0.1.5` with `FAIL: schema_version expected
+   0.1.5, got ...` — different ids on the two arms. Under `--case init` a
+   genuine failure does not even report `case_not_found`: the two *other*
+   `PASS: init` lines still match the green pattern, so the run reads a real red
+   as **green** and the check silently proves nothing.
+
+5. **Verify uniqueness by running the suite — never by grepping call sites.** An
+   id is routinely built from a variable or emitted inside a loop, so the source
+   is not a census of what gets printed. Run it and group what came out:
+
+   ```sh
+   bash tests/test_binding_project_path.sh 2>&1 \
+     | awk '/^[ \t]*(PASS|ok|FAIL):[ \t]/ {print $2}' | sort | uniq -d
+   ```
+
+   Empty output is clean; anything printed is a collision. One limitation: a
+   passing run emits only the green arms, so once those are clean, pair each red
+   arm's id by reading the source.
+
+How the harness classifies a line, precisely: it matches the id as a **whole
+token** (so `--case P1` never matches a `P10` line), keys red on a `FAIL:` line
+and green on an `ok:` or `PASS:` line, and lets a red line win over a stray
+green. Matching neither is reported as `case_not_found` rather than guessed at.
+It reads output **lines**, never the suite's exit status — a suite exits
+non-zero when *any* case is red, which cannot say which one.
+
+These rules are about addressability alone; they hold whatever id vocabulary a
+suite adopts.
+
 ## Contract tests (SKILL.md)
 
 For pure LLM skills, regression coverage is **SKILL.md content invariants**


### PR DESCRIPTION
Closes #1518.

## Summary

Adds a `## Case ids on result lines` section to `cogni-knowledge/tests/README.md`, between the existing `## Convention` block and `## Contract tests (SKILL.md)`. The `## Convention` block already documents what keeps a result line *parsable* (the plain, never-escape-wrapped `PASS:`/`FAIL:` label); nothing documented what makes one *addressable*, so a new suite re-collided by default.

The new section states five rules:

1. The case id is the first whitespace-delimited token **following** the label — not the first token of the line — and it must be unique within its suite.
2. Extend a stem with a hyphenated discriminator; never re-use a bare stem.
3. No trailing colon on an id, and nothing before the label: the id is right-anchored on whitespace-or-end-of-line, so a glued colon makes the token `init-fetch-cache:` and a recipe passing `--case init-fetch-cache` gets `case_not_found` with no hint why.
4. Both arms of one case carry the same id; the discriminator belongs in the id, never only in the message.
5. Uniqueness is verified by **running** the suite and grouping the emitted ids — never by grepping call sites, since an id is routinely built from a variable or emitted inside a loop.

It closes with the matcher's exact behaviour (whole-token match, red keyed on `FAIL:` and green on `ok:`/`PASS:`, a red line winning over a stray green, neither matching reported as `case_not_found`, and output *lines* read rather than the suite's exit status) and a warning that the same-named in-repo `cogni-portfolio` / `cogni-consult` scripts are different, bespoke tools — the harness this convention serves ships with the cogni-service managed-service tooling and is external to this repo.

## Evidence — the worked example is real, and was derived by execution

Every claim in the new section was checked by running the suite, not by reading it. Grouping the emitted ids of `cogni-knowledge/tests/test_binding_project_path.sh` yields three duplicated stems:

```
append-project
init
legacy
```

The `init` collision is three-way, and the example in the doc quotes those three lines verbatim.

Rule 4's consequence is sharper than "the case is unreachable", and is also verified from source: that suite pairs `green "PASS: init writes schema_version 0.1.5"` with `red "FAIL: schema_version expected 0.1.5, got ..."` — different ids on the two arms. So under `--case init` a genuine failure does **not** report `case_not_found`; the two *other* `PASS: init` lines still match the green pattern, and the run reads a real red as **green**. The check silently proves nothing. That is the failure mode the doc exists to prevent, so it is stated explicitly.

## Scope

- **Documentation only.** One file, 78 insertions, 0 deletions. `git diff --name-only` lists exactly `cogni-knowledge/tests/README.md`. No `.sh`, no `.py`, no `plugin.json` / `marketplace.json`, no version value — the post-merge workflow owns the bump.
- The existing plain-emitter bullet is left byte-identical and uncontradicted; the change is purely additive.
- **Not included, deliberately:** any per-suite case-id prefix scheme (a sibling issue owns that design), and any fix to the colliding ids in `test_binding_project_path.sh` — touching a suite here would mix a behaviour change into a documentation-only branch and falsify the issue's own third acceptance criterion.
- **No new breadcrumb** in the prose; provenance is stated semantically.

## Test plan

- [x] `git diff --name-only origin/main...HEAD` lists exactly one path, `cogni-knowledge/tests/README.md`.
- [x] The diff is purely additive — 0 deleted lines, so the plain-emitter bullet and every other line survive.
- [x] `python3 scripts/run-plugin-tests.py --filter knowledge` → **77/77 pass** on the branch (and on the base tree beforehand, so the baseline is established).
- [x] The documented `awk` recipe was copy-pasted verbatim and run in **both** directions: it prints `append-project` / `init` / `legacy` on the colliding suite, and prints nothing on a clean one (`test_plain_result_emitters.sh`). It discriminates rather than always passing.
- [x] Every example line in the new section obeys the rules it states — id as the first token after the label, no colon abutting the id, and the identical id on both arms of the correct example pair. The in-tree counter-examples are marked explicitly as the defect.

## Note on the counter-examples

The acceptance contract asks that example lines obey their own rules. The most instructive material here is the *broken* in-tree case, so the section shows a correct paired example first (`init-fetch-cache` on both arms) and labels each counter-example plainly as the defect it is illustrating. Flagging this because it is a judgement call a reviewer should confirm rather than discover.