### PR TITLE
cogni-website: settle three website-plan internal contradictions

### DIFF
--- a/cogni-website/CLAUDE.md
+++ b/cogni-website/CLAUDE.md
@@ -45,7 +45,7 @@ The primary spine for every narrative page is the arc-structured markdown produc
 | `for/{market-slug}--{persona}.md` | `persona` (one per file) | `jtbd-portfolio` |
 | `approach.md` | `approach` | `engagement-model` |
 
-Any page entry in `website-plan.json` carrying an `arc_id` is rendered through the **Section Block Library** in `libraries/page-templates.md` — not the flat page-type template. `website-plan` step 6a walks the narrative and emits a structured `sections[]` array (hero, problem-statement, stat-row, feature-alternating, feature-grid, comparison, timeline, testimonial, text-block, cta). The ten existing block types cover all five arcs; no arc-specific renderers exist or are needed. The element → block mapping is authoritative in `cogni-workspace/libraries/arc-taxonomy.md`.
+Any page entry in `website-plan.json` carrying an `arc_id` is rendered through the **Section Block Library** in `libraries/page-templates.md` — not the flat page-type template. `website-plan` step 6a walks the narrative and emits a structured `sections[]` array (hero, problem-statement, stat-row, feature-alternating, feature-grid, comparison, timeline, testimonial, text-block, cta). The ten existing block types cover all four arcs; no arc-specific renderers exist or are needed. `cogni-workspace/libraries/arc-taxonomy.md` is authoritative for the arc **element names**; the element → block mapping is this plugin's own, in the Section Block Library in `libraries/page-templates.md`.
 
 **Deduplication discipline** (enforced upstream by the customer-narrative templates — do not break it in page planning):
 - Roadmap appears on `home` only.

--- a/cogni-website/libraries/page-templates.md
+++ b/cogni-website/libraries/page-templates.md
@@ -728,7 +728,7 @@ All page templates use a shared set of CSS classes defined in `css/style.css`:
 
 The page types above (`products`, `product-detail`, `blog-*`, `insights`, `resources`, `contact`, `legal-*`, …) use a **flat** section list — `sections: ["hero", "features", "cta"]`. Narrative pages — any page whose `page_spec` carries an `arc_id` field, which in the v2 `portfolio-communicate` customer-narrative layout means `home` (arc `jtbd-portfolio`, from `home.md`), `about` (arc `company-credo`, from `about.md`), `capability` (arc `corporate-visions`, one per `capabilities/*.md`), `persona` (arc `jtbd-portfolio`, one per `for/*.md`), and `approach` (arc `engagement-model`, from `approach.md`) — instead receive a **structured** section list from `website-plan` step 6a: an ordered array of block objects, each with `block_type`, `section_theme`, `headline`, and `source_anchor`.
 
-**Arc → block mapping (quick reference).** The ten block types below cover the element vocabulary of all five arcs used by customer-narrative v2. No new block types are required. Typical mappings:
+**Arc → block mapping (quick reference).** The ten block types below cover the element vocabulary of all four arcs used by customer-narrative v2. No new block types are required. Typical mappings:
 
 | Arc | Element | Typical block |
 |---|---|---|
