### PR TITLE
repo: re-stem external-dispatch suite result ids to ed10-ed19

### DIFF
--- a/tests/test_check_external_dispatch.sh
+++ b/tests/test_check_external_dispatch.sh
@@ -32,10 +32,19 @@
 #
 # Result-line ids: every emitted PASS:/FAIL: line carries a first-token id,
 # unique PER EMITTED LINE rather than per logical case, so
-# `mutation-check.sh --case <id>` addresses exactly one assertion. Cases 1-5
-# use `edNN`; the registry cases use `R<n><letter>`. The whole-token matching
-# rule the ids depend on is stated once, with the regex, above the registry
-# cases below. A new assertion takes the next free id, never a renumbering.
+# `mutation-check.sh --case <id>` addresses exactly one assertion. Every id in
+# this file is `edNN`: `ed01`-`ed09` for cases 1-5, `ed10`-`ed19` for the
+# registry cases R1-R6 (R1 -> ed10/ed11, R2 -> ed12/ed13, R3 -> ed14,
+# R4 -> ed15, R5 -> ed16/ed17, R6 -> ed18/ed19). `R1`-`R6` remain the names of
+# the LOGICAL case groups in the header notes and the section dividers below;
+# they are not ids and must never be emitted as one. Never introduce an
+# `R<n><letter>` id here: tests/test_check_mcp_tool_grant.sh already emits
+# `R1a`, `R2a`, `R3a`, `R4a` and `R6a` among its own result lines, so an
+# `R`-stemmed id in this file would be ambiguous in any harness run whose
+# `--test` captures both suites. The whole-token matching rule the ids depend
+# on is stated once, with the regex, above the registry cases below. A new
+# assertion takes the next free id — `ed20` onward — never a renumbering and
+# never an `R`-stemmed id.
 
 set -eu
 
@@ -187,12 +196,12 @@ set -e
 check "ed09 real tree passes clean-zero" "$([ "$CODE" -eq 0 ] && echo 0 || echo 1)"
 
 # ===========================================================================
-# Registry-loading cases (R1-R6).
+# Registry-loading cases (R1-R6; emitted ids ed10-ed19).
 #
 # Case labels below are `<id> <description>` — an id token followed by a SPACE,
 # never a colon abutting the id. The mutation harness matches
 # `^[[:space:]]*FAIL:[[:space:]]+<case>([[:space:]]|$)` (and the ok|PASS twin)
-# whole-token, so `--case R3a` matches `FAIL: R3a empty ...` while `--case 'R3a:'`
+# whole-token, so `--case ed14` matches `FAIL: ed14 empty ...` while `--case 'ed14:'`
 # would match neither line and return case_not_found instead of a verdict.
 # ===========================================================================
 
@@ -248,9 +257,9 @@ PLANTED_REL="cogni-demo/agents/planted.md"
 # Also proves the default registry path follows __file__ and not --root: --root
 # points at REG_TREE, which has no registry, and the staged dir has none either.
 run_reg r1 NONE "$CLEAN_REL"
-check "R1a missing registry exits 2 (base exits 0 here)" \
+check "ed10 missing registry exits 2 (base exits 0 here)" \
   "$([ "$CODE" -eq 2 ] && echo 0 || echo 1)"
-assert_json "R1b missing registry reports success:false and names the path" "$OUT" "
+assert_json "ed11 missing registry reports success:false and names the path" "$OUT" "
 import json,sys
 d=json.load(sys.stdin)
 assert d['success'] is False, d
@@ -260,9 +269,9 @@ assert 'retired-plugins.json' in d['error'], d['error']
 
 # --- R2: malformed JSON -> exit 2 ------------------------------------------
 run_reg r2 '{"retired_prefixes": ["cogni-wiki",' "$CLEAN_REL"
-check "R2a malformed registry JSON exits 2 (base exits 0 here)" \
+check "ed12 malformed registry JSON exits 2 (base exits 0 here)" \
   "$([ "$CODE" -eq 2 ] && echo 0 || echo 1)"
-assert_json "R2b malformed registry reports success:false with a non-empty error" "$OUT" "
+assert_json "ed13 malformed registry reports success:false with a non-empty error" "$OUT" "
 import json,sys
 d=json.load(sys.stdin)
 assert d['success'] is False, d
@@ -271,9 +280,9 @@ assert d['error'], d
 
 # --- R3: empty prefix list -> exit 2 ---------------------------------------
 # Kept as its own case rather than folded into R4's table: the recorded mutation
-# recipe targets `--case R3a`, which needs a separately-labelled line.
+# recipe targets `--case ed14`, which needs a separately-labelled line.
 run_reg r3 '{"retired_prefixes": []}' "$CLEAN_REL"
