### PR TITLE
cogni-knowledge: fixed-string assert pair for the shared test helpers

### DIFF
--- a/cogni-knowledge/tests/README.md
+++ b/cogni-knowledge/tests/README.md
@@ -44,6 +44,11 @@ via `trap rm -rf "$WORK" EXIT`.
   wrapped in an escape sequence and never chosen by an environment probe.
   `test_plain_result_emitters.sh` holds this shape.
 - `assert_grep <pattern> <description>` for contract-level SKILL.md checks.
+- `assert_grep_f` / `assert_not_grep_f` are the fixed-string (`grep -qF`)
+  counterparts. Reach for them whenever the pattern is a literal carrying
+  `[`, `]`, `.` or `*` — a wikilink, a glob, a path. `assert_grep` reads such
+  a pattern as a regex, so it can report green against a file that does not
+  contain the string at all.
 - Real Python harness (inline `python3 - <<PY ... PY` heredoc) for
   script-level assertions.
 - Fixtures are minimal — only the files the test actually exercises.

--- a/cogni-knowledge/tests/fixtures/test_helpers.sh
+++ b/cogni-knowledge/tests/fixtures/test_helpers.sh
@@ -42,3 +42,45 @@ assert_not_grep() {
     green "PASS: $description"
   fi
 }
+
+# The fixed-string counterparts of the pair above.
+#
+# Reach for these whenever the pattern is a literal that carries regex
+# metacharacters — a wikilink, a glob, a file path, a JSON key, anything
+# containing [ ] . * ^ $ or a backslash. The BRE pair reads such a pattern as a
+# regex: `[[alpha-synthesis]]` parses as a bracket expression plus a trailing
+# literal ], so it matches any <one-of-those-chars>] sequence and the assertion
+# passes green against a file that does not contain the string at all.
+#
+# These match the pattern verbatim instead, so metacharacters carry no meaning.
+# Keep using the BRE pair when you actually want a regex — an anchored
+# '^# Concepts$', or an alternation written with \| .
+
+# assert_grep_f PATTERN FILE DESCRIPTION
+#   Fixed-string counterpart of assert_grep. Increments the caller's `errors`
+#   variable on failure.
+assert_grep_f() {
+  local pattern="$1" file="$2" description="$3"
+  if grep -qF -- "$pattern" "$file" 2>/dev/null; then
+    green "PASS: $description"
+  else
+    red "FAIL: $description"
+    red "  pattern (fixed): $pattern"
+    red "  file:            $file"
+    errors=$((errors + 1))
+  fi
+}
+
+# assert_not_grep_f PATTERN FILE DESCRIPTION
+#   Symmetric counterpart — fails if PATTERN is present as a literal.
+assert_not_grep_f() {
+  local pattern="$1" file="$2" description="$3"
+  if grep -qF -- "$pattern" "$file" 2>/dev/null; then
+    red "FAIL: $description"
+    red "  pattern (fixed, should NOT appear): $pattern"
+    red "  file: $file"
+    errors=$((errors + 1))
+  else
+    green "PASS: $description"
+  fi
+}

