### PR TITLE
Re-pin L1 liveness floors into the suite's stated margin band

### DIFF
--- a/tests/test_check_mcp_tool_grant.sh
+++ b/tests/test_check_mcp_tool_grant.sh
@@ -651,9 +651,20 @@ check_eq "Z2 an unreadable registry is an error, not a skipped arm" "2" "$CODE"
 
 # --- L: liveness floors on the real tree -----------------------------------
 
+# Observed 101 agents discovered and 92 `tools:` declarations (68 bracketed,
+# 14 comma, 10 block) when these floors were pinned. The previous 100/90 sat
+# at 0.99/0.98 of observed, inside ordinary churn: every plugin here carries
+# at least 3 agents, so retiring any one of them dropped the population below
+# both floors and reddened this arm on a correct tree. 70 and 60 are the
+# largest multiples of 5 at or below 0.7x observed — the sizing rule the L4
+# floor below already records — and sit inside the 0.56x-0.82x span the other
+# floors occupy. The arm stays non-vacuous at that width: the largest
+# single-plugin agent population is 26 (17 of them declaring `tools:`) and the
+# largest single-plugin tools:-declaring population is 20, so a glob that
+# collapsed to one plugin — or to none — still reds.
 py_assert "L1 the scan population is still reaching agent files" "
-assert s['agents_discovered'] >= 100, s['agents_discovered']
-assert sum(s['tools_form_counts'].values()) >= 90, s['tools_form_counts']
+assert s['agents_discovered'] >= 70, s['agents_discovered']
+assert sum(s['tools_form_counts'].values()) >= 60, s['tools_form_counts']
 " "$REPO_OUT"
 # Floors re-derived after cogni-visual's retirement removed its render agents,
 # which carried most of the repo's mcp__excalidraw__*/mcp__pencil__* grants:


### PR DESCRIPTION
Refs #1525

## Summary

The `L1` liveness floors in `tests/test_check_mcp_tool_grant.sh` sat at 100 and 90 against an observed 101 agents and 92 `tools:` declarations — 0.99x and 0.98x of observed. That is inside ordinary churn rather than below it: every plugin in the tree carries at least 3 agents, so retiring any single plugin drops the population under both floors and reds the arm on a correct tree. This re-pins them to **70 and 60**, the band the suite's own header describes and the sizing rule the `L4` floor already records (largest multiple of 5 at or below 0.7x observed).

- Both floors move together, in the single existing `py_assert`, still as `>=`, still against `$REPO_OUT`.
- An adjacent comment records the observed values as measurements, in the style of the existing `L2` and `L4` comments.

## Why both floors, not just the agent floor

The issue names only `agents_discovered`, and lists `form-sum 90/92` among the floors that honour the 0.56x–0.82x band. Re-derived by running the guard against the tree, that floor is **0.978x** — a second outlier, sitting in the **same `py_assert`**:

| Floor | Value | Observed | Ratio |
|---|---|---|---|
| `agents_discovered` (L1) | 100 | 101 | **0.990** |
| `sum(tools_form_counts)` (L1) | 90 | 92 | **0.978** |
| `grant_tokens` (L2) | 60 | 73 | 0.822 |
| `body_call_sites` (L2) | 10 | 14 | 0.714 |
| `provides_tools_vocabulary` (L3) | 10 | 18 | 0.556 |
| `provides_tools_code_span_names` (L3) | 20 | 27 | 0.741 |

Retiring a plugin removes its agent files *and* their `tools:` frontmatter entries, so both counts fall together (101→98, 92→89 on the smallest plugin). Re-pinning only `agents_discovered` would satisfy the issue's first acceptance criterion to the letter while leaving its stated Desired behavior — "ordinary churn cannot red it" — unmet.

## Scope decisions

- **No floor outside `L1` changes.** L2, L3 and L4 already sit inside the band. The comment at `:658-662` documents L2's floors and stays where it is, so the new comment goes *above* L1.
- **`scripts/check-mcp-tool-grant.py` is not modified.** This is a floor re-pin, not a guard change. A repo-wide grep finds `agents_discovered` / `tools_form_counts` only in that script (where they are produced) and this suite (where they are floored) — no third consumer.
- **Liveness preserved.** The largest single-plugin agent population is 26 (`cogni-workspace`, 17 declaring `tools:`); the largest single-plugin `tools:`-declaring population is 20 (`cogni-portfolio`). A glob collapsing to one plugin — or to none — still reds.
- **Floors stay hardcoded literals, deliberately.** Computing them as a ratio of observed would be a regression: a floor derived from the same scan it guards moves with the collapse, and the arm would go green on exactly the failure it exists to catch.
- **No version bump.** The post-merge workflow owns plugin version bumps.

## Test plan

- `bash tests/test_check_mcp_tool_grant.sh` — exits 0, `0 failed`, 60 PASS lines including `PASS: L1 the scan population is still reaching agent files`.
- `python3 scripts/run-plugin-tests.py` — full sweep **124/124 green**.
- `python3 scripts/check-result-line-plainness.py` — clean zero.
- `python3 scripts/check-breadcrumbs.py` — clean (no new breadcrumbs; the comment states provenance semantically).
- `git diff --name-only origin/main...HEAD` — lists only `tests/test_check_mcp_tool_grant.sh`.

## Mutation recipe

This repo ships no repo-root `scripts/mutation-check.sh`; the harness is the external one, exactly as the suite's two existing recipes (header `:65-68` and `:83-86`) already assume.

**Recipe 1 — collapse the scan population, reding the `agents_discovered` floor:**

```
scripts/mutation-check.sh --root . \
  --file scripts/check-mcp-tool-grant.py \
  --expr 's/os\.path\.join\(root, "\*", "agents", "\*\.md"\)/os.path.join(root, "cogni-workspace", "agents", "*.md")/m' \
  --test 'bash tests/test_check_mcp_tool_grant.sh' --case L1
```

The anchor is the real text of `discover()` at `scripts/check-mcp-tool-grant.py:194` — `pattern = os.path.join(root, "*", "agents", "*.md")`, `root` included — and it occurs exactly once, so the non-global substitution is safe. `--expr` is fed to `perl -0pi`, which slurps the file, hence `/m`; `*` and `.` are escaped on the match side only. Narrowed to one plugin the scan reports 26 agents against a floor of 70, so `L1` reds. `--case L1` matches whole-token against the `FAIL: L1 ...` line `py_assert` prints.

**Recipe 2 — keep the scan intact and zero the form counter, reding the *second* assertion:**

```
scripts/mutation-check.sh --root . \
  --file scripts/check-mcp-tool-grant.py \
  --expr 's/counters\["tools_form_counts"\]\[form\] \+= 1/counters["tools_form_counts"][form] += 0/m' \
  --test 'bash tests/test_check_mcp_tool_grant.sh' --case L1
```

That anchor occurs exactly once, at `:397`. The second recipe is necessary because recipe 1 never reaches the form assertion — Python short-circuits at the first failing `assert`. Together they prove **both** floors are load-bearing rather than one riding along.

## Follow-up issues

- #1527 — the block-form `tools:` count is stated as 15 in two surfaces (`tests/test_check_mcp_tool_grant.sh:6-11` and `scripts/check-mcp-tool-grant.py:168-171`) while the tree carries 10. Same retirement-driven drift class, found while re-pinning these floors, but it spans the guard file this change deliberately leaves untouched.

Because work was deferred, this PR links the issue with `Refs` rather than `Closes`. Issue #1525's own acceptance criteria are fully met here; it stays open only so the deferral is visible.