### PR TITLE
cogni-workspace: troubleshoot PPTX guidance names only what exists

### DIFF
--- a/cogni-workspace/skills/troubleshoot/SKILL.md
+++ b/cogni-workspace/skills/troubleshoot/SKILL.md
@@ -164,7 +164,10 @@ Route each hit to `references/known-issues.md`, which carries the full remedy:
   `.workspace-env.sh` exists and is sourced.
 - **GitHub CLI not authenticated**: Required for cogni-issues. Run `gh auth status`;
   when authentication is missing, guide the user through `gh auth login`.
-- **Missing node/npm**: Required for PPTX generation (cogni-visual).
+- **PPTX rendering skill unavailable**: `document-skills:pptx` renders the story-to-slides
+  brief and does not ship from this marketplace. Confirm the session provides it before
+  dispatching the `pptx` agent; otherwise take story-to-slides Step 11, "Guide User to
+  PPTX Rendering".
 
 ## Full Scan Mode
 

--- a/cogni-workspace/skills/troubleshoot/references/known-issues.md
+++ b/cogni-workspace/skills/troubleshoot/references/known-issues.md
@@ -65,13 +65,21 @@ diagnose what's missing.
 
 ---
 
-## PPTX generation fails with "pptxgenjs not found"
+## PPTX generation produces no .pptx file
 
-**Symptom**: `/render-slides` fails.
+**Symptom**: The story-to-slides workflow completes and writes its presentation brief,
+but no `.pptx` file is produced.
 
-**Cause**: PptxGenJS not installed globally.
+**Cause**: story-to-slides produces a presentation brief, not a deck — rendering that
+brief is a separate step, and the skill that performs it does not ship from this
+marketplace. The workflow's last step, "Guide User to PPTX Rendering" (Step 11),
+recommends a claude.ai chat with the Anthropic PPTX skill and notes that Claude Code
+can render via the `document-skills:pptx` skill instead; this plugin's `pptx` agent is
+the Claude Code-side wrapper that delegates to that skill.
 
-**Fix**:
-```bash
-npm install -g pptxgenjs
-```
+**Fix**: Take the claude.ai route — open a new chat there and attach the generated
+`presentation-brief.md` together with the `theme.md` it was built against, then ask for
+the presentation. To render inside Claude Code instead, confirm the
+`document-skills:pptx` skill is available in the current session before dispatching the
+`pptx` agent; when the session does not provide it, the claude.ai route is the
+supported path.


### PR DESCRIPTION
Closes #1538.

## Summary

The troubleshoot skill told users that `.pptx` output depends on three things this repo does not have — a `/render-slides` command (no such command file anywhere in the tree), the `pptxgenjs` npm package (present in no other file), and the `cogni-visual` plugin (absorbed into cogni-workspace, absent from the 8-plugin marketplace roster). A wrong entry in the skill's own catalogue of symptoms and fixes is worse than no entry: it sends a user chasing a missing command and installing a package the toolchain never invokes.

- **`references/known-issues.md` entry 5 rewritten in place.** The heading no longer quotes a `pptxgenjs not found` error, the Symptom no longer names `/render-slides`, the Cause no longer asserts a global PptxGenJS install, and the `npm install -g pptxgenjs` fence is dropped. The replacement is prose-only, matching entries 3 and 4; there is no command to paste, because the remedy is a routing decision rather than a shell step.
- **`SKILL.md` Common Misconfigurations bullet 3 rewritten** at pointer altitude matching its two siblings, handing the full remedy to the catalogue entry rather than restating it.
- Both keep the `**Symptom**:` / `**Cause**:` / `**Fix**:` label shape that the Diagnostic Flow contract at `SKILL.md:65-79` mandates, and the file still holds exactly 5 entries.

## What the replacement names, and why

Every artifact the new prose names resolves on disk:

| Named | Resolves to |
|---|---|
| `document-skills:pptx` | the skill `cogni-workspace/agents/pptx.md` delegates to (agent line 53) |
| the `pptx` agent | `cogni-workspace/agents/pptx.md` |
| story-to-slides Step 11, "Guide User to PPTX Rendering" | `cogni-workspace/skills/story-to-slides/SKILL.md:503` |
| `presentation-brief.md`, `theme.md` | the two filenames that step tells the user to attach |

