### PR TITLE
cogni-knowledge: case ids for store, index and cycle-guard suites

### DIFF
--- a/cogni-knowledge/tests/test_backfill_concepts_index.sh
+++ b/cogni-knowledge/tests/test_backfill_concepts_index.sh
@@ -38,11 +38,11 @@ WSD="$PLUGIN_ROOT/scripts/vendor/cogni-wiki/skills/wiki-ingest/scripts"
 . "$(dirname "$0")/fixtures/test_helpers.sh"
 
 if [ ! -f "$DRIVER" ]; then
-  red "FAIL: backfill_concepts_index.py not found at $DRIVER"
+  red "FAIL: backfill-concepts-index-00-driver-present backfill_concepts_index.py not found at $DRIVER"
   exit 1
 fi
 if [ ! -d "$WSD" ]; then
-  red "FAIL: cogni-wiki wiki-ingest scripts not found at $WSD (needed for _wiki_lock)"
+  red "FAIL: backfill-concepts-index-00-wiki-scripts-present cogni-wiki wiki-ingest scripts not found at $WSD (needed for _wiki_lock)"
   exit 1
 fi
 
@@ -95,42 +95,42 @@ mk_concept "$WIKI" penalties "Penalties" \
 IDX="$WIKI/wiki/concepts/index.md"
 
 # --- 1. RENDER-CREATES: backfill an already-finalized base --------------------
-[ ! -f "$IDX" ] || { red "FAIL: precondition — index.md already exists"; errors=$((errors+1)); }
+[ ! -f "$IDX" ] || { red "FAIL: backfill-concepts-index-00-index-absent precondition — index.md already exists"; errors=$((errors+1)); }
 OUT=$(python3 "$DRIVER" --wiki-root "$WIKI" --wiki-scripts-dir "$WSD")
 if [ "$(echo "$OUT" | field '["success"]')" = "True" ] && [ -f "$IDX" ]; then
-  green "PASS: backfill creates wiki/concepts/index.md on a base with no prior outline"
+  green "PASS: backfill-concepts-index-01-backfill-creates-wiki-concepts backfill creates wiki/concepts/index.md on a base with no prior outline"
 else
-  red "FAIL: backfill did not create the index"; echo "$OUT"; errors=$((errors+1))
+  red "FAIL: backfill-concepts-index-01-backfill-creates-wiki-concepts backfill did not create the index"; echo "$OUT"; errors=$((errors+1))
 fi
 [ "$(echo "$OUT" | field '["data"]["action"]')" = "rendered" ] \
-  && green "PASS: first backfill reports action:rendered" \
-  || { red "FAIL: first backfill action != rendered"; echo "$OUT"; errors=$((errors+1)); }
+  && green "PASS: backfill-concepts-index-02-first-backfill-reports-action first backfill reports action:rendered" \
+  || { red "FAIL: backfill-concepts-index-02-first-backfill-reports-action first backfill action != rendered"; echo "$OUT"; errors=$((errors+1)); }
 [ "$(echo "$OUT" | field '["data"]["changed"]')" = "True" ] \
-  && green "PASS: first backfill reports changed:true" \
-  || { red "FAIL: first backfill changed != true"; errors=$((errors+1)); }
+  && green "PASS: backfill-concepts-index-03-first-backfill-reports-changed first backfill reports changed:true" \
+  || { red "FAIL: backfill-concepts-index-03-first-backfill-reports-changed first backfill changed != true"; errors=$((errors+1)); }
 [ "$(echo "$OUT" | field '["data"]["render_only"]')" = "True" ] \
-  && green "PASS: envelope flags render_only (structural-only outline)" \
-  || { red "FAIL: render_only flag missing"; errors=$((errors+1)); }
-assert_grep '^# Concepts$' "$IDX" "page H1 '# Concepts'"
-assert_grep 'MACHINE-OWNED:CONCEPTS-INDEX' "$IDX" "page ownership marker"
+  && green "PASS: backfill-concepts-index-04-envelope-flags-render-only envelope flags render_only (structural-only outline)" \
+  || { red "FAIL: backfill-concepts-index-04-envelope-flags-render-only render_only flag missing"; errors=$((errors+1)); }
+assert_grep '^# Concepts$' "$IDX" "backfill-concepts-index-05-page-h1-concepts page H1 '# Concepts'"
+assert_grep 'MACHINE-OWNED:CONCEPTS-INDEX' "$IDX" "backfill-concepts-index-06-page-ownership-marker page ownership marker"
 assert_grep 'MACHINE-OWNED:CONCEPTS-LEADIN:regulatory-scope:START' \
-  "$IDX" "Regulatory Scope lead-in sentinel span present"
+  "$IDX" "backfill-concepts-index-07-regulatory-scope-lead-sentinel Regulatory Scope lead-in sentinel span present"
 assert_grep 'This theme groups the concepts below' \
-  "$IDX" "fresh backfill uses the deterministic lead-in fallback (render-only, narration deferred)"
+  "$IDX" "backfill-concepts-index-08-fresh-backfill-uses-deterministic fresh backfill uses the deterministic lead-in fallback (render-only, narration deferred)"
 
 # --- 2. BYTE-IDEMPOTENT re-run -----------------------------------------------
 cp "$IDX" "$WORK/idx.before"
 OUT=$(python3 "$DRIVER" --wiki-root "$WIKI" --wiki-scripts-dir "$WSD")
 [ "$(echo "$OUT" | field '["data"]["action"]')" = "noop" ] \
-  && green "PASS: re-run on a built outline reports action:noop" \
-  || { red "FAIL: idempotent re-run action != noop"; echo "$OUT"; errors=$((errors+1)); }
+  && green "PASS: backfill-concepts-index-09-re-run-built-outline re-run on a built outline reports action:noop" \
+  || { red "FAIL: backfill-concepts-index-09-re-run-built-outline idempotent re-run action != noop"; echo "$OUT"; errors=$((errors+1)); }
 [ "$(echo "$OUT" | field '["data"]["changed"]')" = "False" ] \
-  && green "PASS: re-run reports changed:false" \
-  || { red "FAIL: idempotent re-run changed != false"; errors=$((errors+1)); }
+  && green "PASS: backfill-concepts-index-10-re-run-reports-changed re-run reports changed:false" \
+  || { red "FAIL: backfill-concepts-index-10-re-run-reports-changed idempotent re-run changed != false"; errors=$((errors+1)); }
 if cmp -s "$WORK/idx.before" "$IDX"; then
-  green "PASS: re-run is byte-identical (no stamp churn)"
+  green "PASS: backfill-concepts-index-11-re-run-byte-identical re-run is byte-identical (no stamp churn)"
 else
-  red "FAIL: re-run mutated the page"; errors=$((errors+1))
+  red "FAIL: backfill-concepts-index-11-re-run-byte-identical re-run mutated the page"; errors=$((errors+1))
 fi
 
 # --- 3. LEAD-IN PRESERVED across a re-run ------------------------------------
@@ -147,9 +147,9 @@ open(p, "w", encoding="utf-8").write(t)
 PY
 OUT=$(python3 "$DRIVER" --wiki-root "$WIKI" --wiki-scripts-dir "$WSD")
 assert_grep 'Authored framing: the legal boundaries' \
-  "$IDX" "narrator-authored lead-in carried forward across a backfill re-run (no clobber)"
+  "$IDX" "backfill-concepts-index-12-narrator-authored-lead-carried narrator-authored lead-in carried forward across a backfill re-run (no clobber)"
 assert_grep 'This theme groups the concepts below' \
-  "$IDX" "untouched theme keeps the deterministic fallback after carry-forward"
+  "$IDX" "backfill-concepts-index-13-untouched-theme-keeps-deterministic untouched theme keeps the deterministic fallback after carry-forward"
 
 # --- 4. EMPTY-CONCEPTS base -> noop ------------------------------------------
 EWIKI="$WORK/empty-wiki"
@@ -159,8 +159,8 @@ printf '# Knowledge Portal\n' > "$EWIKI/wiki/index.md"
 OUT=$(python3 "$DRIVER" --wiki-root "$EWIKI" --wiki-scripts-dir "$WSD")
 [ "$(echo "$OUT" | field '["success"]')" = "True" ] \
   && [ "$(echo "$OUT" | field '["data"]["action"]')" = "noop" ] \
-  && green "PASS: empty-concepts base is a clean action:noop (not an abort)" \
-  || { red "FAIL: empty-concepts base did not report success/noop"; echo "$OUT"; errors=$((errors+1)); }
+  && green "PASS: backfill-concepts-index-14-empty-concepts-base-clean empty-concepts base is a clean action:noop (not an abort)" \
+  || { red "FAIL: backfill-concepts-index-14-empty-concepts-base-clean empty-concepts base did not report success/noop"; echo "$OUT"; errors=$((errors+1)); }
 
 # --- 5. DRY-RUN probes without invoking the renderer -------------------------
 DWIKI="$WORK/dry-wiki"
@@ -171,18 +171,18 @@ mk_concept "$DWIKI" dp "Data Protection" "How data is protected." src-scope-a
 OUT=$(python3 "$DRIVER" --wiki-root "$DWIKI" --dry-run)
 [ "$(echo "$OUT" | field '["success"]')" = "True" ] \
   && [ "$(echo "$OUT" | field '["data"]["action"]')" = "would_render" ] \
-  && green "PASS: --dry-run on a base with concepts reports would_render" \
-  || { red "FAIL: --dry-run action != would_render"; echo "$OUT"; errors=$((errors+1)); }
+  && green "PASS: backfill-concepts-index-15-dry-run-base-concepts --dry-run on a base with concepts reports would_render" \
+  || { red "FAIL: backfill-concepts-index-15-dry-run-base-concepts --dry-run action != would_render"; echo "$OUT"; errors=$((errors+1)); }
 [ ! -f "$DWIKI/wiki/concepts/index.md" ] \
-  && green "PASS: --dry-run writes nothing (renderer not invoked)" \
-  || { red "FAIL: --dry-run wrote an index.md"; errors=$((errors+1)); }
+  && green "PASS: backfill-concepts-index-16-dry-run-writes-nothing --dry-run writes nothing (renderer not invoked)" \
+  || { red "FAIL: backfill-concepts-index-16-dry-run-writes-nothing --dry-run wrote an index.md"; errors=$((errors+1)); }
 
 # --- 6. python3.9 floor: __future__ import + ast.parse -----------------------
-assert_grep 'from __future__ import annotations' "$DRIVER" "driver carries __future__ annotations import"
+assert_grep 'from __future__ import annotations' "$DRIVER" "backfill-concepts-index-17-driver-carries-future-annotations driver carries __future__ annotations import"
 if python3 -c 'import ast,sys; ast.parse(open(sys.argv[1]).read())' "$DRIVER"; then
-  green "PASS: driver parses cleanly under ast.parse (python3.9 floor)"
+  green "PASS: backfill-concepts-index-18-driver-parses-cleanly-under driver parses cleanly under ast.parse (python3.9 floor)"
 else
-  red "FAIL: driver does not parse"; errors=$((errors+1))
+  red "FAIL: backfill-concepts-index-18-driver-parses-cleanly-under driver does not parse"; errors=$((errors+1))
 fi
 
 # --- summary -----------------------------------------------------------------

--- a/cogni-knowledge/tests/test_candidate_store.sh
+++ b/cogni-knowledge/tests/test_candidate_store.sh
@@ -30,7 +30,7 @@ SCRIPT="$PLUGIN_ROOT/scripts/candidate-store.py"
 . "$(dirname "$0")/fixtures/test_helpers.sh"
 
 if [ ! -f "$SCRIPT" ]; then
-  red "FAIL: candidate-store.py not found at $SCRIPT"
+  red "FAIL: candidate-store-00-script-present candidate-store.py not found at $SCRIPT"
   exit 1
 fi
 
@@ -53,18 +53,18 @@ assert d['data']['created'] is False, d
 assert d['data']['candidates_count'] == 0, d
 print('OK')
 " | grep -q OK; then
-  green "PASS: init creates empty candidates.json and is idempotent"
+  green "PASS: candidate-store-01-init-idempotent init creates empty candidates.json and is idempotent"
 else
-  red "FAIL: init not idempotent"
+  red "FAIL: candidate-store-01-init-idempotent init not idempotent"
   red "  got: $INIT_AGAIN"
   errors=$((errors + 1))
 fi
 
 SCHEMA=$(python3 -c "import json; print(json.load(open('$PROJ/.metadata/candidates.json'))['schema_version'])")
 if [ "$SCHEMA" = "0.1.0" ]; then
-  green "PASS: init writes schema_version 0.1.0"
+  green "PASS: candidate-store-02-schema-version init writes schema_version 0.1.0"
 else
-  red "FAIL: schema_version expected 0.1.0, got '$SCHEMA'"
+  red "FAIL: candidate-store-02-schema-version schema_version expected 0.1.0, got '$SCHEMA'"
   errors=$((errors + 1))
 fi
 
@@ -116,9 +116,9 @@ assert prios['https://example.org/gdpr-art-30'] == 2, prios
 assert prios['https://acme.io/new-source'] == 3, prios
 PY
 then
-  green "PASS: append-batch dedup, score-win, ref-union, fetch_priority assignment"
+  green "PASS: candidate-store-03-append-batch-merge append-batch dedup, score-win, ref-union, fetch_priority assignment"
 else
-  red "FAIL: dedup/merge semantics broken"
+  red "FAIL: candidate-store-03-append-batch-merge dedup/merge semantics broken"
   errors=$((errors + 1))
 fi
 