-check "R3a empty registry exits 2 and never 0 (base exits 0 here)" \
+check "ed14 empty registry exits 2 and never 0 (base exits 0 here)" \
   "$([ "$CODE" -eq 2 ] && echo 0 || echo 1)"
 
 # --- R4: wrong type / non-string / blank / padded / colon-bearing -> exit 2 -
@@ -296,15 +305,15 @@ do
   run_reg "r4_$R4_N" "$BAD" "$CLEAN_REL"
   [ "$CODE" -eq 2 ] || R4_FAILED=1
 done
-check "R4a degenerate registry entries all exit 2 ($R4_N variants)" "$R4_FAILED"
+check "ed15 degenerate registry entries all exit 2 ($R4_N variants)" "$R4_FAILED"
 
 # --- R5: a prefix added to the registry makes a planted dispatch fire -------
 # The data-driven proof: base's hardcoded regex knows nothing of cogni-demo.
 run_reg r5 '{"retired_prefixes": ["cogni-wiki", "cogni-research", "cogni-demo"]}' \
   "$PLANTED_REL"
-check "R5a registry-added prefix fires on a planted dispatch (exit 1)" \
+check "ed16 registry-added prefix fires on a planted dispatch (exit 1)" \
   "$([ "$CODE" -eq 1 ] && echo 0 || echo 1)"
-assert_json "R5b registry-added prefix reports match cogni-demo: with file+line" "$OUT" "
+assert_json "ed17 registry-added prefix reports match cogni-demo: with file+line" "$OUT" "
 import json,sys
 d=json.load(sys.stdin)
 v=d['data']['violations']
@@ -321,9 +330,9 @@ printf '%s' '{"retired_prefixes": ["cogni-wiki", "cogni-research"]}' \
   > "$WORK/r6/override.json"
 run_reg r6 '{"retired_prefixes": ["cogni-wiki", "cogni-research", "cogni-demo"]}' \
   "$PLANTED_REL" --registry "$WORK/r6/override.json"
-check "R6a --registry replaces the default set rather than unioning (exit 0)" \
+check "ed18 --registry replaces the default set rather than unioning (exit 0)" \
   "$([ "$CODE" -eq 0 ] && echo 0 || echo 1)"
-assert_json "R6b override set reports zero violations on the planted file" "$OUT" "
+assert_json "ed19 override set reports zero violations on the planted file" "$OUT" "
 import json,sys
 d=json.load(sys.stdin)
 assert d['success'] is True, d


### PR DESCRIPTION
## Summary

Re-stems the ten registry-case result-line ids in `tests/test_check_external_dispatch.sh` from the `R<n><letter>` series to `ed10`..`ed19`, so every id this suite emits is unique across the repo's whole discovered suite population. `ed01`..`ed09` are unchanged, the result-line count stays 19, and only `tests/` is touched.

Five of the ten ids collided with `tests/test_check_mcp_tool_grant.sh`, which emits 60 result lines including `R1 R1a R2 R2a R3 R3a R4 R4a R5 R6 R6a`. The colliding tokens were exactly `R1a`, `R2a`, `R3a`, `R4a`, `R6a` — five, not six: `R5a` is this suite's alone, because the sibling emits `R5` and no `R5a`, and `R1b`/`R2b`/`R5b`/`R6b` were already unique.

| Measure | Base | Head |
|---|---|---|
| `ed` suite result lines / distinct ids | 19 / 19 | **19 / 19** |
| Cross-suite first-token intersection | 5 (`R1a R2a R3a R4a R6a`) | **0** |
| `run-plugin-tests.py` `data.total` / failed | 124 / 0 | **124 / 0** |
| `tests/test_check_mcp_tool_grant.sh` | — | **untouched** |

Mapping, in emission order: `R1a→ed10  R1b→ed11  R2a→ed12  R2b→ed13  R3a→ed14  R4a→ed15  R5a→ed16  R5b→ed17  R6a→ed18  R6b→ed19`.

## Why this is latent, not a live break

Nothing is red today, and this should not be read as fixing a live failure.

`mutation-check.sh` classifies a case by scanning harness output for `^[[:space:]]*FAIL:[[:space:]]+<case>([[:space:]]|$)` and its `ok|PASS` twin. The match is **boolean, never a count**, and carries no suite-identity component — so a collision can only bite when a single `--test` invocation puts both suites' result lines into one captured stream. Two things kept that from happening:

- The recorded recipe uses `--test 'bash tests/test_check_external_dispatch.sh'` — one suite, so the case was unambiguous within that stream.
- A repo-wide `--test 'python3 scripts/run-plugin-tests.py'` would not have exposed the collision either; it would have exposed nothing. The runner pops each suite's captured output and echoes it only inside its `if failed:` block, so a green baseline run emits no `PASS:` line at all — and the harness requires a green line on the RESTORED phase, so that invocation returns `case_not_found` (exit 2) whatever the ids are.

