### PR TITLE
repo: repair the drifted block-form tools: count in both surfaces

### DIFF
--- a/scripts/check-mcp-tool-grant.py
+++ b/scripts/check-mcp-tool-grant.py
@@ -166,9 +166,13 @@ def grants_in(text):
 # backticks with each other and mis-slice a fenced block into fragments.
 CODE_SPAN_RE = re.compile(r"```.*?```|`[^`\n]+`", re.S)
 
-# The single anchor for YAML block-list item lines. 15 agents declare `tools:`
-# this way, and 6 of the 7 agents carrying a real body call site are among them,
-# so a reader that misses this form reports those 6 as false offenders.
+# The single anchor for YAML block-list item lines.
+# Measured when this note was pinned: 10 agents declare `tools:` this way (the
+# guard re-derives that count every run as `summary.tools_form_counts.block`),
+# and 3 of the 4 agents carrying a real body call site are among them, so a
+# reader that misses this form reports those 3 as false offenders.
+# The counts are a snapshot; the form stays load-bearing while any block-form
+# agent carries a call site.
 # The indent is `\s*`, not `\s+`: a block list written flush-left under `tools:`
 # is valid YAML and the host accepts it, so requiring indentation would read
 # those grants as absent — the agent would silently drop out of the required_by

--- a/tests/test_check_mcp_tool_grant.sh
+++ b/tests/test_check_mcp_tool_grant.sh
@@ -4,11 +4,15 @@
 # What is being pinned, and why each case earns its place:
 #
 #   * All THREE `tools:` frontmatter forms parse as granting. This is the
-#     load-bearing one. 15 agents declare tools as a YAML block list, and 6 of
-#     the 7 agents that carry a real body call site are among them — so a
-#     reader that only looks at the `tools:` LINE reports those 6 as false
-#     offenders and the guard is red on an otherwise-clean tree. B1 fails
-#     first if that regresses.
+#     load-bearing one.
+#     Measured when this note was pinned: 10 agents declare tools as a YAML
+#     block list (the guard re-derives that count every run as
+#     `summary.tools_form_counts.block`), and 3 of the 4 agents that carry a
+#     real body call site are among them — so a reader that only looks at the
+#     `tools:` LINE reports those 3 as false offenders and the guard is red on
+#     an otherwise-clean tree.
+#     The counts are a snapshot; the form stays load-bearing while any
+#     block-form agent carries a call site. B1 fails first if that regresses.
 #   * The provides_tools arm keys on a BACKTICK CODE SPAN, and V1/V2 are the
 #     both-directions pair that pins it: same body, same vocabulary, backticks
 #     the only difference. A matcher that ignored the span requirement passes


### PR DESCRIPTION
Refs #1527.

## Summary

Two comment surfaces stated the same measured figure about the YAML block-list `tools:` form,
and both had drifted from the tree. This restates them from a fresh measurement and — the part
that matters more — changes the *class* of the claim so the next retirement leaves them
stale-but-honest instead of false.

| Figure | Was stated | Measured now |
|---|---|---|
| Block-form `tools:` declarations | 15 | **10** |
| Agents carrying a real body call site | 7 | **4** |
| ...of those, block-form | 6 | **3** |

Both numbers in the companion clause had drifted, not just the numerator.

Re-measured at `origin/main`: `python3 scripts/check-mcp-tool-grant.py` reports
`tools_form_counts: {bracketed: 68, comma: 14, block: 10}`. The four agents carrying an
affirmative `mcp__` body call site are `cogni-workspace/agents/concept-diagram-svg.md`,
`concept-diagram.md`, `enriched-report-reviewer.md` (block form) and `source-inspector.md`
(bracketed) — 3 of 4.

## What changed beyond the numbers

- **Dated idiom, not a present-tense claim.** Both surfaces now open
  `Measured when this note was pinned:`, matching the two idioms already in the tree
  (`Measured when adopted:` in the guard docstring, `Observed 55 when this floor was pinned`
  in the suite). A present-tense figure is false the moment the roster moves — which is the
  defect being repaired — whereas a dated one just becomes correctly-dated history.