@@ -158,9 +158,9 @@ expected = {f"https://race.test/c-{i}" for i in range(20)} | {f"https://race.tes
 assert urls == expected, urls.symmetric_difference(expected)
 PY
 then
-  green "PASS: concurrent append-batch — file lock preserves both batches' content"
+  green "PASS: candidate-store-04-concurrent-lock concurrent append-batch — file lock preserves both batches' content"
 else
-  red "FAIL: concurrent append lost data"
+  red "FAIL: candidate-store-04-concurrent-lock concurrent append lost data"
   errors=$((errors + 1))
 fi
 
@@ -169,9 +169,9 @@ BAD_BATCH="$WORK/bad-not-array.json"
 echo '{"not": "an array"}' > "$BAD_BATCH"
 OUT=$(python3 "$SCRIPT" append-batch --project-path "$PROJ" --batch-file "$BAD_BATCH" 2>&1 || true)
 if echo "$OUT" | python3 -c "import sys,json; d=json.load(sys.stdin); assert d['success'] is False and 'array' in d['error'].lower()" 2>/dev/null; then
-  green "PASS: non-array batch rejected"
+  green "PASS: candidate-store-05-non-array-rejected non-array batch rejected"
 else
-  red "FAIL: non-array batch not rejected"
+  red "FAIL: candidate-store-05-non-array-rejected non-array batch not rejected"
   red "  got: $OUT"
   errors=$((errors + 1))
 fi
@@ -181,9 +181,9 @@ BAD_URL="$WORK/bad-url.json"
 echo '[{"score": 0.5, "sub_question_refs": []}]' > "$BAD_URL"
 OUT=$(python3 "$SCRIPT" append-batch --project-path "$PROJ" --batch-file "$BAD_URL" 2>&1 || true)
 if echo "$OUT" | python3 -c "import sys,json; d=json.load(sys.stdin); assert d['success'] is False and 'url' in d['error'].lower()" 2>/dev/null; then
-  green "PASS: missing-url candidate rejected"
+  green "PASS: candidate-store-06-missing-url-rejected missing-url candidate rejected"
 else
-  red "FAIL: missing-url candidate not rejected"
+  red "FAIL: candidate-store-06-missing-url-rejected missing-url candidate not rejected"
   red "  got: $OUT"
   errors=$((errors + 1))
 fi
@@ -193,9 +193,9 @@ BAD_SCORE="$WORK/bad-score.json"
 echo '[{"url": "https://x.io/y", "score": 1.5, "sub_question_refs": []}]' > "$BAD_SCORE"
 OUT=$(python3 "$SCRIPT" append-batch --project-path "$PROJ" --batch-file "$BAD_SCORE" 2>&1 || true)
 if echo "$OUT" | python3 -c "import sys,json; d=json.load(sys.stdin); assert d['success'] is False and 'score' in d['error'].lower()" 2>/dev/null; then
-  green "PASS: out-of-range score rejected"
+  green "PASS: candidate-store-07-score-range-rejected out-of-range score rejected"
 else
-  red "FAIL: out-of-range score not rejected"
+  red "FAIL: candidate-store-07-score-range-rejected out-of-range score not rejected"
   red "  got: $OUT"
   errors=$((errors + 1))
 fi
@@ -229,9 +229,9 @@ assert c['score'] == 0.8, c  # higher score wins
 assert sorted(c['sub_question_refs']) == ['sq-1', 'sq-2'], c
 PY
 then
-  green "PASS: URL normalization collapses scheme-case, trailing slash, and tracking params"
+  green "PASS: candidate-store-08-url-normalization URL normalization collapses scheme-case, trailing slash, and tracking params"
 else
-  red "FAIL: URL normalization broken"
+  red "FAIL: candidate-store-08-url-normalization URL normalization broken"
   errors=$((errors + 1))
 fi
 
@@ -252,9 +252,9 @@ import sys, json
 d = json.load(sys.stdin)
 assert d['success'] is True and d['data']['added'] == 0 and d['data']['merged'] == 0, d
 "; then
-  green "PASS: empty batch short-circuits — no rewrite, added=merged=0"
+  green "PASS: candidate-store-09-empty-batch-shortcircuit empty batch short-circuits — no rewrite, added=merged=0"
 else
-  red "FAIL: empty batch triggered a rewrite or wrong envelope"
+  red "FAIL: candidate-store-09-empty-batch-shortcircuit empty batch triggered a rewrite or wrong envelope"
   red "  before: $BEFORE_MTIME, after: $AFTER_MTIME"
   red "  got:    $EMPTY_OUT"
   errors=$((errors + 1))
@@ -305,9 +305,9 @@ assert c['fetch']['cache_key'] == 'abc123', c     # carried from the lower-score
 assert sorted(c['sub_question_refs']) == ['sq-01', 'sq-02'], c  # refs still unioned
 PY
 then
-  green "PASS: fetch sub-object — ok fetch wins a cross-SQ dedup collision against a higher-score failed fetch"
+  green "PASS: candidate-store-10-fetch-dedup-preference fetch sub-object — ok fetch wins a cross-SQ dedup collision against a higher-score failed fetch"
 else
-  red "FAIL: fetch sub-object dedup preference broken"
+  red "FAIL: candidate-store-10-fetch-dedup-preference fetch sub-object dedup preference broken"
   errors=$((errors + 1))
 fi
 

--- a/cogni-knowledge/tests/test_citation_store.sh
+++ b/cogni-knowledge/tests/test_citation_store.sh
@@ -33,7 +33,7 @@ VERIFY="$PLUGIN_ROOT/scripts/verify-store.py"
 . "$(dirname "$0")/fixtures/test_helpers.sh"
 
 if [ ! -f "$SCRIPT" ]; then
-  red "FAIL: citation-store.py not found at $SCRIPT"
+  red "FAIL: citation-store-00-script-present citation-store.py not found at $SCRIPT"
   exit 1
 fi
 
@@ -95,9 +95,9 @@ d = json.load(sys.stdin)
 assert d['success'] is True, d
 assert d['data']['citations_count'] == 3, d
 " 2>/dev/null; then
-  green "PASS: build succeeds on quotes / German pair / backslash → citations_count 3"
+  green "PASS: citation-store-01-build-succeeds-quotes-german build succeeds on quotes / German pair / backslash → citations_count 3"
 else
-  red "FAIL: build envelope wrong"
+  red "FAIL: citation-store-01-build-succeeds-quotes-german build envelope wrong"
   red "  got: $OUT"
   errors=$((errors + 1))
 fi
@@ -122,9 +122,9 @@ assert cites[1]["claim_id"] is None, cites[1]
 assert cites[0]["claim_id"] == "clm-001" and cites[2]["claim_id"] == "clm-009", cites
 PY
 then
-  green "PASS: manifest json.loads clean; draft_sentence byte-equal; claim:null → JSON null"
+  green "PASS: citation-store-02-manifest-json-loads-clean manifest json.loads clean; draft_sentence byte-equal; claim:null → JSON null"
 else
-  red "FAIL: manifest content / round-trip wrong"
+  red "FAIL: citation-store-02-manifest-json-loads-clean manifest content / round-trip wrong"
   errors=$((errors + 1))
 fi
 
@@ -132,9 +132,9 @@ fi
 if python3 "$VERIFY" shard --manifest "$WORK/citation-manifest.json" \
      --draft-version 1 --shard-size 40 --out-dir "$WORK/verify-shards" \
    | python3 -c "import sys,json; d=json.load(sys.stdin); assert d['success'] is True and d['data']['citation_count']==3, d" 2>/dev/null; then
-  green "PASS: verify-store.py shard accepts the built manifest (downstream #325 path)"
+  green "PASS: citation-store-03-verify-store-py-shard verify-store.py shard accepts the built manifest (downstream #325 path)"
 else
-  red "FAIL: verify-store.py shard rejected the built manifest"
+  red "FAIL: citation-store-03-verify-store-py-shard verify-store.py shard rejected the built manifest"
   errors=$((errors + 1))
 fi
 
@@ -155,9 +155,9 @@ d = json.load(sys.stdin)
 assert d['success'] is False and d['error'] == 'write_failed', d
 assert d['data']['failed_check'] == 'sentence_not_in_draft' and d['data']['ids'] == ['cit-001'], d
 " 2>/dev/null && [ ! -f "$WORK/bad-manifest.json" ]; then
-  green "PASS: sentence-not-in-draft → write_failed, no manifest written"
+  green "PASS: citation-store-04-sentence-draft-write-failed sentence-not-in-draft → write_failed, no manifest written"
 else
-  red "FAIL: negative substring case wrong (or manifest leaked)"
+  red "FAIL: citation-store-04-sentence-draft-write-failed negative substring case wrong (or manifest leaked)"
   red "  got: $OUT"
   errors=$((errors + 1))
 fi
@@ -166,9 +166,9 @@ fi
 OUT=$(python3 "$SCRIPT" build --records "$WORK/nope.txt" --draft "$WORK/draft-v1.md" \
   --out "$WORK/x.json" --draft-version 1 2>&1 || true)
 if echo "$OUT" | python3 -c "import sys,json; d=json.load(sys.stdin); assert d['success'] is False and d['error']=='records_not_found', d" 2>/dev/null; then
-  green "PASS: missing records file rejected (records_not_found)"
+  green "PASS: citation-store-05-missing-records-file-rejected missing records file rejected (records_not_found)"
 else
-  red "FAIL: missing records file not rejected"
+  red "FAIL: citation-store-05-missing-records-file-rejected missing records file not rejected"
   red "  got: $OUT"
   errors=$((errors + 1))
 fi
@@ -177,9 +177,9 @@ fi
 OUT=$(python3 "$SCRIPT" build --records "$WORK/records.txt" --draft "$WORK/nope-draft.md" \
   --out "$WORK/y.json" --draft-version 1 2>&1 || true)
 if echo "$OUT" | python3 -c "import sys,json; d=json.load(sys.stdin); assert d['success'] is False and d['error']=='draft_not_found', d" 2>/dev/null; then
-  green "PASS: missing draft rejected (draft_not_found)"
+  green "PASS: citation-store-06-missing-draft-rejected-draft missing draft rejected (draft_not_found)"
 else
-  red "FAIL: missing draft not rejected"
+  red "FAIL: citation-store-06-missing-draft-rejected-draft missing draft not rejected"
   red "  got: $OUT"
   errors=$((errors + 1))
 fi
@@ -191,9 +191,9 @@ OUT=$(python3 "$SCRIPT" build --records "$WORK/empty-records.txt" --draft "$WORK
   --out "$WORK/empty-manifest.json" --draft-version 1)
 if echo "$OUT" | python3 -c "import sys,json; d=json.load(sys.stdin); assert d['success'] is True and d['data']['citations_count']==0, d" 2>/dev/null \
    && python3 -c "import json; m=json.load(open('$WORK/empty-manifest.json')); assert m['citations']==[] and m['schema_version']=='0.1.1', m" 2>/dev/null; then
-  green "PASS: empty records → valid empty manifest (success, count 0)"
+  green "PASS: citation-store-07-empty-records-valid-empty empty records → valid empty manifest (success, count 0)"
 else
-  red "FAIL: empty records did not yield a valid empty manifest"
+  red "FAIL: citation-store-07-empty-records-valid-empty empty records did not yield a valid empty manifest"
   red "  got: $OUT"
   errors=$((errors + 1))
 fi
@@ -218,9 +218,9 @@ d = json.load(sys.stdin)
 assert d['success'] is False and d['error'] == 'write_failed', d
 assert d['data']['failed_check'] == 'duplicate_id' and d['data']['ids'] == ['cit-001'], d
 " 2>/dev/null && [ ! -f "$WORK/dup-manifest.json" ]; then
-  green "PASS: duplicate citation id → write_failed, no manifest written"
+  green "PASS: citation-store-08-duplicate-citation-id-write duplicate citation id → write_failed, no manifest written"
 else
-  red "FAIL: duplicate id not rejected at the build gate"
+  red "FAIL: citation-store-08-duplicate-citation-id-write duplicate id not rejected at the build gate"
   red "  got: $OUT"
   errors=$((errors + 1))
 fi
@@ -242,9 +242,9 @@ d = json.load(sys.stdin)
 assert d['success'] is False and d['error'] == 'write_failed', d
 assert d['data']['failed_check'] == 'sentence_not_in_draft' and d['data']['ids'] == ['cit-001'], d
 " 2>/dev/null && [ ! -f "$WORK/nosent-manifest.json" ]; then
-  green "PASS: record with an empty/missing sentence → write_failed, no manifest"
+  green "PASS: citation-store-09-record-empty-missing-sentence record with an empty/missing sentence → write_failed, no manifest"
 else
-  red "FAIL: empty draft_sentence slipped past the substring check"
+  red "FAIL: citation-store-09-record-empty-missing-sentence empty draft_sentence slipped past the substring check"
   red "  got: $OUT"
   errors=$((errors + 1))
 fi
@@ -272,9 +272,9 @@ c = json.load(open('$WORK/alias-manifest.json'))['citations'][0]
 assert c['draft_position'] == '02:03' and c['wiki_slug'] == 'eu-ai-act-article-6', c
 assert c['claim_id'] == 'clm-001' and c['draft_sentence'].startswith('She said'), c
 " 2>/dev/null; then
-  green "PASS: parser accepts long-key aliases (draft_position/wiki_slug/claim_id/draft_sentence)"
+  green "PASS: citation-store-10-parser-accepts-long-key parser accepts long-key aliases (draft_position/wiki_slug/claim_id/draft_sentence)"
 else
-  red "FAIL: long-key aliases not accepted"
+  red "FAIL: citation-store-10-parser-accepts-long-key long-key aliases not accepted"
   red "  got: $OUT"
   errors=$((errors + 1))
 fi
@@ -303,9 +303,9 @@ c = json.load(open('$WORK/ls-manifest.json'))['citations'][0]
 exp = open('$WORK/ls-expected.txt', encoding='utf-8').read()
 assert c['draft_sentence'] == exp, ('truncated: ' + repr(c['draft_sentence']))
 " 2>/dev/null; then
-  green "PASS: U+2028 inside a sentence is preserved, not truncated (split on \\n only)"
+  green "PASS: citation-store-11-u-2028-inside-sentence U+2028 inside a sentence is preserved, not truncated (split on \\n only)"
 else
-  red "FAIL: sentence with a Unicode line separator was truncated"
+  red "FAIL: citation-store-11-u-2028-inside-sentence sentence with a Unicode line separator was truncated"
   red "  got: $OUT"
   errors=$((errors + 1))
 fi
@@ -331,9 +331,9 @@ d = json.load(sys.stdin)
 assert d['success'] is False and d['error'] == 'write_failed', d
 assert d['data']['failed_check'] == 'empty_id', d
 " 2>/dev/null && [ ! -f "$WORK/noid-manifest.json" ]; then
-  green "PASS: id-less record block → empty_id write_failed, not a silent drop"
+  green "PASS: citation-store-12-id-less-record-block id-less record block → empty_id write_failed, not a silent drop"
 else
-  red "FAIL: id-less record block was silently dropped or mis-handled"
+  red "FAIL: citation-store-12-id-less-record-block id-less record block was silently dropped or mis-handled"
   red "  got: $OUT"
   errors=$((errors + 1))
 fi
@@ -390,9 +390,9 @@ assert d['success'] is False and d['error'] == 'write_failed', d
 assert d['data']['failed_check'] == 'url_not_in_sources', d
 assert d['data']['urls'] == ['https://nis.de/nis-2-mindestmassnahmen-nach-30-bsig'], d
 " 2>/dev/null && [ ! -f "$WORK/url-manifest.json" ]; then
-  green "PASS: slug-derived inline URL → url_not_in_sources, no manifest (good URL not false-flagged)"
+  green "PASS: citation-store-13-slug-derived-inline-url slug-derived inline URL → url_not_in_sources, no manifest (good URL not false-flagged)"
 else
-  red "FAIL: --ingest-manifest gate did not flag the slug-derived URL (or false-flagged the good one)"
+  red "FAIL: citation-store-13-slug-derived-inline-url --ingest-manifest gate did not flag the slug-derived URL (or false-flagged the good one)"
   red "  got: $OUT"
   errors=$((errors + 1))
 fi
@@ -402,9 +402,9 @@ fi
 OUT=$(python3 "$SCRIPT" build --records "$WORK/url-records-ok.txt" --draft "$WORK/url-draft-ok.md" \
   --out "$WORK/url-manifest-ok.json" --draft-version 1 --ingest-manifest "$WORK/ingest.json")
 if echo "$OUT" | python3 -c "import sys,json; d=json.load(sys.stdin); assert d['success'] is True and d['data']['citations_count']==1, d" 2>/dev/null; then
-  green "PASS: all inline URLs in ingested set (trailing-slash normalized) → success"
+  green "PASS: citation-store-14-all-inline-urls-ingested all inline URLs in ingested set (trailing-slash normalized) → success"
 else
-  red "FAIL: positive --ingest-manifest case rejected"
+  red "FAIL: citation-store-14-all-inline-urls-ingested positive --ingest-manifest case rejected"
   red "  got: $OUT"
   errors=$((errors + 1))
 fi
@@ -418,9 +418,9 @@ OK_MISSING=$(python3 "$SCRIPT" build --records "$WORK/url-records.txt" --draft "
   --out "$WORK/url-fs2.json" --draft-version 1 --ingest-manifest "$WORK/does-not-exist.json" \
   | python3 -c "import sys,json; print(json.load(sys.stdin)['success'])" 2>/dev/null || true)
 if [ "$OK_EMPTY" = "True" ] && [ "$OK_MISSING" = "True" ]; then
-  green "PASS: empty / missing ingest-manifest → gate skipped, build succeeds (fail-soft)"
+  green "PASS: citation-store-15-empty-missing-ingest-manifest empty / missing ingest-manifest → gate skipped, build succeeds (fail-soft)"
 else
-  red "FAIL: fail-soft degenerate-input contract broken (empty=$OK_EMPTY missing=$OK_MISSING)"
+  red "FAIL: citation-store-15-empty-missing-ingest-manifest fail-soft degenerate-input contract broken (empty=$OK_EMPTY missing=$OK_MISSING)"
   errors=$((errors + 1))
 fi
 
@@ -429,9 +429,9 @@ fi
 OUT=$(python3 "$SCRIPT" build --records "$WORK/url-records.txt" --draft "$WORK/url-draft.md" \
   --out "$WORK/url-noflag.json" --draft-version 1)
 if echo "$OUT" | python3 -c "import sys,json; d=json.load(sys.stdin); assert d['success'] is True and d['data']['citations_count']==2, d" 2>/dev/null; then
-  green "PASS: no --ingest-manifest → URL gate is opt-in (slug-derived URL builds clean)"
+  green "PASS: citation-store-16-ingest-manifest-url-gate no --ingest-manifest → URL gate is opt-in (slug-derived URL builds clean)"
 else
-  red "FAIL: omitting --ingest-manifest unexpectedly ran the URL gate"
+  red "FAIL: citation-store-16-ingest-manifest-url-gate omitting --ingest-manifest unexpectedly ran the URL gate"
   red "  got: $OUT"
   errors=$((errors + 1))
 fi
@@ -489,9 +489,9 @@ assert d['data']['failed_check'] == 'url_slug_mismatch', d
 ids = [m['id'] for m in d['data']['mismatches']]
 assert ids == ['cit-001'], d
 " 2>/dev/null && [ ! -f "$WORK/misattr-manifest.json" ]; then
-  green "PASS: source-A text with source-B (real, ingested) URL → url_slug_mismatch, no manifest"
+  green "PASS: citation-store-17-source-text-source-b source-A text with source-B (real, ingested) URL → url_slug_mismatch, no manifest"
 else
-  red "FAIL: binding gate did not catch the real-but-mis-attributed URL"
+  red "FAIL: citation-store-17-source-text-source-b binding gate did not catch the real-but-mis-attributed URL"
   red "  got: $OUT"
   errors=$((errors + 1))
 fi
@@ -502,9 +502,9 @@ OUT=$(python3 "$SCRIPT" build --records "$WORK/bound-records.txt" --draft "$WORK
   --out "$WORK/bound-manifest.json" --draft-version 1 --ingest-manifest "$WORK/ingest-slug.json")
 if echo "$OUT" | python3 -c "import sys,json; d=json.load(sys.stdin); assert d['success'] is True and d['data']['citations_count']==1, d" 2>/dev/null \
    && python3 -c "import json,pathlib; m=json.loads(pathlib.Path('$WORK/bound-manifest.json').read_text()); assert m['citations'][0]['url']=='https://a.eu/page-a', m" 2>/dev/null; then
-  green "PASS: correctly-bound record (url == slug's ingested URL == marker) → success, url in manifest"
+  green "PASS: citation-store-18-correctly-bound-record-url correctly-bound record (url == slug's ingested URL == marker) → success, url in manifest"
 else
-  red "FAIL: correctly-bound record rejected (or url not persisted)"
+  red "FAIL: citation-store-18-correctly-bound-record-url correctly-bound record rejected (or url not persisted)"
   red "  got: $OUT"
   errors=$((errors + 1))
 fi
@@ -535,9 +535,9 @@ PY
 OUT=$(python3 "$SCRIPT" build --records "$WORK/noslug-records.txt" --draft "$WORK/noslug-draft.md" \
   --out "$WORK/noslug-manifest.json" --draft-version 1 --ingest-manifest "$WORK/ingest-noslug.json")
 if echo "$OUT" | python3 -c "import sys,json; d=json.load(sys.stdin); assert d['success'] is True and d['data']['citations_count']==1, d" 2>/dev/null; then
-  green "PASS: cited slug absent from ingest manifest → slug leg skipped, build succeeds"
+  green "PASS: citation-store-19-cited-slug-absent-from cited slug absent from ingest manifest → slug leg skipped, build succeeds"
 else
-  red "FAIL: binding gate false-positived on a slug with no ingest entry"
+  red "FAIL: citation-store-19-cited-slug-absent-from binding gate false-positived on a slug with no ingest entry"
   red "  got: $OUT"
   errors=$((errors + 1))
 fi
@@ -548,9 +548,9 @@ fi
 OUT=$(python3 "$SCRIPT" build --records "$WORK/url-records-ok.txt" --draft "$WORK/url-draft-ok.md" \
   --out "$WORK/legacy-bind.json" --draft-version 1 --ingest-manifest "$WORK/ingest.json")
 if echo "$OUT" | python3 -c "import sys,json; d=json.load(sys.stdin); assert d['success'] is True and d['data']['citations_count']==1, d" 2>/dev/null; then
-  green "PASS: legacy records without url: → binding gate skipped per-record (additive field)"
+  green "PASS: citation-store-20-legacy-records-without-url legacy records without url: → binding gate skipped per-record (additive field)"
 else
-  red "FAIL: legacy url-less records broke under the binding gate"
+  red "FAIL: citation-store-20-legacy-records-without-url legacy url-less records broke under the binding gate"
   red "  got: $OUT"
   errors=$((errors + 1))
 fi
@@ -584,9 +584,9 @@ assert d['success'] is False and d['error'] == 'write_failed', d
 assert d['data']['failed_check'] == 'url_slug_mismatch', d
 assert [m['id'] for m in d['data']['mismatches']] == ['cit-001'], d
 " 2>/dev/null && [ ! -f "$WORK/prose-manifest.json" ]; then
-  green "PASS: record.url absent from its own marker (slug leg clean) → prose leg fires alone"
+  green "PASS: citation-store-21-record-url-absent-from record.url absent from its own marker (slug leg clean) → prose leg fires alone"
 else
-  red "FAIL: prose-leg-only mismatch not caught (membership semantics regressed)"
+  red "FAIL: citation-store-21-record-url-absent-from prose-leg-only mismatch not caught (membership semantics regressed)"
   red "  got: $OUT"
   errors=$((errors + 1))
 fi
@@ -633,9 +633,9 @@ assert d['data']['citations_count'] == 4, d
 # Single dict-equality also pins the absence of an 'other' bucket.
 assert d['data']['claim_kinds'] == {'distilled': 1, 'source': 2, 'null': 1}, d
 " 2>/dev/null; then
-  green "PASS: build reports claim_kinds breakdown (distilled=1 source=2 null=1) — the #385 dcl- measurement"
+  green "PASS: citation-store-22-build-reports-claim-kinds build reports claim_kinds breakdown (distilled=1 source=2 null=1) — the #385 dcl- measurement"
 else
-  red "FAIL: claim_kinds breakdown wrong"
+  red "FAIL: citation-store-22-build-reports-claim-kinds claim_kinds breakdown wrong"
   red "  got: $OUT"
   errors=$((errors + 1))
 fi
@@ -688,9 +688,9 @@ assert d['data']['failed_check'] == 'url_not_in_sources', d
 assert d['data'].get('source') == 'draft_body', d
 assert d['data']['urls'] == ['https://b.eu/page-b-falsch-abgeleitet'], d
 " 2>/dev/null && [ ! -f "$WORK/stack-manifest.json" ]; then
-  green "PASS: stacked-citation slug-URL in body → url_not_in_sources (draft_body), pre-empts sentence_not_in_draft"
+  green "PASS: citation-store-23-stacked-citation-slug-url stacked-citation slug-URL in body → url_not_in_sources (draft_body), pre-empts sentence_not_in_draft"
 else
-  red "FAIL: #586 body-URL gate did not pre-empt sentence_not_in_draft on the stacked slug-URL"
+  red "FAIL: citation-store-23-stacked-citation-slug-url #586 body-URL gate did not pre-empt sentence_not_in_draft on the stacked slug-URL"
   red "  got: $OUT"
   errors=$((errors + 1))
 fi
@@ -700,9 +700,9 @@ fi
 OUT=$(python3 "$SCRIPT" build --records "$WORK/stack-records.txt" --draft "$WORK/stack-draft-ok.md" \
   --out "$WORK/stack-manifest-ok.json" --draft-version 1 --ingest-manifest "$WORK/ingest-stack.json")
 if echo "$OUT" | python3 -c "import sys,json; d=json.load(sys.stdin); assert d['success'] is True and d['data']['citations_count']==2, d" 2>/dev/null; then
-  green "PASS: clean stacked citation (both real ingested URLs) → success, no false url_not_in_sources"
+  green "PASS: citation-store-24-clean-stacked-citation-both clean stacked citation (both real ingested URLs) → success, no false url_not_in_sources"
 else
-  red "FAIL: clean stacked-citation positive path rejected"
+  red "FAIL: citation-store-24-clean-stacked-citation-both clean stacked-citation positive path rejected"
   red "  got: $OUT"
   errors=$((errors + 1))
 fi

--- a/cogni-knowledge/tests/test_concept_store.sh
+++ b/cogni-knowledge/tests/test_concept_store.sh
@@ -281,7 +281,7 @@ NEAR="$WIKI/wiki/concepts/annex-iii-risk-categories.md"
 echo "$OUT" | grep -q '"near_existing_total": 1' && green "PASS: concept-store-32-near-existing-total-counted near_existing_total counted (1)" || { red "FAIL: concept-store-32-near-existing-total-counted near_existing_total != 1"; errors=$((errors+1)); }
 # The per-concept envelope carries near_existing_slug with the existing match.
 echo "$OUT" | grep -q '"near_slug": "annex-iii-categories"' && green "PASS: concept-store-33-near-existing-slug-points near_existing_slug points at the cross-run match" || { red "FAIL: concept-store-33-near-existing-slug-points near_existing_slug not surfaced"; errors=$((errors+1)); }
-echo "$OUT" | grep -q '"near_type": "concept"' && green "PASS: concept-store-34-near-existing-slug-carries near_existing_slug carries the type" || { red "FAIL: concept-store-34-near-existing-slug-carries near_existing_slug type missing"; errors=$((errors+1)); }
+echo "$OUT" | grep -q '"near_type": "concept"' && green "PASS: concept-store-34-near-existing-slug-carries-type near_existing_slug carries the type" || { red "FAIL: concept-store-34-near-existing-slug-carries-type near_existing_slug type missing"; errors=$((errors+1)); }
 # Same-type near-match (concept→concept) is NOT a cross-type mis-type (#600).
 python3 -c 'import json,sys;d=json.loads(sys.argv[1])["data"];assert d["mistyped_total"]==0,d;assert d["near_existing_slugs"][0]["type_mismatch"] is False,d' "$OUT" && green "PASS: concept-store-35-same-type-near-match same-type near-match → type_mismatch False, mistyped_total 0 (#600 no false alarm)" || { red "FAIL: concept-store-35-same-type-near-match same-type near-match wrongly flagged as mis-typed"; errors=$((errors+1)); }
 # The schema bumped from 0.1.0 → 0.1.1 because the manifest gained two fields.
@@ -317,7 +317,7 @@ d=json.loads(sys.argv[1])["data"]
 assert d["mistyped_total"]>=1, d
 m=[s for s in d["near_existing_slugs"] if s.get("type_mismatch")]
 assert m and m[0]["near_type"]=="entity", d
-' "$OUT" && green "PASS: concept-store-39-600-cross-type-tripwire #600 cross-type tripwire flags new concept shadowing existing entity (type_mismatch + mistyped_total)" || { red "FAIL: concept-store-39-600-cross-type-tripwire #600 cross-type tripwire not flagged"; red "  got: $OUT"; errors=$((errors+1)); }
+' "$OUT" && green "PASS: concept-store-39-cross-type-tripwire #600 cross-type tripwire flags new concept shadowing existing entity (type_mismatch + mistyped_total)" || { red "FAIL: concept-store-39-cross-type-tripwire #600 cross-type tripwire not flagged"; red "  got: $OUT"; errors=$((errors+1)); }
 
 # --- 11. CLEAN-RUN BASELINE: no near match → empty tripwire ------------------
 # A title with no overlap against any existing concept/entity must yield

--- a/cogni-knowledge/tests/test_concept_store.sh
+++ b/cogni-knowledge/tests/test_concept_store.sh
@@ -33,11 +33,11 @@ WSD="$PLUGIN_ROOT/scripts/vendor/cogni-wiki/skills/wiki-ingest/scripts"
 . "$(dirname "$0")/fixtures/test_helpers.sh"
 
 if [ ! -f "$SCRIPT" ]; then
-  red "FAIL: concept-store.py not found at $SCRIPT"
+  red "FAIL: concept-store-00-script-present concept-store.py not found at $SCRIPT"
   exit 1
 fi
 if [ ! -d "$WSD" ]; then
-  red "FAIL: cogni-wiki wiki-ingest scripts not found at $WSD"
+  red "FAIL: concept-store-00-wiki-scripts-present cogni-wiki wiki-ingest scripts not found at $WSD"
   exit 1
 fi
 
@@ -59,12 +59,12 @@ field() { python3 -c 'import sys,json;d=json.load(sys.stdin);print(eval("d"+sys.
 # --- 1. init -----------------------------------------------------------------
 OUT=$(python3 "$SCRIPT" init --project-path "$PROJ")
 if [ "$(echo "$OUT" | field '["success"]')" = "True" ] && [ -f "$PROJ/.metadata/distill-manifest.json" ]; then
-  green "PASS: init creates distill-manifest.json"
+  green "PASS: concept-store-01-init-creates-distill-manifest init creates distill-manifest.json"
 else
-  red "FAIL: init"; errors=$((errors+1))
+  red "FAIL: concept-store-01-init-creates-distill-manifest init"; errors=$((errors+1))
 fi
 OUT=$(python3 "$SCRIPT" init --project-path "$PROJ")
-[ "$(echo "$OUT" | field '["data"]["created"]')" = "False" ] && green "PASS: init idempotent" || { red "FAIL: init not idempotent"; errors=$((errors+1)); }
+[ "$(echo "$OUT" | field '["data"]["created"]')" = "False" ] && green "PASS: concept-store-02-init-idempotent init idempotent" || { red "FAIL: concept-store-02-init-idempotent init not idempotent"; errors=$((errors+1)); }
 
 # --- 2. merge CREATE ---------------------------------------------------------
 cat > "$PROJ/.metadata/rec1.txt" <<'EOF'
@@ -82,19 +82,19 @@ EOF
 OUT=$(python3 "$SCRIPT" merge --records "$PROJ/.metadata/rec1.txt" --wiki-root "$WIKI" --project-path "$PROJ" --project-slug proj-1 --wiki-scripts-dir "$WSD")
 CPAGE="$WIKI/wiki/concepts/annex-iii-categories.md"
 EPAGE="$WIKI/wiki/entities/european-commission.md"
-[ "$(echo "$OUT" | field '["data"]["n_created"]')" = "2" ] && green "PASS: merge created 2 pages" || { red "FAIL: n_created != 2"; errors=$((errors+1)); }
-[ -f "$CPAGE" ] && [ -f "$EPAGE" ] && green "PASS: concept + entity pages on disk" || { red "FAIL: pages missing"; errors=$((errors+1)); }
-assert_grep 'type: concept' "$CPAGE" "concept page: type"
-assert_grep 'status: distilled' "$CPAGE" "concept page: status distilled"
-assert_grep 'wiki://src-a' "$CPAGE" "concept page: wiki:// source provenance"
-assert_grep 'MACHINE-OWNED:CLAIMS:START' "$CPAGE" "concept page: machine-owned sentinels"
-assert_grep '\[\[src-a\]\]' "$CPAGE" "concept page: bare [[source-slug]] backlink (link-graph edge)"
-assert_grep 'distilled_from_research' "$CPAGE" "concept page: distilled_from_research"
+[ "$(echo "$OUT" | field '["data"]["n_created"]')" = "2" ] && green "PASS: concept-store-03-merge-created-2-pages merge created 2 pages" || { red "FAIL: concept-store-03-merge-created-2-pages n_created != 2"; errors=$((errors+1)); }
+[ -f "$CPAGE" ] && [ -f "$EPAGE" ] && green "PASS: concept-store-04-concept-entity-pages-disk concept + entity pages on disk" || { red "FAIL: concept-store-04-concept-entity-pages-disk pages missing"; errors=$((errors+1)); }
+assert_grep 'type: concept' "$CPAGE" "concept-store-05-concept-page-type concept page: type"
+assert_grep 'status: distilled' "$CPAGE" "concept-store-06-concept-page-status-distilled concept page: status distilled"
+assert_grep 'wiki://src-a' "$CPAGE" "concept-store-07-concept-page-wiki-source concept page: wiki:// source provenance"
+assert_grep 'MACHINE-OWNED:CLAIMS:START' "$CPAGE" "concept-store-08-concept-page-machine-owned concept page: machine-owned sentinels"
+assert_grep '\[\[src-a\]\]' "$CPAGE" "concept-store-09-concept-page-bare-source concept page: bare [[source-slug]] backlink (link-graph edge)"
+assert_grep 'distilled_from_research' "$CPAGE" "concept-store-10-concept-page-distilled-from concept page: distilled_from_research"
 # Reader-facing engine-owned type line directly under the H1 (#931).
-assert_grep '^Type: Concept · distilled$' "$CPAGE" "concept page: Type: Concept · distilled line under H1"
-assert_grep '^Type: Entity · distilled$' "$EPAGE" "entity page: Type: Entity · distilled line under H1"
+assert_grep '^Type: Concept · distilled$' "$CPAGE" "concept-store-11-concept-page-type-concept concept page: Type: Concept · distilled line under H1"
+assert_grep '^Type: Entity · distilled$' "$EPAGE" "concept-store-12-entity-page-type-entity entity page: Type: Entity · distilled line under H1"
 # The type line sits immediately below the H1 (one blank line between).
-python3 - "$CPAGE" <<'PY' && green "PASS: concept page type line is immediately below the H1" || { red "FAIL: type line not directly under H1"; errors=$((errors+1)); }
+python3 - "$CPAGE" <<'PY' && green "PASS: concept-store-13-concept-page-type-line concept page type line is immediately below the H1" || { red "FAIL: concept-store-13-concept-page-type-line type line not directly under H1"; errors=$((errors+1)); }
 import sys
 lines = open(sys.argv[1], encoding="utf-8").read().splitlines()
 h1 = next(i for i, l in enumerate(lines) if l.startswith("# "))
@@ -109,7 +109,7 @@ PY
 # JUST WROTE to that reader and assert the text set round-trips — this is the
 # true no-drift guard between the writer (_render_distilled_claims) and the
 # coverage-side reader, beyond concept-store's own private round-trip self-check.
-python3 - "$PLUGIN_ROOT/scripts" "$CPAGE" "$EPAGE" <<'PY' && green "PASS: lib parse_distilled_claims round-trips concept-store's actual output (no drift)" || { red "FAIL: lib parser drifted from concept-store writer"; errors=$((errors+1)); }
+python3 - "$PLUGIN_ROOT/scripts" "$CPAGE" "$EPAGE" <<'PY' && green "PASS: concept-store-14-lib-parse-distilled-claims lib parse_distilled_claims round-trips concept-store's actual output (no drift)" || { red "FAIL: concept-store-14-lib-parse-distilled-claims lib parser drifted from concept-store writer"; errors=$((errors+1)); }
 import sys
 sys.path.insert(0, sys.argv[1])
 import _knowledge_lib as kl
@@ -137,9 +137,9 @@ cat > "$PROJ/.metadata/rec2.txt" <<'EOF'
   claim: src-c#clm-011 | The Commission may amend Annex III by delegated act.
 EOF
 OUT=$(python3 "$SCRIPT" merge --records "$PROJ/.metadata/rec2.txt" --wiki-root "$WIKI" --project-path "$PROJ" --project-slug proj-2 --wiki-scripts-dir "$WSD")
-[ "$(echo "$OUT" | field '["data"]["n_updated"]')" = "1" ] && green "PASS: merge updated the existing concept" || { red "FAIL: n_updated != 1"; errors=$((errors+1)); }
-[ "$(echo "$OUT" | field '["data"]["claims_deduped_total"]')" = "1" ] && green "PASS: exact-norm_key dedup counted (1)" || { red "FAIL: deduped_total != 1"; errors=$((errors+1)); }
-python3 - "$CPAGE" <<'PY' && green "PASS: cross-run update assertions" || { echo "FAIL: cross-run update"; exit 1; }
+[ "$(echo "$OUT" | field '["data"]["n_updated"]')" = "1" ] && green "PASS: concept-store-15-merge-updated-existing-concept merge updated the existing concept" || { red "FAIL: concept-store-15-merge-updated-existing-concept n_updated != 1"; errors=$((errors+1)); }
+[ "$(echo "$OUT" | field '["data"]["claims_deduped_total"]')" = "1" ] && green "PASS: concept-store-16-exact-norm-key-dedup exact-norm_key dedup counted (1)" || { red "FAIL: concept-store-16-exact-norm-key-dedup deduped_total != 1"; errors=$((errors+1)); }
+python3 - "$CPAGE" <<'PY' && green "PASS: concept-store-17-cross-run-update-assertions cross-run update assertions" || { echo "FAIL: concept-store-17-cross-run-update-assertions cross-run update"; exit 1; }
 import sys, re
 t = open(sys.argv[1], encoding="utf-8").read()
 m = re.search(r'claim_id: dcl-001.*?backlinks: (\[.*?\])', t, re.DOTALL)
@@ -162,14 +162,14 @@ EOF
 python3 "$SCRIPT" merge --records "$PROJ2/.metadata/recns.txt" --wiki-root "$WIKI" --project-path "$PROJ2" --project-slug proj-ns --wiki-scripts-dir "$WSD" >/dev/null
 NS="$WIKI/wiki/concepts/namespacing-probe.md"
 N=$(grep -c 'claim_id: dcl-' "$NS" 2>/dev/null || echo 0)
-[ "$N" = "2" ] && green "PASS: two sources both clm-001 (different facts) -> 2 distinct claims" || { red "FAIL: namespacing collapsed clm-001 (got $N claims)"; errors=$((errors+1)); }
+[ "$N" = "2" ] && green "PASS: concept-store-18-two-sources-both-clm two sources both clm-001 (different facts) -> 2 distinct claims" || { red "FAIL: concept-store-18-two-sources-both-clm namespacing collapsed clm-001 (got $N claims)"; errors=$((errors+1)); }
 
 # --- 5. byte-stable re-run ---------------------------------------------------
 BEFORE=$(cat "$NS")
 OUT=$(python3 "$SCRIPT" merge --records "$PROJ2/.metadata/recns.txt" --wiki-root "$WIKI" --project-path "$PROJ2" --project-slug proj-ns --wiki-scripts-dir "$WSD")
 AFTER=$(cat "$NS")
-[ "$BEFORE" = "$AFTER" ] && green "PASS: identical re-run is byte-stable" || { red "FAIL: re-run changed the page"; errors=$((errors+1)); }
-echo "$OUT" | grep -q '"action": "unchanged"' && green "PASS: re-run reports unchanged" || { red "FAIL: re-run not reported unchanged"; errors=$((errors+1)); }
+[ "$BEFORE" = "$AFTER" ] && green "PASS: concept-store-19-identical-re-run-byte identical re-run is byte-stable" || { red "FAIL: concept-store-19-identical-re-run-byte re-run changed the page"; errors=$((errors+1)); }
+echo "$OUT" | grep -q '"action": "unchanged"' && green "PASS: concept-store-20-re-run-reports-unchanged re-run reports unchanged" || { red "FAIL: concept-store-20-re-run-reports-unchanged re-run not reported unchanged"; errors=$((errors+1)); }
 
 # --- 6. FAIL-SAFE: near-but-distinct claims are KEPT, not over-merged --------
 PROJ3="$WORK/project3"; mkdir -p "$PROJ3/.metadata"
@@ -182,7 +182,7 @@ EOF
 python3 "$SCRIPT" merge --records "$PROJ3/.metadata/recsafe.txt" --wiki-root "$WIKI" --project-path "$PROJ3" --project-slug proj-safe --wiki-scripts-dir "$WSD" >/dev/null
 FS="$WIKI/wiki/concepts/fail-safe-probe.md"
 N=$(grep -c 'claim_id: dcl-' "$FS" 2>/dev/null || echo 0)
-[ "$N" = "2" ] && green "PASS: two distinct facts (sim < 0.85) kept as 2 claims (fail-safe keep-both)" || { red "FAIL: distinct claims over-merged (got $N)"; errors=$((errors+1)); }
+[ "$N" = "2" ] && green "PASS: concept-store-21-two-distinct-facts-sim two distinct facts (sim < 0.85) kept as 2 claims (fail-safe keep-both)" || { red "FAIL: concept-store-21-two-distinct-facts-sim distinct claims over-merged (got $N)"; errors=$((errors+1)); }
 
 # --- 6b. orphan-source guard: a malformed (empty-text) claim's slug must NOT --
 # leak into sources:/## Sources, and must be COUNTED as rejected.
@@ -194,8 +194,8 @@ cat > "$PROJ3/.metadata/reorph.txt" <<'EOF'
 EOF
 OUT=$(python3 "$SCRIPT" merge --records "$PROJ3/.metadata/reorph.txt" --wiki-root "$WIKI" --project-path "$PROJ3" --project-slug proj-safe --wiki-scripts-dir "$WSD")
 OG="$WIKI/wiki/concepts/orphan-guard.md"
-grep -q 'src-orphan' "$OG" && { red "FAIL: malformed claim's source leaked into the page"; errors=$((errors+1)); } || green "PASS: malformed-claim source not added to sources/backlinks"
-echo "$OUT" | grep -q '"claims_rejected_total": 1' && green "PASS: malformed claim counted in claims_rejected_total" || { red "FAIL: rejected claim not counted"; errors=$((errors+1)); }
+grep -q 'src-orphan' "$OG" && { red "FAIL: concept-store-22-malformed-claim-source-added malformed claim's source leaked into the page"; errors=$((errors+1)); } || green "PASS: concept-store-22-malformed-claim-source-added malformed-claim source not added to sources/backlinks"
+echo "$OUT" | grep -q '"claims_rejected_total": 1' && green "PASS: concept-store-23-malformed-claim-counted-claims malformed claim counted in claims_rejected_total" || { red "FAIL: concept-store-23-malformed-claim-counted-claims rejected claim not counted"; errors=$((errors+1)); }
 
 # --- 7b. slug-type collision: same title as concept AND entity -> 2nd skipped -
 cat > "$PROJ3/.metadata/recdual.txt" <<'EOF'
@@ -207,8 +207,8 @@ cat > "$PROJ3/.metadata/recdual.txt" <<'EOF'
   claim: src-b#clm-041 | The authority is an independent body.
 EOF
 OUT=$(python3 "$SCRIPT" merge --records "$PROJ3/.metadata/recdual.txt" --wiki-root "$WIKI" --project-path "$PROJ3" --project-slug proj-safe --wiki-scripts-dir "$WSD")
-echo "$OUT" | grep -q 'slug_type_collision' && green "PASS: concept+entity same slug -> 2nd skipped (slug_type_collision)" || { red "FAIL: slug_type_collision not enforced"; errors=$((errors+1)); }
-[ -f "$WIKI/wiki/concepts/data-protection-authority.md" ] && [ ! -f "$WIKI/wiki/entities/data-protection-authority.md" ] && green "PASS: only ONE page exists for the colliding slug" || { red "FAIL: duplicate slug across type dirs"; errors=$((errors+1)); }
+echo "$OUT" | grep -q 'slug_type_collision' && green "PASS: concept-store-24-concept-entity-same-slug concept+entity same slug -> 2nd skipped (slug_type_collision)" || { red "FAIL: concept-store-24-concept-entity-same-slug slug_type_collision not enforced"; errors=$((errors+1)); }
+[ -f "$WIKI/wiki/concepts/data-protection-authority.md" ] && [ ! -f "$WIKI/wiki/entities/data-protection-authority.md" ] && green "PASS: concept-store-25-only-one-page-exists only ONE page exists for the colliding slug" || { red "FAIL: concept-store-25-only-one-page-exists duplicate slug across type dirs"; errors=$((errors+1)); }
 
 # --- 7. foundation collision (slug must match slugify(title)) ----------------
 cat > "$WIKI/wiki/concepts/risk-management-system.md" <<'EOF'
@@ -229,8 +229,8 @@ cat > "$PROJ2/.metadata/recfound.txt" <<'EOF'
   claim: src-a#clm-050 | A risk management system must run across the lifecycle.
 EOF
 OUT=$(python3 "$SCRIPT" merge --records "$PROJ2/.metadata/recfound.txt" --wiki-root "$WIKI" --project-path "$PROJ2" --project-slug proj-ns --wiki-scripts-dir "$WSD")
-echo "$OUT" | grep -q 'foundation_collision' && green "PASS: foundation page refused (foundation_collision)" || { red "FAIL: foundation not refused"; errors=$((errors+1)); }
-grep -q 'src-a' "$WIKI/wiki/concepts/risk-management-system.md" && { red "FAIL: foundation page was modified"; errors=$((errors+1)); } || green "PASS: foundation page untouched"
+echo "$OUT" | grep -q 'foundation_collision' && green "PASS: concept-store-26-foundation-page-refused-foundation foundation page refused (foundation_collision)" || { red "FAIL: concept-store-26-foundation-page-refused-foundation foundation not refused"; errors=$((errors+1)); }
+grep -q 'src-a' "$WIKI/wiki/concepts/risk-management-system.md" && { red "FAIL: concept-store-27-foundation-page-untouched foundation page was modified"; errors=$((errors+1)); } || green "PASS: concept-store-27-foundation-page-untouched foundation page untouched"
 
 # --- 8. no-sentinel human page ----------------------------------------------
 cat > "$WIKI/wiki/concepts/hand-authored.md" <<'EOF'
@@ -251,12 +251,12 @@ cat > "$PROJ2/.metadata/rechand.txt" <<'EOF'
   claim: src-a#clm-099 | Some new claim.
 EOF
 OUT=$(python3 "$SCRIPT" merge --records "$PROJ2/.metadata/rechand.txt" --wiki-root "$WIKI" --project-path "$PROJ2" --project-slug proj-ns --wiki-scripts-dir "$WSD")
-echo "$OUT" | grep -q 'no_sentinels_human_page' && green "PASS: no-sentinel human page skipped" || { red "FAIL: no-sentinel page not skipped"; errors=$((errors+1)); }
-[ "$(cksum "$WIKI/wiki/concepts/hand-authored.md")" = "$HASH_BEFORE" ] && green "PASS: no-sentinel page left untouched" || { red "FAIL: no-sentinel page modified"; errors=$((errors+1)); }
+echo "$OUT" | grep -q 'no_sentinels_human_page' && green "PASS: concept-store-28-no-sentinel-human-page-skipped no-sentinel human page skipped" || { red "FAIL: concept-store-28-no-sentinel-human-page-skipped no-sentinel page not skipped"; errors=$((errors+1)); }
+[ "$(cksum "$WIKI/wiki/concepts/hand-authored.md")" = "$HASH_BEFORE" ] && green "PASS: concept-store-29-no-sentinel-page-left-untouched no-sentinel page left untouched" || { red "FAIL: concept-store-29-no-sentinel-page-left-untouched no-sentinel page modified"; errors=$((errors+1)); }
 
 # --- 9. manifest read --------------------------------------------------------
 OUT=$(python3 "$SCRIPT" read --project-path "$PROJ")
-echo "$OUT" | grep -q 'claims_attached_total' && green "PASS: manifest carries claims_attached_total" || { red "FAIL: manifest missing dedup totals"; errors=$((errors+1)); }
+echo "$OUT" | grep -q 'claims_attached_total' && green "PASS: concept-store-30-manifest-carries-claims-attached manifest carries claims_attached_total" || { red "FAIL: concept-store-30-manifest-carries-claims-attached manifest missing dedup totals"; errors=$((errors+1)); }
 
 # --- 10. #340 observable title→slug tripwire --------------------------------
 # A new project proposes a title that's title-similar (>= 0.65) but slugifies
@@ -276,16 +276,16 @@ EOF
 OUT=$(python3 "$SCRIPT" merge --records "$PROJ4/.metadata/recnear.txt" --wiki-root "$WIKI" --project-path "$PROJ4" --project-slug proj-near --wiki-scripts-dir "$WSD")
 # Created (no auto-merge): the page lives at the NEW slug.
 NEAR="$WIKI/wiki/concepts/annex-iii-risk-categories.md"
-[ -f "$NEAR" ] && green "PASS: near-title creates a NEW page (no auto-merge)" || { red "FAIL: near-title did not create page"; errors=$((errors+1)); }
+[ -f "$NEAR" ] && green "PASS: concept-store-31-near-title-creates-new near-title creates a NEW page (no auto-merge)" || { red "FAIL: concept-store-31-near-title-creates-new near-title did not create page"; errors=$((errors+1)); }
 # near_existing_total >= 1 in manifest + return envelope.
-echo "$OUT" | grep -q '"near_existing_total": 1' && green "PASS: near_existing_total counted (1)" || { red "FAIL: near_existing_total != 1"; errors=$((errors+1)); }
+echo "$OUT" | grep -q '"near_existing_total": 1' && green "PASS: concept-store-32-near-existing-total-counted near_existing_total counted (1)" || { red "FAIL: concept-store-32-near-existing-total-counted near_existing_total != 1"; errors=$((errors+1)); }
 # The per-concept envelope carries near_existing_slug with the existing match.
-echo "$OUT" | grep -q '"near_slug": "annex-iii-categories"' && green "PASS: near_existing_slug points at the cross-run match" || { red "FAIL: near_existing_slug not surfaced"; errors=$((errors+1)); }
-echo "$OUT" | grep -q '"near_type": "concept"' && green "PASS: near_existing_slug carries the type" || { red "FAIL: near_existing_slug type missing"; errors=$((errors+1)); }
+echo "$OUT" | grep -q '"near_slug": "annex-iii-categories"' && green "PASS: concept-store-33-near-existing-slug-points near_existing_slug points at the cross-run match" || { red "FAIL: concept-store-33-near-existing-slug-points near_existing_slug not surfaced"; errors=$((errors+1)); }
+echo "$OUT" | grep -q '"near_type": "concept"' && green "PASS: concept-store-34-near-existing-slug-carries near_existing_slug carries the type" || { red "FAIL: concept-store-34-near-existing-slug-carries near_existing_slug type missing"; errors=$((errors+1)); }
 # Same-type near-match (concept→concept) is NOT a cross-type mis-type (#600).
-python3 -c 'import json,sys;d=json.loads(sys.argv[1])["data"];assert d["mistyped_total"]==0,d;assert d["near_existing_slugs"][0]["type_mismatch"] is False,d' "$OUT" && green "PASS: same-type near-match → type_mismatch False, mistyped_total 0 (#600 no false alarm)" || { red "FAIL: same-type near-match wrongly flagged as mis-typed"; errors=$((errors+1)); }
+python3 -c 'import json,sys;d=json.loads(sys.argv[1])["data"];assert d["mistyped_total"]==0,d;assert d["near_existing_slugs"][0]["type_mismatch"] is False,d' "$OUT" && green "PASS: concept-store-35-same-type-near-match same-type near-match → type_mismatch False, mistyped_total 0 (#600 no false alarm)" || { red "FAIL: concept-store-35-same-type-near-match same-type near-match wrongly flagged as mis-typed"; errors=$((errors+1)); }
 # The schema bumped from 0.1.0 → 0.1.1 because the manifest gained two fields.
-python3 -c 'import json,sys;d=json.load(open(sys.argv[1]));assert d["schema_version"]=="0.1.1";assert d["near_existing_total"]==1;assert len(d["near_existing_slugs"])==1;assert d["mistyped_total"]==0' "$PROJ4/.metadata/distill-manifest.json" && green "PASS: manifest schema bumped + tripwire fields aggregated" || { red "FAIL: manifest schema/fields wrong"; errors=$((errors+1)); }
+python3 -c 'import json,sys;d=json.load(open(sys.argv[1]));assert d["schema_version"]=="0.1.1";assert d["near_existing_total"]==1;assert len(d["near_existing_slugs"])==1;assert d["mistyped_total"]==0' "$PROJ4/.metadata/distill-manifest.json" && green "PASS: concept-store-36-manifest-schema-bumped-tripwire manifest schema bumped + tripwire fields aggregated" || { red "FAIL: concept-store-36-manifest-schema-bumped-tripwire manifest schema/fields wrong"; errors=$((errors+1)); }
 
 # --- 10b. #600 cross-type tripwire: new concept shadows an existing entity ---
 # The reported bug: the distiller files a NAMED INSTANCE as type:concept when it
@@ -300,7 +300,7 @@ cat > "$PROJ4b/.metadata/recent.txt" <<'EOF'
   claim: src-a#clm-090 | DT operates a global cyber defense center headquartered in Bonn.
 EOF
 python3 "$SCRIPT" merge --records "$PROJ4b/.metadata/recent.txt" --wiki-root "$WIKI" --project-path "$PROJ4b" --project-slug proj-ent --wiki-scripts-dir "$WSD" >/dev/null
-[ -f "$WIKI/wiki/entities/dt-cyber-defense-center.md" ] && green "PASS: entity page deposited for cross-type test" || { red "FAIL: entity page not created"; errors=$((errors+1)); }
+[ -f "$WIKI/wiki/entities/dt-cyber-defense-center.md" ] && green "PASS: concept-store-37-entity-page-deposited-cross entity page deposited for cross-type test" || { red "FAIL: concept-store-37-entity-page-deposited-cross entity page not created"; errors=$((errors+1)); }
 # New project proposes a CONCEPT whose title near-matches the entity (plural →
 # distinct slug dt-cyber-defense-centers, so no slug_type_collision; created).
 PROJ4c="$WORK/project4c"; mkdir -p "$PROJ4c/.metadata"
@@ -310,14 +310,14 @@ cat > "$PROJ4c/.metadata/recmistype.txt" <<'EOF'
   claim: src-b#clm-091 | The defense centers coordinate regional SOCs worldwide.
 EOF
 OUT=$(python3 "$SCRIPT" merge --records "$PROJ4c/.metadata/recmistype.txt" --wiki-root "$WIKI" --project-path "$PROJ4c" --project-slug proj-mistype --wiki-scripts-dir "$WSD")
-[ -f "$WIKI/wiki/concepts/dt-cyber-defense-centers.md" ] && green "PASS: cross-type near-match still CREATES the page (observability only)" || { red "FAIL: cross-type case did not create the concept page"; errors=$((errors+1)); }
+[ -f "$WIKI/wiki/concepts/dt-cyber-defense-centers.md" ] && green "PASS: concept-store-38-cross-type-near-match cross-type near-match still CREATES the page (observability only)" || { red "FAIL: concept-store-38-cross-type-near-match cross-type case did not create the concept page"; errors=$((errors+1)); }
 python3 -c '
 import json,sys
 d=json.loads(sys.argv[1])["data"]
 assert d["mistyped_total"]>=1, d
 m=[s for s in d["near_existing_slugs"] if s.get("type_mismatch")]
 assert m and m[0]["near_type"]=="entity", d
-' "$OUT" && green "PASS: #600 cross-type tripwire flags new concept shadowing existing entity (type_mismatch + mistyped_total)" || { red "FAIL: #600 cross-type tripwire not flagged"; red "  got: $OUT"; errors=$((errors+1)); }
+' "$OUT" && green "PASS: concept-store-39-600-cross-type-tripwire #600 cross-type tripwire flags new concept shadowing existing entity (type_mismatch + mistyped_total)" || { red "FAIL: concept-store-39-600-cross-type-tripwire #600 cross-type tripwire not flagged"; red "  got: $OUT"; errors=$((errors+1)); }
 
 # --- 11. CLEAN-RUN BASELINE: no near match → empty tripwire ------------------
 # A title with no overlap against any existing concept/entity must yield
@@ -329,8 +329,8 @@ cat > "$PROJ5/.metadata/recclean.txt" <<'EOF'
   claim: src-a#clm-090 | Vessels must transmit identifying telemetry.
 EOF
 OUT=$(python3 "$SCRIPT" merge --records "$PROJ5/.metadata/recclean.txt" --wiki-root "$WIKI" --project-path "$PROJ5" --project-slug proj-clean --wiki-scripts-dir "$WSD")
-echo "$OUT" | grep -q '"near_existing_total": 0' && green "PASS: unrelated title → near_existing_total=0 (no false alarm)" || { red "FAIL: false alarm on unrelated title"; errors=$((errors+1)); }
-echo "$OUT" | grep -q '"near_existing_slugs": \[\]' && green "PASS: clean run leaves near_existing_slugs empty" || { red "FAIL: near_existing_slugs not empty on clean run"; errors=$((errors+1)); }
+echo "$OUT" | grep -q '"near_existing_total": 0' && green "PASS: concept-store-40-unrelated-title-near-existing unrelated title → near_existing_total=0 (no false alarm)" || { red "FAIL: concept-store-40-unrelated-title-near-existing false alarm on unrelated title"; errors=$((errors+1)); }
+echo "$OUT" | grep -q '"near_existing_slugs": \[\]' && green "PASS: concept-store-41-clean-run-leaves-near clean run leaves near_existing_slugs empty" || { red "FAIL: concept-store-41-clean-run-leaves-near near_existing_slugs not empty on clean run"; errors=$((errors+1)); }
 
 # --- 12. tripwire NEVER fires on the `updated` path --------------------------
 # Same title as Step 3's update -> action=updated, near_existing_slug must be {}.
@@ -343,7 +343,7 @@ cat > "$PROJ6/.metadata/recupd.txt" <<'EOF'
   claim: src-a#clm-095 | A third source contributes an Annex III statement.
 EOF
 OUT=$(python3 "$SCRIPT" merge --records "$PROJ6/.metadata/recupd.txt" --wiki-root "$WIKI" --project-path "$PROJ6" --project-slug proj-upd --wiki-scripts-dir "$WSD")
-echo "$OUT" | grep -q '"near_existing_total": 0' && green "PASS: updated path never fires the tripwire" || { red "FAIL: tripwire fired on update"; errors=$((errors+1)); }
+echo "$OUT" | grep -q '"near_existing_total": 0' && green "PASS: concept-store-42-updated-path-never-fires updated path never fires the tripwire" || { red "FAIL: concept-store-42-updated-path-never-fires tripwire fired on update"; errors=$((errors+1)); }
 
 # --- 13. QUOTED frontmatter title parses correctly ---------------------------
 # Hand-place a page whose `title:` value is JSON-double-quoted (the writer's
@@ -371,9 +371,9 @@ cat > "$PROJ7/.metadata/recquoted.txt" <<'EOF'
   claim: src-a#clm-100 | The sandbox pilot runs for twelve months.
 EOF
 OUT=$(python3 "$SCRIPT" merge --records "$PROJ7/.metadata/recquoted.txt" --wiki-root "$WIKI" --project-path "$PROJ7" --project-slug proj-quoted --wiki-scripts-dir "$WSD")
-echo "$OUT" | grep -q '"near_existing_total": 1' && green "PASS: quoted title parsed — tripwire fires" || { red "FAIL: quoted title not parsed (tripwire silent)"; errors=$((errors+1)); }
-echo "$OUT" | grep -q '"near_title": "Regulatory Sandbox"' && green "PASS: quoted title round-trips UNQUOTED in manifest" || { red "FAIL: near_title kept literal quotes"; errors=$((errors+1)); }
-echo "$OUT" | grep -q '"near_slug": "regulatory-sandbox"' && green "PASS: quoted title near_slug points at the pre-seeded page" || { red "FAIL: near_slug wrong on quoted title"; errors=$((errors+1)); }
+echo "$OUT" | grep -q '"near_existing_total": 1' && green "PASS: concept-store-43-quoted-title-parsed-tripwire quoted title parsed — tripwire fires" || { red "FAIL: concept-store-43-quoted-title-parsed-tripwire quoted title not parsed (tripwire silent)"; errors=$((errors+1)); }
+echo "$OUT" | grep -q '"near_title": "Regulatory Sandbox"' && green "PASS: concept-store-44-quoted-title-round-trips quoted title round-trips UNQUOTED in manifest" || { red "FAIL: concept-store-44-quoted-title-round-trips near_title kept literal quotes"; errors=$((errors+1)); }
+echo "$OUT" | grep -q '"near_slug": "regulatory-sandbox"' && green "PASS: concept-store-45-quoted-title-near-slug quoted title near_slug points at the pre-seeded page" || { red "FAIL: concept-store-45-quoted-title-near-slug near_slug wrong on quoted title"; errors=$((errors+1)); }
 
 # --- 14. MISSING title key silently degrades to "" ---------------------------
 # Regression guard against the dropped stem-fallback (review-cycle fix in
@@ -399,7 +399,7 @@ cat > "$PROJ8/.metadata/recnotitle.txt" <<'EOF'
   claim: src-a#clm-110 | Quantum research methods include lattice simulation.
 EOF
 OUT=$(python3 "$SCRIPT" merge --records "$PROJ8/.metadata/recnotitle.txt" --wiki-root "$WIKI" --project-path "$PROJ8" --project-slug proj-notitle --wiki-scripts-dir "$WSD")
-echo "$OUT" | grep -q '"near_existing_total": 0' && green "PASS: missing title key silently excluded from tripwire" || { red "FAIL: missing title fell through to slug fallback (false positive)"; errors=$((errors+1)); }
+echo "$OUT" | grep -q '"near_existing_total": 0' && green "PASS: concept-store-46-missing-title-key-silently missing title key silently excluded from tripwire" || { red "FAIL: concept-store-46-missing-title-key-silently missing title fell through to slug fallback (false positive)"; errors=$((errors+1)); }
 
 # --- 15. CROSS-TYPE matching (concept proposal trips on entity page) ---------
 # The title index spans BOTH concepts/ and entities/, so a new concept whose
@@ -415,9 +415,9 @@ cat > "$PROJ9/.metadata/reccross.txt" <<'EOF'
   claim: src-a#clm-120 | The Commission publishes procedural rules for delegated acts.
 EOF
 OUT=$(python3 "$SCRIPT" merge --records "$PROJ9/.metadata/reccross.txt" --wiki-root "$WIKI" --project-path "$PROJ9" --project-slug proj-cross --wiki-scripts-dir "$WSD")
-echo "$OUT" | grep -q '"near_existing_total": 1' && green "PASS: cross-type match (concept → entity) trips" || { red "FAIL: cross-type tripwire silent"; errors=$((errors+1)); }
-echo "$OUT" | grep -q '"near_type": "entity"' && green "PASS: cross-type near_type reports entity" || { red "FAIL: near_type not 'entity' on cross-type match"; errors=$((errors+1)); }
-echo "$OUT" | grep -q '"near_slug": "european-commission"' && green "PASS: cross-type near_slug points at the entity page" || { red "FAIL: cross-type near_slug wrong"; errors=$((errors+1)); }
+echo "$OUT" | grep -q '"near_existing_total": 1' && green "PASS: concept-store-47-cross-type-match-concept cross-type match (concept → entity) trips" || { red "FAIL: concept-store-47-cross-type-match-concept cross-type tripwire silent"; errors=$((errors+1)); }
+echo "$OUT" | grep -q '"near_type": "entity"' && green "PASS: concept-store-48-cross-type-near-type cross-type near_type reports entity" || { red "FAIL: concept-store-48-cross-type-near-type near_type not 'entity' on cross-type match"; errors=$((errors+1)); }
+echo "$OUT" | grep -q '"near_slug": "european-commission"' && green "PASS: concept-store-49-cross-type-near-slug cross-type near_slug points at the entity page" || { red "FAIL: concept-store-49-cross-type-near-slug cross-type near_slug wrong"; errors=$((errors+1)); }
 
 # --- 16. CROSS-LINGUAL candidate gate + crossmerge (#345) --------------------
 # Build a concept page carrying a German claim and its English twin that share
@@ -437,24 +437,24 @@ python3 "$SCRIPT" merge --records "$PROJX/.metadata/recxl.txt" --wiki-root "$WIK
 XLPAGE="$WIKI/wiki/concepts/sanctions-regime.md"
 CAND=$(python3 "$SCRIPT" xlingual-candidates --wiki-root "$WIKI" --slugs "sanctions-regime" --wiki-scripts-dir "$WSD")
 NC=$(echo "$CAND" | field '["data"]["n_candidates"]')
-[ "$NC" = "1" ] && green "PASS: xlingual-candidates flags exactly the DE↔EN twin pair" || { red "FAIL: expected 1 candidate, got $NC"; errors=$((errors+1)); }
-echo "$CAND" | grep -q '"shared_anchors"' && echo "$CAND" | grep -q '"99"' && green "PASS: candidate carries the shared article-number anchor 99" || { red "FAIL: candidate missing anchor 99"; errors=$((errors+1)); }
+[ "$NC" = "1" ] && green "PASS: concept-store-50-xlingual-candidates-flags-exactly xlingual-candidates flags exactly the DE↔EN twin pair" || { red "FAIL: concept-store-50-xlingual-candidates-flags-exactly expected 1 candidate, got $NC"; errors=$((errors+1)); }
+echo "$CAND" | grep -q '"shared_anchors"' && echo "$CAND" | grep -q '"99"' && green "PASS: concept-store-51-candidate-carries-shared-article candidate carries the shared article-number anchor 99" || { red "FAIL: concept-store-51-candidate-carries-shared-article candidate missing anchor 99"; errors=$((errors+1)); }
 
 # Confirm dcl-001 (DE survivor) absorbs dcl-002 (EN twin).
 printf 'merge: sanctions-regime | dcl-001 | dcl-002\n' > "$PROJX/.metadata/xmrec.txt"
 XM=$(python3 "$SCRIPT" crossmerge --records "$PROJX/.metadata/xmrec.txt" --wiki-root "$WIKI" --wiki-scripts-dir "$WSD")
-echo "$XM" | grep -q '"claims_crossmerged_total": 1' && green "PASS: crossmerge reports 1 union" || { red "FAIL: crossmerge total != 1"; errors=$((errors+1)); }
+echo "$XM" | grep -q '"claims_crossmerged_total": 1' && green "PASS: concept-store-52-crossmerge-reports-1-union crossmerge reports 1 union" || { red "FAIL: concept-store-52-crossmerge-reports-1-union crossmerge total != 1"; errors=$((errors+1)); }
 NLEFT=$(grep -c 'claim_id: dcl-' "$XLPAGE")
-[ "$NLEFT" = "2" ] && green "PASS: crossmerge collapsed 3 claims → 2 (absorbed dcl removed)" || { red "FAIL: expected 2 claims after crossmerge, got $NLEFT"; errors=$((errors+1)); }
+[ "$NLEFT" = "2" ] && green "PASS: concept-store-53-crossmerge-collapsed-3-claims crossmerge collapsed 3 claims → 2 (absorbed dcl removed)" || { red "FAIL: concept-store-53-crossmerge-collapsed-3-claims expected 2 claims after crossmerge, got $NLEFT"; errors=$((errors+1)); }
 # Survivor must carry BOTH source refs — no provenance dropped.
 SURV=$(awk '/claim_id: dcl-001$/{f=1} f{print} /source_claim_refs:/{if(f){print; exit}}' "$XLPAGE")
-echo "$SURV" | grep -q 'src-a#clm-200' && echo "$SURV" | grep -q 'src-b#clm-201' && green "PASS: survivor unions both DE+EN source_claim_refs (no fact dropped)" || { red "FAIL: survivor lost a provenance ref"; errors=$((errors+1)); }
+echo "$SURV" | grep -q 'src-a#clm-200' && echo "$SURV" | grep -q 'src-b#clm-201' && green "PASS: concept-store-54-survivor-unions-both-de survivor unions both DE+EN source_claim_refs (no fact dropped)" || { red "FAIL: concept-store-54-survivor-unions-both-de survivor lost a provenance ref"; errors=$((errors+1)); }
 
 # --- 16b. crossmerge BYTE-STABLE re-run (absorbed id already gone) -----------
 BEFORE_XL=$(cat "$XLPAGE")
 python3 "$SCRIPT" crossmerge --records "$PROJX/.metadata/xmrec.txt" --wiki-root "$WIKI" --wiki-scripts-dir "$WSD" >/dev/null
 AFTER_XL=$(cat "$XLPAGE")
-[ "$BEFORE_XL" = "$AFTER_XL" ] && green "PASS: crossmerge re-run is byte-stable (absorbed id gone → claim_not_found)" || { red "FAIL: crossmerge re-run changed the page"; errors=$((errors+1)); }
+[ "$BEFORE_XL" = "$AFTER_XL" ] && green "PASS: concept-store-55-crossmerge-re-run-byte crossmerge re-run is byte-stable (absorbed id gone → claim_not_found)" || { red "FAIL: concept-store-55-crossmerge-re-run-byte crossmerge re-run changed the page"; errors=$((errors+1)); }
 
 # --- 16c. crossmerge REJECTS a non-candidate proposal (LLM can't widen scope)
 # dcl-001 (Artikel 99) vs dcl-003 (Aufsichtsbehörde, no shared anchor) are both
@@ -463,9 +463,9 @@ AFTER_XL=$(cat "$XLPAGE")
 BEFORE_NC=$(cat "$XLPAGE")
 printf 'merge: sanctions-regime | dcl-001 | dcl-003\n' > "$PROJX/.metadata/xmbad.txt"
 XB=$(python3 "$SCRIPT" crossmerge --records "$PROJX/.metadata/xmbad.txt" --wiki-root "$WIKI" --wiki-scripts-dir "$WSD")
-echo "$XB" | grep -q '"reason": "not_a_candidate"' && green "PASS: crossmerge rejects a non-candidate pair (server-side gate)" || { red "FAIL: non-candidate not rejected"; errors=$((errors+1)); }
+echo "$XB" | grep -q '"reason": "not_a_candidate"' && green "PASS: concept-store-56-crossmerge-rejects-non-candidate crossmerge rejects a non-candidate pair (server-side gate)" || { red "FAIL: concept-store-56-crossmerge-rejects-non-candidate non-candidate not rejected"; errors=$((errors+1)); }
 AFTER_NC=$(cat "$XLPAGE")
-[ "$BEFORE_NC" = "$AFTER_NC" ] && green "PASS: rejected crossmerge leaves the page byte-unchanged" || { red "FAIL: rejected crossmerge mutated the page"; errors=$((errors+1)); }
+[ "$BEFORE_NC" = "$AFTER_NC" ] && green "PASS: concept-store-57-rejected-crossmerge-leaves-page rejected crossmerge leaves the page byte-unchanged" || { red "FAIL: concept-store-57-rejected-crossmerge-leaves-page rejected crossmerge mutated the page"; errors=$((errors+1)); }
 
 # --- 16d. single-language page yields ZERO candidates (the auto-skip) --------
 # Two English claims sharing anchor 99 but ALSO high overlap would auto-merge in
@@ -480,7 +480,7 @@ cat > "$PROJY/.metadata/recmono.txt" <<'EOF'
 EOF
 python3 "$SCRIPT" merge --records "$PROJY/.metadata/recmono.txt" --wiki-root "$WIKI" --project-path "$PROJY" --project-slug proj-mono --wiki-scripts-dir "$WSD" >/dev/null
 MC=$(python3 "$SCRIPT" xlingual-candidates --wiki-root "$WIKI" --slugs "monolingual-probe" --wiki-scripts-dir "$WSD" | field '["data"]["n_candidates"]')
-[ "$MC" = "0" ] && green "PASS: single-language page (year 2025 not an anchor) → 0 candidates (auto-skip)" || { red "FAIL: expected 0 candidates on monolingual page, got $MC"; errors=$((errors+1)); }
+[ "$MC" = "0" ] && green "PASS: concept-store-58-single-language-page-year single-language page (year 2025 not an anchor) → 0 candidates (auto-skip)" || { red "FAIL: concept-store-58-single-language-page-year expected 0 candidates on monolingual page, got $MC"; errors=$((errors+1)); }
 
 echo ""
 if [ "$errors" -eq 0 ]; then

--- a/cogni-knowledge/tests/test_concepts_index.sh
+++ b/cogni-knowledge/tests/test_concepts_index.sh
@@ -43,11 +43,11 @@ WSD="$PLUGIN_ROOT/scripts/vendor/cogni-wiki/skills/wiki-ingest/scripts"
 . "$(dirname "$0")/fixtures/test_helpers.sh"
 
 if [ ! -f "$SCRIPT" ]; then
-  red "FAIL: concepts_index.py not found at $SCRIPT"
+  red "FAIL: concepts-index-00-script-present concepts_index.py not found at $SCRIPT"
   exit 1
 fi
 if [ ! -d "$WSD" ]; then
-  red "FAIL: cogni-wiki wiki-ingest scripts not found at $WSD (needed for _wiki_lock)"
+  red "FAIL: concepts-index-00-wiki-scripts-present cogni-wiki wiki-ingest scripts not found at $WSD (needed for _wiki_lock)"
   exit 1
 fi
 
@@ -131,41 +131,41 @@ IDX="$WIKI/wiki/concepts/index.md"
 # --- 1. render creates the page ----------------------------------------------
 OUT=$(python3 "$SCRIPT" render --wiki-root "$WIKI" --wiki-scripts-dir "$WSD")
 if [ "$(echo "$OUT" | field '["success"]')" = "True" ] && [ -f "$IDX" ]; then
-  green "PASS: render creates wiki/concepts/index.md"
+  green "PASS: concepts-index-01-render-creates-wiki-concepts render creates wiki/concepts/index.md"
 else
-  red "FAIL: render did not create the index"; echo "$OUT"; errors=$((errors+1))
+  red "FAIL: concepts-index-01-render-creates-wiki-concepts render did not create the index"; echo "$OUT"; errors=$((errors+1))
 fi
 [ "$(echo "$OUT" | field '["data"]["changed"]')" = "True" ] \
-  && green "PASS: first render reports changed:true" \
-  || { red "FAIL: first render changed != true"; errors=$((errors+1)); }
-assert_grep '^# Concepts$' "$IDX" "page H1 '# Concepts'"
-assert_grep 'MACHINE-OWNED:CONCEPTS-INDEX' "$IDX" "page ownership marker"
-assert_grep 'Auto-generated concept map' "$IDX" "page intro line"
+  && green "PASS: concepts-index-02-first-render-reports-changed first render reports changed:true" \
+  || { red "FAIL: concepts-index-02-first-render-reports-changed first render changed != true"; errors=$((errors+1)); }
+assert_grep '^# Concepts$' "$IDX" "concepts-index-03-page-h1-concepts page H1 '# Concepts'"
+assert_grep 'MACHINE-OWNED:CONCEPTS-INDEX' "$IDX" "concepts-index-04-page-ownership-marker page ownership marker"
+assert_grep 'Auto-generated concept map' "$IDX" "concepts-index-05-page-intro-line page intro line"
 
 # --- 2. theme grouping (wiki-resident derivation) ----------------------------
 [ "$(bullet_section data-protection "$IDX")" = "Regulatory Scope" ] \
-  && green "PASS: unanimous concept -> Regulatory Scope" \
-  || { red "FAIL: data-protection not under Regulatory Scope"; errors=$((errors+1)); }
+  && green "PASS: concepts-index-06-unanimous-concept-regulatory-scope unanimous concept -> Regulatory Scope" \
+  || { red "FAIL: concepts-index-06-unanimous-concept-regulatory-scope data-protection not under Regulatory Scope"; errors=$((errors+1)); }
 [ "$(bullet_section penalties "$IDX")" = "Enforcement" ] \
-  && green "PASS: single-source concept -> Enforcement" \
-  || { red "FAIL: penalties not under Enforcement"; errors=$((errors+1)); }
+  && green "PASS: concepts-index-07-single-source-concept-enforcement single-source concept -> Enforcement" \
+  || { red "FAIL: concepts-index-07-single-source-concept-enforcement penalties not under Enforcement"; errors=$((errors+1)); }
 [ "$(bullet_section scope-vs-enforcement "$IDX")" = "Regulatory Scope" ] \
-  && green "PASS: mixed backing set -> MAJORITY (Regulatory Scope)" \
-  || { red "FAIL: majority theme resolution wrong"; errors=$((errors+1)); }
+  && green "PASS: concepts-index-08-mixed-backing-set-majority mixed backing set -> MAJORITY (Regulatory Scope)" \
+  || { red "FAIL: concepts-index-08-mixed-backing-set-majority majority theme resolution wrong"; errors=$((errors+1)); }
 [ "$(bullet_section loose-concept "$IDX")" = "Uncategorized" ] \
-  && green "PASS: no-resolvable-theme concept -> Uncategorized fallback" \
-  || { red "FAIL: loose-concept not under Uncategorized"; errors=$((errors+1)); }
+  && green "PASS: concepts-index-09-no-resolvable-theme-uncategorized no-resolvable-theme concept -> Uncategorized fallback" \
+  || { red "FAIL: concepts-index-09-no-resolvable-theme-uncategorized loose-concept not under Uncategorized"; errors=$((errors+1)); }
 
 # --- 3. summary + wikilink bullet --------------------------------------------
 assert_grep 'How personal data is protected under the regime. \[\[data-protection\]\]' \
-  "$IDX" "concept bullet renders summary + [[slug]] link"
-assert_grep '\[\[penalties\]\]' "$IDX" "penalties bullet has [[slug]] wikilink"
+  "$IDX" "concepts-index-10-concept-bullet-renders-summary concept bullet renders summary + [[slug]] link"
+assert_grep '\[\[penalties\]\]' "$IDX" "concepts-index-11-penalties-bullet-has-slug penalties bullet has [[slug]] wikilink"
 
 # --- 4. lead-in sentinel spans, placeholder on a fresh render ----------------
 assert_grep 'MACHINE-OWNED:CONCEPTS-LEADIN:regulatory-scope:START' \
-  "$IDX" "Regulatory Scope lead-in sentinel span present"
+  "$IDX" "concepts-index-12-regulatory-scope-lead-sentinel Regulatory Scope lead-in sentinel span present"
 assert_grep 'This theme groups the concepts below' \
-  "$IDX" "fresh render uses the deterministic lead-in fallback"
+  "$IDX" "concepts-index-13-fresh-render-uses-deterministic fresh render uses the deterministic lead-in fallback"
 
 # --- 5. CARRY-FORWARD: a narrator-authored lead-in survives a re-render -------
 python3 - "$IDX" "$SCRIPTS_DIR" <<'PY'
@@ -181,21 +181,21 @@ open(p, "w", encoding="utf-8").write(t)
 PY
 OUT=$(python3 "$SCRIPT" render --wiki-root "$WIKI" --wiki-scripts-dir "$WSD")
 assert_grep 'Authored framing: the legal boundaries' \
-  "$IDX" "authored lead-in carried forward across re-render (no clobber)"
+  "$IDX" "concepts-index-14-authored-lead-carried-forward authored lead-in carried forward across re-render (no clobber)"
 # The untouched Enforcement theme still shows the deterministic fallback.
 assert_grep 'This theme groups the concepts below' \
-  "$IDX" "untouched theme keeps the deterministic fallback after carry-forward"
+  "$IDX" "concepts-index-15-untouched-theme-keeps-deterministic untouched theme keeps the deterministic fallback after carry-forward"
 
 # --- 6. BYTE-IDEMPOTENT re-render --------------------------------------------
 cp "$IDX" "$WORK/idx.before"
 OUT=$(python3 "$SCRIPT" render --wiki-root "$WIKI" --wiki-scripts-dir "$WSD")
 [ "$(echo "$OUT" | field '["data"]["changed"]')" = "False" ] \
-  && green "PASS: unchanged re-render reports changed:false" \
-  || { red "FAIL: idempotent re-render changed != false"; errors=$((errors+1)); }
+  && green "PASS: concepts-index-16-unchanged-re-render-reports unchanged re-render reports changed:false" \
+  || { red "FAIL: concepts-index-16-unchanged-re-render-reports idempotent re-render changed != false"; errors=$((errors+1)); }
 if cmp -s "$WORK/idx.before" "$IDX"; then
-  green "PASS: re-render is byte-identical (no stamp churn)"
+  green "PASS: concepts-index-17-re-render-byte-identical re-render is byte-identical (no stamp churn)"
 else
-  red "FAIL: re-render mutated the page"; errors=$((errors+1))
+  red "FAIL: concepts-index-17-re-render-byte-identical re-render mutated the page"; errors=$((errors+1))
 fi
 
 # --- 7. HUMAN-PAGE skip ------------------------------------------------------
@@ -209,12 +209,12 @@ printf '# My hand-written concept map\n\nNothing machine-owned here.\n' \
 cp "$HWIKI/wiki/concepts/index.md" "$WORK/human.before"
 OUT=$(python3 "$SCRIPT" render --wiki-root "$HWIKI" --wiki-scripts-dir "$WSD")
 [ "$(echo "$OUT" | field '["data"]["skipped_human_page"]')" = "True" ] \
-  && green "PASS: human-authored index skipped (skipped_human_page)" \
-  || { red "FAIL: human page not skipped"; echo "$OUT"; errors=$((errors+1)); }
+  && green "PASS: concepts-index-18-human-authored-index-skipped human-authored index skipped (skipped_human_page)" \
+  || { red "FAIL: concepts-index-18-human-authored-index-skipped human page not skipped"; echo "$OUT"; errors=$((errors+1)); }
 if cmp -s "$WORK/human.before" "$HWIKI/wiki/concepts/index.md"; then
-  green "PASS: human page left byte-untouched"
+  green "PASS: concepts-index-19-human-page-left-byte human page left byte-untouched"
 else
-  red "FAIL: human page was modified"; errors=$((errors+1))
+  red "FAIL: concepts-index-19-human-page-left-byte human page was modified"; errors=$((errors+1))
 fi
 
 # --- 8. stage subcommand (lock-free) -----------------------------------------
@@ -226,22 +226,22 @@ cp "$WIKI/wiki/concepts/penalties.md" "$SWIKI/wiki/concepts/penalties.md"
 OUT=$(python3 "$SCRIPT" stage --wiki-root "$SWIKI")
 STAGED="$SWIKI/.cogni-wiki/concepts-index-proposed.md"
 [ "$(echo "$OUT" | field '["success"]')" = "True" ] && [ -f "$STAGED" ] \
-  && green "PASS: stage writes the proposed page" \
-  || { red "FAIL: stage did not write the proposal"; echo "$OUT"; errors=$((errors+1)); }
+  && green "PASS: concepts-index-20-stage-writes-proposed-page stage writes the proposed page" \
+  || { red "FAIL: concepts-index-20-stage-writes-proposed-page stage did not write the proposal"; echo "$OUT"; errors=$((errors+1)); }
 [ "$(echo "$OUT" | field '["data"]["would_change"]')" = "True" ] \
-  && green "PASS: stage reports would_change on a missing live page" \
-  || { red "FAIL: stage would_change != true"; errors=$((errors+1)); }
+  && green "PASS: concepts-index-21-stage-reports-would-change stage reports would_change on a missing live page" \
+  || { red "FAIL: concepts-index-21-stage-reports-would-change stage would_change != true"; errors=$((errors+1)); }
 [ ! -f "$SWIKI/wiki/concepts/index.md" ] \
-  && green "PASS: stage does not touch the live page" \
-  || { red "FAIL: stage wrote the live page"; errors=$((errors+1)); }
+  && green "PASS: concepts-index-22-stage-does-not-touch-live stage does not touch the live page" \
+  || { red "FAIL: concepts-index-22-stage-does-not-touch-live stage wrote the live page"; errors=$((errors+1)); }
 
 # --- 9. python3.9 floor ------------------------------------------------------
 assert_grep 'from __future__ import annotations' "$SCRIPT" \
-  "script carries the py3.9 future-annotations import"
+  "concepts-index-23-script-carries-py3-9 script carries the py3.9 future-annotations import"
 if python3 -c "import ast,sys; ast.parse(open(sys.argv[1],encoding='utf-8').read())" "$SCRIPT"; then
-  green "PASS: concepts_index.py parses cleanly (ast.parse)"
+  green "PASS: concepts-index-24-concepts-index-py-parses concepts_index.py parses cleanly (ast.parse)"
 else
-  red "FAIL: concepts_index.py has a syntax error"; errors=$((errors+1))
+  red "FAIL: concepts-index-24-concepts-index-py-parses concepts_index.py has a syntax error"; errors=$((errors+1))
 fi
 
 # --- summary -----------------------------------------------------------------

--- a/cogni-knowledge/tests/test_contradiction_finalize_store.sh
+++ b/cogni-knowledge/tests/test_contradiction_finalize_store.sh
@@ -25,7 +25,7 @@ SCRIPT="$PLUGIN_ROOT/scripts/contradiction-finalize-store.py"
 . "$(dirname "$0")/fixtures/test_helpers.sh"
 
 if [ ! -f "$SCRIPT" ]; then
-  red "FAIL: contradiction-finalize-store.py not found at $SCRIPT"
+  red "FAIL: contradiction-finalize-store-00-script-present contradiction-finalize-store.py not found at $SCRIPT"
   exit 1
 fi
 
@@ -48,9 +48,9 @@ assert d["resolution_coverage"] == {"resolved": 0, "contradictions": 0, "pct": 0
 assert d["output_language"] == "en", d["output_language"]
 PY
 then
-  green "PASS: init writes an empty canonical file (schema 0.1.0, zeroed rates)"
+  green "PASS: contradiction-finalize-store-01-init-shape init writes an empty canonical file (schema 0.1.0, zeroed rates)"
 else
-  red "FAIL: init canonical file shape wrong"
+  red "FAIL: contradiction-finalize-store-01-init-shape init canonical file shape wrong"
   errors=$((errors + 1))
 fi
 
@@ -88,9 +88,9 @@ assert s["synthesis_slug"] == "eu-ai-act-classification", s
 assert s["unresolved_high"] == 0 and s["clean"] is True, s
 PY
 then
-  green "PASS: record marks a resolved-high synthesis clean (pct=100, coverage=1/1)"
+  green "PASS: contradiction-finalize-store-02-record-clean-synthesis record marks a resolved-high synthesis clean (pct=100, coverage=1/1)"
 else
-  red "FAIL: record clean-synthesis shape wrong"
+  red "FAIL: contradiction-finalize-store-02-record-clean-synthesis record clean-synthesis shape wrong"
   errors=$((errors + 1))
 fi
 
@@ -124,9 +124,9 @@ rc = d["resolution_coverage"]
 assert rc["contradictions"] == 2 and rc["resolved"] == 0, rc
 PY
 then
-  green "PASS: record marks an unresolved-high synthesis not-clean (pct=0); medium ignored for cleanliness"
+  green "PASS: contradiction-finalize-store-03-record-unresolved-high record marks an unresolved-high synthesis not-clean (pct=0); medium ignored for cleanliness"
 else
-  red "FAIL: record unresolved-high shape wrong"
+  red "FAIL: contradiction-finalize-store-03-record-unresolved-high record unresolved-high shape wrong"
   errors=$((errors + 1))
 fi
 
@@ -151,9 +151,9 @@ assert d["syntheses"][0]["draft_version"] == 2, d["syntheses"]   # latest, not v
 assert d["consistency_rate"]["pct"] == 100.0, d["consistency_rate"]  # v2 has no findings -> clean
 PY
 then
-  green "PASS: record reads the latest contradictor-vN.json (v2 over v1)"
+  green "PASS: contradiction-finalize-store-04-latest-contradictor-version record reads the latest contradictor-vN.json (v2 over v1)"
 else
-  red "FAIL: record did not select the latest contradictor version"
+  red "FAIL: contradiction-finalize-store-04-latest-contradictor-version record did not select the latest contradictor version"
   errors=$((errors + 1))
 fi
 
@@ -169,13 +169,13 @@ assert d["consistency_rate"] == {"syntheses_total": 0, "syntheses_clean": 0, "pc
 assert d["syntheses"] == [], d["syntheses"]
 PY
   then
-    green "PASS: record is fail-soft on a missing contradictor (zeroed artifact, exit 0)"
+    green "PASS: contradiction-finalize-store-05-record-fail-soft record is fail-soft on a missing contradictor (zeroed artifact, exit 0)"
   else
-    red "FAIL: fail-soft artifact shape wrong"
+    red "FAIL: contradiction-finalize-store-05-record-fail-soft fail-soft artifact shape wrong"
     errors=$((errors + 1))
   fi
 else
-  red "FAIL: record exited non-zero on a missing contradictor (must be fail-soft)"
+  red "FAIL: contradiction-finalize-store-05-record-fail-soft record exited non-zero on a missing contradictor (must be fail-soft)"
   errors=$((errors + 1))
 fi
 
@@ -185,9 +185,9 @@ H1=$(python3 -c "import hashlib,sys;print(hashlib.sha256(open(sys.argv[1],'rb').
 python3 "$SCRIPT" record --project-path "$PROJ" --out "$OUT2" --output-language en >/dev/null
 H2=$(python3 -c "import hashlib,sys;print(hashlib.sha256(open(sys.argv[1],'rb').read()).hexdigest())" "$OUT2")
 if [ "$H1" = "$H2" ]; then
-  green "PASS: record is idempotent (byte-identical re-record)"
+  green "PASS: contradiction-finalize-store-06-record-idempotent record is idempotent (byte-identical re-record)"
 else
-  red "FAIL: record is not idempotent"
+  red "FAIL: contradiction-finalize-store-06-record-idempotent record is not idempotent"
   errors=$((errors + 1))
 fi
 

--- a/cogni-knowledge/tests/test_contradiction_ingest_store.sh
+++ b/cogni-knowledge/tests/test_contradiction_ingest_store.sh
@@ -25,7 +25,7 @@ SCRIPT="$PLUGIN_ROOT/scripts/contradiction-ingest-store.py"
 . "$(dirname "$0")/fixtures/test_helpers.sh"
 
 if [ ! -f "$SCRIPT" ]; then
-  red "FAIL: contradiction-ingest-store.py not found at $SCRIPT"
+  red "FAIL: contradiction-ingest-store-00-script-present contradiction-ingest-store.py not found at $SCRIPT"
   exit 1
 fi
 
@@ -49,9 +49,9 @@ assert c == {"contradiction": 0, "unknown": 0, "total": 0, "high": 0, "medium": 
 assert d["output_language"] == "en", d["output_language"]
 PY
 then
-  green "PASS: init writes an empty canonical file (schema 0.1.0, zeroed counts)"
+  green "PASS: contradiction-ingest-store-01-init-shape init writes an empty canonical file (schema 0.1.0, zeroed counts)"
 else
-  red "FAIL: init canonical file shape wrong"
+  red "FAIL: contradiction-ingest-store-01-init-shape init canonical file shape wrong"
   errors=$((errors + 1))
 fi
 
@@ -115,9 +115,9 @@ assert g[0]["finding_count"] == 2 and g[1]["finding_count"] == 2, g
 assert g[1]["missing_pages"] == ["src-vanished"], g
 PY
 then
-  green "PASS: merge re-ids globally, recomputes aggregate counts, records groups_compared[], invariants hold"
+  green "PASS: contradiction-ingest-store-02-merge-reid-aggregate merge re-ids globally, recomputes aggregate counts, records groups_compared[], invariants hold"
 else
-  red "FAIL: merged canonical file wrong"
+  red "FAIL: contradiction-ingest-store-02-merge-reid-aggregate merged canonical file wrong"
   errors=$((errors + 1))
 fi
 
@@ -133,9 +133,9 @@ assert len(d["findings"]) == 4, len(d["findings"])
 assert [x["id"] for x in d["findings"]] == ["ctr-001", "ctr-002", "ctr-003", "ctr-004"]
 PY
 then
-  green "PASS: re-merge is idempotent (overwrites the canonical file)"
+  green "PASS: contradiction-ingest-store-03-remerge-idempotent re-merge is idempotent (overwrites the canonical file)"
 else
-  red "FAIL: re-merge not idempotent"
+  red "FAIL: contradiction-ingest-store-03-remerge-idempotent re-merge not idempotent"
   errors=$((errors + 1))
 fi
 
@@ -160,9 +160,9 @@ assert d["data"]["shards_merged"] == 2, d["data"]
 assert d["data"]["counts"]["total"] == 4, d["data"]
 PY
 then
-  green "PASS: merge skips a malformed / wrong-schema fragment fail-soft (records skipped_shards[])"
+  green "PASS: contradiction-ingest-store-04-malformed-shard-failsoft merge skips a malformed / wrong-schema fragment fail-soft (records skipped_shards[])"
 else
-  red "FAIL: fail-soft skip not handled"
+  red "FAIL: contradiction-ingest-store-04-malformed-shard-failsoft fail-soft skip not handled"
   errors=$((errors + 1))
 fi
 
@@ -202,9 +202,9 @@ assert c["total"] == c["contradiction"] + c["unknown"]
 assert c["contradiction"] == c["high"] + c["medium"] + c["low"]
 PY
 then
-  green "PASS: out-of-vocab finding dropped+recorded (skipped_findings[]), merge still writes the file"
+  green "PASS: contradiction-ingest-store-05-out-of-vocab-dropped out-of-vocab finding dropped+recorded (skipped_findings[]), merge still writes the file"
 else
-  red "FAIL: out-of-vocab finding not handled fail-soft"
+  red "FAIL: contradiction-ingest-store-05-out-of-vocab-dropped out-of-vocab finding not handled fail-soft"
   errors=$((errors + 1))
 fi
 
@@ -223,9 +223,9 @@ assert d["findings"] == [] and d["groups_compared"] == [], d
 assert d["counts"]["total"] == 0, d["counts"]
 PY
 then
-  green "PASS: zero matching shards merges to an empty canonical file (success)"
+  green "PASS: contradiction-ingest-store-06-zero-shard-merge zero matching shards merges to an empty canonical file (success)"
 else
-  red "FAIL: zero-shard merge not handled"
+  red "FAIL: contradiction-ingest-store-06-zero-shard-merge zero-shard merge not handled"
   errors=$((errors + 1))
 fi
 
@@ -270,9 +270,9 @@ assert cov == {"resolved": 1, "contradictions": 2, "pct": 50.0}, cov
 assert env["data"]["resolution_coverage"] == cov, env["data"].get("resolution_coverage")
 PY
 then
-  green "PASS: resolution{} survives merge verbatim (id-only re-write) + resolution_coverage reported"
+  green "PASS: contradiction-ingest-store-07-resolution-passthrough resolution{} survives merge verbatim (id-only re-write) + resolution_coverage reported"
 else
-  red "FAIL: resolution passthrough / coverage wrong"
+  red "FAIL: contradiction-ingest-store-07-resolution-passthrough resolution passthrough / coverage wrong"
   errors=$((errors + 1))
 fi
 

--- a/cogni-knowledge/tests/test_cycle_guard_clear.sh
+++ b/cogni-knowledge/tests/test_cycle_guard_clear.sh
@@ -48,8 +48,10 @@ set -e
 
 errors=0
 if [ $RC -ne 0 ]; then
-  red "FAIL: expected exit 0 (clear), got $RC"
+  red "FAIL: cycle-guard-clear-01-exit-zero expected exit 0 (clear), got $RC"
   errors=$((errors + 1))
+else
+  green "PASS: cycle-guard-clear-01-exit-zero cycle-guard exits 0 on a legitimate cross-project citation"
 fi
 
 if ! echo "$OUT" | python3 -c "
@@ -63,10 +65,11 @@ assert data['transitive_self_cycles'] == [], data['transitive_self_cycles']
 assert len(data['cross_lineage_overlap']) > 0, 'cross_lineage_overlap empty'
 print('OK')
 " | grep -q OK; then
-  red "FAIL: output did not match clear contract"
+  red "FAIL: cycle-guard-clear-02-clear-contract output did not match clear contract"
   red "  got: $OUT"
   errors=$((errors + 1))
+else
+  green "PASS: cycle-guard-clear-02-clear-contract legitimate cross-project citation reports status: clear with overlap recorded"
 fi
 
 if [ $errors -gt 0 ]; then exit 1; fi
-green "PASS: legitimate cross-project citation reports status: clear with overlap recorded"

--- a/cogni-knowledge/tests/test_cycle_guard_depth_bound.sh
+++ b/cogni-knowledge/tests/test_cycle_guard_depth_bound.sh
@@ -45,8 +45,10 @@ set -e
 
 errors=0
 if [ $RC -ne 0 ]; then
-  red "FAIL: expected exit 0 (clear with depth 0), got $RC"
+  red "FAIL: cycle-guard-depth-bound-01-exit-zero expected exit 0 (clear with depth 0), got $RC"
   errors=$((errors + 1))
+else
+  green "PASS: cycle-guard-depth-bound-01-exit-zero cycle-guard exits 0 when depth 0 bounds the walk"
 fi
 
 if ! echo "$OUT" | python3 -c "
@@ -60,10 +62,11 @@ assert data['direct_self_cycles'] == [], data['direct_self_cycles']
 assert data['max_depth'] == 0, data['max_depth']
 print('OK')
 " | grep -q OK; then
-  red "FAIL: output did not match clear-at-depth-0 contract"
+  red "FAIL: cycle-guard-depth-bound-02-depth-zero-contract output did not match clear-at-depth-0 contract"
   red "  got: $OUT"
   errors=$((errors + 1))
+else
+  green "PASS: cycle-guard-depth-bound-02-depth-zero-contract max-depth 0 disables transitive recursion (status: clear)"
 fi
 
 if [ $errors -gt 0 ]; then exit 1; fi
-green "PASS: --max-depth 0 disables transitive recursion (status: clear)"

--- a/cogni-knowledge/tests/test_cycle_guard_direct.sh
+++ b/cogni-knowledge/tests/test_cycle_guard_direct.sh
@@ -44,8 +44,10 @@ set -e
 
 errors=0
 if [ $RC -ne 1 ]; then
-  red "FAIL: expected exit 1 (cycle_detected), got $RC"
+  red "FAIL: cycle-guard-direct-01-exit-one expected exit 1 (cycle_detected), got $RC"
   errors=$((errors + 1))
+else
+  green "PASS: cycle-guard-direct-01-exit-one cycle-guard exits 1 when a direct self-cycle is present"
 fi
 
 if ! echo "$OUT" | python3 -c "
@@ -58,10 +60,11 @@ assert len(data['direct_self_cycles']) > 0, 'direct_self_cycles empty'
 assert data['cycle_path'] == ['project-a', 'project-a'], f\"cycle_path={data['cycle_path']}\"
 print('OK')
 " | grep -q OK; then
-  red "FAIL: output did not match direct-cycle contract"
+  red "FAIL: cycle-guard-direct-02-direct-contract output did not match direct-cycle contract"
   red "  got: $OUT"
   errors=$((errors + 1))
+else
+  green "PASS: cycle-guard-direct-02-direct-contract direct self-cycle detected with cycle_path [project-a, project-a]"
 fi
 
 if [ $errors -gt 0 ]; then exit 1; fi
-green "PASS: direct self-cycle detected with cycle_path [project-a, project-a]"

--- a/cogni-knowledge/tests/test_cycle_guard_distilled.sh
+++ b/cogni-knowledge/tests/test_cycle_guard_distilled.sh
@@ -55,8 +55,10 @@ RC_A=$?
 set -e
 
 if [ $RC_A -ne 0 ]; then
-  red "FAIL[A]: expected exit 0 (clear), got $RC_A"
+  red "FAIL: cycle-guard-distilled-01-a-exit-zero expected exit 0 (clear), got $RC_A"
   errors=$((errors + 1))
+else
+  green "PASS: cycle-guard-distilled-01-a-exit-zero scenario A exits 0 on a clear distilled-page citation"
 fi
 if ! echo "$OUT_A" | python3 -c "
 import sys, json
@@ -72,11 +74,11 @@ assert data['cited_distilled_pages'][0]['type'] == 'concept', data['cited_distil
 assert data['wiki_pages_cited_missing'] == [], data['wiki_pages_cited_missing']
 print('OK')
 " | grep -q OK; then
-  red "FAIL[A]: clear-with-distilled contract not met"
+  red "FAIL: cycle-guard-distilled-02-a-clear-contract clear-with-distilled contract not met"
   red "  got: $OUT_A"
   errors=$((errors + 1))
 else
-  green "PASS[A]: concept citation is clear; recorded in cited_distilled_pages, not missing"
+  green "PASS: cycle-guard-distilled-02-a-clear-contract concept citation is clear; recorded in cited_distilled_pages, not missing"
 fi
 
 # --- Scenario B: see-through cycle ------------------------------------------
@@ -103,9 +105,11 @@ RC_B=$?
 set -e
 
 if [ $RC_B -ne 1 ]; then
-  red "FAIL[B]: expected exit 1 (cycle_detected via see-through), got $RC_B"
+  red "FAIL: cycle-guard-distilled-03-b-exit-one expected exit 1 (cycle_detected via see-through), got $RC_B"
   red "  got: $OUT_B"
   errors=$((errors + 1))
+else
+  green "PASS: cycle-guard-distilled-03-b-exit-one scenario B exits 1 on a see-through cycle behind a concept citation"
 fi
 if ! echo "$OUT_B" | python3 -c "
 import sys, json
@@ -117,15 +121,15 @@ assert len(data['direct_self_cycles']) > 0, data['direct_self_cycles']
 assert data['direct_self_cycles'][0]['page'] == 'wiki/syntheses/prior-synth-of-a.md', data['direct_self_cycles']
 print('OK')
 " | grep -q OK; then
-  red "FAIL[B]: see-through cycle contract not met"
+  red "FAIL: cycle-guard-distilled-04-b-see-through-contract see-through cycle contract not met"
   red "  got: $OUT_B"
   errors=$((errors + 1))
 else
-  green "PASS[B]: see-through trace surfaces the direct cycle behind a concept citation"
+  green "PASS: cycle-guard-distilled-04-b-see-through-contract see-through trace surfaces the direct cycle behind a concept citation"
 fi
 
 if [ $errors -ne 0 ]; then
-  red "FAIL: $errors assertion(s) failed"
+  red "FAIL: cycle-guard-distilled-05-aggregate $errors assertion(s) failed"
   exit 1
 fi
-green "PASS: distilled-page citations handled (clear see-through + cycle detection)"
+green "PASS: cycle-guard-distilled-05-aggregate distilled-page citations handled (clear see-through + cycle detection)"

--- a/cogni-knowledge/tests/test_cycle_guard_dry_run.sh
+++ b/cogni-knowledge/tests/test_cycle_guard_dry_run.sh
@@ -40,8 +40,10 @@ set -e
 
 errors=0
 if [ $RC -ne 0 ]; then
-  red "FAIL: dry-run must exit 0 even on cycle, got $RC"
+  red "FAIL: cycle-guard-dry-run-01-exit-zero dry-run must exit 0 even on cycle, got $RC"
   errors=$((errors + 1))
+else
+  green "PASS: cycle-guard-dry-run-01-exit-zero dry-run exits 0 even on a cycle (report-don't-gate)"
 fi
 
 if ! echo "$OUT" | python3 -c "
@@ -53,10 +55,11 @@ assert data['status'] == 'cycle_detected', data['status']
 assert len(data['direct_self_cycles']) > 0, 'direct_self_cycles empty'
 print('OK')
 " | grep -q OK; then
-  red "FAIL: output did not match dry-run contract"
+  red "FAIL: cycle-guard-dry-run-02-dry-run-contract output did not match dry-run contract"
   red "  got: $OUT"
   errors=$((errors + 1))
+else
+  green "PASS: cycle-guard-dry-run-02-dry-run-contract dry-run reports cycle_detected with success=true"
 fi
 
 if [ $errors -gt 0 ]; then exit 1; fi
-green "PASS: --dry-run reports cycle_detected with success=true (report-don't-gate)"

--- a/cogni-knowledge/tests/test_cycle_guard_not_applicable.sh
+++ b/cogni-knowledge/tests/test_cycle_guard_not_applicable.sh
@@ -42,8 +42,10 @@ set -e
 
 errors=0
 if [ $RC -ne 0 ]; then
-  red "FAIL: expected exit 0 (not_applicable), got $RC"
+  red "FAIL: cycle-guard-not-applicable-01-exit-zero expected exit 0 (not_applicable), got $RC"
   errors=$((errors + 1))
+else
+  green "PASS: cycle-guard-not-applicable-01-exit-zero cycle-guard exits 0 for a non-applicable report source"
 fi
 
 if ! echo "$OUT" | python3 -c "
@@ -56,10 +58,11 @@ assert data['wiki_pages_cited'] == [], data['wiki_pages_cited']
 assert data['direct_self_cycles'] == [], data['direct_self_cycles']
 print('OK')
 " | grep -q OK; then
-  red "FAIL: output did not match not_applicable contract"
+  red "FAIL: cycle-guard-not-applicable-02-not-applicable-contract output did not match not_applicable contract"
   red "  got: $OUT"
   errors=$((errors + 1))
+else
+  green "PASS: cycle-guard-not-applicable-02-not-applicable-contract report_source=web yields status: not_applicable, no walk"
 fi
 
 if [ $errors -gt 0 ]; then exit 1; fi
-green "PASS: report_source=web yields status: not_applicable, no walk"

--- a/cogni-knowledge/tests/test_cycle_guard_question.sh
+++ b/cogni-knowledge/tests/test_cycle_guard_question.sh
@@ -54,9 +54,11 @@ RC_A=$?
 set -e
 
 if [ $RC_A -ne 0 ]; then
-  red "FAIL[A]: expected exit 0 (clear), got $RC_A"
+  red "FAIL: cycle-guard-question-01-a-exit-zero expected exit 0 (clear), got $RC_A"
   red "  got: $OUT_A"
   errors=$((errors + 1))
+else
+  green "PASS: cycle-guard-question-01-a-exit-zero scenario A exits 0 on a clear question-node citation"
 fi
 if ! echo "$OUT_A" | python3 -c "
 import sys, json
@@ -72,11 +74,11 @@ assert data['cited_question_pages'][0]['type'] == 'question', data['cited_questi
 assert data['wiki_pages_cited_missing'] == [], data['wiki_pages_cited_missing']
 print('OK')
 " | grep -q OK; then
-  red "FAIL[A]: clear-with-question contract not met"
+  red "FAIL: cycle-guard-question-02-a-clear-contract clear-with-question contract not met"
   red "  got: $OUT_A"
   errors=$((errors + 1))
 else
-  green "PASS[A]: question citation is clear; recorded in cited_question_pages, not missing"
+  green "PASS: cycle-guard-question-02-a-clear-contract question citation is clear; recorded in cited_question_pages, not missing"
 fi
 
 # --- Scenario B: see-through cycle ------------------------------------------
@@ -102,9 +104,11 @@ RC_B=$?
 set -e
 
 if [ $RC_B -ne 1 ]; then
-  red "FAIL[B]: expected exit 1 (cycle_detected via see-through), got $RC_B"
+  red "FAIL: cycle-guard-question-03-b-exit-one expected exit 1 (cycle_detected via see-through), got $RC_B"
   red "  got: $OUT_B"
   errors=$((errors + 1))
+else
+  green "PASS: cycle-guard-question-03-b-exit-one scenario B exits 1 on a see-through cycle behind a question citation"
 fi
 if ! echo "$OUT_B" | python3 -c "
 import sys, json
@@ -116,15 +120,15 @@ assert len(data['direct_self_cycles']) > 0, data['direct_self_cycles']
 assert data['direct_self_cycles'][0]['page'] == 'wiki/syntheses/prior-synth-of-a.md', data['direct_self_cycles']
 print('OK')
 " | grep -q OK; then
-  red "FAIL[B]: see-through cycle contract not met"
+  red "FAIL: cycle-guard-question-04-b-see-through-contract see-through cycle contract not met"
   red "  got: $OUT_B"
   errors=$((errors + 1))
 else
-  green "PASS[B]: see-through trace surfaces the direct cycle behind a question citation"
+  green "PASS: cycle-guard-question-04-b-see-through-contract see-through trace surfaces the direct cycle behind a question citation"
 fi
 
 if [ $errors -ne 0 ]; then
-  red "FAIL: $errors assertion(s) failed"
+  red "FAIL: cycle-guard-question-05-aggregate $errors assertion(s) failed"
   exit 1
 fi
-green "PASS: question-node citations handled (clear see-through + cycle detection)"
+green "PASS: cycle-guard-question-05-aggregate question-node citations handled (clear see-through + cycle detection)"

--- a/cogni-knowledge/tests/test_cycle_guard_transitive.sh
+++ b/cogni-knowledge/tests/test_cycle_guard_transitive.sh
@@ -54,8 +54,10 @@ set -e
 
 errors=0
 if [ $RC -ne 1 ]; then
-  red "FAIL: expected exit 1 (cycle_detected), got $RC"
+  red "FAIL: cycle-guard-transitive-01-exit-one expected exit 1 (cycle_detected), got $RC"
   errors=$((errors + 1))
+else
+  green "PASS: cycle-guard-transitive-01-exit-one cycle-guard exits 1 when a transitive self-cycle is present"
 fi
 
 if ! echo "$OUT" | python3 -c "
@@ -70,10 +72,11 @@ assert data['direct_self_cycles'] == [], data['direct_self_cycles']
 assert data['cycle_path'] == ['project-a', 'project-b', 'project-a'], data['cycle_path']
 print('OK')
 " | grep -q OK; then
-  red "FAIL: output did not match transitive-cycle contract"
+  red "FAIL: cycle-guard-transitive-02-transitive-contract output did not match transitive-cycle contract"
   red "  got: $OUT"
   errors=$((errors + 1))
+else
+  green "PASS: cycle-guard-transitive-02-transitive-contract transitive self-cycle detected with cycle_path [project-a, project-b, project-a]"
 fi
 
 if [ $errors -gt 0 ]; then exit 1; fi
-green "PASS: transitive self-cycle detected with cycle_path [project-a, project-b, project-a]"

--- a/cogni-knowledge/tests/test_migrate_question_index.sh
+++ b/cogni-knowledge/tests/test_migrate_question_index.sh
@@ -31,7 +31,7 @@ WSD="$PLUGIN_ROOT/scripts/vendor/cogni-wiki/skills/wiki-ingest/scripts"
 errors=0
 
 if [ ! -d "$WSD" ]; then
-  red "FAIL: cogni-wiki wiki-ingest scripts not found at $WSD"
+  red "FAIL: migrate-question-index-00-wiki-scripts-present cogni-wiki wiki-ingest scripts not found at $WSD"
   exit 1
 fi
 
@@ -111,13 +111,13 @@ assert moved == {'records-of-processing-scope', 'high-risk-obligations'}, d
 skipped = {s['slug'] for s in d['data']['skipped']}
 assert 'legacy-no-theme' in skipped, d
 print('OK')
-" | grep -q OK && green "PASS: dry-run reports the two moves and skips the empty-theme node" \
-  || { red "FAIL: dry-run output assertion"; errors=$((errors + 1)); }
+" | grep -q OK && green "PASS: migrate-question-index-01-dry-run-reports-two dry-run reports the two moves and skips the empty-theme node" \
+  || { red "FAIL: migrate-question-index-01-dry-run-reports-two dry-run output assertion"; errors=$((errors + 1)); }
 
 if diff -q "$INDEX_BEFORE" "$WIKI/wiki/index.md" >/dev/null 2>&1; then
-  green "PASS: dry-run left index.md byte-identical"
+  green "PASS: migrate-question-index-02-dry-run-left-index dry-run left index.md byte-identical"
 else
-  red "FAIL: dry-run modified index.md"
+  red "FAIL: migrate-question-index-02-dry-run-left-index dry-run modified index.md"
   errors=$((errors + 1))
 fi
 
@@ -136,11 +136,11 @@ assert actions.get('high-risk-obligations') == 'moved', d
 skipped = {s['slug'] for s in d['data']['skipped']}
 assert 'legacy-no-theme' in skipped, d
 print('OK')
-" | grep -q OK && green "PASS: wet run reports both nodes moved, empty-theme node skipped" \
-  || { red "FAIL: wet-run output assertion"; errors=$((errors + 1)); }
+" | grep -q OK && green "PASS: migrate-question-index-03-wet-run-reports-both wet run reports both nodes moved, empty-theme node skipped" \
+  || { red "FAIL: migrate-question-index-03-wet-run-reports-both wet-run output assertion"; errors=$((errors + 1)); }
 
-assert_grep '## Compliance Scope' "$WIKI/wiki/index.md" "Compliance Scope heading created"
-assert_grep '## Risk Tiers' "$WIKI/wiki/index.md" "Risk Tiers heading created"
+assert_grep '## Compliance Scope' "$WIKI/wiki/index.md" "migrate-question-index-04-compliance-scope-heading-created Compliance Scope heading created"
+assert_grep '## Risk Tiers' "$WIKI/wiki/index.md" "migrate-question-index-05-risk-tiers-heading-created Risk Tiers heading created"
 
 # Each slug now sits under its theme_label heading, not under Research questions.
 LOC_RESULT=$(python3 - "$WIKI/wiki/index.md" <<'PY'
@@ -164,16 +164,16 @@ print("OK" if ok else f"BAD {loc}")
 PY
 )
 if [ "$LOC_RESULT" = "OK" ]; then
-  green "PASS: each slug sits under its theme_label heading, Sources untouched"
+  green "PASS: migrate-question-index-06-each-slug-sits-under each slug sits under its theme_label heading, Sources untouched"
 else
-  red "FAIL: heading placement wrong — $LOC_RESULT"
+  red "FAIL: migrate-question-index-06-each-slug-sits-under heading placement wrong — $LOC_RESULT"
   errors=$((errors + 1))
 fi
 
 # The flat Research questions heading is now empty and dropped.
-assert_not_grep '## Research questions' "$WIKI/wiki/index.md" "empty Research questions heading dropped"
+assert_not_grep '## Research questions' "$WIKI/wiki/index.md" "migrate-question-index-07-empty-research-questions-heading empty Research questions heading dropped"
 # The unrelated Sources bullet is untouched.
-assert_grep '\[\[some-source\]\]' "$WIKI/wiki/index.md" "unrelated Sources bullet preserved"
+assert_grep '\[\[some-source\]\]' "$WIKI/wiki/index.md" "migrate-question-index-08-unrelated-sources-bullet-preserved unrelated Sources bullet preserved"
 
 # ---------------------------------------------------------------------------
 # Test 3: idempotent re-run — every node is a noop, index unchanged
@@ -190,13 +190,13 @@ assert d['data']['moved'] == [], d
 noop = {n['slug'] for n in d['data']['noop']}
 assert noop == {'records-of-processing-scope', 'high-risk-obligations'}, d
 print('OK')
-" | grep -q OK && green "PASS: idempotent re-run reports both nodes as noop" \
-  || { red "FAIL: idempotent re-run assertion"; errors=$((errors + 1)); }
+" | grep -q OK && green "PASS: migrate-question-index-09-idempotent-re-run-reports idempotent re-run reports both nodes as noop" \
+  || { red "FAIL: migrate-question-index-09-idempotent-re-run-reports idempotent re-run assertion"; errors=$((errors + 1)); }
 
 if diff -q "$INDEX_AFTER_WET" "$WIKI/wiki/index.md" >/dev/null 2>&1; then
-  green "PASS: idempotent re-run left index.md unchanged"
+  green "PASS: migrate-question-index-10-idempotent-re-run-left idempotent re-run left index.md unchanged"
 else
-  red "FAIL: idempotent re-run modified index.md"
+  red "FAIL: migrate-question-index-10-idempotent-re-run-left idempotent re-run modified index.md"
   errors=$((errors + 1))
 fi
 
@@ -241,11 +241,11 @@ assert d['data']['dry_run'] is False, d
 actions = {m['slug']: m['action'] for m in d['data']['moved']}
 assert actions.get('records-of-processing-scope') == 'moved', d
 print('OK')
-" | grep -q OK && green "PASS: self-resolve (no --wiki-scripts-dir) probes the sibling checkout and relocates the node" \
-  || { red "FAIL: self-resolve output assertion (probe or move failed)"; errors=$((errors + 1)); }
+" | grep -q OK && green "PASS: migrate-question-index-11-self-resolve-wiki-scripts self-resolve (no --wiki-scripts-dir) probes the sibling checkout and relocates the node" \
+  || { red "FAIL: migrate-question-index-11-self-resolve-wiki-scripts self-resolve output assertion (probe or move failed)"; errors=$((errors + 1)); }
 
-assert_grep '## Compliance Scope' "$WIKI2/wiki/index.md" "self-resolve run created the theme_label heading"
-assert_not_grep '## Research questions' "$WIKI2/wiki/index.md" "self-resolve run dropped the empty flat heading"
+assert_grep '## Compliance Scope' "$WIKI2/wiki/index.md" "migrate-question-index-12-self-resolve-run-created self-resolve run created the theme_label heading"
+assert_not_grep '## Research questions' "$WIKI2/wiki/index.md" "migrate-question-index-13-self-resolve-run-dropped self-resolve run dropped the empty flat heading"
 
 # ---------------------------------------------------------------------------
 if [ "$errors" -eq 0 ]; then

--- a/cogni-knowledge/tests/test_perspectives_index.sh
+++ b/cogni-knowledge/tests/test_perspectives_index.sh
@@ -44,11 +44,11 @@ errors=0
 
 # --- 10. python3.9 floor (no _wikilib needed) --------------------------------
 grep -q 'from __future__ import annotations' "$PERSP_SCRIPT" \
-  && green "PASS: perspectives_index.py declares __future__ annotations (py3.9 floor)" \
-  || { red "FAIL: missing __future__ annotations import"; errors=$((errors+1)); }
+  && green "PASS: perspectives-index-01-perspectives-index-py-declares perspectives_index.py declares __future__ annotations (py3.9 floor)" \
+  || { red "FAIL: perspectives-index-01-perspectives-index-py-declares missing __future__ annotations import"; errors=$((errors+1)); }
 python3 -c "import ast,sys; ast.parse(open('$PERSP_SCRIPT').read())" \
-  && green "PASS: perspectives_index.py parses cleanly (ast.parse)" \
-  || { red "FAIL: perspectives_index.py does not parse"; errors=$((errors+1)); }
+  && green "PASS: perspectives-index-02-perspectives-index-py-parses perspectives_index.py parses cleanly (ast.parse)" \
+  || { red "FAIL: perspectives-index-02-perspectives-index-py-parses perspectives_index.py does not parse"; errors=$((errors+1)); }
 
 if [ ! -f "$WSD/_wikilib.py" ]; then
   red "SKIP: cogni-wiki _wikilib not found at $WSD (render needs _wiki_lock)"
@@ -123,27 +123,27 @@ PAGE="$WIKI/wiki/perspectives.md"
 # --- 1. render creates the page, envelope changed:true -----------------------
 OUT="$(python3 "$PERSP_SCRIPT" render --wiki-root "$WIKI" --wiki-scripts-dir "$WSD")"
 echo "$OUT" | grep -q '"changed": true' \
-  && green "PASS: render reports changed:true on first render" \
-  || { red "FAIL: render did not report changed:true"; errors=$((errors+1)); }
+  && green "PASS: perspectives-index-03-render-reports-changed-true render reports changed:true on first render" \
+  || { red "FAIL: perspectives-index-03-render-reports-changed-true render did not report changed:true"; errors=$((errors+1)); }
 [ -f "$PAGE" ] \
-  && green "PASS: render created wiki/perspectives.md" \
-  || { red "FAIL: wiki/perspectives.md not created"; errors=$((errors+1)); }
+  && green "PASS: perspectives-index-04-render-created-wiki-perspectives render created wiki/perspectives.md" \
+  || { red "FAIL: perspectives-index-04-render-created-wiki-perspectives wiki/perspectives.md not created"; errors=$((errors+1)); }
 
 # --- 2. H1 + ownership marker + intro ----------------------------------------
 grep -q '^# Perspectives$' "$PAGE" \
-  && green "PASS: page carries the # Perspectives H1" \
-  || { red "FAIL: missing # Perspectives H1"; errors=$((errors+1)); }
+  && green "PASS: perspectives-index-05-page-carries-perspectives-h1 page carries the # Perspectives H1" \
+  || { red "FAIL: perspectives-index-05-page-carries-perspectives-h1 missing # Perspectives H1"; errors=$((errors+1)); }
 grep -q 'MACHINE-OWNED:PERSPECTIVES-INDEX' "$PAGE" \
-  && green "PASS: page carries the PERSPECTIVES-INDEX ownership marker" \
-  || { red "FAIL: missing PERSPECTIVES-INDEX marker"; errors=$((errors+1)); }
+  && green "PASS: perspectives-index-06-page-carries-perspectives-index page carries the PERSPECTIVES-INDEX ownership marker" \
+  || { red "FAIL: perspectives-index-06-page-carries-perspectives-index missing PERSPECTIVES-INDEX marker"; errors=$((errors+1)); }
 
 # --- 2b. secondary-view labels (R10) + overview-stub signpost (R11) -----------
 grep -q 'Other views:' "$PAGE" \
-  && green "PASS: page carries the secondary-view labels line (R10)" \
-  || { red "FAIL: missing secondary-view labels line"; errors=$((errors+1)); }
+  && green "PASS: perspectives-index-07-page-carries-secondary-view page carries the secondary-view labels line (R10)" \
+  || { red "FAIL: perspectives-index-07-page-carries-secondary-view missing secondary-view labels line"; errors=$((errors+1)); }
 grep -q '\[Recent syntheses\](overview.md)' "$PAGE" \
-  && green "PASS: page signposts the overview stub — Recent syntheses (R11)" \
-  || { red "FAIL: missing overview.md (Recent syntheses) signpost"; errors=$((errors+1)); }
+  && green "PASS: perspectives-index-08-page-signposts-overview-stub page signposts the overview stub — Recent syntheses (R11)" \
+  || { red "FAIL: perspectives-index-08-page-signposts-overview-stub missing overview.md (Recent syntheses) signpost"; errors=$((errors+1)); }
 
 # --- 3. every facet renders its heading + PERSPECTIVES-FACET span -------------
 # Five facets now (the dead `How` facet was dropped).
@@ -154,16 +154,16 @@ for pair in "Who who" "What what" "Why why" "When when" "Where where"; do
   grep -q "MACHINE-OWNED:PERSPECTIVES-FACET:${slug}:START" "$PAGE" || { facet_ok=0; red "  missing FACET span ${slug}"; }
 done
 [ "$facet_ok" -eq 1 ] \
-  && green "PASS: all five 5W1H facets render heading + PERSPECTIVES-FACET span" \
-  || { red "FAIL: a facet heading or span is missing"; errors=$((errors+1)); }
+  && green "PASS: perspectives-index-09-all-five-5w1h-facets all five 5W1H facets render heading + PERSPECTIVES-FACET span" \
+  || { red "FAIL: perspectives-index-09-all-five-5w1h-facets a facet heading or span is missing"; errors=$((errors+1)); }
 
 # --- 3b. the dead How facet no longer renders --------------------------------
 grep -q '^## How$' "$PAGE" \
-  && { red "FAIL: the dropped How facet still renders"; errors=$((errors+1)); } \
-  || green "PASS: the dead How facet no longer renders (R9)"
+  && { red "FAIL: perspectives-index-10-dead-how-facet-no-longer-renders the dropped How facet still renders"; errors=$((errors+1)); } \
+  || green "PASS: perspectives-index-10-dead-how-facet-no-longer-renders the dead How facet no longer renders (R9)"
 grep -q 'MACHINE-OWNED:PERSPECTIVES-FACET:how:START' "$PAGE" \
-  && { red "FAIL: a How PERSPECTIVES-FACET span still renders"; errors=$((errors+1)); } \
-  || green "PASS: no How PERSPECTIVES-FACET span renders (R9)"
+  && { red "FAIL: perspectives-index-11-how-perspectives-facet-span a How PERSPECTIVES-FACET span still renders"; errors=$((errors+1)); } \
+  || green "PASS: perspectives-index-11-how-perspectives-facet-span no How PERSPECTIVES-FACET span renders (R9)"
 
 # --- 4. backed facets show count-links ---------------------------------------
 grep -q '\[People (1)\](people/index.md)' "$PAGE" \
@@ -172,8 +172,8 @@ grep -q '\[People (1)\](people/index.md)' "$PAGE" \
   && grep -q '\[Sources (1)\](sources/index.md)' "$PAGE" \
   && grep -q '\[Questions (1)\](questions/index.md)' "$PAGE" \
   && grep -q '\[Syntheses (1)\](syntheses/index.md)' "$PAGE" \
-  && green "PASS: backed facets (Who/What/Why) show count-links to the sub-indexes" \
-  || { red "FAIL: a backed-facet count-link is missing/incorrect"; errors=$((errors+1)); }
+  && green "PASS: perspectives-index-12-backed-facets-who-what backed facets (Who/What/Why) show count-links to the sub-indexes" \
+  || { red "FAIL: perspectives-index-12-backed-facets-who-what a backed-facet count-link is missing/incorrect"; errors=$((errors+1)); }
 
 # --- 5. no facet renders the generic honest-empty line in this fixture --------
 # How was dropped (it was the only generic-empty emitter); When carries the
@@ -182,52 +182,52 @@ grep -q '\[People (1)\](people/index.md)' "$PAGE" \
 # "_(no pages in this facet yet)_" line renders zero times here.
 EMPTY_COUNT="$(grep -c '_(no pages in this facet yet)_' "$PAGE" || true)"
 [ "$EMPTY_COUNT" -eq 0 ] \
-  && green "PASS: no generic honest-empty line renders (How dropped; When/Where backed)" \
-  || { red "FAIL: expected 0 generic honest-empty lines, got $EMPTY_COUNT"; errors=$((errors+1)); }
+  && green "PASS: perspectives-index-13-generic-honest-empty-line no generic honest-empty line renders (How dropped; When/Where backed)" \
+  || { red "FAIL: perspectives-index-13-generic-honest-empty-line expected 0 generic honest-empty lines, got $EMPTY_COUNT"; errors=$((errors+1)); }
 
 # --- 5c. Where (v1) groups source pages by their market: frontmatter ----------
 # Where is now the last facet (How dropped), so the block runs to EOF.
 WHERE_BLOCK="$(sed -n '/^## Where$/,$p' "$PAGE")"
 echo "$WHERE_BLOCK" | grep -q 'Sources grouped by the market' \
-  && green "PASS: Where facet renders the market-grouping intro" \
-  || { red "FAIL: Where grouping intro missing"; errors=$((errors+1)); }
+  && green "PASS: perspectives-index-14-where-facet-renders-market Where facet renders the market-grouping intro" \
+  || { red "FAIL: perspectives-index-14-where-facet-renders-market Where grouping intro missing"; errors=$((errors+1)); }
 echo "$WHERE_BLOCK" | grep -qF -- '- **dach** — [1 source](sources/index.md)' \
-  && green "PASS: Where groups the src-a source under its market (dach, singular), linked to the sources sub-index" \
-  || { red "FAIL: Where 'dach' grouping row missing/incorrect"; errors=$((errors+1)); }
+  && green "PASS: perspectives-index-15-where-groups-src-source Where groups the src-a source under its market (dach, singular), linked to the sources sub-index" \
+  || { red "FAIL: perspectives-index-15-where-groups-src-source Where 'dach' grouping row missing/incorrect"; errors=$((errors+1)); }
 echo "$WHERE_BLOCK" | grep -q '_(no pages in this facet yet)_' \
-  && { red "FAIL: Where facet wrongly rendered the honest-empty page line"; errors=$((errors+1)); } \
-  || green "PASS: Where facet does not render the honest-empty page line (it has a market grouping)"
+  && { red "FAIL: perspectives-index-16-where-facet-does-not-render Where facet wrongly rendered the honest-empty page line"; errors=$((errors+1)); } \
+  || green "PASS: perspectives-index-16-where-facet-does-not-render Where facet does not render the honest-empty page line (it has a market grouping)"
 
 # --- 5b. When (v1) renders a deterministic log-derived timeline ---------------
 # The When facet derives a month-grouped timeline (newest first) from wiki/log.md.
 WHEN_BLOCK="$(sed -n '/^## When$/,/^## Where$/p' "$PAGE")"
 echo "$WHEN_BLOCK" | grep -q 'Activity timeline from the base' \
-  && green "PASS: When facet renders the timeline intro" \
-  || { red "FAIL: When timeline intro missing"; errors=$((errors+1)); }
+  && green "PASS: perspectives-index-17-when-facet-renders-timeline When facet renders the timeline intro" \
+  || { red "FAIL: perspectives-index-17-when-facet-renders-timeline When timeline intro missing"; errors=$((errors+1)); }
 echo "$WHEN_BLOCK" | grep -qF -- '- **2026-06** — [4 operations](log.md) (compose · finalize · ingest · verify)' \
-  && green "PASS: When timeline groups 2026-06 by month with sorted op counts, linked to the activity log" \
-  || { red "FAIL: 2026-06 timeline row missing/incorrect"; errors=$((errors+1)); }
+  && green "PASS: perspectives-index-18-when-timeline-groups-2026 When timeline groups 2026-06 by month with sorted op counts, linked to the activity log" \
+  || { red "FAIL: perspectives-index-18-when-timeline-groups-2026 2026-06 timeline row missing/incorrect"; errors=$((errors+1)); }
 echo "$WHEN_BLOCK" | grep -qF -- '- **2026-05** — [1 operation](log.md) (setup)' \
-  && green "PASS: When timeline groups 2026-05 (singular 'operation'), linked to the activity log" \
-  || { red "FAIL: 2026-05 timeline row missing/incorrect"; errors=$((errors+1)); }
+  && green "PASS: perspectives-index-19-when-timeline-groups-2026 When timeline groups 2026-05 (singular 'operation'), linked to the activity log" \
+  || { red "FAIL: perspectives-index-19-when-timeline-groups-2026 2026-05 timeline row missing/incorrect"; errors=$((errors+1)); }
 # Newest-first ordering: 2026-06 row must precede the 2026-05 row.
 echo "$WHEN_BLOCK" | grep -nE '2026-0[56]' | head -1 | grep -q '2026-06' \
-  && green "PASS: When timeline is newest-month-first" \
-  || { red "FAIL: When timeline ordering is not newest-first"; errors=$((errors+1)); }
+  && green "PASS: perspectives-index-20-when-timeline-newest-month When timeline is newest-month-first" \
+  || { red "FAIL: perspectives-index-20-when-timeline-newest-month When timeline ordering is not newest-first"; errors=$((errors+1)); }
 # The When facet does NOT render the honest-empty page line (it has a timeline).
 echo "$WHEN_BLOCK" | grep -q '_(no pages in this facet yet)_' \
-  && { red "FAIL: When facet wrongly rendered the honest-empty page line"; errors=$((errors+1)); } \
-  || green "PASS: When facet does not render the honest-empty page line"
+  && { red "FAIL: perspectives-index-21-when-facet-does-not-render When facet wrongly rendered the honest-empty page line"; errors=$((errors+1)); } \
+  || green "PASS: perspectives-index-21-when-facet-does-not-render When facet does not render the honest-empty page line"
 
 # --- 6. byte-idempotent re-render --------------------------------------------
 BEFORE="$(cat "$PAGE")"
 OUT2="$(python3 "$PERSP_SCRIPT" render --wiki-root "$WIKI" --wiki-scripts-dir "$WSD")"
 echo "$OUT2" | grep -q '"changed": false' \
-  && green "PASS: re-render on unchanged wiki reports changed:false" \
-  || { red "FAIL: re-render was not idempotent (changed != false)"; errors=$((errors+1)); }
+  && green "PASS: perspectives-index-22-re-render-unchanged-wiki re-render on unchanged wiki reports changed:false" \
+  || { red "FAIL: perspectives-index-22-re-render-unchanged-wiki re-render was not idempotent (changed != false)"; errors=$((errors+1)); }
 [ "$BEFORE" = "$(cat "$PAGE")" ] \
-  && green "PASS: re-render left the page byte-identical" \
-  || { red "FAIL: re-render mutated the page"; errors=$((errors+1)); }
+  && green "PASS: perspectives-index-23-re-render-left-page re-render left the page byte-identical" \
+  || { red "FAIL: perspectives-index-23-re-render-left-page re-render mutated the page"; errors=$((errors+1)); }
 
 # --- 7. carry-forward a narrator-edited facet lead-in ------------------------
 python3 - "$PAGE" <<'PY'
@@ -242,18 +242,18 @@ open(p, "w").write(s)
 PY
 python3 "$PERSP_SCRIPT" render --wiki-root "$WIKI" --wiki-scripts-dir "$WSD" >/dev/null
 grep -q 'Narrated Who lead-in, authored by hand.' "$PAGE" \
-  && green "PASS: a narrated PERSPECTIVES-FACET lead-in survives a re-render" \
-  || { red "FAIL: narrated facet lead-in was clobbered"; errors=$((errors+1)); }
+  && green "PASS: perspectives-index-24-narrated-perspectives-facet-lead a narrated PERSPECTIVES-FACET lead-in survives a re-render" \
+  || { red "FAIL: perspectives-index-24-narrated-perspectives-facet-lead narrated facet lead-in was clobbered"; errors=$((errors+1)); }
 
 # --- 8. human-page skip (no marker) ------------------------------------------
 printf '# Hand-authored perspectives\n\nNothing machine-owned here.\n' > "$PAGE"
 OUT3="$(python3 "$PERSP_SCRIPT" render --wiki-root "$WIKI" --wiki-scripts-dir "$WSD")"
 echo "$OUT3" | grep -q '"skipped_human_page": true' \
-  && green "PASS: a hand-authored page (no marker) is skipped_human_page" \
-  || { red "FAIL: human page not skipped"; errors=$((errors+1)); }
+  && green "PASS: perspectives-index-25-hand-authored-page-marker a hand-authored page (no marker) is skipped_human_page" \
+  || { red "FAIL: perspectives-index-25-hand-authored-page-marker human page not skipped"; errors=$((errors+1)); }
 grep -q 'Hand-authored perspectives' "$PAGE" \
-  && green "PASS: the hand-authored page was preserved, not clobbered" \
-  || { red "FAIL: human page was clobbered"; errors=$((errors+1)); }
+  && green "PASS: perspectives-index-26-hand-authored-page-preserved the hand-authored page was preserved, not clobbered" \
+  || { red "FAIL: perspectives-index-26-hand-authored-page-preserved human page was clobbered"; errors=$((errors+1)); }
 
 # --- 9. stage writes the proposed file, never touches the live page ----------
 rm -f "$PAGE"
@@ -262,11 +262,11 @@ LIVE_BEFORE="$(cat "$PAGE")"
 OUT4="$(python3 "$PERSP_SCRIPT" stage --wiki-root "$WIKI")"
 echo "$OUT4" | grep -q '"subcommand": "stage"' \
   && [ -f "$WIKI/.cogni-wiki/perspectives-proposed.md" ] \
-  && green "PASS: stage wrote .cogni-wiki/perspectives-proposed.md" \
-  || { red "FAIL: stage did not write the proposed file"; errors=$((errors+1)); }
+  && green "PASS: perspectives-index-27-stage-wrote-cogni-wiki stage wrote .cogni-wiki/perspectives-proposed.md" \
+  || { red "FAIL: perspectives-index-27-stage-wrote-cogni-wiki stage did not write the proposed file"; errors=$((errors+1)); }
 [ "$LIVE_BEFORE" = "$(cat "$PAGE")" ] \
-  && green "PASS: stage left the live page untouched" \
-  || { red "FAIL: stage mutated the live page"; errors=$((errors+1)); }
+  && green "PASS: perspectives-index-28-stage-left-live-page stage left the live page untouched" \
+  || { red "FAIL: perspectives-index-28-stage-left-live-page stage mutated the live page"; errors=$((errors+1)); }
 
 # --- 10. When (v1) honest no-timeline fallback (absent log) -------------------
 # A wiki with no log.md must render the honest fallback, never a fabricated
@@ -285,20 +285,20 @@ NOLOG_WHEN="$(sed -n '/^## When$/,/^## Where$/p' "$NOLOG/wiki/perspectives.md")"
 # R9: thin When renders an honest signpost (names why it is empty + how it fills),
 # not a bare "no pages" line.
 echo "$NOLOG_WHEN" | grep -q 'When: no activity timeline yet' \
-  && green "PASS: When facet renders the honest no-timeline signpost when log.md is absent (R9)" \
-  || { red "FAIL: missing no-timeline signpost for an absent log.md"; errors=$((errors+1)); }
+  && green "PASS: perspectives-index-29-when-facet-renders-honest When facet renders the honest no-timeline signpost when log.md is absent (R9)" \
+  || { red "FAIL: perspectives-index-29-when-facet-renders-honest missing no-timeline signpost for an absent log.md"; errors=$((errors+1)); }
 echo "$NOLOG_WHEN" | grep -q 'Activity timeline from the base' \
-  && { red "FAIL: When fabricated a timeline intro with no log.md"; errors=$((errors+1)); } \
-  || green "PASS: When does not fabricate a timeline when log.md is absent"
+  && { red "FAIL: perspectives-index-30-when-does-not-fabricate-timeline When fabricated a timeline intro with no log.md"; errors=$((errors+1)); } \
+  || green "PASS: perspectives-index-30-when-does-not-fabricate-timeline When does not fabricate a timeline when log.md is absent"
 # R9: thin Where (no market-tagged sources in this fixture) renders its own honest
 # signpost, distinct from the generic "_(no pages in this facet yet)_" line.
 NOLOG_WHERE="$(sed -n '/^## Where$/,$p' "$NOLOG/wiki/perspectives.md")"
 echo "$NOLOG_WHERE" | grep -q 'Where: no market-tagged sources yet' \
-  && green "PASS: Where facet renders the honest thin-facet signpost when no source carries a market (R9)" \
-  || { red "FAIL: missing Where thin-facet signpost"; errors=$((errors+1)); }
+  && green "PASS: perspectives-index-31-where-facet-renders-honest Where facet renders the honest thin-facet signpost when no source carries a market (R9)" \
+  || { red "FAIL: perspectives-index-31-where-facet-renders-honest missing Where thin-facet signpost"; errors=$((errors+1)); }
 echo "$NOLOG_WHERE" | grep -q '_(no pages in this facet yet)_' \
-  && { red "FAIL: Where reused the generic honest-empty line instead of its signpost"; errors=$((errors+1)); } \
-  || green "PASS: Where uses its own signpost, not the generic honest-empty line (R9)"
+  && { red "FAIL: perspectives-index-32-where-uses-own-signpost Where reused the generic honest-empty line instead of its signpost"; errors=$((errors+1)); } \
+  || green "PASS: perspectives-index-32-where-uses-own-signpost Where uses its own signpost, not the generic honest-empty line (R9)"
 rm -rf "$NOLOG" 2>/dev/null || true
 
 if [ "$errors" -eq 0 ]; then

--- a/cogni-knowledge/tests/test_perspectives_index.sh
+++ b/cogni-knowledge/tests/test_perspectives_index.sh
@@ -205,11 +205,11 @@ echo "$WHEN_BLOCK" | grep -q 'Activity timeline from the base' \
   && green "PASS: perspectives-index-17-when-facet-renders-timeline When facet renders the timeline intro" \
   || { red "FAIL: perspectives-index-17-when-facet-renders-timeline When timeline intro missing"; errors=$((errors+1)); }
 echo "$WHEN_BLOCK" | grep -qF -- '- **2026-06** — [4 operations](log.md) (compose · finalize · ingest · verify)' \
-  && green "PASS: perspectives-index-18-when-timeline-groups-2026 When timeline groups 2026-06 by month with sorted op counts, linked to the activity log" \
-  || { red "FAIL: perspectives-index-18-when-timeline-groups-2026 2026-06 timeline row missing/incorrect"; errors=$((errors+1)); }
+  && green "PASS: perspectives-index-18-when-timeline-groups-june-plural When timeline groups 2026-06 by month with sorted op counts, linked to the activity log" \
+  || { red "FAIL: perspectives-index-18-when-timeline-groups-june-plural 2026-06 timeline row missing/incorrect"; errors=$((errors+1)); }
 echo "$WHEN_BLOCK" | grep -qF -- '- **2026-05** — [1 operation](log.md) (setup)' \
-  && green "PASS: perspectives-index-19-when-timeline-groups-2026 When timeline groups 2026-05 (singular 'operation'), linked to the activity log" \
-  || { red "FAIL: perspectives-index-19-when-timeline-groups-2026 2026-05 timeline row missing/incorrect"; errors=$((errors+1)); }
+  && green "PASS: perspectives-index-19-when-timeline-groups-may-singular When timeline groups 2026-05 (singular 'operation'), linked to the activity log" \
+  || { red "FAIL: perspectives-index-19-when-timeline-groups-may-singular 2026-05 timeline row missing/incorrect"; errors=$((errors+1)); }
 # Newest-first ordering: 2026-06 row must precede the 2026-05 row.
 echo "$WHEN_BLOCK" | grep -nE '2026-0[56]' | head -1 | grep -q '2026-06' \
   && green "PASS: perspectives-index-20-when-timeline-newest-month When timeline is newest-month-first" \

--- a/cogni-knowledge/tests/test_question_store.sh
+++ b/cogni-knowledge/tests/test_question_store.sh
@@ -33,7 +33,7 @@ WSD="$PLUGIN_ROOT/scripts/vendor/cogni-wiki/skills/wiki-ingest/scripts"
 errors=0
 
 if [ ! -d "$WSD" ]; then
-  red "FAIL: cogni-wiki wiki-ingest scripts not found at $WSD"
+  red "FAIL: question-store-00-wiki-scripts-present cogni-wiki wiki-ingest scripts not found at $WSD"
   exit 1
 fi
 
@@ -117,35 +117,35 @@ emit() {
 # ===== Run 1 =================================================================
 OUT="$(emit)"
 echo "$OUT" | python3 -c 'import json,sys; d=json.load(sys.stdin); sys.exit(0 if d["success"] else 1)' \
-  && green "PASS: emit returns success" || { red "FAIL: emit not success"; echo "$OUT"; errors=$((errors+1)); }
+  && green "PASS: question-store-01-emit-returns-success emit returns success" || { red "FAIL: question-store-01-emit-returns-success emit not success"; echo "$OUT"; errors=$((errors+1)); }
 
 # 0) questions/ was created on demand by the first emit (not pre-made above).
 [ -d "$WIKI/wiki/questions" ] \
-  && green "PASS: wiki/questions/ created on demand by first emit" \
-  || { red "FAIL: wiki/questions/ not created on demand"; errors=$((errors+1)); }
+  && green "PASS: question-store-02-wiki-questions-created-demand wiki/questions/ created on demand by first emit" \
+  || { red "FAIL: question-store-02-wiki-questions-created-demand wiki/questions/ not created on demand"; errors=$((errors+1)); }
 
 # 1) sq-01 + sq-03 pages exist; sq-02 (no findings) does not.
 SQ1="$WIKI/wiki/questions/records-of-processing-scope.md"
 SQ3="$WIKI/wiki/questions/pflichten-fuer-risikoklassen.md"
-[ -f "$SQ1" ] && green "PASS: sq-01-1 question page written at slugified theme_label" \
-  || { red "FAIL: sq-01-1 missing $SQ1"; errors=$((errors+1)); }
-[ -f "$SQ3" ] && green "PASS: sq-03-1 page uses transliterated slug (für->fuer)" \
-  || { red "FAIL: sq-03-1 missing $SQ3"; errors=$((errors+1)); }
+[ -f "$SQ1" ] && green "PASS: question-store-03-sq-01-1-question sq-01-1 question page written at slugified theme_label" \
+  || { red "FAIL: question-store-03-sq-01-1-question sq-01-1 missing $SQ1"; errors=$((errors+1)); }
+[ -f "$SQ3" ] && green "PASS: question-store-04-sq-03-1-page sq-03-1 page uses transliterated slug (für->fuer)" \
+  || { red "FAIL: question-store-04-sq-03-1-page sq-03-1 missing $SQ3"; errors=$((errors+1)); }
 [ ! -f "$WIKI/wiki/questions/court-interpretation.md" ] \
-  && green "PASS: sq-02-1 (zero findings) wrote no page" \
-  || { red "FAIL: sq-02-1 page should not exist"; errors=$((errors+1)); }
+  && green "PASS: question-store-05-sq-02-1-zero sq-02-1 (zero findings) wrote no page" \
+  || { red "FAIL: question-store-05-sq-02-1-zero sq-02-1 page should not exist"; errors=$((errors+1)); }
 
-echo "$OUT" | grep -q '"sq-02"' && green "PASS: sq-02-2 reported in skipped_no_findings" \
-  || { red "FAIL: sq-02-2 not in skipped_no_findings"; errors=$((errors+1)); }
+echo "$OUT" | grep -q '"sq-02"' && green "PASS: question-store-06-sq-02-2-reported sq-02-2 reported in skipped_no_findings" \
+  || { red "FAIL: question-store-06-sq-02-2-reported sq-02-2 not in skipped_no_findings"; errors=$((errors+1)); }
 
 # 2) forward links + frontmatter
-assert_grep 'type: question' "$SQ1" "sq-01-2 page is type: question"
-assert_grep 'sub_question_id: sq-01' "$SQ1" "sq-01-3 page carries sub_question_id"
-assert_grep '## Findings' "$SQ1" "sq-01-4 page has ## Findings section"
+assert_grep 'type: question' "$SQ1" "question-store-07-sq-01-2-page sq-01-2 page is type: question"
+assert_grep 'sub_question_id: sq-01' "$SQ1" "question-store-08-sq-01-3-page sq-01-3 page carries sub_question_id"
+assert_grep '## Findings' "$SQ1" "question-store-09-sq-01-4-page sq-01-4 page has ## Findings section"
 # #931: the question page now emits an H1 + reader-facing type line (it had no body
 # H1 before). Assert the type line and that the order is H1 -> type line -> ## Findings.
-assert_grep '^Type: Question · raw$' "$SQ1" "sq-01-5 page: Type: Question · raw line"
-python3 - "$SQ1" <<'PY' && green "PASS: sq-01-6 page renders H1 then 'Type: Question · raw' then ## Findings" || { red "FAIL: sq-01-6 question H1/type-line/findings order wrong"; errors=$((errors+1)); }
+assert_grep '^Type: Question · raw$' "$SQ1" "question-store-10-sq-01-5-page sq-01-5 page: Type: Question · raw line"
+python3 - "$SQ1" <<'PY' && green "PASS: question-store-11-sq-01-6-page sq-01-6 page renders H1 then 'Type: Question · raw' then ## Findings" || { red "FAIL: question-store-11-sq-01-6-page sq-01-6 question H1/type-line/findings order wrong"; errors=$((errors+1)); }
 import sys
 lines = [l for l in open(sys.argv[1], encoding="utf-8").read().splitlines()]
 h1 = next(i for i, l in enumerate(lines) if l.startswith("# "))
@@ -156,22 +156,22 @@ fnd = lines.index("## Findings")
 sys.exit(0 if h1 < typ < fnd else 1)
 PY
 # sq-01 is answered by records-scope (sq-01 ref) AND controller-obligations (sq-01+sq-03 ref)
-assert_grep '\[\[records-scope\]\]' "$SQ1" "sq-01-7 Findings links its source finding"
-assert_grep 'sources_answering: \[records-scope, controller-obligations\]' "$SQ1" "sq-01-8 sources_answering lists both findings in order"
+assert_grep '\[\[records-scope\]\]' "$SQ1" "question-store-12-sq-01-7-findings sq-01-7 Findings links its source finding"
+assert_grep 'sources_answering: \[records-scope, controller-obligations\]' "$SQ1" "question-store-13-sq-01-8-sources sq-01-8 sources_answering lists both findings in order"
 # sq-03 has two findings (controller-obligations via sq-03 ref + risk-classes)
-assert_grep '\[\[controller-obligations\]\]' "$SQ3" "sq-03-2 links shared finding controller-obligations"
-assert_grep '\[\[risk-classes\]\]' "$SQ3" "sq-03-3 links risk-classes finding"
+assert_grep '\[\[controller-obligations\]\]' "$SQ3" "question-store-14-sq-03-2-links sq-03-2 links shared finding controller-obligations"
+assert_grep '\[\[risk-classes\]\]' "$SQ3" "question-store-15-sq-03-3-links sq-03-3 links risk-classes finding"
 
 # ===== Idempotency: add a human ## Notes tail, re-run ========================
 printf '\n## Notes\n\nHuman annotation that must survive a re-run.\n' >> "$SQ1"
 OUT2="$(emit)"
-echo "$OUT2" | grep -q '"action": "merged"' && green "PASS: re-run reports action=merged" \
-  || { red "FAIL: re-run did not merge"; echo "$OUT2"; errors=$((errors+1)); }
-assert_grep 'Human annotation that must survive' "$SQ1" "## Notes tail preserved across re-run"
+echo "$OUT2" | grep -q '"action": "merged"' && green "PASS: question-store-16-re-run-reports-action re-run reports action=merged" \
+  || { red "FAIL: question-store-16-re-run-reports-action re-run did not merge"; echo "$OUT2"; errors=$((errors+1)); }
+assert_grep 'Human annotation that must survive' "$SQ1" "question-store-17-notes-tail-preserved-across ## Notes tail preserved across re-run"
 # exactly one page per slug (no duplication)
 N=$(ls "$WIKI/wiki/questions/" | wc -l | tr -d ' ')
-[ "$N" = "2" ] && green "PASS: still exactly 2 question pages after re-run" \
-  || { red "FAIL: expected 2 question pages, found $N"; errors=$((errors+1)); }
+[ "$N" = "2" ] && green "PASS: question-store-18-still-exactly-2-question still exactly 2 question pages after re-run" \
+  || { red "FAIL: question-store-18-still-exactly-2-question expected 2 question pages, found $N"; errors=$((errors+1)); }
 
 # ===== Cross-type collision: a source page owns 'court-interpretation' =======
 # Give sq-02 a finding so it would now want the slug, but plant a same-slug source first.
@@ -194,13 +194,13 @@ cat > "$PROJ/.metadata/candidates.json" <<'EOF'
 EOF
 OUT3="$(emit)"
 [ -f "$WIKI/wiki/questions/court-interpretation-q.md" ] \
-  && green "PASS: cross-type collision disambiguated to court-interpretation-q" \
-  || { red "FAIL: expected court-interpretation-q.md"; echo "$OUT3"; errors=$((errors+1)); }
+  && green "PASS: question-store-19-cross-type-collision-disambiguated cross-type collision disambiguated to court-interpretation-q" \
+  || { red "FAIL: question-store-19-cross-type-collision-disambiguated expected court-interpretation-q.md"; echo "$OUT3"; errors=$((errors+1)); }
 assert_grep 'type: source' "$WIKI/wiki/sources/court-interpretation.md" \
-  "pre-existing source page left untouched (still type: source)"
+  "question-store-20-pre-existing-source-page pre-existing source page left untouched (still type: source)"
 [ ! -f "$WIKI/wiki/questions/court-interpretation.md" ] \
-  && green "PASS: did-1 did not write a question at the colliding bare slug" \
-  || { red "FAIL: did-1 question shadowed the source slug"; errors=$((errors+1)); }
+  && green "PASS: question-store-21-did-1-did-not-write did-1 did not write a question at the colliding bare slug" \
+  || { red "FAIL: question-store-21-did-1-did-not-write did-1 question shadowed the source slug"; errors=$((errors+1)); }
 
 # ===== Within-run collision: two DISTINCT sub-questions, identical slug ======
 # Two sub-questions whose theme_label slugifies to the same base must NOT
@@ -228,19 +228,19 @@ OUTC="$(emit)"
 DR1="$WIKI/wiki/questions/data-retention.md"
 DR2="$WIKI/wiki/questions/data-retention-q.md"
 { [ -f "$DR1" ] && [ -f "$DR2" ]; } \
-  && green "PASS: two same-slug sub-questions wrote two distinct pages (-q disambiguation)" \
-  || { red "FAIL: within-run collision did not split into two pages"; echo "$OUTC"; errors=$((errors+1)); }
+  && green "PASS: question-store-22-two-same-slug-sub two same-slug sub-questions wrote two distinct pages (-q disambiguation)" \
+  || { red "FAIL: question-store-22-two-same-slug-sub within-run collision did not split into two pages"; echo "$OUTC"; errors=$((errors+1)); }
 # Distinct sub_question_ids, not conflated onto the last writer.
 DR1ID="$(grep '^sub_question_id:' "$DR1" | awk '{print $2}')"
 DR2ID="$(grep '^sub_question_id:' "$DR2" | awk '{print $2}')"
 [ "$DR1ID" != "$DR2ID" ] \
-  && green "PASS: each page kept its own sub_question_id ($DR1ID / $DR2ID)" \
-  || { red "FAIL: sub_question_id conflated ($DR1ID == $DR2ID)"; errors=$((errors+1)); }
+  && green "PASS: question-store-23-each-page-kept-own each page kept its own sub_question_id ($DR1ID / $DR2ID)" \
+  || { red "FAIL: question-store-23-each-page-kept-own sub_question_id conflated ($DR1ID == $DR2ID)"; errors=$((errors+1)); }
 # No finding bleed: the base page links only its own source, not both.
 if grep -q '\[\[retain-a\]\]' "$DR1" && ! grep -q '\[\[retain-b\]\]' "$DR1"; then
-  green "PASS: base page lists only its own finding (no finding conflation)"
+  green "PASS: question-store-24-base-page-lists-only base page lists only its own finding (no finding conflation)"
 else
-  red "FAIL: findings conflated across the two same-slug sub-questions"; errors=$((errors+1))
+  red "FAIL: question-store-24-base-page-lists-only findings conflated across the two same-slug sub-questions"; errors=$((errors+1))
 fi
 
 # ===== Legacy plan: no theme_label -> sq-NN slug fallback ====================
@@ -255,8 +255,8 @@ cat > "$PROJ/.metadata/ingest-manifest.json" <<'EOF'
 EOF
 OUT4="$(emit)"
 [ -f "$WIKI/wiki/questions/sq-09.md" ] \
-  && green "PASS: legacy plan (no theme_label) falls back to sq-NN slug" \
-  || { red "FAIL: expected sq-09.md fallback"; echo "$OUT4"; errors=$((errors+1)); }
+  && green "PASS: question-store-25-legacy-plan-theme-label legacy plan (no theme_label) falls back to sq-NN slug" \
+  || { red "FAIL: question-store-25-legacy-plan-theme-label expected sq-09.md fallback"; echo "$OUT4"; errors=$((errors+1)); }
 
 # ===== Lineage match (#409): variant theme_label routes to existing node ======
 # A binding pre-seeded with a covered_theme whose theme_key == the norm key of
@@ -333,18 +333,18 @@ OUTL="$(python3 "$SCRIPT" emit \
   --binding "$LINKB")"
 # Routed to the EXISTING node (merge), did NOT create a scope-of-processing-records page.
 echo "$OUTL" | grep -q '"action": "merged"' \
-  && green "PASS: variant theme_label lineage-merged into the existing node (action=merged)" \
-  || { red "FAIL: variant did not merge into the lineage node"; echo "$OUTL"; errors=$((errors+1)); }
+  && green "PASS: question-store-26-variant-theme-label-lineage variant theme_label lineage-merged into the existing node (action=merged)" \
+  || { red "FAIL: question-store-26-variant-theme-label-lineage variant did not merge into the lineage node"; echo "$OUTL"; errors=$((errors+1)); }
 [ ! -f "$WIKI/wiki/questions/scope-of-processing-records.md" ] \
-  && green "PASS: did-2 did NOT fork a second node for the variant theme_label" \
-  || { red "FAIL: did-2 variant forked a second question node"; errors=$((errors+1)); }
+  && green "PASS: question-store-27-did-2-did-not-fork did-2 did NOT fork a second node for the variant theme_label" \
+  || { red "FAIL: question-store-27-did-2-did-not-fork did-2 variant forked a second question node"; errors=$((errors+1)); }
 echo "$OUTL" | grep -q '"action": "lineage_reused"' \
-  && green "PASS: theme_bindings[] records action=lineage_reused" \
-  || { red "FAIL: no lineage_reused theme_binding emitted"; echo "$OUTL"; errors=$((errors+1)); }
+  && green "PASS: question-store-28-theme-bindings-records-action theme_bindings[] records action=lineage_reused" \
+  || { red "FAIL: question-store-28-theme-bindings-records-action no lineage_reused theme_binding emitted"; echo "$OUTL"; errors=$((errors+1)); }
 # created: preserved; human ## Notes tail survived; new finding unioned in.
-assert_grep 'created: 2025-12-01' "$WIKI/wiki/questions/$LSLUG.md" "lineage-1 merge preserves created:"
-assert_grep 'Prior-run human note that must survive' "$WIKI/wiki/questions/$LSLUG.md" "lineage-2 merge preserves human ## Notes tail"
-assert_grep '\[\[controller-obligations\]\]' "$WIKI/wiki/questions/$LSLUG.md" "lineage-3 merge unions the new finding"
+assert_grep 'created: 2025-12-01' "$WIKI/wiki/questions/$LSLUG.md" "question-store-29-lineage-1-merge-preserves lineage-1 merge preserves created:"
+assert_grep 'Prior-run human note that must survive' "$WIKI/wiki/questions/$LSLUG.md" "question-store-30-lineage-2-merge-preserves lineage-2 merge preserves human ## Notes tail"
+assert_grep '\[\[controller-obligations\]\]' "$WIKI/wiki/questions/$LSLUG.md" "question-store-31-lineage-3-merge-unions lineage-3 merge unions the new finding"
 
 # ===== Fail-soft binding read error (#426): degrade to slug-only success ======
 # A corrupt / unreadable --binding must NOT abort emit — lineage is an
@@ -362,14 +362,14 @@ OUTCB="$(python3 "$SCRIPT" emit \
   --ingest-manifest "$PROJ/.metadata/ingest-manifest.json" \
   --binding "$WORK/corrupt-binding.json")"
 echo "$OUTCB" | python3 -c 'import json,sys; d=json.load(sys.stdin); sys.exit(0 if d["success"] and d["data"].get("binding_skipped") else 1)' \
-  && green "PASS: corrupt-1 --binding degrades to success + data.binding_skipped (no abort)" \
-  || { red "FAIL: corrupt-1 --binding did not fail-soft"; echo "$OUTCB"; errors=$((errors+1)); }
+  && green "PASS: question-store-32-corrupt-1-binding-degrades corrupt-1 --binding degrades to success + data.binding_skipped (no abort)" \
+  || { red "FAIL: question-store-32-corrupt-1-binding-degrades corrupt-1 --binding did not fail-soft"; echo "$OUTCB"; errors=$((errors+1)); }
 # No lineage map -> the variant theme_label falls back to slugify(theme_label)
 # and writes its OWN node (it does NOT route into $LSLUG), proving the degrade
 # to slug-only accumulation actually changed behavior vs the lineage case.
 [ -f "$WIKI/wiki/questions/scope-of-processing-records.md" ] \
-  && green "PASS: corrupt-2 --binding ran slug-only (variant got its own slug node, no lineage routing)" \
-  || { red "FAIL: corrupt-2 --binding did not degrade to slug-only"; errors=$((errors+1)); }
+  && green "PASS: question-store-33-corrupt-2-binding-ran corrupt-2 --binding ran slug-only (variant got its own slug node, no lineage routing)" \
+  || { red "FAIL: question-store-33-corrupt-2-binding-ran corrupt-2 --binding did not degrade to slug-only"; errors=$((errors+1)); }
 
 # -- Unreadable-path arm (OSError) --
 OUTMB="$(python3 "$SCRIPT" emit \
@@ -379,8 +379,8 @@ OUTMB="$(python3 "$SCRIPT" emit \
   --ingest-manifest "$PROJ/.metadata/ingest-manifest.json" \
   --binding "$WORK/does-not-exist.json")"
 echo "$OUTMB" | python3 -c 'import json,sys; d=json.load(sys.stdin); sys.exit(0 if d["success"] and d["data"].get("binding_skipped") else 1)' \
-  && green "PASS: missing --binding path degrades to success + data.binding_skipped (OSError arm)" \
-  || { red "FAIL: missing --binding path did not fail-soft"; echo "$OUTMB"; errors=$((errors+1)); }
+  && green "PASS: question-store-34-missing-binding-path-degrades missing --binding path degrades to success + data.binding_skipped (OSError arm)" \
+  || { red "FAIL: question-store-34-missing-binding-path-degrades missing --binding path did not fail-soft"; echo "$OUTMB"; errors=$((errors+1)); }
 
 # ===== Fail-soft structurally-invalid binding (#428): valid JSON, wrong shape =
 # A binding that PARSES as valid JSON but is the wrong shape for the lineage
@@ -399,8 +399,8 @@ OUTAB="$(python3 "$SCRIPT" emit \
   --ingest-manifest "$PROJ/.metadata/ingest-manifest.json" \
   --binding "$WORK/array-binding.json")"
 echo "$OUTAB" | python3 -c 'import json,sys; d=json.load(sys.stdin); sys.exit(0 if d["success"] and d["data"].get("binding_skipped") else 1)' \
-  && green "PASS: JSON-array --binding degrades to success + data.binding_skipped (not-a-dict)" \
-  || { red "FAIL: JSON-array --binding did not fail-soft"; echo "$OUTAB"; errors=$((errors+1)); }
+  && green "PASS: question-store-35-json-array-binding-degrades JSON-array --binding degrades to success + data.binding_skipped (not-a-dict)" \
+  || { red "FAIL: question-store-35-json-array-binding-degrades JSON-array --binding did not fail-soft"; echo "$OUTAB"; errors=$((errors+1)); }
 
 # -- topic_lineage: null arm (None.get(...) -> AttributeError pre-#428; the {}
 #    default only fires on an ABSENT key, so a present-but-null is unprotected) --
@@ -412,8 +412,8 @@ OUTTL="$(python3 "$SCRIPT" emit \
   --ingest-manifest "$PROJ/.metadata/ingest-manifest.json" \
   --binding "$WORK/null-tl-binding.json")"
 echo "$OUTTL" | python3 -c 'import json,sys; d=json.load(sys.stdin); sys.exit(0 if d["success"] and d["data"].get("binding_skipped") else 1)' \
-  && green "PASS: topic_lineage:null --binding degrades to success + data.binding_skipped" \
-  || { red "FAIL: topic_lineage:null --binding did not fail-soft"; echo "$OUTTL"; errors=$((errors+1)); }
+  && green "PASS: question-store-36-topic-lineage-null-binding topic_lineage:null --binding degrades to success + data.binding_skipped" \
+  || { red "FAIL: question-store-36-topic-lineage-null-binding topic_lineage:null --binding did not fail-soft"; echo "$OUTTL"; errors=$((errors+1)); }
 
 # ===== Backward compat: emit WITHOUT --binding still works (slug-only) ========
 OUTNB="$(python3 "$SCRIPT" emit \
@@ -422,8 +422,8 @@ OUTNB="$(python3 "$SCRIPT" emit \
   --candidates "$PROJ/.metadata/candidates.json" \
   --ingest-manifest "$PROJ/.metadata/ingest-manifest.json")"
 echo "$OUTNB" | python3 -c 'import json,sys; d=json.load(sys.stdin); sys.exit(0 if d["success"] and "theme_bindings" in d["data"] else 1)' \
-  && green "PASS: no-binding emit succeeds and still carries theme_bindings[] (back-compat)" \
-  || { red "FAIL: no-binding emit broke"; echo "$OUTNB"; errors=$((errors+1)); }
+  && green "PASS: question-store-37-no-binding-emit-succeeds no-binding emit succeeds and still carries theme_bindings[] (back-compat)" \
+  || { red "FAIL: question-store-37-no-binding-emit-succeeds no-binding emit broke"; echo "$OUTNB"; errors=$((errors+1)); }
 
 if [ "$errors" -eq 0 ]; then
   green "ALL TESTS PASS"

--- a/cogni-knowledge/tests/test_root_index.sh
+++ b/cogni-knowledge/tests/test_root_index.sh
@@ -200,111 +200,111 @@ PROSE=""; BEFORE=""
 # === 1. render → curated MAP ===
 OUT="$(python3 "$ROOT_SCRIPT" render --wiki-root "$WIKI" --wiki-scripts-dir "$WSD")"
 echo "$OUT" | grep -q '"changed": true' \
-  && green "PASS: 1-1 render reports changed:true" \
-  || { red "FAIL: 1-1 render not changed:true ($OUT)"; errors=$((errors+1)); }
-assert_grep "MACHINE-OWNED:ROOT-INDEX" "$IDX" "1-2 ROOT-INDEX ownership marker present"
-assert_grep "Curated map of this knowledge base" "$IDX" "1-3 curated intro line present"
+  && green "PASS: root-index-01-1-1-render-reports 1-1 render reports changed:true" \
+  || { red "FAIL: root-index-01-1-1-render-reports 1-1 render not changed:true ($OUT)"; errors=$((errors+1)); }
+assert_grep "MACHINE-OWNED:ROOT-INDEX" "$IDX" "root-index-02-1-2-root-index 1-2 ROOT-INDEX ownership marker present"
+assert_grep "Curated map of this knowledge base" "$IDX" "root-index-03-1-3-curated-intro 1-3 curated intro line present"
 # AC#3 (no-fabrication half): the source fixture index carried no
 # OVERVIEW-NARRATIVE block, so the renderer must NOT invent a placeholder one.
-assert_not_grep "MACHINE-OWNED:OVERVIEW-NARRATIVE" "$IDX" "1b no narrative span fabricated when none authored"
+assert_not_grep "MACHINE-OWNED:OVERVIEW-NARRATIVE" "$IDX" "root-index-04-1b-narrative-span-fabricated 1b no narrative span fabricated when none authored"
 
 # === 1c. the 5W1H intent spine is a PRIMARY front-door entry (R8) ===
 # Promoted from a secondary italic "_See also:_" line to a bold primary
 # wayfinding entry leading with the intent spine.
-assert_grep "Start here — browse by intent:" "$IDX" "1c-1 intent spine promoted to a primary front-door line (R8)"
-assert_grep "Perspectives (5W1H) →](perspectives.md)" "$IDX" "1c-2 spine links the 5W1H perspectives overlay (R8)"
-assert_not_grep "_See also: \[Perspectives (5W1H)\](perspectives.md)" "$IDX" "1c-3 old secondary 'See also' framing is gone (R8)"
+assert_grep "Start here — browse by intent:" "$IDX" "root-index-05-1c-1-intent-spine 1c-1 intent spine promoted to a primary front-door line (R8)"
+assert_grep "Perspectives (5W1H) →](perspectives.md)" "$IDX" "root-index-06-1c-2-spine-links 1c-2 spine links the 5W1H perspectives overlay (R8)"
+assert_not_grep "_See also: \[Perspectives (5W1H)\](perspectives.md)" "$IDX" "root-index-07-1c-3-old-secondary 1c-3 old secondary 'See also' framing is gone (R8)"
 # === 1d. secondary-view labels (R10) + overview-stub signpost (R11) ===
-assert_grep "Other views:" "$IDX" "1d-1 secondary-view labels render on the root portal (R10)"
-assert_grep "\[Recent syntheses\](overview.md)" "$IDX" "1d-2 overview stub signposted from the spine — Recent syntheses (R11)"
+assert_grep "Other views:" "$IDX" "root-index-08-1d-1-secondary-view 1d-1 secondary-view labels render on the root portal (R10)"
+assert_grep "\[Recent syntheses\](overview.md)" "$IDX" "root-index-09-1d-2-overview-stub 1d-2 overview stub signposted from the spine — Recent syntheses (R11)"
 
 # === 2. per-theme count-links with counts AND theme-scoped deep-link anchors ===
 # The link now deep-links into the theme's `## <theme>` section of each
 # sub-index (`<type>/index.md#<anchor>`), not the bare unfiltered sub-index.
 # Obsidian resolves a heading link by the heading's literal text: the anchor
 # preserves case (theme "Scope" → `## Scope` → #Scope), spaces → %20.
-assert_grep "Sources (2)](sources/index.md#Scope)" "$IDX" "2-1 Sources (2) deep-link to #Scope"
-assert_grep "Concepts (1)](concepts/index.md#Scope)" "$IDX" "2-2 Concepts (1) deep-link to #Scope"
-assert_grep "Questions (1)](questions/index.md#Scope)" "$IDX" "2-3 Questions (1) deep-link to #Scope"
-assert_grep "Syntheses (1)](syntheses/index.md#Scope)" "$IDX" "2-4 Syntheses (1) deep-link to #Scope (folded into theme)"
+assert_grep "Sources (2)](sources/index.md#Scope)" "$IDX" "root-index-10-2-1-sources-2 2-1 Sources (2) deep-link to #Scope"
+assert_grep "Concepts (1)](concepts/index.md#Scope)" "$IDX" "root-index-11-2-2-concepts-1 2-2 Concepts (1) deep-link to #Scope"
+assert_grep "Questions (1)](questions/index.md#Scope)" "$IDX" "root-index-12-2-3-questions-1 2-3 Questions (1) deep-link to #Scope"
+assert_grep "Syntheses (1)](syntheses/index.md#Scope)" "$IDX" "root-index-13-2-4-syntheses-1 2-4 Syntheses (1) deep-link to #Scope (folded into theme)"
 
 # === 2b. distinct per-theme anchors + non-ASCII heading-anchor (Obsidian convention) ===
-assert_grep '^## KI Bußgelder' "$IDX" "2b-1 non-ASCII theme heading kept verbatim"
+assert_grep '^## KI Bußgelder' "$IDX" "root-index-14-2b-1-non-ascii 2b-1 non-ASCII theme heading kept verbatim"
 # The deep link is the Obsidian heading-text anchor for `## KI Bußgelder`:
 # literal text, space → %20, case + ß preserved verbatim (#KI%20Bußgelder) —
 # distinct from the Scope theme's #Scope (so per-theme Explore lines differ).
-assert_grep "Sources (1)](sources/index.md#KI%20Bußgelder)" "$IDX" "2b-2 non-ASCII theme deep-links to #KI%20Bußgelder"
+assert_grep "Sources (1)](sources/index.md#KI%20Bußgelder)" "$IDX" "root-index-15-2b-2-non-ascii 2b-2 non-ASCII theme deep-links to #KI%20Bußgelder"
 # Regression: NOT the GFM slug form, and NOT slugify's transliterated form
 # (neither resolves to the heading in Obsidian).
-assert_not_grep "sources/index.md#ki-bußgelder)" "$IDX" "2b-3 anchor is NOT the GFM slug form #ki-bußgelder"
-assert_not_grep "sources/index.md#ki-bussgelder)" "$IDX" "2b-4 anchor is NOT the transliterated slugify form #ki-bussgelder"
+assert_not_grep "sources/index.md#ki-bußgelder)" "$IDX" "root-index-16-2b-3-anchor-gfm 2b-3 anchor is NOT the GFM slug form #ki-bußgelder"
+assert_not_grep "sources/index.md#ki-bussgelder)" "$IDX" "root-index-17-2b-4-anchor-transliterated 2b-4 anchor is NOT the transliterated slugify form #ki-bussgelder"
 
 # === 2c. A1 false-filtering fix (#933): theme-label whitespace is normalized so
 #         the rendered `## <theme>` heading and the count-link anchor AGREE. ===
 # The fixture theme_label is "AI  Liability " (double internal space + trailing).
 # The producer-site _collapse normalizes it to "AI Liability", so the heading is
 # single-space and the anchor is the matching single-%20 fragment.
-assert_grep '^## AI Liability' "$IDX" "2c-1 double-space theme heading collapsed to single space"
-assert_not_grep '^## AI  Liability' "$IDX" "2c-2 heading does NOT keep the double space (the drift)"
-assert_grep "Sources (1)](sources/index.md#AI%20Liability)" "$IDX" "2c-3 count-link anchors to the single-%20 fragment that matches the heading"
+assert_grep '^## AI Liability' "$IDX" "root-index-18-2c-1-double-space 2c-1 double-space theme heading collapsed to single space"
+assert_not_grep '^## AI  Liability' "$IDX" "root-index-19-2c-2-heading-does 2c-2 heading does NOT keep the double space (the drift)"
+assert_grep "Sources (1)](sources/index.md#AI%20Liability)" "$IDX" "root-index-20-2c-3-count-link 2c-3 count-link anchors to the single-%20 fragment that matches the heading"
 # Regression: the heading↔anchor MUST agree — the drift would have rendered the
 # double-space heading while the anchor collapsed, landing the click at page top.
-assert_not_grep "sources/index.md#AI%20%20Liability)" "$IDX" "2c-4 anchor is NOT the un-collapsed double-%20 form"
+assert_not_grep "sources/index.md#AI%20%20Liability)" "$IDX" "root-index-21-2c-4-anchor-un 2c-4 anchor is NOT the un-collapsed double-%20 form"
 
 # === 3. no per-page source bullets remain on the root ===
-assert_not_grep '^- \[\[src-a\]\]' "$IDX" "3-1 per-page src-a bullet dropped from root"
-assert_not_grep '^- \[\[scope-synth\]\]' "$IDX" "3-2 per-page synthesis bullet dropped from root"
+assert_not_grep '^- \[\[src-a\]\]' "$IDX" "root-index-22-3-1-per-page 3-1 per-page src-a bullet dropped from root"
+assert_not_grep '^- \[\[scope-synth\]\]' "$IDX" "root-index-23-3-2-per-page 3-2 per-page synthesis bullet dropped from root"
 
 # === 4. carried PORTAL-LEADIN span (verbatim, date intact) ===
-assert_grep "refreshed:2026-06-01 bullets:3" "$IDX" "4-1 PORTAL-LEADIN carried with original date"
-assert_grep "Framing for the scope theme." "$IDX" "4-2 PORTAL-LEADIN inner prose carried"
+assert_grep "refreshed:2026-06-01 bullets:3" "$IDX" "root-index-24-4-1-portal-leadin 4-1 PORTAL-LEADIN carried with original date"
+assert_grep "Framing for the scope theme." "$IDX" "root-index-25-4-2-portal-leadin 4-2 PORTAL-LEADIN inner prose carried"
 
 # === 4b. seeded default lead-in for a theme that carries none (#946) ===
 # KI Bußgelder has NO authored lead-in in the legacy root, so the renderer seeds a
 # deterministic engine-owned PORTAL-LEADIN span that names the theme — the
 # legibility default, mirroring the perspectives facet defaults. AC1.
-assert_grep "grouped under the \*\*KI Bußgelder\*\* theme" "$IDX" "4b-1 no-lead-in theme seeded a default PORTAL-LEADIN one-liner"
+assert_grep "grouped under the \*\*KI Bußgelder\*\* theme" "$IDX" "root-index-26-4b-1-lead-theme 4b-1 no-lead-in theme seeded a default PORTAL-LEADIN one-liner"
 # AC2 (no clobber): the Scope theme's authored span is NOT replaced by the default.
-assert_not_grep "grouped under the \*\*Scope\*\* theme" "$IDX" "4b-2 authored lead-in not clobbered by the seeded default"
+assert_not_grep "grouped under the \*\*Scope\*\* theme" "$IDX" "root-index-27-4b-2-authored-lead 4b-2 authored lead-in not clobbered by the seeded default"
 
 # === 5. container headings dropped ===
-assert_not_grep '^## Categories' "$IDX" "5-1 ## Categories container heading dropped"
-assert_not_grep '^## Syntheses' "$IDX" "5-2 ## Syntheses fixed heading dropped (folded per-theme)"
-assert_grep '^## Scope' "$IDX" "5-3 real theme heading kept"
+assert_not_grep '^## Categories' "$IDX" "root-index-28-5-1-categories-container 5-1 ## Categories container heading dropped"
+assert_not_grep '^## Syntheses' "$IDX" "root-index-29-5-2-syntheses-fixed 5-2 ## Syntheses fixed heading dropped (folded per-theme)"
+assert_grep '^## Scope' "$IDX" "root-index-30-5-3-real-theme 5-3 real theme heading kept"
 
 # === 6. OVERVIEW-NARRATIVE fold carried into intro ===
 PROSE="$(mktemp)"; printf 'This base maps scope for SMEs.' > "$PROSE"
 python3 "$OVR_SCRIPT" narrative-splice --wiki-root "$WIKI" --prose-file "$PROSE" \
   --target-file index.md --wiki-scripts-dir "$WSD" >/dev/null
 python3 "$ROOT_SCRIPT" render --wiki-root "$WIKI" --wiki-scripts-dir "$WSD" >/dev/null
-assert_grep "MACHINE-OWNED:OVERVIEW-NARRATIVE" "$IDX" "6-1 OVERVIEW-NARRATIVE block in index.md"
-assert_grep "This base maps scope for SMEs." "$IDX" "6-2 overview narrative prose in intro"
+assert_grep "MACHINE-OWNED:OVERVIEW-NARRATIVE" "$IDX" "root-index-31-6-1-overview-narrative 6-1 OVERVIEW-NARRATIVE block in index.md"
+assert_grep "This base maps scope for SMEs." "$IDX" "root-index-32-6-2-overview-narrative 6-2 overview narrative prose in intro"
 
 # === 7. idempotent re-render ===
 OUT2="$(python3 "$ROOT_SCRIPT" render --wiki-root "$WIKI" --wiki-scripts-dir "$WSD")"
 echo "$OUT2" | grep -q '"changed": false' \
-  && green "PASS: 7 re-render is byte-identical no-op (changed:false)" \
-  || { red "FAIL: 7 re-render not idempotent ($OUT2)"; errors=$((errors+1)); }
+  && green "PASS: root-index-33-7-re-render-byte 7 re-render is byte-identical no-op (changed:false)" \
+  || { red "FAIL: root-index-33-7-re-render-byte 7 re-render not idempotent ($OUT2)"; errors=$((errors+1)); }
 
 # === 7b. AC#3 (verbatim-preservation half): a real OVERVIEW-NARRATIVE survives
 #         another re-render byte-for-byte (section 6 authored it; re-render again
 #         and confirm the prose is still carried verbatim, not reset/placeheld). ===
 python3 "$ROOT_SCRIPT" render --wiki-root "$WIKI" --wiki-scripts-dir "$WSD" >/dev/null
-assert_grep "This base maps scope for SMEs." "$IDX" "7b real OVERVIEW-NARRATIVE preserved verbatim across re-render"
+assert_grep "This base maps scope for SMEs." "$IDX" "root-index-34-7b-real-overview-narrative 7b real OVERVIEW-NARRATIVE preserved verbatim across re-render"
 
 # === 8. reflow/collapse stability ===
 BEFORE="$(mktemp)"; cp "$IDX" "$BEFORE"
 python3 "$WSD/wiki_index_update.py" --wiki-root "$WIKI" --reflow-only >/dev/null 2>&1 || true
 python3 "$WSD/wiki_index_update.py" --wiki-root "$WIKI" --collapse-only >/dev/null 2>&1 || true
 if diff -q "$BEFORE" "$IDX" >/dev/null 2>&1; then
-  green "PASS: 8-1 curated MAP byte-stable under reflow-only + collapse-only"
+  green "PASS: root-index-35-8-1-curated-map 8-1 curated MAP byte-stable under reflow-only + collapse-only"
 else
-  red "FAIL: 8-1 curated MAP drifted under reflow/collapse"; diff "$BEFORE" "$IDX" || true; errors=$((errors+1))
+  red "FAIL: root-index-35-8-1-curated-map 8-1 curated MAP drifted under reflow/collapse"; diff "$BEFORE" "$IDX" || true; errors=$((errors+1))
 fi
 OUT3="$(python3 "$ROOT_SCRIPT" render --wiki-root "$WIKI" --wiki-scripts-dir "$WSD")"
 echo "$OUT3" | grep -q '"changed": false' \
-  && green "PASS: 8-2 re-render after reflow/collapse stays changed:false" \
-  || { red "FAIL: 8-2 re-render after fixers not idempotent ($OUT3)"; errors=$((errors+1)); }
+  && green "PASS: root-index-36-8-2-re-render 8-2 re-render after reflow/collapse stays changed:false" \
+  || { red "FAIL: root-index-36-8-2-re-render 8-2 re-render after fixers not idempotent ($OUT3)"; errors=$((errors+1)); }
 
 # === 9. transient bullets: a freshly re-filed bullet is dropped next render ===
 python3 - "$IDX" <<'PY'
@@ -315,42 +315,42 @@ t = open(p, encoding="utf-8").read()
 t = t.replace("## Scope\n", "## Scope\n\n- [[src-c]] — a freshly ingested source\n", 1)
 open(p, "w", encoding="utf-8").write(t)
 PY
-assert_grep '\[\[src-c\]\]' "$IDX" "9-1 transient bullet present before render"
+assert_grep '\[\[src-c\]\]' "$IDX" "root-index-37-9-1-transient-bullet 9-1 transient bullet present before render"
 python3 "$ROOT_SCRIPT" render --wiki-root "$WIKI" --wiki-scripts-dir "$WSD" >/dev/null
-assert_not_grep '\[\[src-c\]\]' "$IDX" "9-2 transient bullet dropped on next render"
+assert_not_grep '\[\[src-c\]\]' "$IDX" "root-index-38-9-2-transient-bullet 9-2 transient bullet dropped on next render"
 
 # === 10. counts subcommand ===
 CNT="$(python3 "$SUB_SCRIPT" counts --type sources --wiki-root "$WIKI")"
 echo "$CNT" | grep -q '"Scope": 2' \
-  && green "PASS: 10 counts subcommand returns {theme: n}" \
-  || { red "FAIL: 10 counts wrong ($CNT)"; errors=$((errors+1)); }
+  && green "PASS: root-index-39-10-counts-subcommand-returns 10 counts subcommand returns {theme: n}" \
+  || { red "FAIL: root-index-39-10-counts-subcommand-returns 10 counts wrong ($CNT)"; errors=$((errors+1)); }
 
 # === 11. overview_update --target-file back-compat (default overview.md) ===
 python3 "$OVR_SCRIPT" narrative-splice --wiki-root "$WIKI" --prose-file "$PROSE" \
   --wiki-scripts-dir "$WSD" >/dev/null
 [ -f "$WIKI/wiki/overview.md" ] \
-  && green "PASS: 11 narrative-splice default still writes wiki/overview.md" \
-  || { red "FAIL: 11 default target did not write overview.md"; errors=$((errors+1)); }
+  && green "PASS: root-index-40-11-narrative-splice-default 11 narrative-splice default still writes wiki/overview.md" \
+  || { red "FAIL: root-index-40-11-narrative-splice-default 11 default target did not write overview.md"; errors=$((errors+1)); }
 
 # === 12. human-page skip ===
 HWIKI="$(mktemp -d)"; mkdir -p "$HWIKI/wiki/sources" "$HWIKI/.cogni-wiki"
 printf '# My hand-written portal\n\nJust prose, no headings, no markers.\n' > "$HWIKI/wiki/index.md"
 HOUT="$(python3 "$ROOT_SCRIPT" render --wiki-root "$HWIKI" --wiki-scripts-dir "$WSD")"
 echo "$HOUT" | grep -q '"skipped_human_page": true' \
-  && green "PASS: 12-1 hand-authored portal skipped" \
-  || { red "FAIL: 12-1 human page not skipped ($HOUT)"; errors=$((errors+1)); }
+  && green "PASS: root-index-41-12-1-hand-authored 12-1 hand-authored portal skipped" \
+  || { red "FAIL: root-index-41-12-1-hand-authored 12-1 human page not skipped ($HOUT)"; errors=$((errors+1)); }
 grep -q "hand-written portal" "$HWIKI/wiki/index.md" \
-  && green "PASS: 12-2 hand-authored portal left untouched" \
-  || { red "FAIL: 12-2 human page clobbered"; errors=$((errors+1)); }
+  && green "PASS: root-index-42-12-2-hand-authored 12-2 hand-authored portal left untouched" \
+  || { red "FAIL: root-index-42-12-2-hand-authored 12-2 human page clobbered"; errors=$((errors+1)); }
 rm -rf "$HWIKI"
 
 # === 13. python3.9 floor ===
 grep -q "from __future__ import annotations" "$ROOT_SCRIPT" \
-  && green "PASS: 13-1 root_index.py carries __future__ annotations" \
-  || { red "FAIL: 13-1 missing __future__ annotations"; errors=$((errors+1)); }
+  && green "PASS: root-index-43-13-1-root-index 13-1 root_index.py carries __future__ annotations" \
+  || { red "FAIL: root-index-43-13-1-root-index 13-1 missing __future__ annotations"; errors=$((errors+1)); }
 python3 -c "import ast,sys; ast.parse(open(sys.argv[1]).read())" "$ROOT_SCRIPT" \
-  && green "PASS: 13-2 root_index.py parses under ast" \
-  || { red "FAIL: 13-2 ast.parse failed"; errors=$((errors+1)); }
+  && green "PASS: root-index-44-13-2-root-index 13-2 root_index.py parses under ast" \
+  || { red "FAIL: root-index-44-13-2-root-index 13-2 ast.parse failed"; errors=$((errors+1)); }
 
 # === 14. render stamps last_rendered_engine_version into config.json (#947) ===
 # A live render records the producing engine version so health.py can flag a
@@ -363,8 +363,8 @@ python3 "$ROOT_SCRIPT" render --wiki-root "$WIKI" --wiki-scripts-dir "$WSD" >/de
 PLUGIN_VER="$(python3 -c "import json; print(json.load(open('$PLUGIN_ROOT/.claude-plugin/plugin.json'))['version'])")"
 STAMP="$(python3 -c "import json; print(json.load(open('$WIKI/.cogni-wiki/config.json')).get('last_rendered_engine_version',''))")"
 [ "$STAMP" = "$PLUGIN_VER" ] \
-  && green "PASS: 14 render stamped last_rendered_engine_version=$STAMP" \
-  || { red "FAIL: 14 stamp '$STAMP' != plugin version '$PLUGIN_VER'"; errors=$((errors+1)); }
+  && green "PASS: root-index-45-14-render-stamped-last 14 render stamped last_rendered_engine_version=$STAMP" \
+  || { red "FAIL: root-index-45-14-render-stamped-last 14 stamp '$STAMP' != plugin version '$PLUGIN_VER'"; errors=$((errors+1)); }
 
 echo
 if [ "$errors" -eq 0 ]; then

--- a/cogni-knowledge/tests/test_root_index.sh
+++ b/cogni-knowledge/tests/test_root_index.sh
@@ -245,11 +245,11 @@ assert_not_grep "sources/index.md#ki-bussgelder)" "$IDX" "root-index-17-2b-4-anc
 # The producer-site _collapse normalizes it to "AI Liability", so the heading is
 # single-space and the anchor is the matching single-%20 fragment.
 assert_grep '^## AI Liability' "$IDX" "root-index-18-2c-1-double-space 2c-1 double-space theme heading collapsed to single space"
-assert_not_grep '^## AI  Liability' "$IDX" "root-index-19-2c-2-heading-does 2c-2 heading does NOT keep the double space (the drift)"
+assert_not_grep '^## AI  Liability' "$IDX" "root-index-19-2c-2-heading-space-collapsed 2c-2 heading does NOT keep the double space (the drift)"
 assert_grep "Sources (1)](sources/index.md#AI%20Liability)" "$IDX" "root-index-20-2c-3-count-link 2c-3 count-link anchors to the single-%20 fragment that matches the heading"
 # Regression: the heading↔anchor MUST agree — the drift would have rendered the
 # double-space heading while the anchor collapsed, landing the click at page top.
-assert_not_grep "sources/index.md#AI%20%20Liability)" "$IDX" "root-index-21-2c-4-anchor-un 2c-4 anchor is NOT the un-collapsed double-%20 form"
+assert_not_grep "sources/index.md#AI%20%20Liability)" "$IDX" "root-index-21-2c-4-anchor-space-collapsed 2c-4 anchor is NOT the un-collapsed double-%20 form"
 
 # === 3. no per-page source bullets remain on the root ===
 assert_not_grep '^- \[\[src-a\]\]' "$IDX" "root-index-22-3-1-per-page 3-1 per-page src-a bullet dropped from root"

--- a/cogni-knowledge/tests/test_sub_index.sh
+++ b/cogni-knowledge/tests/test_sub_index.sh
@@ -403,7 +403,7 @@ done
 
 # --- 11. python3.9 floor -----------------------------------------------------
 assert_grep 'from __future__ import annotations' "$SCRIPT" \
-  "sub-index-26-sub-index-py-carries sub_index.py carries the py3.9 future-annotations import"
+  "sub-index-26-future-annotations-import sub_index.py carries the py3.9 future-annotations import"
 if python3 -c "import ast,sys; ast.parse(open(sys.argv[1],encoding='utf-8').read())" "$SCRIPT"; then
   green "PASS: sub-index-27-sub-index-py-parses sub_index.py parses cleanly (ast.parse)"
 else

--- a/cogni-knowledge/tests/test_sub_index.sh
+++ b/cogni-knowledge/tests/test_sub_index.sh
@@ -45,11 +45,11 @@ WSD="$PLUGIN_ROOT/scripts/vendor/cogni-wiki/skills/wiki-ingest/scripts"
 . "$(dirname "$0")/fixtures/test_helpers.sh"
 
 if [ ! -f "$SCRIPT" ]; then
-  red "FAIL: sub_index.py not found at $SCRIPT"
+  red "FAIL: sub-index-00-script-present sub_index.py not found at $SCRIPT"
   exit 1
 fi
 if [ ! -d "$WSD" ]; then
-  red "FAIL: cogni-wiki wiki-ingest scripts not found at $WSD (needed for _wiki_lock)"
+  red "FAIL: sub-index-00-wiki-scripts-present cogni-wiki wiki-ingest scripts not found at $WSD (needed for _wiki_lock)"
   exit 1
 fi
 
@@ -189,37 +189,37 @@ for T in $TYPES; do
 
   OUT=$(python3 "$SCRIPT" render --type "$T" --wiki-root "$WIKI" --wiki-scripts-dir "$WSD")
   if [ "$(echo "$OUT" | field '["success"]')" = "True" ] && [ -f "$IDX" ]; then
-    green "PASS[$T]: render creates wiki/$T/index.md"
+    green "PASS: sub-index-01-render-creates-wiki-index-$T render creates wiki/$T/index.md"
   else
-    red "FAIL[$T]: render did not create the index"; echo "$OUT"; errors=$((errors+1))
+    red "FAIL: sub-index-01-render-creates-wiki-index-$T render did not create the index"; echo "$OUT"; errors=$((errors+1))
   fi
   [ "$(echo "$OUT" | field '["data"]["changed"]')" = "True" ] \
-    && green "PASS[$T]: first render reports changed:true" \
-    || { red "FAIL[$T]: first render changed != true"; errors=$((errors+1)); }
+    && green "PASS: sub-index-02-first-render-reports-changed-$T first render reports changed:true" \
+    || { red "FAIL: sub-index-02-first-render-reports-changed-$T first render changed != true"; errors=$((errors+1)); }
 
-  assert_grep "MACHINE-OWNED:$U-INDEX" "$IDX" "[$T] page ownership marker"
+  assert_grep "MACHINE-OWNED:$U-INDEX" "$IDX" "sub-index-03-page-ownership-marker-$T [$T] page ownership marker"
   [ "$(bullet_section "$THEMED" "$IDX")" = "Regulatory Scope" ] \
-    && green "PASS[$T]: themed page -> Regulatory Scope" \
-    || { red "FAIL[$T]: $THEMED not under Regulatory Scope"; errors=$((errors+1)); }
+    && green "PASS: sub-index-04-themed-page-regulatory-scope-$T themed page -> Regulatory Scope" \
+    || { red "FAIL: sub-index-04-themed-page-regulatory-scope-$T $THEMED not under Regulatory Scope"; errors=$((errors+1)); }
   [ "$(bullet_section "$LOOSE" "$IDX")" = "Uncategorized" ] \
-    && green "PASS[$T]: loose page -> Uncategorized fallback" \
-    || { red "FAIL[$T]: $LOOSE not under Uncategorized"; errors=$((errors+1)); }
-  assert_grep "\[\[$THEMED\]\]" "$IDX" "[$T] themed bullet has [[slug]] wikilink"
+    && green "PASS: sub-index-05-loose-page-uncategorized-fallback-$T loose page -> Uncategorized fallback" \
+    || { red "FAIL: sub-index-05-loose-page-uncategorized-fallback-$T $LOOSE not under Uncategorized"; errors=$((errors+1)); }
+  assert_grep "\[\[$THEMED\]\]" "$IDX" "sub-index-06-themed-bullet-has-slug-$T [$T] themed bullet has [[slug]] wikilink"
   assert_grep "MACHINE-OWNED:$U-LEADIN:regulatory-scope:START" "$IDX" \
-    "[$T] Regulatory Scope lead-in sentinel span present"
+    "sub-index-07-regulatory-scope-lead-sentinel-$T [$T] Regulatory Scope lead-in sentinel span present"
   assert_grep "This theme groups the $T below" "$IDX" \
-    "[$T] fresh render uses the deterministic lead-in fallback"
+    "sub-index-08-fresh-render-uses-deterministic-$T [$T] fresh render uses the deterministic lead-in fallback"
 
   # BYTE-IDEMPOTENT re-render
   cp "$IDX" "$WORK/$T.before"
   OUT=$(python3 "$SCRIPT" render --type "$T" --wiki-root "$WIKI" --wiki-scripts-dir "$WSD")
   [ "$(echo "$OUT" | field '["data"]["changed"]')" = "False" ] \
-    && green "PASS[$T]: unchanged re-render reports changed:false" \
-    || { red "FAIL[$T]: idempotent re-render changed != false"; errors=$((errors+1)); }
+    && green "PASS: sub-index-09-unchanged-re-render-reports-$T unchanged re-render reports changed:false" \
+    || { red "FAIL: sub-index-09-unchanged-re-render-reports-$T idempotent re-render changed != false"; errors=$((errors+1)); }
   if cmp -s "$WORK/$T.before" "$IDX"; then
-    green "PASS[$T]: re-render is byte-identical (no stamp churn)"
+    green "PASS: sub-index-10-re-render-byte-identical-$T re-render is byte-identical (no stamp churn)"
   else
-    red "FAIL[$T]: re-render mutated the page"; errors=$((errors+1))
+    red "FAIL: sub-index-10-re-render-byte-identical-$T re-render mutated the page"; errors=$((errors+1))
   fi
 
   # stage (lock-free) writes the proposal, never touches the live page.
@@ -231,11 +231,11 @@ for T in $TYPES; do
   OUT=$(python3 "$SCRIPT" stage --type "$T" --wiki-root "$SWIKI")
   STAGED="$SWIKI/.cogni-wiki/$T-index-proposed.md"
   [ "$(echo "$OUT" | field '["success"]')" = "True" ] && [ -f "$STAGED" ] \
-    && green "PASS[$T]: stage writes the proposed page" \
-    || { red "FAIL[$T]: stage did not write the proposal"; echo "$OUT"; errors=$((errors+1)); }
+    && green "PASS: sub-index-11-stage-writes-proposed-page-$T stage writes the proposed page" \
+    || { red "FAIL: sub-index-11-stage-writes-proposed-page-$T stage did not write the proposal"; echo "$OUT"; errors=$((errors+1)); }
   [ ! -f "$SWIKI/wiki/$T/index.md" ] \
-    && green "PASS[$T]: stage does not touch the live page" \
-    || { red "FAIL[$T]: stage wrote the live page"; errors=$((errors+1)); }
+    && green "PASS: sub-index-12-stage-does-not-touch-live-$T stage does not touch the live page" \
+    || { red "FAIL: sub-index-12-stage-does-not-touch-live-$T stage wrote the live page"; errors=$((errors+1)); }
 done
 
 # --- 7. CARRY-FORWARD (sources type) -----------------------------------------
@@ -253,7 +253,7 @@ open(p, "w", encoding="utf-8").write(t)
 PY
 OUT=$(python3 "$SCRIPT" render --type sources --wiki-root "$WIKI" --wiki-scripts-dir "$WSD")
 assert_grep 'Authored framing: the primary sources' "$SIDX" \
-  "sources: authored lead-in carried forward across re-render (no clobber)"
+  "sub-index-13-sources-authored-lead-carried sources: authored lead-in carried forward across re-render (no clobber)"
 
 # --- 8. HUMAN-PAGE skip (questions type) -------------------------------------
 HWIKI="$WORK/human-wiki"
@@ -266,12 +266,12 @@ printf '# My hand-written question index\n\nNothing machine-owned here.\n' \
 cp "$HWIKI/wiki/questions/index.md" "$WORK/human.before"
 OUT=$(python3 "$SCRIPT" render --type questions --wiki-root "$HWIKI" --wiki-scripts-dir "$WSD")
 [ "$(echo "$OUT" | field '["data"]["skipped_human_page"]')" = "True" ] \
-  && green "PASS: human-authored questions index skipped (skipped_human_page)" \
-  || { red "FAIL: human page not skipped"; echo "$OUT"; errors=$((errors+1)); }
+  && green "PASS: sub-index-14-human-authored-questions-index human-authored questions index skipped (skipped_human_page)" \
+  || { red "FAIL: sub-index-14-human-authored-questions-index human page not skipped"; echo "$OUT"; errors=$((errors+1)); }
 if cmp -s "$WORK/human.before" "$HWIKI/wiki/questions/index.md"; then
-  green "PASS: human page left byte-untouched"
+  green "PASS: sub-index-15-human-page-left-byte human page left byte-untouched"
 else
-  red "FAIL: human page was modified"; errors=$((errors+1))
+  red "FAIL: sub-index-15-human-page-left-byte human page was modified"; errors=$((errors+1))
 fi
 
 # --- 9. FRONTMATTER MEMBERSHIP: curated root with NO per-page bullets ---------
@@ -322,11 +322,11 @@ EOF
 python3 "$SCRIPT" render --type sources  --wiki-root "$FMWIKI" --wiki-scripts-dir "$WSD" >/dev/null
 python3 "$SCRIPT" render --type concepts --wiki-root "$FMWIKI" --wiki-scripts-dir "$WSD" >/dev/null
 [ "$(bullet_section src-fm "$FMWIKI/wiki/sources/index.md")" = "Regulatory Scope" ] \
-  && green "PASS: source resolves theme from frontmatter (no root bullet)" \
-  || { red "FAIL: src-fm not under Regulatory Scope via frontmatter"; errors=$((errors+1)); }
+  && green "PASS: sub-index-16-source-resolves-theme-from source resolves theme from frontmatter (no root bullet)" \
+  || { red "FAIL: sub-index-16-source-resolves-theme-from src-fm not under Regulatory Scope via frontmatter"; errors=$((errors+1)); }
 [ "$(bullet_section con-fm "$FMWIKI/wiki/concepts/index.md")" = "Regulatory Scope" ] \
-  && green "PASS: distilled page resolves theme transitively via frontmatter source map" \
-  || { red "FAIL: con-fm not under Regulatory Scope via backing-source frontmatter"; errors=$((errors+1)); }
+  && green "PASS: sub-index-17-distilled-page-resolves-theme distilled page resolves theme transitively via frontmatter source map" \
+  || { red "FAIL: sub-index-17-distilled-page-resolves-theme con-fm not under Regulatory Scope via backing-source frontmatter"; errors=$((errors+1)); }
 
 # --- 9b. A1 false-filtering fix (#933): theme-label whitespace is normalized ---
 # A source whose theme_label carries a double internal space + trailing whitespace
@@ -350,19 +350,19 @@ python3 "$SCRIPT" render --type concepts --wiki-root "$FMWIKI" --wiki-scripts-di
 } > "$FMWIKI/wiki/sources/src-drift.md"
 python3 "$SCRIPT" render --type sources --wiki-root "$FMWIKI" --wiki-scripts-dir "$WSD" >/dev/null
 [ "$(bullet_section src-drift "$FMWIKI/wiki/sources/index.md")" = "AI Liability" ] \
-  && green "PASS: double-space theme_label collapsed to single-space heading (#933)" \
-  || { red "FAIL: src-drift heading not collapsed to 'AI Liability' (A1 drift)"; errors=$((errors+1)); }
+  && green "PASS: sub-index-18-double-space-theme-label double-space theme_label collapsed to single-space heading (#933)" \
+  || { red "FAIL: sub-index-18-double-space-theme-label src-drift heading not collapsed to 'AI Liability' (A1 drift)"; errors=$((errors+1)); }
 if grep -q '^## AI  Liability' "$FMWIKI/wiki/sources/index.md"; then
-  red "FAIL: sub-index heading kept the double space (the A1 drift, #933)"; errors=$((errors+1))
+  red "FAIL: sub-index-19-heading-does-not-keep-double-space sub-index heading kept the double space (the A1 drift, #933)"; errors=$((errors+1))
 else
-  green "PASS: sub-index heading does NOT keep the double space (#933)"
+  green "PASS: sub-index-19-heading-does-not-keep-double-space sub-index heading does NOT keep the double space (#933)"
 fi
 
 # --- 10. unknown type is a clean fail-soft error -----------------------------
 if python3 "$SCRIPT" stage --type bogus --wiki-root "$WIKI" >/dev/null 2>&1; then
-  red "FAIL: unknown --type did not error"; errors=$((errors+1))
+  red "FAIL: sub-index-20-unknown-type-rejected-argparse unknown --type did not error"; errors=$((errors+1))
 else
-  green "PASS: unknown --type rejected (argparse choices guard)"
+  green "PASS: sub-index-20-unknown-type-rejected-argparse unknown --type rejected (argparse choices guard)"
 fi
 
 # --- 10b. R6 instance-free legibility (the three distilled sub-indexes) -------
@@ -376,11 +376,11 @@ for T in concepts entities syntheses; do
     entities)  DEF="An entity is a named organization" ;;
     syntheses) DEF="A synthesis is a composed, verified report" ;;
   esac
-  assert_grep "$DEF" "$IDX" "[$T] renders an instance-free type-definition preamble"
+  assert_grep "$DEF" "$IDX" "sub-index-21-renders-instance-free-type-$T [$T] renders an instance-free type-definition preamble"
   DEFLINE=$(grep -F "$DEF" "$IDX" | head -1)
   case "$DEFLINE" in
-    *'[['*) red "FAIL: [$T] definition preamble carries a [[wikilink]] (not instance-free)"; errors=$((errors+1)) ;;
-    *)      green "PASS: [$T] definition preamble is instance-free (no [[wikilink]])" ;;
+    *'[['*) red "FAIL: sub-index-22-definition-preamble-instance-free-$T [$T] definition preamble carries a [[wikilink]] (not instance-free)"; errors=$((errors+1)) ;;
+    *)      green "PASS: sub-index-22-definition-preamble-instance-free-$T [$T] definition preamble is instance-free (no [[wikilink]])" ;;
   esac
 done
 
@@ -396,18 +396,18 @@ for T in $TYPES; do
     sources|questions)        STAGE="ingest" ;;
     syntheses)                STAGE="compose" ;;
   esac
