### PR TITLE
repo: restate the MCP-guard residual with a reproducible figure

### DIFF
--- a/scripts/check-mcp-tool-grant.py
+++ b/scripts/check-mcp-tool-grant.py
@@ -27,18 +27,18 @@ provisioned.
 Detection is an AFFIRMATIVE CALL SITE, not a prose match. A prose heuristic
 ("<server> MCP" appearing in the body) is sound only inside a plugin whose
 agents never talk about a server they deliberately do not use. Repo-wide it is
-not: several agents DISCLAIM a server in exactly that phrasing — cogni-visual
-and cogni-workspace both ship a `concept-diagram-svg` agent whose body says "no
-Excalidraw MCP", and cogni-knowledge's `source-curator` says "no
-claude-in-chrome MCP tools". Those sentences carry no `mcp__<ns>__<tool>`
-token, so requiring a literal token is what makes the guard safe at this scope.
-That reasoning held while the only affirmative signal was the token itself. It
-no longer does, and the evaluation of the alternative resolved to ADOPT. The
-registry already names each server's tools in `provides_tools[]`, so a body can
-be read affirmatively with NEITHER prose NOR a token, by asking whether it names
-one of those tools inside a backtick code span. That second arm lives below, and
-the plugin-scoped prose detector that formerly sat in cogni-website's own test
-directory is retired with it.
+not: two agents DISCLAIM a server in exactly that phrasing — cogni-workspace's
+`concept-diagram-svg` agent says "no Excalidraw MCP" in its body, and
+cogni-knowledge's `source-curator` says "no claude-in-chrome MCP tools". Those
+sentences carry no `mcp__<ns>__<tool>` token, so requiring a literal token is
+what makes the guard safe at this scope. That reasoning held while the only
+affirmative signal was the token itself. It no longer does, and the evaluation
+of the alternative resolved to ADOPT. The registry already names each server's
+tools in `provides_tools[]`, so a body can be read affirmatively with NEITHER
+prose NOR a token, by asking whether it names one of those tools inside a
+backtick code span. That second arm lives below, and the plugin-scoped prose
+detector that formerly sat in cogni-website's own test directory is retired
+with it.
 
 Measured when adopted: the registry registers 2 servers carrying 18 distinct
 bare names, with NO name owned by more than one server; of the 103 agents that
@@ -63,17 +63,25 @@ old heuristic plugin-scoped.
 Three residuals, stated rather than implied away. An agent that names a server
 in prose while naming NONE of its tools in a code span is outside both arms.
 The no-`tools:`-key skip is inherited here, and it is not hypothetical: the
-`storyboard` and `web` agents in cogni-visual and cogni-workspace declare no
-`tools:` key and together carry 22 in-span name hits this arm deliberately does
-not judge. And a code span inside a DISCLAIMING sentence would read as affirmative
-— that has no instance today, and the span requirement is what keeps the edge
-narrow, but it is real. Finally, the vocabulary is only as complete as the
-registry: agents grant 26 distinct tool names across the two registered
-servers while `provides_tools[]` lists 18, so 9 granted names are outside this
-arm's reach. That completeness question is now ANSWERED rather than deferred:
-each granted `mcp__<registered-ns>__<tool>` is resolved against its own
-server's `provides_tools[]`, and a name absent from it is surfaced as a
-`granted_outside_vocabulary` observation. Today that reports 9 gaps. Each is
+`storyboard` and `web` agents in cogni-workspace declare no `tools:` key, so
+they never reach this arm and their in-span registry names go unjudged.
+Measured when this residual was restated — counting the registry
+`provides_tools[]` bare names that `vocabulary_re` matches inside the body's
+`CODE_SPAN_RE` spans, DISTINCT per agent, the unit
+`summary.provides_tools_code_span_names` itself uses — `storyboard` carries 5
+and `web` carries 6. Unlike the block-form snapshot below, no `summary.*`
+counter re-derives these two: the skip returns before the arm that would have
+counted them, so the figure is hand-taken and goes stale silently. The
+residual stays real while either agent keeps a `tools:`-free frontmatter,
+whatever the count. And a code span inside a DISCLAIMING sentence would read
+as affirmative — that has no instance today, and the span requirement is what
+keeps the edge narrow, but it is real. Finally, the vocabulary is only as
+complete as the registry: agents grant 26 distinct tool names across the two
+registered servers while `provides_tools[]` lists 18, so 9 granted names are
+outside this arm's reach. That completeness question is now ANSWERED rather
+than deferred: each granted `mcp__<registered-ns>__<tool>` is resolved against
+its own server's `provides_tools[]`, and a name absent from it is surfaced as
+a `granted_outside_vocabulary` observation. Today that reports 9 gaps. Each is
 one record naming the gap once and carrying its granting agents as evidence,
 because the fix is one edit to the registry however many agents grant the name
 — emitting per agent would have restated one fact 17 times and pointed each


### PR DESCRIPTION
Closes #1530.

## Summary

The residuals paragraph in `scripts/check-mcp-tool-grant.py` named `cogni-visual` as a live home of the `storyboard` / `web` agents, and carried an in-span hit figure of **22** that no counting method reproduces.