@@ -745,7 +745,7 @@ The page types above (`products`, `product-detail`, `blog-*`, `insights`, `resou
 | `engagement-model` | Partnership | feature-alternating |
 | `engagement-model` | Outcomes | stat-row (or cta) |
 
-The authoritative element → visual-type mapping lives in `cogni-workspace/libraries/arc-taxonomy.md`. The table above is a rendering shortcut, not a replacement for the step 6a decision tree, which still chooses block types based on actual content shape (bullets, numeric density, parallel capabilities, sequential steps).
+`cogni-workspace/libraries/arc-taxonomy.md` is authoritative for the arc **element names** — the ordered elements of each arc and their German labels. The element → block mapping is this plugin's own, and the table above is a rendering shortcut rather than a replacement for the step 6a decision tree, which still chooses block types based on actual content shape (bullets, numeric density, parallel capabilities, sequential steps).
 
 The section-block taxonomy mirrors cogni-workspace's story-to-web skill so that narratives surface as scroll-driven reading experiences instead of entity-card dumps. The decomposition rules (decision tree, assertion-headline discipline, number plays, bullet scan-optimization) live in the story-to-web references and are **not** duplicated here:
 

--- a/cogni-website/skills/website-plan/SKILL.md
+++ b/cogni-website/skills/website-plan/SKILL.md
@@ -85,7 +85,7 @@ Based on discovered content, propose a page list. Apply these rules:
 | `capability` | Per `customer-narrative/capabilities/*.md` found | `customer-narrative/capabilities/{feature-slug}.md` | `corporate-visions` | One page per capability narrative. Replaces `product-detail` for features that have a v2 narrative. |
 | `persona` | Per `customer-narrative/for/*.md` found | `customer-narrative/for/{market}--{persona}.md` | `jtbd-portfolio` | One page per persona narrative. Renamed from v1 `audience`. |
 | `approach` | If `customer-narrative/approach.md` present | `customer-narrative/approach.md` | `engagement-model` | Conditional on v2 narrative. Single page (How We Work / Unser Ansatz). |
-| `products` | ≥2 products | `products/*.json` | — | Always (even with 1 product). Acts as an index for capability pages. |
+| `products` | Always | `products/*.json` | — | Always — proposed even when exactly one product exists; it is the index for the capability and product-detail pages. `references/page-type-registry.md` is authoritative for inclusion — `products` sits in its `Always include` row. |
 | `product-detail` | Per product without a capability narrative | `products/{slug}.json` + features + propositions | — | Flat fallback when no `capabilities/{slug}.md` exists |
 | `solutions` | ≥1 solution | `solutions/*.json` | — | Conditional |
 | `blog-index` | Marketing content exists AND `include_blog: true` | Marketing `content/` tree | — | Conditional |
@@ -148,19 +148,30 @@ Iterate until the user confirms.
 
 Auto-generate navigation from the confirmed page list:
 
-**Header navigation rules:**
-- Products gets a dropdown with all product-detail pages as children
-- Blog, Case Studies, About are top-level links
-- CTA button always links to Contact
-- Maximum 5-6 top-level items (combine if needed)
+**Header navigation rules**, applied in this precedence order:
+
+1. **Produkte / Products** — dropdown over the `product-detail` pages (rule 2 may add a lone capability page here).
+2. **Leistungen / Capabilities** — dropdown with all `capability` pages when at least two exist (step 3). With exactly one, emit no dropdown and attach that page as a child of the Produkte dropdown — the products page already indexes capability pages (step 3).
+3. **Für Sie / For You** — dropdown with all `persona` pages when at least two exist. With exactly one, emit no dropdown and link it from the footer only, so a single page never claims a top-level slot.
+4. **Unser Ansatz / Approach** — top-level link whenever an `approach` page exists.
+5. **Blog** and **Fallstudien / Case Studies** — top-level links when those pages exist.
+6. **Über uns / About** — top-level, last before the CTA.
+7. **Lösungen / Solutions**, **Insights**, **Resources** and any `custom` page — top-level links when they exist and the cap allows, otherwise a footer column under the same demotion rule below.
+8. **CTA button** always links to Kontakt / Contact.
+
+Cap the header at 6 top-level items, excluding the CTA; 5 reads better where the page set allows it. When the rules above produce more than 6, demote in this order until the header fits — Fallstudien first, then Blog, then Unser Ansatz — into a footer column. Never drop a page to satisfy the cap: Produkte, the two narrative dropdowns and Über uns are never demoted, and pages carrying `footer_only: true` (step 7, legal pages) never count toward it.
 
 **Footer columns:**
-- Column 1: Products (all product detail links)
-- Column 2: Company (About, Contact, Blog, Case Studies)
+- Column 1: Produkte — the products index plus all product-detail links
+- Column 2: Leistungen — all capability pages, when any exist
+- Column 3: Für Sie — all persona pages, when any exist
+- Column 4: Unternehmen — Über uns, Kontakt, Unser Ansatz, Blog, Fallstudien
+
+Every page demoted from the header must appear in one of these columns.
 
 Present navigation for approval:
 
-> "Navigation: **Produkte** (mit Dropdown) | **Lösungen** | **Blog** | **Über uns** — CTA: **Kontakt aufnehmen**"
+> "Navigation: **Produkte** (mit Dropdown) | **Leistungen** (mit Dropdown) | **Für Sie** (mit Dropdown) | **Unser Ansatz** | **Über uns** — CTA: **Kontakt aufnehmen**"
 
 ### 6. Map Content to Pages
 
@@ -174,9 +185,9 @@ Use the page type definitions from `${CLAUDE_PLUGIN_ROOT}/libraries/page-templat
 
 ### 6a. Decompose Narrative Pages into Section Blocks
 
-For every page whose spine is a `customer-narrative/*.md` file (`home`, `about`, `capability`, `persona`, `approach` — any page entry that carries an `arc_id`), do not emit a flat list of generic template section names. Instead, decompose the narrative into an ordered sequence of **section blocks** using the story-to-web pattern. This produces scroll-driven reading experiences instead of entity-card dumps. The existing block_type library (hero, problem-statement, stat-row, feature-alternating, feature-grid, comparison, timeline, testimonial, text-block, cta) covers all five arcs — no new block types are required for `company-credo` or `engagement-model`.
+For every page whose spine is a `customer-narrative/*.md` file (`home`, `about`, `capability`, `persona`, `approach` — any page entry that carries an `arc_id`), do not emit a flat list of generic template section names. Instead, decompose the narrative into an ordered sequence of **section blocks** using the story-to-web pattern. This produces scroll-driven reading experiences instead of entity-card dumps. The existing block_type library (hero, problem-statement, stat-row, feature-alternating, feature-grid, comparison, timeline, testimonial, text-block, cta) covers all four arcs — no new block types are required for `company-credo` or `engagement-model`.
 
-**Arc-to-block hints** (use as a starting point; the decision tree in step 6a step 2 below still governs final block selection based on content shape):
+**Arc-to-block hints** (a starting point — the decision tree below selects the final block):
 
 | Arc | Element | Typical block |
 |---|---|---|
@@ -185,7 +196,9 @@ For every page whose spine is a `customer-narrative/*.md` file (`home`, `about`,
 | `corporate-visions` | Why Change → Why Now → Why You → Why Pay | problem-statement → stat-row → feature-alternating → cta |
 | `engagement-model` | Principles → Process → Partnership → Outcomes | feature-grid → timeline → feature-alternating → stat-row / cta |
 
-The element → block mapping is authoritative in `$CLAUDE_PLUGIN_ROOT/../cogni-workspace/libraries/arc-taxonomy.md` (visual-type column). Read that file once per plan to confirm the mapping instead of duplicating it here.
+`$CLAUDE_PLUGIN_ROOT/../cogni-workspace/libraries/arc-taxonomy.md` is authoritative for the **arc element names** — the ordered elements of each arc and their German labels, under its `## Arc Element Names` section. Read that file once per plan to confirm the element sequence and its localized labels instead of duplicating them here. That file maps each `arc_id` to a *visual arc type* for the rendering skills; it carries no element → block mapping.
+
+The element → block choice is this plugin's own. The hint table above is the short form; the fuller quick reference is the Section Block Library appendix in `${CLAUDE_PLUGIN_ROOT}/libraries/page-templates.md`. Either way the step 2 decision tree below governs the final block, because it types each section on actual content shape.
 
 The decomposition rules are defined in cogni-workspace's story-to-web skill and referenced rather than duplicated here. Read once, apply per page:
 


### PR DESCRIPTION
Closes #1547.

## Summary

Three internal-accuracy defects in `cogni-website/skills/website-plan/SKILL.md`, each making a step tell the executing model something the tree does not support. All three reproduce on the base tree and were verified before any edit.

**1 — step 6a named a source that does not carry what it promised.** The sentence claimed the element → block mapping is authoritative in `cogni-workspace/libraries/arc-taxonomy.md` "(visual-type column)". That file has neither: `grep -cE 'stat-row|feature-alternating|problem-statement'` → `0`, `grep -c 'visual-type'` → `0`. Its two mapping sections are `## Arc ID to Visual Arc Type Mapping` (arc_id → visual arc type) and `## Arc Element Names`. The sentence now states what that file genuinely owns — the ordered arc element names and their German labels — keeps its runtime read instruction, says plainly that it carries no element → block mapping, and points at the real source: the hint table directly above plus the Section Block Library appendix in `libraries/page-templates.md`, with the step 2 decision tree still governing the final block.

**2 — step 5 dropped three page types step 3 had just planned.** Step 3 makes `capability`, `persona` and `approach` first-class and states their navigation behaviour; step 5's rules named only Products / Blog / Case Studies / About in the header and Products / Company in the footer, mentioning the three **zero** times. Executed literally it dropped all three. Step 5 is now a precedence order covering them on exactly step 3's terms (dropdowns at ≥2, approach top-level), and it settles two things step 3 left open: the exactly-one-page case for both narrative dropdowns, and how the pre-existing header cap resolves when the enlarged set overflows it (demote in a named order into a footer column, never drop).

**3 — the `products` row contradicted itself.** Include When said `≥2 products`; Always/Conditional on the same row said `Always (even with 1 product)`. The base tree decides this one rather than preference: `references/page-type-registry.md` lists `products` under `Always include`. The row now defers to that registry as the authority instead of asserting the two files agree — an agreement claim goes stale silently, which is the very failure mode this issue exists to fix.

## Beyond the issue's three — please read

Two additions the issue did not ask for. Both are disclosed rather than folded in silently.

- **The same false arc-taxonomy claim lived in `CLAUDE.md` and `libraries/page-templates.md`.** They are corrected to match. This is not tidiness: the corrected step 6a now *cites* `page-templates.md` as the fuller quick reference, so shipping without it would leave the plugin asserting both readings at once — a fresh contradiction of exactly the class being closed.
- **A pre-existing "all five arcs" miscount**, in all three files. There are **four** distinct arcs (`jtbd-portfolio`, `company-credo`, `corporate-visions`, `engagement-model`); five is the count of narrative *page types* — `jtbd-portfolio` serves both `home` and `persona`. Surfaced by the pre-commit skill-quality gate, two lines above the changed region, in a PR whose whole subject is internal accuracy. Corrected to four. **If you would rather this rode in its own issue, say so and I will split it out.**

## The constraint that shaped the diff

`tests/test-cross-plugin-path-hygiene.sh` floors repo-relative cross-plugin refs at **13** against a live **14** (margin 1) and sibling-form refs at **3** against a live **3** — *zero margin* — and all three sibling-form refs live in the edited SKILL.md.

So the most natural reading of criterion 1, deleting the false sentence, would drop the sibling count to 2 and **red the suite criterion 4 requires green** — and it would fail as a liveness floor, reading as unrelated to the change rather than caused by it. Every edit therefore rewrites the *claim* around each path and never the path itself. Both counts come out unchanged.

## Verification

All run on the head tree, executed rather than read:

| Check | Result |
|---|---|
| `bash cogni-website/tests/test-cross-plugin-path-hygiene.sh` | exit 0 — `all cases green` |
| ↳ repo-relative refs | `extracted 14` — identical to base, floor 13 |
| ↳ sibling-form refs | `found 3` — identical to base, floor 3 (zero margin held) |
| `python3 scripts/run-plugin-tests.py --filter cogni-website` | exit 0 |
| `python3 scripts/check-breadcrumbs.py` | exit 0 |
| `python3 scripts/check-version-bump.py` | exit 0 — 0 touched, 0 violations |
| `check-frontmatter.sh cogni-website` | exit 0 — `clean: true`, 9 files |
| `grep -c 'visual-type'` across all three files | `0`, `0`, `0` |
| `grep -rl 'five arcs' cogni-website/` | 0 files |
| Step headings `### 5.` / `### 6a.` | byte-identical (sibling files cite them by number) |
| German labels | real umlauts — `Für Sie`, `Über uns`, `Lösungen`; no ASCII substitutes |
| Skill length | `chars_body` 17489 → 19783 against a 28500 cap (69%), `over_cap: false` |
| Version manifests | untouched — the post-merge workflow owns the bump |

## Deliberately unchanged

- **`cogni-workspace/libraries/arc-taxonomy.md`** — the upstream file is correct as written; the defect was the downstream claim *about* it. Nothing outside `cogni-website/` is touched.
- **`references/page-type-registry.md`** — its `Always include` row is already the consistent reading, so resolving defect 3 to `Always` needs no amendment there.
- **`libraries/EXAMPLE_WEBSITE_PLAN.md`** — its navigation block omits the same three page types. Left alone as out of scope; flag it if you want it in.

## Review notes

One structural observation from the skill-quality gate, tagged `introduced_by_change: false` and **not** fully resolved here. Step 3 also proposes `solutions`, `insights`, `resources` and `custom` pages. The base step 5 was an obviously partial four-bullet sketch, so its silence on them read as an unfinished list; the rewrite makes step 5 look exhaustive and adds a closure promise ("never drop a page", "every demoted page must appear in a column"), which would make that same silence read as a deliberate "these get no navigation".

Rather than leave the promise false, rule 7 gives those four page types a routing rule under the same cap-and-demote logic. That keeps the closure honest **without** making a design decision about where each belongs — which is a call for a human, not this PR.

<!-- cogni-service: comment v1 -->