So the defect is one of **id-namespace hygiene**: ids are the harness's addressing vocabulary, and two suites claimed the same five addresses. What it forecloses is a future `--test` that concatenates both suites, or a runner change that echoes passing output — where the sibling's same-named case could carry the verdict and hand back a false `guard_verified`. Closing it now costs one label-only diff.

## Scope decisions

- **Labels and legend prose only. No executable line changes.** Every changed line is a comment or the quoted first token of a `check` / `assert_json` label. The `red()`/`green()` emitters, `check()`/`assert_json()`, the `stage_guard`/`run_reg` helpers, the lowercase staging directory names (`r1`, `r2`, `r3`, `r4_1`..`r4_6`, `r5`, `r6`) and their call sites, the `REG_TREE` fixture, and the `R4` loop counter are untouched. The `ed15` label keeps its interpolated `($R4_N variants)` **suffix**, so the id itself stays a literal whole token.
- **`R1`..`R6` survive as logical group names** in the header narrative and the six section dividers — deliberate, not residue. The file's own legend states ids are unique *per emitted line rather than per logical case*: `R3` is one logical case emitting one line, `R1` is one logical case emitting two. Renaming the dividers would erase that distinction and force a divider per emitted line.
- **The `R<n><letter>` stem is retired by an imperative, not a description.** Leaving the old legend's "the registry cases use `R<n><letter>`" would have invited the next editor to add `R7a` and reopen the class. The rewritten legend names the colliding sibling suite by path, forbids the stem outright, and pins the successor rule: a new registry assertion takes the next free `edNN` (`ed20` onward), never a renumbering and never an `R`-stemmed id.
- **Out of scope:** repo-wide first-token uniqueness, and whether a CI guard should enforce it rather than convention. The issue explicitly assigns that design question elsewhere. The chosen stem is nonetheless free across the whole discovered population, so it does not prejudge that decision.
- **No version bump** — the post-merge workflow owns the patch bump. Nothing outside `tests/` is touched.

## Verification (all by execution on the head tree)

- [x] `bash tests/test_check_external_dispatch.sh` exits **0**; `bash tests/test_check_mcp_tool_grant.sh` exits **0**.
- [x] Result-line census by execution: **19 lines, 19 distinct** first tokens — `ed01 … ed19`.
- [x] No `R`-stemmed token survives as a first token of the suite's run output.
- [x] Cross-suite intersection by execution — `comm -12` over both suites' sorted-unique first-token sets — is **empty**.
- [x] Both in-file `--case` literals (`ed14` and the `'ed14:'` counterexample) resolve against real run output.
- [x] `git diff --name-only` lists **only** `tests/test_check_external_dispatch.sh`; no manifest or version line touched.
- [x] `python3 scripts/run-plugin-tests.py` exits 0, `data.total` **124** (unchanged), `failed: 0`.
- [x] `python3 scripts/check-result-line-plainness.py` exits 0 — 0 violations across 124 files.
- [x] `check-breadcrumbs.py`, `check-mcp-tool-grant.py`, `check-external-dispatch.py` all exit 0.
- [x] Base moved `a9db25f7` → `c6bd3426` mid-run (#1531 landed, editing the sibling suite). Re-censused on the merged tree: that change was comment-only, the intersection was still exactly the five, and all ten anchors re-resolved with zero drift.

## Mutation recipe

Anchor: `scripts/check-external-dispatch.py` line 143, `    if not isinstance(prefixes, list) or not prefixes:` — the sole occurrence in that file, with the "Mutation-recipe invariant" comment directly above it warning that the recipe rewrites the FIRST match only.

```
bash "$CLAUDE_PLUGIN_ROOT/scripts/mutation-check.sh" \
  --root . \
  --file scripts/check-external-dispatch.py \
  --expr 's/^    if not isinstance\(prefixes, list\) or not prefixes:$/    if not isinstance(prefixes, list):/m' \
  --test 'bash tests/test_check_external_dispatch.sh' \
  --case ed14
```

**Run on this head, not retyped.** Actual result:

```json
{"case": "ed14", "mutated_result": "red", "restored_result": "green", "verdict": "guard_verified"}
```

- `/m` is load-bearing: `--expr` is fed to `perl -0pi`, which slurps the whole file, so without it the `^`/`$` anchors never bind to the target line. The four leading spaces are part of the pattern.
- It is a perl substitution, not a `sed` delete form: the mutant keeps the `isinstance` arm and drops only `or not prefixes`, so an empty `retired_prefixes` stops raising and the guard exits 1 instead of 2.
- The mutant reddens `ed14` alone. `ed10`/`ed11` raise earlier on the missing registry and `ed12`/`ed13` on the malformed JSON, so neither reaches the mutated line; all six `ed15` variants are still rejected downstream; `ed16`..`ed19` and `ed01`..`ed09` supply non-empty lists.
- The harness restores the file it mutates — `scripts/` carries no change in this PR.

Closes #1516