- **cogni-visual is retired.** `git ls-tree -d origin/main` lists no `cogni-visual`; both agents resolve only under `cogni-workspace/agents/`. The paragraph now names only cogni-workspace.
- **The figure was the more durable defect.** It stated a number without stating its *unit*, which is why three good-faith re-measurements disagreed: 22 as recorded, 23 counting raw occurrences, 11 counting distinct names. (The issue's third figure, 13, was itself a method conflation — it paired `storyboard`'s distinct count with `storyboard`'s occurrence count rather than reading `web`.)
- **The method is now stated in full**, naming all three free variables a reader needs: **vocabulary** — the bare names in the registry's `provides_tools[]`; **matcher** — `vocabulary_re` over the body's `CODE_SPAN_RE` spans; **unit** — DISTINCT names per agent, the same unit the `provides_tools_code_span_names` counter uses. Under that method `storyboard` carries **5** and `web` carries **6**.
- **No `summary.*` counter re-derives this figure**, and the paragraph now says so. The no-`tools:`-key skip runs `continue` before the arm that would have counted these two agents, so unlike the block-form snapshot the guard cannot re-derive it. The block-form note's "the guard re-derives that count every run" phrasing is true of `tools_form_counts.block` and was deliberately **not** copied here — that would have been a false claim.
- **The residual's substance survives**: both agents still declare no `tools:` key, are still recorded as skipped, and still carry in-span registry names this arm deliberately does not judge.
- **Second site, same defect class.** The disclaiming-agent example one paragraph up also named cogni-visual as shipping `concept-diagram-svg`. Corrected to name only cogni-workspace, **keeping both examples** so the quantifier stays accurate — exactly two agent bodies disclaim in that phrasing (`cogni-workspace/agents/concept-diagram-svg.md` and `cogni-knowledge/agents/source-curator.md`), so collapsing to one example would have introduced a new inaccuracy in the course of fixing an old one.

## Scope decisions

- **Included** the second `cogni-visual` mention (the disclaiming-agent example). It sits outside AC 1's falsifier, which scopes its evidence to the residuals paragraph; the issue-time acceptance contract records that correcting it in the same pass is in scope and not creep. Fixed here because it is the identical retirement-drift class in the same docstring with no measurement question attached, and leaving it would have guaranteed a near-identical follow-up issue. After this change the file carries **zero** `cogni-visual` mentions.
- **Excluded** the present-tense vocabulary figures further down the same paragraph ("26 distinct tool names", "9 granted names outside"). They lie outside both AC falsifiers, the guard re-derives that channel at runtime through `granted_outside_vocabulary`, and no measurement here contradicts them — so there is nothing to file.
- **Excluded** the repo-wide `cogni-visual` roster drift in `README.md`, `CLAUDE.md` and `docs/`. That is a separate class already tracked on the board; it is not implied by this issue's acceptance criteria.
- **Excluded** every regex, counter, summary key, threshold and test assertion.

## Verification

- `bash tests/test_check_mcp_tool_grant.sh` → exit 0, `0 failed`. All four liveness floors (L1–L4) intact; the suite pins numeric `summary` counters, never docstring text.
- `python3 scripts/run-plugin-tests.py` → exit 0, **124/124 suites passed**, `failed: 0`.
- **Behaviour identity (the load-bearing check for a prose-only claim):** `python3 scripts/check-mcp-tool-grant.py` run on the base tree and on head produces a byte-identical `data.summary` — including `provides_tools_code_span_names = 27` and `skipped_no_tools = 9`. If the edit had touched anything executable, this would have moved.
- **Prose-only containment:** both diff hunks (new lines 30–41 and 66–84) fall entirely inside the module docstring, which ends at line 135. No `re.compile`, no `counters[`, no summary key, no threshold, no indented line.
- **Figure reproduces from the stated method:** applying the registry's 18 `provides_tools[]` names through the guard's own `CODE_SPAN_RE` + `vocabulary_re` and counting distinct-per-agent yields `storyboard` 5, `web` 6 — matching the text exactly.
- `python3 scripts/check-breadcrumbs.py` → no violations; the new prose carries no issue ref, version tag or slice code.
- `grep -n cogni-visual scripts/check-mcp-tool-grant.py` → no match.
- No `plugin.json` / `marketplace.json` version field touched — the post-merge workflow owns the bump.

## Reviewer notes

**Wrap.** Both edited paragraphs were reflowed whole at 78 columns rather than patched line-by-line, which is why the diff is larger than the sentence changes alone. Patching in place left a cascade of ragged 14–19 character lines as each fix pushed the short line one further down. The reflow is confined to the two paragraphs actually edited; no neighbouring paragraph moved. Measured band in this docstring is 75–80 columns, and no lint config in the repo enforces a width.

**No mutation recipe.** The preflight's `mutation-recipe` check fires on `*/tests/test-*.sh` and `*/scripts/check-*.sh`; this diff touches `scripts/check-mcp-tool-grant.py`, a `.py`, so the check does not apply. It would also be meaningless here: the diff changes zero executable lines, so there is nothing a mutation could flip, and any recipe written against it would report `case_not_found` or a false green. The discrimination this change rests on is the base-vs-head counter identity above.

## Choice worth a second opinion

The figure is stated in **distinct-names-per-agent**, matching the guard's own counter semantics. An occurrence reading is also defensible — "hits" reads naturally as occurrences, and the adoption-time snapshot at line 43 ("52 name hits" across 9 agents) fits the occurrence sum more closely than the distinct sum. Either unit satisfies the acceptance criteria now that the unit is stated explicitly; I chose the one the code itself uses. Worth a reviewer's eye rather than a silent call.