-  assert_grep "stage: $STAGE" "$IDX" "[$T] population cue shows stage: $STAGE"
-  assert_grep "listed alphabetically by slug" "$IDX" "[$T] population cue shows the order flag"
-  assert_grep "2 pages · 2 themes" "$IDX" "[$T] population cue reflects the actual page/theme counts"
+  assert_grep "stage: $STAGE" "$IDX" "sub-index-23-population-cue-shows-stage-$T [$T] population cue shows stage: $STAGE"
+  assert_grep "listed alphabetically by slug" "$IDX" "sub-index-24-population-cue-shows-order-$T [$T] population cue shows the order flag"
+  assert_grep "2 pages · 2 themes" "$IDX" "sub-index-25-population-cue-reflects-actual-$T [$T] population cue reflects the actual page/theme counts"
 done
 
 # --- 11. python3.9 floor -----------------------------------------------------
 assert_grep 'from __future__ import annotations' "$SCRIPT" \
-  "sub_index.py carries the py3.9 future-annotations import"
+  "sub-index-26-sub-index-py-carries sub_index.py carries the py3.9 future-annotations import"
 if python3 -c "import ast,sys; ast.parse(open(sys.argv[1],encoding='utf-8').read())" "$SCRIPT"; then
-  green "PASS: sub_index.py parses cleanly (ast.parse)"
+  green "PASS: sub-index-27-sub-index-py-parses sub_index.py parses cleanly (ast.parse)"
 else
