### PR TITLE
Freeze the vendored-license audit as a dated attestation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,8 @@ insight-wave/
 
 The repo-wide documentation-drift audit belongs at `docs/audit-report.md` — that is the single home for audit output, and it is replaced wholesale by a fresh `cogni-docs` audit run rather than hand-edited. A stale header there means the audit is due to be re-run, not patched by hand. `.claude-plugin/` holds the marketplace manifest and nothing else. An older drift report once sat at `.claude-plugin/doc-audit-report.md` and was removed rather than regenerated: nothing in this repo referenced or wrote that path, `docs/audit-report.md` supersedes it, and its plugin roster predated the current marketplace by several retirements. Do not add a report back under `.claude-plugin/`.
 
+Not all of `docs/` is regenerated, and one file there is neither generated nor maintained. `docs/relicensing/vendored-license-audit.md` is a **frozen attestation**: it records the repository as of its stated audit date, so its findings are history and are deliberately not reconciled against the current tree. Do not hand-patch paths, names or counts inside it when an absorption or a relocation moves an asset it names — update the repo-root `NOTICE`, which is the live third-party attribution surface, and leave the attestation as written. The absorption-side statement of the same rule lives in `docs/contributing/plugin-absorption-slicing.md`.
+
 ## Cross-Plugin Conventions
 
 ### Script Output Format

--- a/docs/contributing/plugin-absorption-slicing.md
+++ b/docs/contributing/plugin-absorption-slicing.md
@@ -40,6 +40,22 @@ surface after the deletion. Do not plan it that way. The **wiki** half of that s
 graded against the manifest, so it must merge *with* the deletion — see stage 3. Only the
 ungraded narrative surfaces can defer to stage 4.
 
+### Frozen records stage 4 must not patch
+
+Not every prose surface stage 4 touches is maintained. `docs/relicensing/vendored-license-audit.md`
+is a **frozen attestation** — it records the repository as of a stated audit date, so its
+findings are history rather than a live index. When an absorption moves an asset it names —
+a vendored tree, a data file, a per-plugin `LICENSE` — do not hand-patch the path inside it
+to keep the reference resolving. Repoint the repo-root `NOTICE`, which is the live
+third-party attribution surface, and leave the attestation as written. Editing a record to
+match the current tree destroys the one thing it is for, and it re-opens the question of
+which kind of document it is every time an absorption runs.
+
+Generalise it: any stage-4 surface that declares its own "as of" date is **out of scope for
+the stage**. The stage's licence is editorial correctness on surfaces that describe the tree
+now; a dated record does not describe the tree now, and correcting the live surface it points
+at is the fix.
+
 ## Per-stage size bound
 
 Target **400 changed lines per stage**. That figure is the review gate's advisory
@@ -178,3 +194,4 @@ single pull request.
 
 - [plugin-development.md](plugin-development.md) — how to build a plugin, and the conventions an adopted tree must still satisfy
 - [../architecture/plugin-anatomy.md](../architecture/plugin-anatomy.md) — every file type an absorption relocates
+- [../relicensing/vendored-license-audit.md](../relicensing/vendored-license-audit.md) — a frozen attestation stage 4 leaves alone; repoint the repo-root `NOTICE` instead

--- a/docs/relicensing/vendored-license-audit.md
+++ b/docs/relicensing/vendored-license-audit.md
@@ -1,5 +1,23 @@
 # Vendored / incorporated code license audit
 