The step is cited by **title as well as number** on purpose: story-to-slides renumbers freely (it already carries Steps 7.5, 8.1, 8.2 and 9b), so the title is the durable half of the reference.

## Three things this change deliberately does not say

- **It does not deny that this repo uses PptxGenJS.** `cogni-workspace/libraries/pptx-layouts.md` is live layout vocabulary consumed by story-to-slides Step 7. Only the *global npm install* was unevidenced, so the entry is silent on the library. An affirmative denial would replace one false claim with another.
- **It does not present the `pptx` agent as the sole render route.** Step 11 recommends the claude.ai path first and names `document-skills:pptx` as the Claude Code alternative; the entry keeps that ordering.
- **It does not offer `/render-html-slides` as a PPTX remedy.** That command exists, but it renders self-contained HTML slides — a different deliverable. Conflating the two would reintroduce the defect class under repair.

It also **names no slash command at all**. `cogni-workspace/commands/` holds no `story-to-slides.md`, so the prose names the skill and the agent instead.

**Wording improved over the issue's proposal.** The issue suggested telling the user to "confirm the document-skills plugin is installed". `document-skills` is not in this repo's marketplace and appears nowhere under `scripts/` — it ships with the Claude product surface — so that would not be a followable instruction from inside this repo. The entry is phrased against *session availability* instead.

## Untouched, deliberately

- `SKILL.md:50` Scope Boundary row `| Stale state from renames | Dependency tool versions (node, gh, etc.) |` — correct as written, and it routes node-version concerns to `workspace-status`. It survives the removal of the `node/npm` bullet because the two say different things.
- `SKILL.md:65-79` Diagnostic Flow label contract — it is the spec both rewrites conform to.
- `SKILL.md:155-159` Stale State Detection cross-references — they name entries 1 and 2 by heading; entry 5 is cross-referenced nowhere, so the heading rename owes no companion edit.
- No version bump. The patch bump is applied post-merge per plugin actually touched.

## Verification

Run on the committed branch tree.

| Check | Result |
|---|---|
| `grep -rniE 'pptxgenjs\|render-slides\|cogni-visual\|node/npm' cogni-workspace/skills/troubleshoot/` | nothing — case-**in**sensitive, so a re-spelled `PptxGenJS` could not slip through (base returned 4 lines) |
| `grep -rniE 'archiv\|removed' cogni-workspace/skills/troubleshoot/` | nothing, across **both** files — the single-vocabulary property does not regress |
| entry count / separators | `^## ` = 5, `^---$` = 5 |
| label shape | `^**Symptom**:` = 5, `^**Cause**:` = 5, `^**Fix**:` = 5 |
| EOF shape | single trailing newline, no trailing `---`, no fence |
| Common Misconfigurations bullets | still exactly 3 |
| `python3 scripts/run-plugin-tests.py --filter cogni-workspace` | 14/14 pass, `data.total` 14, `data.failed` 0 — matching the pre-change baseline |
| `check-breadcrumbs.py` / `check-external-dispatch.py` / `check-result-line-plainness.py` / `check-mcp-tool-grant.py` / `check-workflow-yaml.py` / `check-version-bump.py` | rc 0 each |
| `check-frontmatter.sh cogni-workspace` | clean, 52 files scanned |
| `measure-skill-length.sh` | body 6914 / cap 24000 chars, `over_cap` false |

`grep -nE '#1(467\|538)' cogni-workspace/skills/troubleshoot/references/known-issues.md` also returns nothing — worth checking explicitly because the breadcrumb guard's globs cover `SKILL.md` and `agents/*.md` but **not** `references/`, so provenance leaking into the catalogue would not be caught by CI.

No test is added: both surfaces are prose in a `SKILL.md` and a `references/*.md`, not executable code, so the achievable bar is the code-shape-anchored greps above plus the existing suite staying green.

## Observation, not filed as deferred work

No guard anywhere in this repo asserts that a troubleshoot catalogue entry names a live command or a non-retired plugin, so this defect class can recur silently. `check-external-dispatch.py` matches only the *colon-suffixed* retired-plugin dispatch form — which is exactly why the parenthesised `(cogni-visual)` at `SKILL.md:167` never tripped it — and its globs exclude `references/` by design. Building that guard is a separate deliverable with its own review surface and sits outside this issue's acceptance criteria, so it is recorded here rather than filed.

---

Plan record: https://github.com/cogni-work/insight-wave/issues/1538#issuecomment-5356000351