-  red "FAIL: sub_index.py has a syntax error"; errors=$((errors+1))
+  red "FAIL: sub-index-27-sub-index-py-parses sub_index.py has a syntax error"; errors=$((errors+1))
 fi
 
 # --- summary -----------------------------------------------------------------

--- a/cogni-knowledge/tests/test_verify_store.sh
+++ b/cogni-knowledge/tests/test_verify_store.sh
@@ -32,7 +32,7 @@ SCRIPT="$PLUGIN_ROOT/scripts/verify-store.py"
 . "$(dirname "$0")/fixtures/test_helpers.sh"
 
 if [ ! -f "$SCRIPT" ]; then
-  red "FAIL: verify-store.py not found at $SCRIPT"
+  red "FAIL: verify-store-00-script-present verify-store.py not found at $SCRIPT"
   exit 1
 fi
 
@@ -70,9 +70,9 @@ counts = [s['citation_count'] for s in d['data']['shards']]
 assert counts == [2, 2, 1], counts
 print('OK')
 " | grep -q OK; then
-  green "PASS: shard splits 5 citations into 3 shards (2,2,1)"
+  green "PASS: verify-store-01-shard-splits-5-citations shard splits 5 citations into 3 shards (2,2,1)"
 else
-  red "FAIL: shard split shape wrong"
+  red "FAIL: verify-store-01-shard-splits-5-citations shard split shape wrong"
   red "  got: $SHARD_OUT"
   errors=$((errors + 1))
 fi