+**Status:** Frozen attestation, not a maintained index. Everything below records this
+repository **as of the audit date, 2026-07-10** — the day this record was committed. Its
+findings, inventories and decisions are point-in-time history: they stand as written, and
+they are deliberately **not** reconciled where the tree has since moved on. The relicense
+this audit cleared has since happened, a repo-root `NOTICE` now exists, and the plugin
+roster has changed — none of it corrected below, because correcting a record destroys the
+one thing a record is for. Read every claim here as what was true on 2026-07-10, never as
+a description of the tree today.
+
+**Live attribution surface:** the repo-root `NOTICE` file, not this document. When an
+absorption or a relocation moves an asset named here — a vendored tree, a data file, a
+per-plugin `LICENSE` — do not hand-patch the path, name or count inside this record to
+keep the reference resolving. Repoint `NOTICE` and leave the attestation as written. Four
+asset paths were repointed inside this file during a plugin absorption on 2026-08-19; they
+stay as they are rather than being reverted, and that is the last such patch. The forward
+convention is written up in
+[../contributing/plugin-absorption-slicing.md](../contributing/plugin-absorption-slicing.md).
+
 **Purpose:** Phase 1 (audit gate) of the AGPL-3.0 → Apache-2.0 relicense roadmap
 (epic #1059). This is the blocking legal gate before the LICENSE-text swap
 (#1056): it confirms that no incorporated third-party code carries a copyleft


### PR DESCRIPTION
Closes #1509.

## Summary

- Declares `docs/relicensing/vendored-license-audit.md` a **frozen attestation** in its own opening block, dated **2026-07-10** — the date of `393cc160`, the commit that added the file — so a reader no longer has to infer the document's kind.
- Leaves both stale claims (`## NOTICE stub decision` and `## Full LICENSE-file inventory`) **byte-for-byte untouched**. Under the frozen reading they are history; the header's "as of" framing is what resolves the contradiction, and reconciling them would destroy the one thing a record is for.
- Names the repo-root `NOTICE` as the live third-party attribution surface, and states the forward convention: absorptions stop hand-patching paths inside the audit file.
- Writes that convention where an absorption author will actually find it — a new `### Frozen records stage 4 must not patch` subsection in `docs/contributing/plugin-absorption-slicing.md`, immediately after the stage-4 material it governs — plus a repo-wide mirror in root `CLAUDE.md`.

37 added lines, 0 removed, across 3 files.

## Scope decisions

**Three files, each doing one job.**

| File | Job |
|---|---|
| `docs/relicensing/vendored-license-audit.md` | Declare the kind, in the file's own text, above the first heading |
| `docs/contributing/plugin-absorption-slicing.md` | Reach the absorption author *before* they edit — its line 7 already says "Read this before planning an absorption", and its stage-4 row is the licence the 2026-08-19 hand-patch was taken under |
| `CLAUDE.md` | Repo-wide discoverability, mirroring the existing `docs/audit-report.md` "replaced wholesale rather than hand-edited" rule in the same section |

**The audit file's edit is purely additive.** Every change is an insertion above the old line 3. Nothing inside the two frozen sections moves: no AGPL-to-Apache substitution in the inventory, no negation or deletion of the "No repo-root `NOTICE` stub is warranted." sentence, no trimming of the retired-plugin list. Verified mechanically — see the test plan.

**No rollback of the four repointed asset paths.** The ruling is forward-looking only. Two of the four sit *inside* the frozen sections; they are neither reverted nor re-patched. Whether the header should *acknowledge* that residual was left open by the ruling — see **Open questions**.

**Repo-root `NOTICE` is not edited.** It is already the live attribution surface in fact. Adding process prose to a legal attribution artifact puts the convention in the wrong category, and no acceptance criterion asks for it. No second attribution document is created.

**No `tests/*.sh` guard — a reasoned no, not an omission.**

1. *Nothing to protect.* `tests/`, `*/tests/`, `scripts/`, `.github/workflows/` and `cogni-docs/` contain zero references to `relicensing`, `vendored-license` or `NOTICE`. There is no drift channel for a guard to sit in front of.
2. *The checkable proposition is the wrong one.* The only mechanically decidable form of "do not hand-patch this file" is a content freeze, which cannot distinguish a forbidden path-patch from a legitimate future supersession — and would need a baseline this PR's own header churns. A guard that fires on the correct edit as loudly as the incorrect one trains reviewers to override it.
3. *The residual assertion is a tautology.* A guard checking "a header exists and names a date" goes red only when someone deliberately deletes the header — a reviewed diff, not silent drift.

The repo's closest precedent settles it the same way: `docs/audit-report.md` is governed by a `CLAUDE.md` paragraph and no guard. Adding a suite here would also newly activate the handoff preflight's `tests/` instrument on a prose-only PR for zero discriminating power.

**No version bump** — the post-merge workflow owns it. **No routing to any `cogni-docs` skill**: `doc-hub` holds `Write`/`Edit` and generates `docs/`, so dispatching it at a file this PR declares must never be regenerated invites the exact violation the PR exists to prevent; `doc-claude` generates per-plugin `CLAUDE.md` guides, never the repo-root one. All three files are hand-authored.

## Test plan

All checks run against `origin/main` in an isolated worktree. Every one passed.

| # | Check | Result |
|---|---|---|
| 1 | Audit edit strictly additive — `git diff origin/main -- <audit> \| grep -c '^-[^-]'` | `0` |
| 2 | One contiguous hunk — `grep -c '^@@'` | `1` |
| 3 | Line count 122 → 140 (insertion-only) | confirmed |
| 4 | Frozen declaration precedes the first `##` | line 3 < line 44 |
| 5 | Audit date defensible — `git log --diff-filter=A` | `393cc160 2026-07-10` |
| 6 | Four repointed paths intact, neither reverted nor re-patched | `4` before, `4` after |
| 7 | Frozen sections byte-identical — `diff` of old 77-103 vs new 95-121 | identical |
| 8 | Convention named by path outside the audit file | 2 hits in the slicing guide, 1 in `CLAUDE.md` |
| 9 | Both new relative links resolve | both |
| 10 | No new issue refs in added lines — `grep -Ec '#[0-9]{3,}'` | `0` |
| 11 | Exactly 3 changed paths, none under `*/skills/`, `*/agents/`, `scripts/`, `.github/`, any `LICENSE`, `.claude-plugin/` | confirmed |
| 12 | No version manifest touched | `0` |
| 13 | `check-version-bump.py` | rc 0, `status: ok`, 0 violations, 8 plugins scanned |
| 14 | `check-breadcrumbs.py` (CI parity only — see note) | rc 0 |
| 15 | `run-plugin-tests.py` | **125/125 suites green** |

**Note on check 14.** `scripts/check-breadcrumbs.py` is **vacuous on this PR** — its `DEFAULT_GLOBS` are `*/skills/*/SKILL.md` and `*/agents/*.md`, so it never reads any of these three paths and would exit 0 whatever the new prose contained. Check 10 is what actually carries the no-new-issue-ref assertion; the guard is listed for CI parity, not as evidence.

**Note on `/simplify`.** Skipped with reason rather than run as a vacuous pass: the diff is 100% markdown prose with zero code lines, and the skill would have run against the session's working directory rather than the execution worktree.

## Open questions

- **(avoidable — decided, surfaced for a maintainer's eye)** The maintainer ruling is forward-looking and does not say whether the new header should *acknowledge* the four asset paths the 2026-08-19 absorption already repointed inside the file. This PR names them in one dated sentence — they stay as they are, and that is the last such patch — on the reasoning that a frozen record whose paths were quietly patched once is exactly the ambiguity this issue closed. A maintainer who prefers the header stay silent can delete that single sentence without affecting any acceptance criterion.