- **Each surface names its own emitter.** The guard re-derives the block count on every run as
  `summary.tools_form_counts.block`, so a reader can re-measure instead of only re-reading. This
  is a pointer, not an assertion — no floor, no equality.
- **Greppable shared markers.** `Measured when this note was pinned:` and
  `The counts are a snapshot` each appear unbroken on one line in *both* files, so a future
  editor greps one string and finds both sites rather than reconciling two paraphrases.

## Scope decisions

- **Comment-only, proven.** `git diff -U0 | grep '^[+-]' | grep -v '^[+-][+-]'` filtered of
  `#`-prefixed lines yields **0** lines. No assertion, expected value, case label or liveness
  floor changes.
- **No new assertion pinning the count.** A `tools_form_counts['block'] == 10` check would red on
  the next agent added and contradicts the suite's own recorded floor philosophy (inequalities
  pinned strictly below observed).
- **Deliberately untouched:** the L1 floor `sum(tools_form_counts.values()) >= 90` (a sibling
  issue owns floor re-pinning); the `\s*` vs `\s+` indent rationale beneath the edited comment;
  the guard's historical `Measured when adopted:` snapshot; root `CLAUDE.md`, whose MCP-guard
  paragraph states the rationale figure-free on purpose and warns against a second copy.
- Neighbouring figures were re-measured and left alone because they are **accurate**: the suite's
  "18 bare names across 2 servers" and "9 gaps", and the guard's "18 of the 73 grant tokens".
- No `plugin.json` / `marketplace.json` version field is touched.

## Verification

- `bash tests/test_check_mcp_tool_grant.sh` → exit 0, `0 failed`.
- `python3 scripts/check-mcp-tool-grant.py` → exit 0, emits `tools_form_counts.block == 10`,
  matching the number both surfaces now state.
- `python3 scripts/run-plugin-tests.py` → green repo-wide.
- `python3 scripts/check-breadcrumbs.py`, `check-result-line-plainness.py` → exit 0.

## Mutation recipe

Replayed on this branch — verdict `guard_verified` (`mutated_result: red`, `restored_result:
green`), tree restored clean:

```
scripts/mutation-check.sh --root . \
  --file scripts/check-mcp-tool-grant.py \
  --expr 's/\^\\s\*-\\s\+/^ZZZ\\s*-\\s+/m' \
  --test 'bash tests/test_check_mcp_tool_grant.sh' --case B1
```

Recorded as evidence for the sentence this diff rewrites — that B1 reds first when the
block-form anchor regresses — not to satisfy a gate: the preflight scopes its mutation-recipe
check to `*/tests/test-*.sh` and `*/scripts/check-*.sh`, and these repo-root, underscore-named
paths match neither.

The recipe depends on the literal block-list anchor occurring **exactly once** in the guard. The
rewritten comment above `BLOCK_ITEM_RE` deliberately does not repeat it — verified still 1
occurrence — because repeating it would make the non-global `perl -0pi` substitution mutate the
comment instead of the code and report a vacuous guard.

## Follow-up issues

- #1530 — the guard docstring's residuals paragraph names the retired `cogni-visual` plugin as a
  live home of the `storyboard` / `web` agents, and its `22 in-span name hits` figure does not
  reproduce (three measurements disagree: 22 stated, 23 from the plan refine pass, 13 from a
  `CODE_SPAN_RE` + registry-vocabulary count). Same drift class, different sentence, outside this
  issue's acceptance criteria — and its hit-count needs a decision about *how* an in-span hit is
  counted, not a substitution.

## Note for the reviewer — `Refs` rather than `Closes`

This PR links `Refs #1527`, not `Closes`, because a follow-up was filed and the pipeline rule is
that a PR with deferred work must never auto-close its parent. Stated plainly so you can
override: **#1527's own five acceptance criteria are all met by this diff** — the deferred item
is a separate defect in a different sentence, now tracked as #1530. If you agree, #1527 can be
closed manually on merge rather than left open.