@@ -94,9 +94,9 @@ for f in shard_files:
 assert union_ids == ['cit-001','cit-002','cit-003','cit-004','cit-005'], union_ids
 PY
 then
-  green "PASS: shard files are valid manifests; id/draft_sentence preserved; union exact + no dup"
+  green "PASS: verify-store-02-shard-files-valid-manifests shard files are valid manifests; id/draft_sentence preserved; union exact + no dup"
 else
-  red "FAIL: shard file contents wrong"
+  red "FAIL: verify-store-02-shard-files-valid-manifests shard file contents wrong"
   errors=$((errors + 1))
 fi
 
@@ -104,9 +104,9 @@ fi
 SHARDS_ONE="$WORK/shards-one"
 ONE_OUT=$(python3 "$SCRIPT" shard --manifest "$MANIFEST" --draft-version 1 --shard-size 10 --out-dir "$SHARDS_ONE")
 if echo "$ONE_OUT" | python3 -c "import sys,json; d=json.load(sys.stdin); assert d['data']['shard_count']==1, d" 2>/dev/null; then
-  green "PASS: citations <= shard-size yields a single shard"
+  green "PASS: verify-store-03-citations-shard-size-yields citations <= shard-size yields a single shard"
 else
-  red "FAIL: expected single shard"
+  red "FAIL: verify-store-03-citations-shard-size-yields expected single shard"
   red "  got: $ONE_OUT"
   errors=$((errors + 1))
 fi