--- a/cogni-knowledge/tests/test_fixed_string_assert.sh
+++ b/cogni-knowledge/tests/test_fixed_string_assert.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# test_fixed_string_assert.sh — the fixed-string assert pair discriminates.
+#
+# `assert_grep` matches under BRE, so a pattern that is meant as a literal but
+# carries regex metacharacters can match a file that does not contain it. The
+# canonical case is a wikilink: `[[alpha-synthesis]]` parses as a bracket
+# expression plus a trailing literal `]`, and the `a-s` range covers the `s` in
+# `[[omega-synthesis]]` — so the assertion reports green against a decoy. That
+# is a vacuous guard: a test asserting nothing while looking like it passed.
+#
+# `assert_grep_f` / `assert_not_grep_f` match the pattern verbatim and close it.
+#
+# Both arms of every case below are fed by ONE label argument, so a case's pass
+# and fail ids can never drift apart. Cases that expect the helper to FAIL run it
+# inside a command substitution and decide from the CAPTURED text — never from
+# the helper's `errors` side effect, which happens in the subshell and is
+# invisible here, and never as a live line, which would look like a red case.
+
+set -eu
+
+TESTS_DIR="$(cd "$(dirname "$0")" && pwd)"
+HELPER="$TESTS_DIR/fixtures/test_helpers.sh"
+
+. "$TESTS_DIR/fixtures/test_helpers.sh"
+
+WORKDIR="$(mktemp -d)"
+cleanup() { rm -rf "$WORKDIR"; }
+trap cleanup EXIT
+
+# The decoy carries omega but never alpha, and one ordinary heading line.
+DECOY="$WORKDIR/decoy.md"
+{
+  printf '%s\n' '# Concepts'
+  printf '%s\n' '- [[omega-synthesis]] — only this one'
+} > "$DECOY"
+
+errors=0
+
+# One label argument reaches both arms, so the ids cannot diverge.
+fail()  { red "FAIL: $1"; errors=$((errors + 1)); }
+check() { if [ "$1" = "yes" ]; then green "PASS: $2"; else fail "$2"; fi; }
+
+# Did a captured helper run report failure?
+reported_fail() {
+  case "$1" in
+    "FAIL:"*) printf '%s' 'yes' ;;
+    *)        printf '%s' 'no' ;;
+  esac
+}
+
+# --- Direct calls: the helper's own pass arm is the result line ---------------
+
+assert_grep_f '[[omega-synthesis]]' "$DECOY" \
+  'fixed-assert-01 assert_grep_f matches a bracketed literal that is present'
+
+assert_grep '[[alpha-synthesis]]' "$DECOY" \
+  'fixed-assert-03 assert_grep still matches the absent literal under BRE (the false pass being closed)'
+
+assert_grep '^# Concepts$' "$DECOY" \
+  'fixed-assert-04 assert_grep still honours an anchored regex, so BRE behaviour is unchanged'
+
+assert_not_grep_f '[[alpha-synthesis]]' "$DECOY" \
+  'fixed-assert-06 assert_not_grep_f passes when the literal is genuinely absent'
+
+# --- Captured probes: the helper is expected to FAIL --------------------------
+
+OUT_02="$(assert_grep_f '[[alpha-synthesis]]' "$DECOY" 'probe')"
+check "$(reported_fail "$OUT_02")" \
+  'fixed-assert-02 assert_grep_f reports failure on the absent bracketed literal'
+
+OUT_05="$(assert_grep_f '^# Concepts$' "$DECOY" 'probe')"
+check "$(reported_fail "$OUT_05")" \
+  'fixed-assert-05 assert_grep_f treats an anchored pattern as a literal, so it does not match'
+
+OUT_07="$(assert_not_grep_f '[[omega-synthesis]]' "$DECOY" 'probe')"
+check "$(reported_fail "$OUT_07")" \
+  'fixed-assert-07 assert_not_grep_f reports failure when the literal is present'
+
+# --- Both-arms rule: one label argument, verbatim, on each arm ----------------
+
+LABEL='both-arms probe label'
+ARM_PASS="$(assert_grep_f '[[omega-synthesis]]' "$DECOY" "$LABEL")"
+ARM_FAIL="$(assert_grep_f '[[alpha-synthesis]]' "$DECOY" "$LABEL" | head -1)"
+if [ "$ARM_PASS" = "PASS: $LABEL" ] && [ "$ARM_FAIL" = "FAIL: $LABEL" ]; then
+  BOTH_ARMS=yes
+else
+  BOTH_ARMS=no
+fi
+check "$BOTH_ARMS" \
+  'fixed-assert-08 one label argument reaches both arms verbatim'
+
+# --- Caller errors accounting: exactly one increment per failure --------------
+# Run in a child shell that owns its own counter, because the increment made by
+# a captured call above happens in a subshell and never reaches this one.
+
+COUNT_09="$(bash -c '. "$1"; errors=0; assert_grep_f "[[alpha-synthesis]]" "$2" probe >/dev/null 2>&1; printf "%s" "$errors"' _ "$HELPER" "$DECOY")"
+check "$([ "$COUNT_09" = "1" ] && printf '%s' yes || printf '%s' no)" \
+  'fixed-assert-09 a failing assert_grep_f increments the caller errors count by exactly one'
+
+COUNT_10="$(bash -c '. "$1"; errors=0; assert_not_grep_f "[[omega-synthesis]]" "$2" probe >/dev/null 2>&1; printf "%s" "$errors"' _ "$HELPER" "$DECOY")"
+check "$([ "$COUNT_10" = "1" ] && printf '%s' yes || printf '%s' no)" \
+  'fixed-assert-10 a failing assert_not_grep_f increments the caller errors count by exactly one'
+
+if [ "$errors" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/cogni-knowledge/tests/test_plain_result_emitters.sh
+++ b/cogni-knowledge/tests/test_plain_result_emitters.sh
@@ -158,8 +158,8 @@ done
 errors=$((errors + shape_errors))
 
 # Liveness floor — a broken glob must fail loudly rather than pass vacuously.
-# 78 files exercise the contract today (1 defines the emitters — the shared
-# helper — and 77 source it). The floor sits at 50 so either direction of drift
+# 79 files exercise the contract today (1 defines the emitters — the shared
+# helper — and 78 source it). The floor sits at 50 so either direction of drift
 # has room, and consolidating definers onto the helper cannot trip it.
 if [ "$exercisers" -lt 50 ]; then
   red "FAIL: only $exercisers file(s) exercising the emitter contract were found (expected at least 50) — the scan is not reaching them"


### PR DESCRIPTION
Refs #1522

`fixtures/test_helpers.sh` offered only a BRE pair, so `assert_grep '[[alpha-synthesis]]' …` parses as a bracket expression plus a trailing literal `]` — and the `a-s` range covers the `s` in `[[omega-synthesis]]`. The assertion reports green against a file that does not contain the string. This adds the fixed-string pair beside it and proves the false pass is closed.

Reproduced at base before any edit:

```
grep -q  -- "[[alpha-synthesis]]" decoy.md  ->  MATCH     (false pass)
grep -qF -- "[[alpha-synthesis]]" decoy.md  ->  no match  (correct)
```

## Summary

- `fixtures/test_helpers.sh` gains `assert_grep_f` / `assert_not_grep_f` — same `(pattern, file, description)` signature, same one-label-feeds-both-arms shape, same caller `errors` increment as the BRE pair, differing only in matching fixed-string. A comment above them states when to prefer each.
- `assert_grep` / `assert_not_grep` are **byte-identical**; the fixture diff has no removed line.
- New suite `tests/test_fixed_string_assert.sh` covers all four arms plus the BRE differential — ten cases, ids `fixed-assert-01` … `fixed-assert-10`.
- `tests/README.md` gains one `## Convention` bullet naming the new pair.
- The liveness-floor comment in `test_plain_result_emitters.sh` is refreshed from 78/77 to the **measured** 79/78. Comment-only: the floor of 50, the fixtures-definer floor, the D1 label and every assertion are untouched.

## Why additive, not a re-point

The issue's additive-only constraint is load-bearing rather than cautious. Real callers depend on BRE semantics, verified against the base tree:

| Call site | Pattern | Breaks under `-F` |
|---|---|---|
| `test_backfill_concepts_index.sh:114` | `^# Concepts$` | anchors become literal characters |
| `test_compose_contract.sh:145,216` | `\[\[sources/`, `\[\[N\]\]` | the escaping backslashes become literal |
| `test_compose_contract.sh:168,208,212,228` | `\|` alternation | alternation becomes literal |

Switching the existing pair would red all of these. 78 suites source this fixture across roughly 1350 assert call sites.

## The negative-probe trap, and how the suite avoids it

The helpers always return 0 and signal failure only by printing `FAIL:` and incrementing the caller's `errors`. A naive `OUT=$(assert_grep_f …)` captures the text but **silently loses the count** — command substitution runs in a subshell, so that increment never reaches the parent.

Every case that expects the helper to fail therefore runs it inside a command substitution and decides from the **captured text**, never from the `errors` side effect. A green run emits no stray `FAIL:` line the mutation harness could misread as a red case. Cases 09 and 10 check the increment separately, in a child shell that owns its own counter.

## Test plan — all executed

- [x] `bash cogni-knowledge/tests/test_fixed_string_assert.sh` — exit 0, ten `PASS:` lines, zero `FAIL:` lines.
- [x] Case ids unique — `… | awk '/^[ \t]*(PASS|ok|FAIL):[ \t]/ {print $2}' | sort | uniq -d` prints nothing; no id carries a trailing colon.
- [x] `python3 scripts/run-plugin-tests.py --filter knowledge` — `total: 78, passed: 78, failed: 0`, run **post-commit**. Base ref carries 77 one-segment suites under `cogni-knowledge/tests/`, so discovery is +1 and the new suite appears in `suites[]`.
- [x] `bash cogni-knowledge/tests/test_plain_result_emitters.sh` — green; `1 emitter-defining file(s) … of 79 exercising the contract`, D1 floor holds.
- [x] `python3 scripts/check-result-line-plainness.py` — `summary.total: 0`, 125 files scanned, 98 definitions inspected.
- [x] `python3 scripts/check-breadcrumbs.py` — 0 files affected.
- [x] `python3 scripts/check-version-bump.py` — 8 plugins scanned, 0 touched, 0 violations. No manifest is in the diff.
- [x] Scope boundary — all four changed paths are under `cogni-knowledge/tests/`.

## Mutation recipe

Reverting the new pair to BRE makes the decoy case pass vacuously, which is exactly the defect this closes — so `fixed-assert-02` must go red. The expression is pinned to `assert_grep_f` **by name** rather than to first-match order, so a later reorder of the two new functions cannot silently retarget the arm onto `assert_not_grep_f` and report `case_not_found`.

```
bash "$MANAGED_SERVICE"/cogni-service/scripts/mutation-check.sh --root . --file cogni-knowledge/tests/fixtures/test_helpers.sh --expr 's/(assert_grep_f\(\)\s*\{[^}]*?)grep -qF --/$1grep -q --/' --test 'bash cogni-knowledge/tests/test_fixed_string_assert.sh' --case fixed-assert-02
```

`$MANAGED_SERVICE` is a `cogni-work/managed-service` checkout — the harness ships there, not in this repo, and the same-named `cogni-portfolio` / `cogni-consult` scripts are different tools. No `/m` modifier is needed; the expression carries no `^`/`$` anchor.

**Verified locally before opening this PR.** Under the mutant the suite exits 1 and `fixed-assert-02` reports `FAIL:`. Cases `fixed-assert-05`, `08` and `09` also red — they key on the same `assert_grep_f` semantics, so that is the expected blast radius, not collateral. `fixed-assert-07` and `10` (the `assert_not_grep_f` cases) stay green, confirming the substitution hit `assert_grep_f` alone. The anchor literal occurs exactly twice in the tree, once per new function body and in no comment, so the arm cannot land on inert prose.

## Scope decisions

- **Included** the `tests/README.md` bullet: the issue's "why now" is that the rollout points converting authors at `assert_grep` as the model, so shipping the helper without listing it keeps aiming new assertions at the vacuous one.
- **Not included** — any change to `assert_grep` / `assert_not_grep` (see the table above).
- **Not included** — converting the seven suites that already hand-roll a fixed-string grep. They are correct today; rewriting them is churn with regression risk and no defect closed.
- **Not included** — `cogni-knowledge/CLAUDE.md`. Its "Both arms" bullet cites `assert_grep` only as the *shape* exemplar, and the new pair follows that same shape, so the line does not go stale.
- No version value moves in this branch — the post-merge workflow owns the bump.

## Follow-up issues

- #1535 — `tests/README.md` documents a 2-argument `assert_grep` the fixture has never had (it takes three), and omits `assert_not_grep` from that bullet list. Pre-existing drift, independent of this change. The bullet added here deliberately carries no arity claim, so the list stays internally consistent either way.

Because a follow-up was filed, this PR links the parent with `Refs` rather than `Closes`.

## Operational note

The token-scope preflight reports `over_scoped` (extra: `gist`, `read:org`, `workflow`) and `--strict` exits 1. The runner is on the standard `gh auth login` `gho_` token, whose scope set is fixed by the GitHub CLI OAuth app and cannot be narrowed; the check itself names `--allow-overscoped` as the sanctioned opt-out for exactly that case. Recorded here rather than silently waived.

Plan record: https://github.com/cogni-work/insight-wave/issues/1522#issuecomment-5352768504