### PR TITLE
cogni-website: repoint retired cogni-visual paths + hygiene guard

### DIFF
--- a/cogni-website/CLAUDE.md
+++ b/cogni-website/CLAUDE.md
@@ -45,7 +45,7 @@ The primary spine for every narrative page is the arc-structured markdown produc
 | `for/{market-slug}--{persona}.md` | `persona` (one per file) | `jtbd-portfolio` |
 | `approach.md` | `approach` | `engagement-model` |
 
-Any page entry in `website-plan.json` carrying an `arc_id` is rendered through the **Section Block Library** in `libraries/page-templates.md` — not the flat page-type template. `website-plan` step 6a walks the narrative and emits a structured `sections[]` array (hero, problem-statement, stat-row, feature-alternating, feature-grid, comparison, timeline, testimonial, text-block, cta). The ten existing block types cover all five arcs; no arc-specific renderers exist or are needed. The element → block mapping is authoritative in `cogni-visual/libraries/arc-taxonomy.md`.
+Any page entry in `website-plan.json` carrying an `arc_id` is rendered through the **Section Block Library** in `libraries/page-templates.md` — not the flat page-type template. `website-plan` step 6a walks the narrative and emits a structured `sections[]` array (hero, problem-statement, stat-row, feature-alternating, feature-grid, comparison, timeline, testimonial, text-block, cta). The ten existing block types cover all five arcs; no arc-specific renderers exist or are needed. The element → block mapping is authoritative in `cogni-workspace/libraries/arc-taxonomy.md`.
 
 **Deduplication discipline** (enforced upstream by the customer-narrative templates — do not break it in page planning):
 - Roadmap appears on `home` only.
@@ -59,11 +59,10 @@ Any page entry in `website-plan.json` carrying an `arc_id` is rendered through t
 | Plugin | Required | Purpose |
 |--------|----------|---------|
 | cogni-portfolio | Yes | Products, features, propositions, solutions, customer narratives |
-| cogni-workspace | Yes | Theme system (pick-theme skill, design-variables pattern) |
+| cogni-workspace | Yes | Theme system (pick-theme skill, design-variables pattern); arc taxonomy and story-to-web decomposition references (website-plan); image-prompt conventions (hero-renderer) |
 | cogni-marketing | No | Blog posts, articles, whitepapers |
 | cogni-trends | No | Trend reports, investment themes for insights page |
 | cogni-knowledge | No | Research syntheses for resources page |
-| cogni-visual | No | Arc taxonomy and story-to-web decomposition references (website-plan); image-prompt conventions (hero-renderer) |
 
 ## Output
 

--- a/cogni-website/README.md
+++ b/cogni-website/README.md
@@ -217,11 +217,10 @@ cogni-website/
 | Plugin | Required | Purpose |
 |--------|----------|---------|
 | cogni-portfolio | Yes | Products, features, propositions, solutions, markets, customer narratives — core page content |
-| cogni-workspace | Yes | Theme selection (`pick-theme`) and design-variables pattern reference |
+| cogni-workspace | Yes | Theme selection (`pick-theme`) and design-variables pattern reference; arc taxonomy (element → block mapping) and story-to-web section-architecture and copywriting references read by website-plan; image-prompt conventions for the hero-renderer agent |
 | cogni-marketing | No | Blog posts, demand-generation articles, lead-generation landing pages |
 | cogni-trends | No | Trend report with investment themes for an Insights page |
 | cogni-knowledge | No | Research syntheses as whitepapers for a Resources page |
-| cogni-visual | No | Arc taxonomy (element → block mapping) and story-to-web section-architecture and copywriting references read by website-plan; image-prompt conventions for the hero-renderer agent |
 
 ## Custom development
 