@@ -141,9 +141,9 @@ assert c['total'] == 5, c
 assert c['paraphrase'] == 2 and c['verbatim'] == 1 and c['synthesis'] == 1 and c['unsupported'] == 1, c
 print('OK')
 " | grep -q OK; then
-  green "PASS: merge recombines 3 fragments; counts recomputed; shards_merged reported"
+  green "PASS: verify-store-04-merge-recombines-3-fragments merge recombines 3 fragments; counts recomputed; shards_merged reported"
 else
-  red "FAIL: merge envelope wrong"
+  red "FAIL: verify-store-04-merge-recombines-3-fragments merge envelope wrong"
   red "  got: $MERGE_OUT"
   errors=$((errors + 1))
 fi
@@ -163,9 +163,9 @@ assert gm['grounded'] == 0 and gm['ungrounded'] == 0 and gm['unscored'] == 5, gm
 assert gm['grounding_rate'] is None, gm
 PY
 then
-  green "PASS: merged verify-v1.json — total==verified+deviations, draft_version/revision_round set, ids intact"
+  green "PASS: verify-store-05-merged-verify-v1-json merged verify-v1.json — total==verified+deviations, draft_version/revision_round set, ids intact"
 else
-  red "FAIL: merged verify-v1.json malformed"
+  red "FAIL: verify-store-05-merged-verify-v1-json merged verify-v1.json malformed"
   errors=$((errors + 1))
 fi
 