--- a/cogni-website/libraries/page-templates.md
+++ b/cogni-website/libraries/page-templates.md
@@ -745,12 +745,12 @@ The page types above (`products`, `product-detail`, `blog-*`, `insights`, `resou
 | `engagement-model` | Partnership | feature-alternating |
 | `engagement-model` | Outcomes | stat-row (or cta) |
 
-The authoritative element → visual-type mapping lives in `cogni-visual/libraries/arc-taxonomy.md`. The table above is a rendering shortcut, not a replacement for the step 6a decision tree, which still chooses block types based on actual content shape (bullets, numeric density, parallel capabilities, sequential steps).
+The authoritative element → visual-type mapping lives in `cogni-workspace/libraries/arc-taxonomy.md`. The table above is a rendering shortcut, not a replacement for the step 6a decision tree, which still chooses block types based on actual content shape (bullets, numeric density, parallel capabilities, sequential steps).
 
-The section-block taxonomy mirrors cogni-visual's story-to-web skill so that narratives surface as scroll-driven reading experiences instead of entity-card dumps. The decomposition rules (decision tree, assertion-headline discipline, number plays, bullet scan-optimization) live in the story-to-web references and are **not** duplicated here:
+The section-block taxonomy mirrors cogni-workspace's story-to-web skill so that narratives surface as scroll-driven reading experiences instead of entity-card dumps. The decomposition rules (decision tree, assertion-headline discipline, number plays, bullet scan-optimization) live in the story-to-web references and are **not** duplicated here:
 
-- Taxonomy + decision tree: `cogni-visual/skills/story-to-web/references/02-section-architecture.md`
-- Copywriting rules: `cogni-visual/skills/story-to-web/references/03-section-copywriting.md`
+- Taxonomy + decision tree: `cogni-workspace/skills/story-to-web/references/02-section-architecture.md`
+- Copywriting rules: `cogni-workspace/skills/story-to-web/references/03-section-copywriting.md`
 
 This appendix only defines the HTML patterns the page-generator emits for each block type, mapping onto the existing stylesheet (no new CSS classes — everything reuses `.section`, `.section--{theme}`, `.hero`, `.stat`, `.card-grid`, `.btn`, `.timeline` already defined in the style reference above).
 

--- a/cogni-website/skills/website-plan/SKILL.md
+++ b/cogni-website/skills/website-plan/SKILL.md
@@ -185,12 +185,12 @@ For every page whose spine is a `customer-narrative/*.md` file (`home`, `about`,
 | `corporate-visions` | Why Change → Why Now → Why You → Why Pay | problem-statement → stat-row → feature-alternating → cta |
 | `engagement-model` | Principles → Process → Partnership → Outcomes | feature-grid → timeline → feature-alternating → stat-row / cta |
 
-The element → block mapping is authoritative in `$CLAUDE_PLUGIN_ROOT/../cogni-visual/libraries/arc-taxonomy.md` (visual-type column). Read that file once per plan to confirm the mapping instead of duplicating it here.
+The element → block mapping is authoritative in `$CLAUDE_PLUGIN_ROOT/../cogni-workspace/libraries/arc-taxonomy.md` (visual-type column). Read that file once per plan to confirm the mapping instead of duplicating it here.
 
-The decomposition rules are defined in cogni-visual's story-to-web skill and referenced rather than duplicated here. Read once, apply per page:
+The decomposition rules are defined in cogni-workspace's story-to-web skill and referenced rather than duplicated here. Read once, apply per page:
 
-- Section taxonomy + decision tree: `$CLAUDE_PLUGIN_ROOT/../cogni-visual/skills/story-to-web/references/02-section-architecture.md` (decision tree lives around lines 145–187)
-- Copywriting rules (assertion headlines, number plays, bullet discipline): `$CLAUDE_PLUGIN_ROOT/../cogni-visual/skills/story-to-web/references/03-section-copywriting.md`
+- Section taxonomy + decision tree: `$CLAUDE_PLUGIN_ROOT/../cogni-workspace/skills/story-to-web/references/02-section-architecture.md` (see the "Section Type Decision Tree" heading)
+- Copywriting rules (assertion headlines, number plays, bullet discipline): `$CLAUDE_PLUGIN_ROOT/../cogni-workspace/skills/story-to-web/references/03-section-copywriting.md`
 
 For each narrative page, walk the markdown in order:
 

--- a/cogni-website/tests/test-cross-plugin-path-hygiene.sh
+++ b/cogni-website/tests/test-cross-plugin-path-hygiene.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+#
+# Cross-plugin path hygiene for cogni-website.
+#
+# Every cross-plugin file path this plugin documents must resolve. A plugin that
+# names a path into a tree that no longer exists sends its reader — often the
+# agent running the skill — to a file that is not there, and nothing else in the
+# repository grades it.
+#
+# SCOPE: cogni-website only, and that narrowness is deliberate rather than an
+# oversight. A repo-wide form of this check is red on arrival and cannot be made
+# green without edits well outside any one plugin's remit: cogni-knowledge alone
+# carries dozens of files naming retired-plugin trees, because it vendors a
+# retired engine and records its own absorption history as prose, and further
+# references live in the repository-root guide and in the dated, deliberately
+# frozen sweep artifacts under docs/. The sibling check for the absorption
+# destination lives in cogni-workspace/tests/test-relocated-skill-hygiene.sh,
+# whose own header states the same boundary for the same reason.
+#
+# The assertion is MUST-RESOLVE, never must-not-appear. Naming another live
+# plugin's file is legitimate and common; naming one that is absent is the
+# defect. That choice is what lets this suite carry no registry of retired
+# plugin names, so it cannot go stale as the roster changes.
+#
+# Mutation recipe: see the pull request body. Three arms cover the repo-relative
+# resolver, the sibling-form resolver, and the extraction floor.
+
+set -u
+
+SUITE_DIR=$(cd "$(dirname "$0")" && pwd)
+PLUGIN_DIR=$(cd "$SUITE_DIR/.." && pwd)
+REPO_ROOT=$(cd "$PLUGIN_DIR/.." && pwd)
+
+failures=0
+
+pass() { printf '%s\n' "PASS: $1 $2"; }
+fail() { printf '%s\n' "FAIL: $1 $2"; failures=$((failures + 1)); }
+
+# Text surfaces this plugin ships. Kept to the shapes that carry prose paths.
+FILE_LIST=$(find "$PLUGIN_DIR" -type f \
+    \( -name '*.md' -o -name '*.sh' -o -name '*.py' -o -name '*.json' \) \
+    | LC_ALL=C sort)
+
+files_walked=0
+for f in $FILE_LIST; do
+    files_walked=$((files_walked + 1))
+done
+
+# --- w3: surface-shape floors -------------------------------------------------
+# The two resolver cases below can only grade what the walk reaches. These three
+# pin that it reaches each shape this plugin actually documents paths in, so a
+# narrowed walk shows up here rather than as a quietly smaller reference set.
+
+if printf '%s\n' "$FILE_LIST" | grep -q "^$PLUGIN_DIR/CLAUDE.md$"; then
+    pass w3-surface-claude-md-reached "walk reached the plugin-root CLAUDE.md"
+else
+    fail w3-surface-claude-md-reached "walk did not reach the plugin-root CLAUDE.md"
+fi
+
+if printf '%s\n' "$FILE_LIST" | grep -q "^$PLUGIN_DIR/libraries/.*\.md$"; then
+    pass w3-surface-libraries-reached "walk reached at least one libraries/*.md"
+else
+    fail w3-surface-libraries-reached "walk reached no libraries/*.md"
+fi
+
+if printf '%s\n' "$FILE_LIST" | grep -q "^$PLUGIN_DIR/skills/.*/SKILL\.md$"; then
+    pass w3-surface-skill-md-reached "walk reached at least one skills/*/SKILL.md"
+else
+    fail w3-surface-skill-md-reached "walk reached no skills/*/SKILL.md"
+fi
+
+if [ "$files_walked" -ge 15 ]; then
+    pass w1-floor-files-walked "walked $files_walked files"
+else
+    fail w1-floor-files-walked "walked only $files_walked files, expected at least 15"
+fi
+
+# --- w1: repo-relative cross-plugin references must resolve -------------------
+# Extract <plugin>/<component-dir>/<path> and resolve it from the repository
+# root. The component-dir alternation is what keeps a data-directory convention
+# such as {source_dir}/cogni-foo/ from being read as a source path.
+
+repo_refs=$(grep -rhoE 'cogni-[a-z-]+/(agents|skills|scripts|libraries|references|commands|hooks|tests)/[A-Za-z0-9_./-]+' \
+    $FILE_LIST 2>/dev/null | LC_ALL=C sort)
+
+refs_extracted=0
+repo_bad=""
+for ref in $repo_refs; do
+    # Strip trailing sentence punctuation the pattern may have absorbed.
+    clean=$(printf '%s\n' "$ref" | sed -e 's/[.,)]*$//')
+    [ -n "$clean" ] || continue
+    refs_extracted=$((refs_extracted + 1))
+    if [ ! -e "$REPO_ROOT/$clean" ]; then
+        repo_bad="$repo_bad $clean"
+    fi
+done
+
+if [ "$refs_extracted" -ge 13 ]; then
+    pass w1-floor-refs-extracted "extracted $refs_extracted repo-relative references"
+else
+    fail w1-floor-refs-extracted "extracted only $refs_extracted references, expected at least 13 — the resolver case below would pass vacuously"
+fi
+
+if [ -z "$repo_bad" ]; then
+    pass w1-repo-relative-refs-resolve "all $refs_extracted repo-relative references resolve"
+else
+    fail w1-repo-relative-refs-resolve "unresolved:$repo_bad"
+fi
+
+# --- w2: sibling-form references must resolve through their own hop -----------
+# The runtime form a skill tells its reader to open. Resolution goes through the
+# literal hop so that damaging the hop alone is caught here even when the tail
+# still resolves from the repository root, which is what w1 would see.
+# Both the bare and braced spellings are accepted: the live sites spell it bare,
+# while the braced spelling appears elsewhere in this plugin without a hop.
+
+sibling_refs=$(grep -rhoE '[$]\{?CLAUDE_PLUGIN_ROOT\}?/[A-Za-z0-9_./-]+' \
+    $FILE_LIST 2>/dev/null | grep -E '/\.\.?/' | LC_ALL=C sort)
+
+sibling_found=0
+sibling_bad=""
+for ref in $sibling_refs; do
+    tail_path=$(printf '%s\n' "$ref" | sed -e 's/^[$]{*CLAUDE_PLUGIN_ROOT}*//' -e 's/[.,)]*$//')
+    [ -n "$tail_path" ] || continue
+    sibling_found=$((sibling_found + 1))
+    if [ ! -e "$PLUGIN_DIR$tail_path" ]; then
+        sibling_bad="$sibling_bad $tail_path"
+    fi
+done
+
+if [ "$sibling_found" -ge 3 ]; then
+    pass w2-floor-sibling-refs-found "found $sibling_found sibling-form references"
+else
+    fail w2-floor-sibling-refs-found "found only $sibling_found sibling-form references, expected at least 3"
+fi
+
+if [ -z "$sibling_bad" ]; then
+    pass w2-sibling-form-refs-resolve "all $sibling_found sibling-form references resolve"
+else
+    fail w2-sibling-form-refs-resolve "unresolved:$sibling_bad"
+fi
+
+if [ "$failures" -ne 0 ]; then
+    printf '%s\n' "cross-plugin path hygiene: $failures failing case(s)"
+    exit 1
+fi
+printf '%s\n' "cross-plugin path hygiene: all cases green"
+exit 0


### PR DESCRIPTION
Closes #1503.

## Summary

`cogni-website` carried references into the retired `cogni-visual` tree. Re-derived at `origin/main`, the plugin held **eleven** `cogni-visual` occurrences, not the six the issue listed:

- **7 dangling paths** — `CLAUDE.md:48`; `libraries/page-templates.md:748,752,753`; `skills/website-plan/SKILL.md:188,192,193`. The `CLAUDE.md:48` site is **not named in the issue** and is the same defect class as the six that are.
- **4 prose / dependency-table mentions** — `CLAUDE.md:66`, `README.md:224`, `libraries/page-templates.md:750`, `skills/website-plan/SKILL.md:190`.

All three repoint targets exist at the identical sub-path (verified at `origin/main`): `cogni-workspace/libraries/arc-taxonomy.md`, `cogni-workspace/skills/story-to-web/references/02-section-architecture.md`, `.../03-section-copywriting.md`.

**Reference form is preserved per site.** The three `website-plan/SKILL.md` sites keep the bare `$CLAUDE_PLUGIN_ROOT/../<plugin>/…` sibling form — the established cross-plugin runtime-read idiom (cf. `cogni-knowledge/skills/knowledge-curate/SKILL.md:75`); the four repo-relative sites keep the repo-relative form. No site is converted between forms.

## Every pre-change occurrence, and its disposition

`grep -rn 'cogni-visual' cogni-website/` now returns **zero** matches.

| Pre-change site | Disposition |
|---|---|
| `CLAUDE.md:48` | path repointed |
| `CLAUDE.md:66` | table row merged into the `cogni-workspace \| Yes` row at 62; row deleted |
| `README.md:224` | table row merged into the `cogni-workspace \| Yes` row at 220; row deleted |
| `libraries/page-templates.md:748` | path repointed |
| `libraries/page-templates.md:750` | prose → "mirrors cogni-workspace's" |
| `libraries/page-templates.md:752,753` | paths repointed |
| `skills/website-plan/SKILL.md:188` | sibling-form path repointed, `Read that file once per plan` preserved |
| `skills/website-plan/SKILL.md:190` | prose → "cogni-workspace's" |
| `skills/website-plan/SKILL.md:192,193` | sibling-form paths repointed |

## Scope decisions

**Dependency tables are merge-and-delete, never rename.** Both tables already carried a live `cogni-workspace | Yes` row (`CLAUDE.md:62`, `README.md:220`). Renaming the `cogni-visual` row in place — or any blanket `s/cogni-visual/cogni-workspace/` — would leave **two** rows keyed on one plugin with contradictory `Required` values (`Yes` and `No`). Each table now holds exactly one `cogni-workspace` row. The merge is also a correction rather than a transfer: `agents/hero-renderer.md:34` already attributes the image-prompt conventions to cogni-workspace, so both tables were already factually wrong at HEAD.

**AC 2 takes branch (A): a guard, pinned by a mutation arm — scoped to `cogni-website/`.** A repo-wide guard was evaluated and rejected as red-on-arrival and unfixable inside this issue's fence:

- `cogni-knowledge` alone holds **66 files** naming retired-plugin trees — it vendors a retired engine under `scripts/vendor/` and records its absorption history as deliberate provenance prose.
- Repo-root `CLAUDE.md:190` names two `cogni-visual/tests/*.sh` files in the present tense (they now live under `cogni-workspace/tests/`), and `docs/architecture/loop-health-map.md` carries five more — but both are fenced out of this diff as ecosystem-doc surfaces.
- Neither existing host fits. `cogni-workspace/tests/test-relocated-skill-hygiene.sh` case P3 has the right detection shape but a cogni-workspace-only scope its own header states as load-bearing. `scripts/check-external-dispatch.py` cannot help at any glob scope: its detector requires a mandatory trailing colon, so it matches dispatch tokens and structurally cannot see a path.

**The guard asserts must-resolve, never must-not-appear.** Naming another live plugin's file is legitimate; naming an absent one is the defect. That choice means the suite carries no registry of retired plugin names and cannot go stale as the roster changes.

**Its clean state is a non-zero floor.** `cogni-website` holds 14 cross-plugin path references — 7 were dangling, the rest already resolved. After the repoint all 14 resolve, so the suite floors on files walked, references extracted **and** sibling references found: a narrowed walk fails rather than passing vacuously.

## Test plan

`cogni-website/tests/test-cross-plugin-path-hygiene.sh` — the plugin's first suite. Discovered by `scripts/run-plugin-tests.py` through the `*/tests/*.sh` glob; no registration needed.

- [x] `bash cogni-website/tests/test-cross-plugin-path-hygiene.sh` — exit 0, all 8 cases PASS
- [x] `python3 scripts/run-plugin-tests.py --filter cogni-website` — `total: 1, passed: 1`
- [x] `python3 scripts/check-result-line-plainness.py` — 0 violations, 126 files scanned
- [x] `python3 scripts/check-breadcrumbs.py` — 0 violations
- [x] `python3 scripts/check-version-bump.py` — clean, 0 plugins touched
- [x] `grep -rn 'cogni-visual' cogni-website/` — zero hits
- [x] Each table holds exactly one `cogni-workspace` row and no `cogni-visual` row

The eight result lines: `w1-repo-relative-refs-resolve`, `w1-floor-files-walked`, `w1-floor-refs-extracted`, `w2-sibling-form-refs-resolve`, `w2-floor-sibling-refs-found`, `w3-surface-claude-md-reached`, `w3-surface-libraries-reached`, `w3-surface-skill-md-reached`. Ids are unique per emitted line, hyphenated, never bare numerals, and none is a prefix or suffix of another.

## Mutation recipe

All three arms were **run and confirmed to discriminate** before this PR was opened. `mutation-check.sh` ships with the cogni-service plugin rather than this repo.

**Arm 1 — the repo-relative resolver is load-bearing.**

```
bash scripts/mutation-check.sh --root . \
  --file cogni-website/libraries/page-templates.md \
  --expr 's{cogni-workspace/libraries/arc-taxonomy\.md}{cogni-visual/libraries/arc-taxonomy.md}g' \
  --test 'bash cogni-website/tests/test-cross-plugin-path-hygiene.sh' \
  --case w1-repo-relative-refs-resolve
```

Observed: `FAIL: w1-repo-relative-refs-resolve unresolved: cogni-visual/libraries/arc-taxonomy.md`, exit 1.

**Arm 2 — the sibling arm catches what the repo-relative arm cannot.**

```
bash scripts/mutation-check.sh --root . \
  --file cogni-website/skills/website-plan/SKILL.md \
  --expr 's{CLAUDE_PLUGIN_ROOT/\.\./cogni-workspace/}{CLAUDE_PLUGIN_ROOT/./cogni-workspace/}g' \
  --test 'bash cogni-website/tests/test-cross-plugin-path-hygiene.sh' \
  --case w2-sibling-form-refs-resolve
```

Damages only the `..` hop. Observed: `w1-repo-relative-refs-resolve` stayed **PASS** (the tail still resolves from the repo root) while `w2-sibling-form-refs-resolve` went **FAIL** on all three sites, exit 1. This is why both arms exist rather than one standing in for the other.

**Arm 3 — the extraction floor is not decorative.**

```
bash scripts/mutation-check.sh --root . \
  --file cogni-website/tests/test-cross-plugin-path-hygiene.sh \
  --expr 's{cogni-\[a-z-\]\+/}{cogni-ZZZNOMATCH/}g' \
  --test 'bash cogni-website/tests/test-cross-plugin-path-hygiene.sh' \
  --case w1-floor-refs-extracted
```

Observed: `FAIL: w1-floor-refs-extracted extracted only 0 references` while `w1-repo-relative-refs-resolve` reported `all 0 repo-relative references resolve` — precisely the vacuity the floor exists to catch.

## Review notes

A pre-commit skill-quality pass over `website-plan/SKILL.md` returned `needs_revision` with four items and **no** structural issues. One was applied here: the pointer at line 192 carried a brittle `(decision tree lives around lines 145–187)` citation into another plugin's file, replaced with a stable heading reference — a line-range going stale silently is the same class of defect this PR exists to fix.

The other three are pre-existing content-accuracy drift, none introduced by this change, and rewriting what a step instructs is a behavioural documentation change rather than a repoint. They are filed together as **#1547** rather than folded in. The most notable: `website-plan/SKILL.md:188` calls `arc-taxonomy.md` authoritative for "the element → block mapping (visual-type column)", but that file contains no block-type names at all (`grep -cE 'stat-row|feature-alternating|problem-statement'` returns `0`) and no "visual-type" string. The pointer now resolves; the claim about what it contains was already wrong.

## Follow-up issues

- **#1545** — `cogni-workspace` documents `cogni-research/references/market-sources.json` in eight places, including `scripts/get-market-config.py` and the canonical `references/supported-markets-registry.json`; the file exists nowhere in the tree. Same defect class, different plugin, one site executable.
- **#1546** — repo-root `CLAUDE.md:185` names `cogni-website` among the three plugins shipping no `tests/`. This PR makes that roster stale; that file is fenced out of this diff.
- **#1547** — the three `website-plan` content-accuracy defects above.

## Notes for the reviewer

- **`Closes`, not `Refs`.** The resolve flow marks a PR partial when `deferred[]` is non-empty, which would link `Refs`. Both of #1503's acceptance criteria are fully met here, and all three follow-ups are separate defects in other files rather than unmet scope — and the commit already carries `closes #1503`, so a partial link would claim partial delivery while the merge closed the issue regardless. Flagging the deviation rather than making it silently.
- **Token-scope preflight.** `check-token-scope.sh --strict` exits 1 against the runner's `gho_` CLI token, which carries `gist`, `read:org` and `workflow` beyond `repo`. That is a GitHub OAuth-app token that cannot be narrowed, so the sanctioned `--allow-overscoped` opt-out was taken. Recording it rather than leaving it implicit.
- No version was bumped — the patch bump is applied post-merge.