@@ -178,18 +178,18 @@ assert glob.glob("$SHARDS/verify-shard-*-v1.json") == [], glob.glob("$SHARDS/ver
 assert len(glob.glob("$SHARDS/shard-*-v1.json")) == 3
 PY
 then
-  green "PASS: re-shard clears stale verify-shard fragments for the version"
+  green "PASS: verify-store-06-re-shard-clears-stale re-shard clears stale verify-shard fragments for the version"
 else
-  red "FAIL: re-shard did not clear stale fragments"
+  red "FAIL: verify-store-06-re-shard-clears-stale re-shard did not clear stale fragments"
   errors=$((errors + 1))
 fi
 
 # 5a. Missing manifest → reject.
 OUT=$(python3 "$SCRIPT" shard --manifest "$WORK/nope.json" --draft-version 1 --shard-size 2 --out-dir "$WORK/x" 2>&1 || true)
 if echo "$OUT" | python3 -c "import sys,json; d=json.load(sys.stdin); assert d['success'] is False and 'exist' in d['error'].lower()" 2>/dev/null; then
-  green "PASS: missing manifest rejected"
+  green "PASS: verify-store-07-missing-manifest-rejected missing manifest rejected"
 else
-  red "FAIL: missing manifest not rejected"
+  red "FAIL: verify-store-07-missing-manifest-rejected missing manifest not rejected"
   red "  got: $OUT"
   errors=$((errors + 1))
 fi
@@ -199,9 +199,9 @@ BAD_SCHEMA="$WORK/bad-schema.json"
 echo '{"schema_version": "0.0.9", "draft_version": 1, "citations": []}' > "$BAD_SCHEMA"
 OUT=$(python3 "$SCRIPT" shard --manifest "$BAD_SCHEMA" --draft-version 1 --shard-size 2 --out-dir "$WORK/y" 2>&1 || true)
 if echo "$OUT" | python3 -c "import sys,json; d=json.load(sys.stdin); assert d['success'] is False and 'schema_version' in d['error']" 2>/dev/null; then
-  green "PASS: non-0.1.0 schema rejected"
+  green "PASS: verify-store-08-non-0-1-0 non-0.1.0 schema rejected"
 else
-  red "FAIL: non-0.1.0 schema not rejected"
+  red "FAIL: verify-store-08-non-0-1-0 non-0.1.0 schema not rejected"
   red "  got: $OUT"
   errors=$((errors + 1))
 fi
@@ -209,9 +209,9 @@ fi
 # 5c. draft_version mismatch → reject.
 OUT=$(python3 "$SCRIPT" shard --manifest "$MANIFEST" --draft-version 9 --shard-size 2 --out-dir "$WORK/z" 2>&1 || true)
 if echo "$OUT" | python3 -c "import sys,json; d=json.load(sys.stdin); assert d['success'] is False and 'draft_version' in d['error']" 2>/dev/null; then
-  green "PASS: draft_version mismatch rejected"
+  green "PASS: verify-store-09-draft-version-mismatch-rejected draft_version mismatch rejected"
 else
-  red "FAIL: draft_version mismatch not rejected"
+  red "FAIL: verify-store-09-draft-version-mismatch-rejected draft_version mismatch not rejected"
   red "  got: $OUT"
   errors=$((errors + 1))
 fi
@@ -221,9 +221,9 @@ EMPTY_DIR="$WORK/empty-shards"
 mkdir -p "$EMPTY_DIR"
 OUT=$(python3 "$SCRIPT" merge --shard-dir "$EMPTY_DIR" --draft-version 1 --revision-round 0 --out "$WORK/nope-v1.json" 2>&1 || true)
 if echo "$OUT" | python3 -c "import sys,json; d=json.load(sys.stdin); assert d['success'] is False and 'fragment' in d['error'].lower()" 2>/dev/null; then
-  green "PASS: merge with no fragments rejected"
+  green "PASS: verify-store-10-merge-fragments-rejected merge with no fragments rejected"
 else
-  red "FAIL: merge with no fragments not rejected"
+  red "FAIL: verify-store-10-merge-fragments-rejected merge with no fragments not rejected"
   red "  got: $OUT"
   errors=$((errors + 1))
 fi
@@ -243,9 +243,9 @@ cat > "$PRE028" <<'JSON'
 JSON
 OUT=$(python3 "$SCRIPT" shard --manifest "$PRE028" --draft-version 1 --shard-size 2 --out-dir "$WORK/pre028-out" 2>&1 || true)
 if echo "$OUT" | python3 -c "import sys,json; d=json.load(sys.stdin); assert d['success'] is False and 'v0.0.28' in d['error']" 2>/dev/null; then
-  green "PASS: pre-0.0.28 manifest (citation missing id/draft_sentence) rejected"
+  green "PASS: verify-store-11-pre-0-0-28 pre-0.0.28 manifest (citation missing id/draft_sentence) rejected"
 else
-  red "FAIL: pre-0.0.28 manifest not rejected"
+  red "FAIL: verify-store-11-pre-0-0-28 pre-0.0.28 manifest not rejected"
   red "  got: $OUT"
   errors=$((errors + 1))
 fi
@@ -276,9 +276,9 @@ frag_full_01='{"schema_version":"0.1.0","draft_version":1,"revision_round":0,"ve
 clear_frags; write_frag verify-shard-00-v1.json "$frag_full_00"
 OUT=$(python3 "$SCRIPT" merge --shard-dir "$MR" --draft-version 1 --revision-round 0 --out "$WORK/mr-a.json" 2>&1 || true)
 if echo "$OUT" | python3 -c "import sys,json; d=json.load(sys.stdin); assert d['success'] is False and 'of 4' in d['error']" 2>/dev/null; then
-  green "PASS: merge rejects a missing fragment (2 of 4 sharded citations)"
+  green "PASS: verify-store-12-merge-rejects-missing-fragment merge rejects a missing fragment (2 of 4 sharded citations)"
 else
-  red "FAIL: missing fragment not caught by completeness check"
+  red "FAIL: verify-store-12-merge-rejects-missing-fragment missing fragment not caught by completeness check"
   red "  got: $OUT"
   errors=$((errors + 1))
 fi
@@ -288,9 +288,9 @@ clear_frags; write_frag verify-shard-00-v1.json "$frag_full_00"; write_frag veri
 write_frag verify-shard-02-v1.json '{"schema_version":"0.1.0","draft_version":1,"revision_round":0,"verified":[{"id":"cit-001","verdict":"paraphrase"}],"deviations":[],"counts":{"total":1}}'
 OUT=$(python3 "$SCRIPT" merge --shard-dir "$MR" --draft-version 1 --revision-round 0 --out "$WORK/mr-b.json" 2>&1 || true)
 if echo "$OUT" | python3 -c "import sys,json; d=json.load(sys.stdin); assert d['success'] is False and 'duplicate' in d['error'].lower()" 2>/dev/null; then
-  green "PASS: merge rejects duplicate citation id across fragments"
+  green "PASS: verify-store-13-merge-rejects-duplicate-citation merge rejects duplicate citation id across fragments"
 else
-  red "FAIL: duplicate id not rejected"
+  red "FAIL: verify-store-13-merge-rejects-duplicate-citation duplicate id not rejected"
   red "  got: $OUT"
   errors=$((errors + 1))
 fi
@@ -300,9 +300,9 @@ clear_frags; write_frag verify-shard-01-v1.json "$frag_full_01"
 write_frag verify-shard-00-v1.json '{"schema_version":"0.1.0","draft_version":1,"revision_round":0,"verified":[{"id":"cit-001","verdict":"paraphrase"},{"id":"cit-002","verdict":"unsupported","reason":"x"}],"deviations":[],"counts":{"total":2}}'
 OUT=$(python3 "$SCRIPT" merge --shard-dir "$MR" --draft-version 1 --revision-round 0 --out "$WORK/mr-c.json" 2>&1 || true)
 if echo "$OUT" | python3 -c "import sys,json; d=json.load(sys.stdin); assert d['success'] is False and 'mis-filed' in d['error']" 2>/dev/null; then
-  green "PASS: merge rejects unsupported verdict mis-filed in verified[]"
+  green "PASS: verify-store-14-merge-rejects-unsupported-verdict merge rejects unsupported verdict mis-filed in verified[]"
 else
-  red "FAIL: mis-filed unsupported not rejected"
+  red "FAIL: verify-store-14-merge-rejects-unsupported-verdict mis-filed unsupported not rejected"
   red "  got: $OUT"
   errors=$((errors + 1))
 fi
@@ -311,9 +311,9 @@ fi
 clear_frags; write_frag verify-shard-00-v1.json "$frag_full_00"; write_frag verify-shard-01-v1.json '[1,2,3]'
 OUT=$(python3 "$SCRIPT" merge --shard-dir "$MR" --draft-version 1 --revision-round 0 --out "$WORK/mr-d.json" 2>&1 || true)
 if echo "$OUT" | python3 -c "import sys,json; d=json.load(sys.stdin); assert d['success'] is False and 'object' in d['error']" 2>/dev/null; then
-  green "PASS: merge returns an envelope (not a traceback) on a non-dict fragment"
+  green "PASS: verify-store-15-merge-returns-envelope-not-traceback merge returns an envelope (not a traceback) on a non-dict fragment"
 else
-  red "FAIL: non-dict fragment crashed instead of returning the envelope"
+  red "FAIL: verify-store-15-merge-returns-envelope-not-traceback non-dict fragment crashed instead of returning the envelope"
   red "  got: $OUT"
   errors=$((errors + 1))
 fi
@@ -323,9 +323,9 @@ NONDICT="$WORK/nondict-manifest.json"
 echo '[1,2,3]' > "$NONDICT"
 OUT=$(python3 "$SCRIPT" shard --manifest "$NONDICT" --draft-version 1 --shard-size 2 --out-dir "$WORK/nd" 2>&1 || true)
 if echo "$OUT" | python3 -c "import sys,json; d=json.load(sys.stdin); assert d['success'] is False and 'object' in d['error']" 2>/dev/null; then
-  green "PASS: shard returns an envelope (not a traceback) on a non-dict manifest"
+  green "PASS: verify-store-16-shard-returns-envelope-not-traceback shard returns an envelope (not a traceback) on a non-dict manifest"
 else
-  red "FAIL: non-dict manifest crashed instead of returning the envelope"
+  red "FAIL: verify-store-16-shard-returns-envelope-not-traceback non-dict manifest crashed instead of returning the envelope"
   red "  got: $OUT"
   errors=$((errors + 1))
 fi
@@ -353,9 +353,9 @@ for f in files:
 assert sorted(ids) == ['cit-002','cit-004'], ids
 PY
 then
-  green "PASS: shard --only-ids splits only the requested delta subset (#305)"
+  green "PASS: verify-store-17-shard-only-ids-splits shard --only-ids splits only the requested delta subset (#305)"
 else
-  red "FAIL: shard --only-ids did not restrict to the subset"
+  red "FAIL: verify-store-17-shard-only-ids-splits shard --only-ids did not restrict to the subset"
   red "  got: $OUT"
   errors=$((errors + 1))
 fi
@@ -421,9 +421,9 @@ assert d['success'] is True, d
 assert d['data']['matched_ids'] == ['cit-p1'], d['data']
 assert sorted(d['data']['remaining_ids']) == ['cit-p2', 'cit-p3'], d['data']
 " 2>/dev/null; then
-  green "PASS: prefilter matches the verbatim citation, falls through on cross-lang + unparseable (#305)"
+  green "PASS: verify-store-18-prefilter-matches-verbatim-citation prefilter matches the verbatim citation, falls through on cross-lang + unparseable (#305)"
 else
-  red "FAIL: prefilter match/remaining split wrong"
+  red "FAIL: verify-store-18-prefilter-matches-verbatim-citation prefilter match/remaining split wrong"
   red "  got: $OUT"
   errors=$((errors + 1))
 fi
@@ -436,9 +436,9 @@ e = frag['verified'][0]
 assert e['id'] == 'cit-p1' and e['verdict'] == 'verbatim', e
 PY
 then
-  green "PASS: prefilter fragment carries only verbatim verdicts, no deviations"
+  green "PASS: verify-store-19-prefilter-fragment-carries-only prefilter fragment carries only verbatim verdicts, no deviations"
 else
-  red "FAIL: prefilter fragment malformed"
+  red "FAIL: verify-store-19-prefilter-fragment-carries-only prefilter fragment malformed"
   errors=$((errors + 1))
 fi
 
@@ -459,9 +459,9 @@ assert sorted(d['data']['remaining_ids']) == ['cit-p1', 'cit-p2', 'cit-p3'], d['
 assert d['data']['remaining_count'] == 3, d['data']
 assert d['data'].get('skipped') == 'executive-density', d['data']
 " 2>/dev/null; then
-  green "PASS: prefilter --prose-density executive routes every citation to remaining (0 matched), bypassing the scan (#842)"
+  green "PASS: verify-store-20-prefilter-prose-density-executive prefilter --prose-density executive routes every citation to remaining (0 matched), bypassing the scan (#842)"
 else
-  red "FAIL: executive-density bypass did not route all citations to remaining"
+  red "FAIL: verify-store-20-prefilter-prose-density-executive executive-density bypass did not route all citations to remaining"
   red "  got: $OUT"
   errors=$((errors + 1))
 fi
@@ -473,9 +473,9 @@ assert frag['deviations'] == [], frag
 assert frag['counts']['total'] == 0 and frag['counts']['verbatim'] == 0, frag
 PY
 then
-  green "PASS: executive-density bypass writes a zeroed prefilter fragment (#842)"
+  green "PASS: verify-store-21-executive-density-bypass-writes executive-density bypass writes a zeroed prefilter fragment (#842)"
 else
-  red "FAIL: executive-density fragment not zeroed"
+  red "FAIL: verify-store-21-executive-density-bypass-writes executive-density fragment not zeroed"
   errors=$((errors + 1))
 fi
 
@@ -519,9 +519,9 @@ d = json.load(sys.stdin)
 assert d['success'] is True, d
 assert d['data']['matched_ids'] == ['cit-q1'], d['data']
 " 2>/dev/null; then
-  green "PASS: prefilter resolves a question-node answer_claims: (acl-NNN, text needle) → verbatim (#432)"
+  green "PASS: verify-store-22-prefilter-resolves-question-node prefilter resolves a question-node answer_claims: (acl-NNN, text needle) → verbatim (#432)"
 else
-  red "FAIL: question-family prefilter did not match"; red "  got: $OUT"; errors=$((errors + 1))
+  red "FAIL: verify-store-22-prefilter-resolves-question-node question-family prefilter did not match"; red "  got: $OUT"; errors=$((errors + 1))
 fi
 
 # 7b-fp. FALSE-POSITIVE GUARDS — the prefilter must NOT mark verbatim on a
@@ -577,9 +577,9 @@ assert d['success'] is True, d
 assert d['data']['matched_ids'] == ['cit-real'], 'only the whole-sentence in-draft match should be verbatim; got '+repr(d['data']['matched_ids'])
 assert sorted(d['data']['remaining_ids']) == ['cit-block','cit-qual','cit-short','cit-stale'], d['data']
 " 2>/dev/null; then
-  green "PASS: prefilter rejects block-scalar / short-needle / qualifier-wrapped / stale-sentence false positives (#305 review)"
+  green "PASS: verify-store-23-prefilter-rejects-block-scalar prefilter rejects block-scalar / short-needle / qualifier-wrapped / stale-sentence false positives (#305 review)"
 else
-  red "FAIL: prefilter false-positive guard regressed"
+  red "FAIL: verify-store-23-prefilter-rejects-block-scalar prefilter false-positive guard regressed"
   red "  got: $OUT"
   errors=$((errors + 1))
 fi
@@ -606,9 +606,9 @@ open(draft_path,"w",encoding="utf-8").write(sentence_nfc + "\n")
 PY
 OUT=$(python3 "$SCRIPT" prefilter --manifest "$WORK/nfc-manifest.json" --wiki-root "$NFCWIKI" --draft-version 1 --draft "$WORK/nfc-draft-v1.md" --out-dir "$WORK/nfc-sh")
 if echo "$OUT" | python3 -c "import sys,json; d=json.load(sys.stdin); assert d['data']['matched_ids']==['cit-de'], d['data']" 2>/dev/null; then
-  green "PASS: prefilter matches a verbatim non-ASCII citation across NFC/NFD composition (#305 review)"
+  green "PASS: verify-store-24-prefilter-matches-verbatim-non prefilter matches a verbatim non-ASCII citation across NFC/NFD composition (#305 review)"
 else
-  red "FAIL: prefilter NFC/NFD normalization missing"
+  red "FAIL: verify-store-24-prefilter-matches-verbatim-non prefilter NFC/NFD normalization missing"
   red "  got: $OUT"
   errors=$((errors + 1))
 fi
@@ -639,9 +639,9 @@ A system shall be considered high-risk under Annex III<sup>[1](https://x.eu/d)</
 EOF
 OUT=$(python3 "$SCRIPT" prefilter --manifest "$WORK/dup-manifest.json" --wiki-root "$DUPWIKI" --draft-version 1 --draft "$WORK/dup-draft-v1.md" --out-dir "$WORK/dup-sh")
 if echo "$OUT" | python3 -c "import sys,json; d=json.load(sys.stdin); assert d['data']['matched_ids']==[] and d['data']['remaining_ids']==['cit-dup'], d['data']" 2>/dev/null; then
-  green "PASS: prefilter treats a duplicate claim_id on a page as ambiguous → LLM fallthrough (#305 review)"
+  green "PASS: verify-store-25-prefilter-treats-duplicate-claim prefilter treats a duplicate claim_id on a page as ambiguous → LLM fallthrough (#305 review)"
 else
-  red "FAIL: prefilter duplicate-claim_id ambiguity not handled"
+  red "FAIL: verify-store-25-prefilter-treats-duplicate-claim prefilter duplicate-claim_id ambiguity not handled"
   red "  got: $OUT"
   errors=$((errors + 1))
 fi
@@ -723,9 +723,9 @@ assert ids == ['cit-d1', 'cit-d2'], ids
 assert all(e['verdict'] == 'verbatim' and e['method'] == 'prefilter-substring' for e in frag['verified']), frag
 PY
 then
-  green "PASS: prefilter fast-paths distilled-page citations across concepts/+entities/, falls through on qualifier + missing-claim (#362)"
+  green "PASS: verify-store-26-prefilter-fast-paths-distilled prefilter fast-paths distilled-page citations across concepts/+entities/, falls through on qualifier + missing-claim (#362)"
 else
-  red "FAIL: prefilter distilled-page fast-path regressed"
+  red "FAIL: verify-store-26-prefilter-fast-paths-distilled prefilter distilled-page fast-path regressed"
   red "  got: $OUT"
   errors=$((errors + 1))
 fi
@@ -767,9 +767,9 @@ AI systems referred to in Annex III shall be considered high-risk<sup>[1](https:
 EOF
 OUT=$(python3 "$SCRIPT" prefilter --manifest "$WORK/col-manifest.json" --wiki-root "$COLWIKI" --draft-version 1 --draft "$WORK/col-draft-v1.md" --out-dir "$WORK/col-sh")
 if echo "$OUT" | python3 -c "import sys,json; d=json.load(sys.stdin); assert d['data']['matched_ids']==[] and d['data']['remaining_ids']==['cit-col'], d['data']" 2>/dev/null; then
-  green "PASS: prefilter treats a cross-family slug collision as ambiguous → LLM fallthrough (#362 review)"
+  green "PASS: verify-store-27-prefilter-treats-cross-family prefilter treats a cross-family slug collision as ambiguous → LLM fallthrough (#362 review)"
 else
-  red "FAIL: prefilter cross-family slug-collision guard regressed"
+  red "FAIL: verify-store-27-prefilter-treats-cross-family prefilter cross-family slug-collision guard regressed"
   red "  got: $OUT"
   errors=$((errors + 1))
 fi
@@ -789,9 +789,9 @@ assert d['success'] is True, d
 c = d['data']['counts']
 assert c['total'] == 3 and c['verbatim'] == 1 and c['paraphrase'] == 1 and c['unsupported'] == 1, c
 " 2>/dev/null; then
-  green "PASS: merge --manifest unions prefilter + LLM fragments to the full manifest (#305)"
+  green "PASS: verify-store-28-merge-manifest-unions-prefilter merge --manifest unions prefilter + LLM fragments to the full manifest (#305)"
 else
-  red "FAIL: merge --manifest conservation wrong"
+  red "FAIL: verify-store-28-merge-manifest-unions-prefilter merge --manifest conservation wrong"
   red "  got: $OUT"
   errors=$((errors + 1))
 fi
@@ -801,9 +801,9 @@ fi
 #     reconcile it — this is exactly why --manifest is required for the new flow.
 OUT=$(python3 "$SCRIPT" merge --shard-dir "$PFSH" --draft-version 1 --revision-round 0 --out "$WORK/pf-nomani.json" 2>&1 || true)
 if echo "$OUT" | python3 -c "import sys,json; d=json.load(sys.stdin); assert d['success'] is False and 'of 2' in d['error']" 2>/dev/null; then
-  green "PASS: merge without --manifest rejects the prefilter+delta union (conservation needs the manifest)"
+  green "PASS: verify-store-29-merge-without-manifest-rejects merge without --manifest rejects the prefilter+delta union (conservation needs the manifest)"
 else
-  red "FAIL: merge without --manifest should fail conservation against the delta-only shard inputs"
+  red "FAIL: verify-store-29-merge-without-manifest-rejects merge without --manifest should fail conservation against the delta-only shard inputs"
   red "  got: $OUT"
   errors=$((errors + 1))
 fi
@@ -817,9 +817,9 @@ assert os.path.exists("$PFSH/verify-shard-prefilter-v1.json"), "prefilter fragme
 assert glob.glob("$PFSH/verify-shard-[0-9]*-v1.json") == [], "numbered fragments not cleared"
 PY
 then
-  green "PASS: reshard preserves the prefilter fragment, clears numbered fragments (#305)"
+  green "PASS: verify-store-30-reshard-preserves-prefilter-fragment reshard preserves the prefilter fragment, clears numbered fragments (#305)"
 else
-  red "FAIL: reshard fragment-cleanup scope wrong"
+  red "FAIL: verify-store-30-reshard-preserves-prefilter-fragment reshard fragment-cleanup scope wrong"
   errors=$((errors + 1))
 fi
 
@@ -861,9 +861,9 @@ ids = sorted(e['id'] for e in v['verified'] + v['deviations'])
 assert ids == ['cit-001','cit-002','cit-003'], ids
 PY
 then
-  green "PASS: merge --carry-forward-from re-scores the delta + carries untouched → complete (#305)"
+  green "PASS: verify-store-31-merge-carry-forward-from merge --carry-forward-from re-scores the delta + carries untouched → complete (#305)"
 else
-  red "FAIL: carry-forward merge wrong"
+  red "FAIL: verify-store-31-merge-carry-forward-from carry-forward merge wrong"
   red "  got: $OUT"
   errors=$((errors + 1))
 fi
@@ -877,9 +877,9 @@ cat > "$EMPTYSH/verify-shard-prefilter-v2.json" <<'EOF'
 EOF
 OUT=$(python3 "$SCRIPT" merge --shard-dir "$EMPTYSH" --draft-version 2 --revision-round 1 --manifest "$CFM" --carry-forward-from "$PREV" --out "$WORK/cf-empty-v2.json")
 if echo "$OUT" | python3 -c "import sys,json; d=json.load(sys.stdin); assert d['success'] is True and d['data']['counts']['total'] == 3, d" 2>/dev/null; then
-  green "PASS: empty-delta round rebuilds the full file by carry-forward alone (#305)"
+  green "PASS: verify-store-32-empty-delta-round-rebuilds empty-delta round rebuilds the full file by carry-forward alone (#305)"
 else
-  red "FAIL: empty-delta carry-forward wrong"
+  red "FAIL: verify-store-32-empty-delta-round-rebuilds empty-delta carry-forward wrong"
   red "  got: $OUT"
   errors=$((errors + 1))
 fi
@@ -887,9 +887,9 @@ fi
 # 7h. --carry-forward-from without --manifest → reject.
 OUT=$(python3 "$SCRIPT" merge --shard-dir "$CFSH" --draft-version 2 --revision-round 1 --carry-forward-from "$PREV" --out "$WORK/cf-bad.json" 2>&1 || true)
 if echo "$OUT" | python3 -c "import sys,json; d=json.load(sys.stdin); assert d['success'] is False and 'requires --manifest' in d['error']" 2>/dev/null; then
-  green "PASS: --carry-forward-from without --manifest rejected"
+  green "PASS: verify-store-33-carry-forward-from-without --carry-forward-from without --manifest rejected"
 else
-  red "FAIL: --carry-forward-from without --manifest not rejected"
+  red "FAIL: verify-store-33-carry-forward-from-without --carry-forward-from without --manifest not rejected"
   red "  got: $OUT"
   errors=$((errors + 1))
 fi
@@ -903,9 +903,9 @@ cat > "$PREV_GAP" <<'EOF'
 EOF
 OUT=$(python3 "$SCRIPT" merge --shard-dir "$CFSH" --draft-version 2 --revision-round 1 --manifest "$CFM" --carry-forward-from "$PREV_GAP" --out "$WORK/cf-gap.json" 2>&1 || true)
 if echo "$OUT" | python3 -c "import sys,json; d=json.load(sys.stdin); assert d['success'] is False and 'no prior verdict' in d['error']" 2>/dev/null; then
-  green "PASS: carry-forward rejects a manifest id with no prior verdict (forces full re-shard)"
+  green "PASS: verify-store-34-carry-forward-rejects-manifest carry-forward rejects a manifest id with no prior verdict (forces full re-shard)"
 else
-  red "FAIL: carry-forward did not reject a missing prior verdict"
+  red "FAIL: verify-store-34-carry-forward-rejects-manifest carry-forward did not reject a missing prior verdict"
   red "  got: $OUT"
   errors=$((errors + 1))
 fi
@@ -920,9 +920,9 @@ cat > "$DUPMAN" <<'EOF'
 EOF
 OUT=$(python3 "$SCRIPT" merge --shard-dir "$CFSH" --draft-version 2 --revision-round 1 --manifest "$DUPMAN" --carry-forward-from "$PREV" --out "$WORK/dupman-out.json" 2>&1 || true)
 if echo "$OUT" | python3 -c "import sys,json; d=json.load(sys.stdin); assert d['success'] is False and 'duplicate citation id' in d['error']" 2>/dev/null; then
-  green "PASS: merge rejects a manifest with duplicate citation ids (#305 review)"
+  green "PASS: verify-store-35-merge-rejects-manifest-duplicate merge rejects a manifest with duplicate citation ids (#305 review)"
 else
-  red "FAIL: merge did not reject a duplicate-id manifest"
+  red "FAIL: verify-store-35-merge-rejects-manifest-duplicate merge did not reject a duplicate-id manifest"
   red "  got: $OUT"
   errors=$((errors + 1))
 fi
@@ -936,9 +936,9 @@ cat > "$PREV_DUP" <<'EOF'
 EOF
 OUT=$(python3 "$SCRIPT" merge --shard-dir "$CFSH" --draft-version 2 --revision-round 1 --manifest "$CFM" --carry-forward-from "$PREV_DUP" --out "$WORK/cf-dup.json" 2>&1 || true)
 if echo "$OUT" | python3 -c "import sys,json; d=json.load(sys.stdin); assert d['success'] is False and 'duplicate citation id' in d['error']" 2>/dev/null; then
-  green "PASS: carry-forward rejects a prior file with duplicate citation ids (#305 review)"
+  green "PASS: verify-store-36-carry-forward-rejects-prior carry-forward rejects a prior file with duplicate citation ids (#305 review)"
 else
-  red "FAIL: carry-forward did not reject a duplicate-id prior file"
+  red "FAIL: verify-store-36-carry-forward-rejects-prior carry-forward did not reject a duplicate-id prior file"
   red "  got: $OUT"
   errors=$((errors + 1))
 fi
@@ -975,9 +975,9 @@ env = json.loads('''$OUT''')
 assert env["success"] is True and env["data"]["grounding_metrics"]["grounded"] == 3, env
 PY
 then
-  green "PASS: merge aggregates grounded → grounding_metrics rate 3/4 = 0.75 (grounding L3)"
+  green "PASS: verify-store-37-merge-aggregates-grounded-grounding merge aggregates grounded → grounding_metrics rate 3/4 = 0.75 (grounding L3)"
 else
-  red "FAIL: grounding_metrics aggregation wrong"
+  red "FAIL: verify-store-37-merge-aggregates-grounded-grounding grounding_metrics aggregation wrong"
   red "  got: $OUT"
   errors=$((errors + 1))
 fi


### PR DESCRIPTION
Closes #1497.

## Summary

Applies the recorded result-line case-id scheme (`cogni-knowledge/CLAUDE.md` § "Test result-line case ids") to the **21 not-yet-conforming suites** across the three families the issue names: `tests/test_cycle_guard_*.sh` (8), `tests/test_*_store.sh` (7 — `test_portal_store.sh` already conformed 15/15 and shows a zero-line diff), `tests/test_*index*.sh` (6).

Every emitted result line now leads with `<suite-slug>-<NN>[-<discriminator>]`, so the mutation harness can address one case. Uniqueness and shape were verified **by running** all 22 suites and grouping emitted first tokens — never by grepping call sites, per the scheme's own rule.

## Baseline correction

Triage's first census under-counted: its matcher missed the bracket form (`PASS[concepts]:`, `FAIL[A]:`) several suites emit. Corrected and re-measured:

| | first census | corrected |
|---|---|---|
| emitted result lines across the 22 | 392 | **444** |
| lines in a colliding first-token group | 181 | **193** |
| `test_sub_index.sh` | 58 | **106** |
| `test_cycle_guard_distilled.sh` / `_question.sh` | 1 each | **3 each** |

The issue's acceptance criterion pinning a no-deletion floor at "≥ 392" should be read as **≥ 444**. After this change the population is **454** and no suite emits fewer lines than at base, so nothing was deleted to make a collision go away.

## Two structural changes, both behaviour-preserving

**1. The eight cycle-guard suites paired their unpaired FAIL arms.** Each carried two *sequential* `if` blocks emitting `FAIL` under a single trailing aggregate `PASS`, so neither check was addressable on a green run — a `--case` against either returned `case_not_found`. Each check now owns a pass arm carrying the same id as its fail arm. Conditions, the `errors` counter and exit status are untouched; only the set of lines printed on a green run grows (six suites 1 → 2, `_distilled`/`_question` 3 → 5).

This is the change that makes mutation run 2 below meaningful: before it, one aggregate PASS covered both checks, so **no** mutation could discriminate between them.

`test_contradiction_finalize_store.sh:164-180` looks like the same shape but is **not** — it is a nested `if/else` emitting exactly one of three literals per run, so all three share one id and no split was made.

**2. `test_sub_index.sh` label-shape normalisation.** It emitted two shapes — `PASS[$T]:` from direct `green`/`red` calls and `PASS: [$T]` from `assert_grep`. Neither the harness matcher nor the verification recipe in `tests/README.md` matches the bracket form, so all 106 of its result lines were unaddressable. Both are normalised onto `PASS: sub-index-NN-<disc>-$T`, threading the loop variable per the scheme's Loops rule and the exemplar's `portal-store-05-bullet-$b`.

## Scope decisions

- **All 21 suites, nothing deferred.** Scope is defined idempotently over three globs.
- **Uniqueness and shape are independent axes.** The 8 cycle-guard suites plus `test_root_index.sh` (45/45 unique, all ids bare numerals) and `test_question_store.sh` (37/37 unique, 17 off-shape) already satisfied acceptance criteria 1 and 2 — only criterion 3 forced their conversion. A collisions-only reading would have left 9 suites untouched and still reported green.
- **The `-00-` band is FAIL-only and takes no pass twin**, per `test_portal_store.sh:52`, which emits `FAIL: portal-store-00-engine-present` with that id absent from its clean-run PASS set. Since that suite must show a zero-line diff, the exemplar settles the question. Where a suite has two or three precondition guards they share the `00` band with distinct discriminators.
- **Ids start at `-01-` in the cycle-guard suites** — none of them has a precondition guard for a `-00-` to name.
- **Family slug guards a neighbour.** `test_finalize_contract.sh` used to emit a bare `cycle-guard` first token, so this family takes `cycle-guard-<scenario>-NN`. (The sibling batch #1529 has since converted that file to `finalize-NN-`; all 21 slugs here were re-checked free against the new base.)
- **Two `SKIP:` lines carry no id.** `SKIP` matches neither `PASS: <id>` nor `FAIL: <id>`, so an id there names something `--case` can never resolve. Those two lines are byte-identical to base.
- **The `-05-aggregate` pair in `_distilled`/`_question` is kept deliberately**, unlike the six siblings whose aggregate was folded away. Those six had only a bare `exit 1` gate to fold; these two have a real aggregate `FAIL` emitter carrying diagnostics, and removing it would drop failure output rather than relabel it. Both arms share one id.
- **Untouched by design:** `test_portal_store.sh`, `cogni-knowledge/CLAUDE.md` (the scheme is fixed input), `tests/fixtures/test_helpers.sh`, and every version value.

## Verification

- `python3 scripts/run-plugin-tests.py --filter cogni-knowledge` — **77/77 green**
- `python3 scripts/run-plugin-tests.py` (full sweep) — **124/124 green**
- Per-suite uniqueness **by execution** for all 22: emitted first tokens grouped, maximum group size 1 everywhere
- Global distinctness: 454 emitted tokens across the 22 suites, **0 duplicates**
- Shape: every emitted token matches `^[a-z0-9]+(-[a-z0-9]+)*-[0-9]{2}(-[a-z0-9]+)*$`; no bare numeral, no bare namespace prefix, none colon-abutted
- Arm pairing checked **structurally in the source**, not just by running: every `if/else` span and `case` arm-pair holding one PASS and ≥1 FAIL carries a single id. Three arm-drift defects were found and fixed this way in `test_sub_index.sh` (a `FAIL` wearing its neighbour's id is invisible on a green run and misattributes a real failure). The checker was proven to discriminate by re-introducing one drift and confirming it reds.
- `scripts/check-result-line-plainness.py`, `scripts/check-breadcrumbs.py`, `scripts/check-version-bump.py`, `scripts/check-mcp-tool-grant.py`, `scripts/check-workflow-yaml.py` — all clean, run **after** the commit
- `bash cogni-knowledge/tests/test_plain_result_emitters.sh` — green; no new `red()`/`green()` definition introduced, so the pairing census and the ≥ 50 exerciser floor are unaffected
- `git diff --name-only` lists 21 paths, all under `cogni-knowledge/tests/`; `test_portal_store.sh` zero-line diff; no manifest version moved

## Mutation recipe

Both runs verified against this branch. `mutation-check.sh` is the cogni-service managed-service harness — it ships in the `cogni-work/managed-service` repo, **not** in this tree, so the invocations below are shown with `<managed-service>` and `<insight-wave>` placeholders rather than a relative path that would not resolve from an insight-wave checkout. It is **not** the same-named bespoke scripts in `cogni-portfolio/scripts/` or `cogni-consult/scripts/`.

**Run 1 of 2 — a `test_*_store.sh` suite.**

```
bash <managed-service>/cogni-service/scripts/mutation-check.sh \
  --root <insight-wave> \
  --file cogni-knowledge/scripts/candidate-store.py \
  --expr 's/^SCHEMA_VERSION = "0\.1\.0"$/SCHEMA_VERSION = "9.9.9"/m' \
  --test 'bash cogni-knowledge/tests/test_candidate_store.sh' \
  --case candidate-store-02-schema-version
```

`candidate-store.py:52` is exactly `SCHEMA_VERSION = "0.1.0"` and matches once under `/m`, so the run cannot degenerate to `expr_no_op`. Verdict `guard_verified` — mutated red, restored green, with all nine sibling cases green.

**Run 2 of 2 — reverting the transitive-cycle detection property.**

```
bash <managed-service>/cogni-service/scripts/mutation-check.sh \
  --root <insight-wave> \
  --file cogni-knowledge/scripts/cycle-guard.py \
  --expr 's/^                out\["cycle_path"\] = via_chain$/                out["cycle_path"] = []/m' \
  --test 'bash cogni-knowledge/tests/test_cycle_guard_transitive.sh' \
  --case cycle-guard-transitive-02-transitive-contract
```

Verdict `guard_verified`, and it reds **exactly** the addressed case: `cycle-guard-transitive-01-exit-one` stays green.

The expression is deliberately narrower than the obvious one. Mutating `DEFAULT_MAX_DEPTH = 5` → `0` also disables transitive recursion, but it reds **both** of the suite's cases, which the acceptance criterion forbids ("falsified by a sibling reding"). `cycle-guard.py:699` keys status and exit on `transitive_self_cycles`, not on `cycle_path`, so emptying `cycle_path` alone breaks the contract assertion while leaving the exit-code assertion intact. The anchor occurs exactly once.

## Note for the reviewer

`check-token-scope.sh --strict` reports `over_scoped` on the `gho_` GitHub CLI token (`gist`, `read:org`, `workflow` beyond `repo`). Those scopes are fixed by the GitHub CLI OAuth app and cannot be narrowed, so this run took the sanctioned `--allow-overscoped` opt-out. Flagging rather than passing silently.

## Recommended follow-up (not deferred scope of this issue)

Promote a one-argument assert wrapper into `fixtures/test_helpers.sh`. The exemplar gets same-id-both-arms **structurally** via local one-argument wrappers (`test_portal_store.sh:89-91`), while these suites hand-write independent PASS and FAIL strings — which is exactly how the three arm-drift defects fixed here arose, and they can recur on the next edit. It is not a slice of this issue: the dominant call-site shape pairs each arm with unprefixed diagnostic lines a single-argument wrapper has nowhere to put, so converting ~250 sites is a semantic restructure, and it applies plugin-wide rather than to these three families.
