### PR TITLE
cogni-workspace: prune retired-plugin env keys on workspace update

### DIFF
--- a/cogni-workspace/scripts/generate-settings.sh
+++ b/cogni-workspace/scripts/generate-settings.sh
@@ -4,7 +4,8 @@
 # --language takes an ISO 639-1 code. Codes with a natural-language name in
 # LANGUAGE_NAMES below also get the Claude Code "language" settings key; anything
 # else is reported as data.language_key_skipped and gets no key.
-# Optional: --update (preserve custom env vars)
+# Optional: --update (preserve custom env vars; drop generated ones for
+# plugins no longer in the list)
 
 set -euo pipefail
 
@@ -49,7 +50,7 @@ TARGET_ABS=$(cd "$TARGET_DIR" && pwd)
 
 # Generate all config files via single Python call
 python3 << PYEOF
-import json, os, sys
+import json, os, re, sys
 from datetime import datetime, timezone
 
 target = "$TARGET_ABS"
@@ -59,6 +60,16 @@ update_mode = $( [ "$UPDATE_MODE" = true ] && echo "True" || echo "False" )
 with open("$PLUGINS_TMPFILE") as f:
     plugins = json.load(f)
 
+# The generated namespace: every env key this script writes for a plugin has one
+# of these two shapes. The prune below keys on that derived namespace rather than
+# on a list of retired plugin names, because a name list encodes one historical
+# event, needs hand-maintaining, and says nothing about the next plugin removed.
+#
+# No ^/$ anchors: this Python body sits in an unquoted heredoc, where $ and
+# backticks are live. fullmatch() supplies the anchoring, so the pattern carries
+# no shell-live metacharacter at all.
+GENERATED_KEY = re.compile(r"((?:COGNI|PLUGIN)_.+)_(?:ROOT|PLUGIN)")
+
 # Build env vars
 env = {}
 env["PROJECT_AGENTS_OPS_ROOT"] = target
@@ -67,6 +78,13 @@ env["COGNI_WORKSPACE_ROOT"] = os.path.join(target, "cogni-workspace")
 # across all workspaces on this host, mirroring ~/.claude/mcp-servers/. This is
 # the exact path consumers re-exec under (e.g. cogni-knowledge pdf-extract.py).
 env["COGNI_WORKSPACE_PYTHON_VENV"] = os.path.expanduser(os.path.join("~", ".claude", "workspace-python-venv"))
+
+# Keyspace stems of the plugins in THIS run's set, accumulated from the same
+# root_var the loop already builds so there is no second name source to drift.
+# A stem is recorded per plugin, not per key written: a plugin supplied without
+# a path writes no _PLUGIN key this run, and its existing one must still count
+# as owned rather than read as stale.
+current_keyspaces = set()
 
 for p in plugins:
     name = p.get("name", "") if isinstance(p, dict) else p
@@ -82,20 +100,45 @@ for p in plugins:
         plugin_var = f"PLUGIN_{suffix}_PLUGIN"
 
     env[root_var] = os.path.join(target, name)
+    current_keyspaces.add(root_var[: -len("_ROOT")])
     if path:
         env[plugin_var] = path
 
 # Merge with existing settings if update mode. Read-modify-write the whole
 # document, not just "env": the file is the user's too (permissions, hooks,
 # outputStyle), and replacing it wholesale destroys anything we don't generate.
+#
+# Carrying every prior key over unconditionally is what kept a retired plugin's
+# vars alive forever, pointing at directories that no longer exist. Each prior
+# key now takes one of three arms:
+#
+#   1. regenerated this run  -> keep what this run computed
+#   2. ours, plugin now gone -> prune
+#   3. anything else         -> preserve untouched, value included
+#
+# Arm 1 is also what spares PROJECT_AGENTS_OPS_ROOT, COGNI_WORKSPACE_ROOT and
+# COGNI_WORKSPACE_PYTHON_VENV: they are assigned unconditionally above, so they
+# are already in env before any shape test runs. That identity check is required
+# rather than merely convenient - cogni-workspace reaches the loop as an ordinary
+# plugin, so COGNI_WORKSPACE_ROOT is a shape a real plugin genuinely produces, and
+# a shape-only rule would delete the workspace's own root pointer for anyone who
+# deselects cogni-workspace at the confirm step.
+#
+# Accepted residual: a hand-added key wearing the generated shape for an absent
+# plugin is pruned. That is the intent of keying on the namespace - it names
+# wiring this workspace no longer maintains.
 settings_path = os.path.join(target, ".claude", "settings.local.json")
 settings = {}
 if update_mode and os.path.isfile(settings_path):
     with open(settings_path) as f:
         settings = json.load(f)
     for k, v in settings.get("env", {}).items():
-        if k not in env:
-            env[k] = v
+        if k in env:
+            continue
+        m = GENERATED_KEY.fullmatch(k)
+        if m and m.group(1) not in current_keyspaces:
+            continue
+        env[k] = v
 
 settings["env"] = env
 

--- a/cogni-workspace/skills/manage-workspace/SKILL.md
+++ b/cogni-workspace/skills/manage-workspace/SKILL.md
@@ -253,7 +253,16 @@ bash ${CLAUDE_PLUGIN_ROOT}/scripts/generate-settings.sh \
   --update
 ```
 
-The `--update` flag preserves any custom env vars the user added manually.
+The `--update` flag preserves any custom env vars the user added manually. It
+also removes the per-plugin vars it generated for plugins that are no longer in
+the confirmed list: `COGNI_<NAME>_ROOT` and `COGNI_<NAME>_PLUGIN`, or
+`PLUGIN_<NAME>_ROOT` and `PLUGIN_<NAME>_PLUGIN` for a plugin outside the
+`cogni-` namespace. So deselecting a plugin at step 2 retires its wiring instead
+of leaving a var pointing at a directory that no longer exists.
+
+`PROJECT_AGENTS_OPS_ROOT`, `COGNI_WORKSPACE_ROOT` and
+`COGNI_WORKSPACE_PYTHON_VENV` are kept regardless of that list, since the
+workspace needs its own pointers even when `cogni-workspace` is deselected.
 
 ### 3.5. Refresh Optional Python Dependencies
 

--- a/cogni-workspace/skills/workspace-status/SKILL.md
+++ b/cogni-workspace/skills/workspace-status/SKILL.md
@@ -254,7 +254,8 @@ Plugins:      WARNING  | 5 registered, 6 installed
 Environment:  WARNING  | 12 vars set, 2 broken
   Broken: COGNI_NARRATIVE_ROOT -> /path/does/not/exist
   Broken: COGNI_NARRATIVE_PLUGIN -> /path/does/not/exist
-  -> Run manage-workspace to refresh environment variables
+  -> Run manage-workspace to refresh environment variables (an update also
+     removes generated vars for plugins no longer installed)
 
 Themes:       WARNING  | 2 themes available, 1 tiered, 1 drift advisory
   cogni-work   workspace  tiered (1.0) | tokens, assets, components.web, components.deck

--- a/cogni-workspace/tests/test-generate-settings-prune.sh
+++ b/cogni-workspace/tests/test-generate-settings-prune.sh
@@ -50,6 +50,7 @@ seed_ws() {
     "COGNI_VISUAL_ROOT": "/gone/cogni-visual",
     "COGNI_VISUAL_PLUGIN": "/gone/cogni-visual/plugin",
     "PLUGIN_LEGACY_ROOT": "/gone/legacy",
+    "PLUGIN_LEGACY_PLUGIN": "/gone/legacy/plugin",
     "COGNI_TRENDS_ROOT": "/stale/cogni-trends",
     "COGNI_KNOWLEDGE_PLUGIN": "/kept/knowledge/plugin",
     "MY_OWN_VAR": "keep-me-exactly"
@@ -90,8 +91,8 @@ assert_py "P1 retired plugin ROOT key pruned" "$WS" \
   '"COGNI_VISUAL_ROOT" not in env'
 assert_py "P2 retired plugin PLUGIN twin pruned" "$WS" \
   '"COGNI_VISUAL_PLUGIN" not in env'
-assert_py "P3 non-cogni PLUGIN_ namespace key pruned" "$WS" \
-  '"PLUGIN_LEGACY_ROOT" not in env'
+assert_py "P3 non-cogni PLUGIN_ namespace pair pruned" "$WS" \
+  '"PLUGIN_LEGACY_ROOT" not in env and "PLUGIN_LEGACY_PLUGIN" not in env'
 assert_py "P4 user key outside the namespace preserved with its value" "$WS" \
   'env.get("MY_OWN_VAR") == "keep-me-exactly"'
 assert_py "P5 live plugin ROOT key refreshed to the computed path" "$WS" \

--- a/cogni-workspace/tests/test-generate-settings-prune.sh
+++ b/cogni-workspace/tests/test-generate-settings-prune.sh
@@ -1,0 +1,202 @@
+#!/usr/bin/env bash
+# Regression test for the update-mode env-key prune in
+# scripts/generate-settings.sh.
+#
+# Contract under test: an --update run removes the env keys the script itself
+# generated for plugins absent from the current plugin set, and removes nothing
+# else. A key outside that generated namespace survives with its value
+# byte-identical, the three unconditional workspace keys survive regardless of
+# the plugin list, and the non-"env" top-level keys of settings.local.json are
+# untouched.
+#
+# The discriminator is the derived generated namespace, never a list of retired
+# plugin names, so these cases stay meaningful for the next plugin removed.
+#
+# Case labels use a letter-prefixed two-character id with no colon after the id,
+# matching the convention test-mcp-declaration-hygiene.sh documents: the
+# mutation harness matches --case as a whole token, so no id may be a prefix of
+# another.
+#
+# stdlib-only: bash + python3, no pip deps, no network, per the repo-wide script
+# convention.
+
+set -u
+HERE="$(cd "$(dirname "$0")" && pwd)"
+WS_ROOT="$(cd "$HERE/.." && pwd)"
+GEN="$WS_ROOT/scripts/generate-settings.sh"
+TMPROOT="$(mktemp -d)"
+trap 'rm -rf "$TMPROOT"' EXIT
+
+failures=0
+pass() { printf 'PASS: %s\n' "$1"; }
+fail() { printf 'FAIL: %s\n' "$1"; failures=$((failures + 1)); }
+
+# A missing script is a broken suite, never a clean one: without this floor
+# every later assertion would pass vacuously against a file that never ran.
+if [ ! -f "$GEN" ]; then
+  fail "L1 generate-settings.sh located at $GEN"
+  echo
+  echo "1 test(s) failed."
+  exit 1
+fi
+
+# seed_ws <dir> — a workspace carrying stale generated keys, a live-plugin key,
+# a pathless-plugin key, a user key, and non-env top-level keys.
+seed_ws() {
+  mkdir -p "$1/.claude"
+  cat > "$1/.claude/settings.local.json" <<'JSON'
+{
+  "env": {
+    "COGNI_VISUAL_ROOT": "/gone/cogni-visual",
+    "COGNI_VISUAL_PLUGIN": "/gone/cogni-visual/plugin",
+    "PLUGIN_LEGACY_ROOT": "/gone/legacy",
+    "COGNI_TRENDS_ROOT": "/stale/cogni-trends",
+    "COGNI_KNOWLEDGE_PLUGIN": "/kept/knowledge/plugin",
+    "MY_OWN_VAR": "keep-me-exactly"
+  },
+  "permissions": { "allow": ["Bash"] },
+  "hooks": { "marker": 1 },
+  "outputStyle": "custom"
+}
+JSON
+}
+
+PLUGINS='[{"name":"cogni-trends","path":"/p/cogni-trends"},{"name":"cogni-knowledge"}]'
+
+# assert_py <label> <workspace-dir> <python expr over `env`, `doc`, True to pass>
+assert_py() {
+  local label="$1" ws="$2" expr="$3" out
+  out=$(WS="$ws" EXPR="$expr" python3 - <<'PY' 2>/dev/null
+import json, os, sys
+doc = json.load(open(os.path.join(os.environ["WS"], ".claude", "settings.local.json")))
+env = doc.get("env", {})
+sys.stdout.write("1" if eval(os.environ["EXPR"]) else "0")
+PY
+) || out=""
+  if [ "$out" = "1" ]; then pass "$label"; else fail "$label"; fi
+}
+
+# ---------------------------------------------------------------- main run
+WS="$TMPROOT/main"
+seed_ws "$WS"
+STDOUT_MAIN="$TMPROOT/main.out"
+if bash "$GEN" --target "$WS" --plugins "$PLUGINS" --update > "$STDOUT_MAIN" 2>/dev/null; then
+  pass "L1 baseline update run succeeded"
+else
+  fail "L1 baseline update run succeeded"
+fi
+
+assert_py "P1 retired plugin ROOT key pruned" "$WS" \
+  '"COGNI_VISUAL_ROOT" not in env'
+assert_py "P2 retired plugin PLUGIN twin pruned" "$WS" \
+  '"COGNI_VISUAL_PLUGIN" not in env'
+assert_py "P3 non-cogni PLUGIN_ namespace key pruned" "$WS" \
+  '"PLUGIN_LEGACY_ROOT" not in env'
+assert_py "P4 user key outside the namespace preserved with its value" "$WS" \
+  'env.get("MY_OWN_VAR") == "keep-me-exactly"'
+assert_py "P5 live plugin ROOT key refreshed to the computed path" "$WS" \
+  'env.get("COGNI_TRENDS_ROOT", "").endswith("/cogni-trends") and not env.get("COGNI_TRENDS_ROOT", "").startswith("/stale")'
+assert_py "P7 non-env top-level keys survive unchanged" "$WS" \
+  'doc.get("permissions") == {"allow": ["Bash"]} and doc.get("hooks") == {"marker": 1} and doc.get("outputStyle") == "custom"'
+assert_py "Q4 installed-but-pathless plugin keeps its PLUGIN key" "$WS" \
+  'env.get("COGNI_KNOWLEDGE_PLUGIN") == "/kept/knowledge/plugin"'
+
+# P8 — .workspace-env.sh is regenerated from env, so it inherits the prune.
+if [ -f "$WS/.workspace-env.sh" ] \
+   && ! grep -q 'COGNI_VISUAL_ROOT' "$WS/.workspace-env.sh" \
+   && grep -q 'MY_OWN_VAR' "$WS/.workspace-env.sh"; then
+  pass "P8 regenerated shell exports drop the pruned key and keep the user key"
+else
+  fail "P8 regenerated shell exports drop the pruned key and keep the user key"
+fi
+
+# P9 — the reported count must equal what was actually written.
+if COUNT_OUT="$STDOUT_MAIN" WSDIR="$WS" python3 - <<'PY' >/dev/null 2>&1
+import json, os, sys
+reported = json.load(open(os.environ["COUNT_OUT"]))["data"]["env_vars_count"]
+actual = len(json.load(open(os.path.join(os.environ["WSDIR"], ".claude", "settings.local.json")))["env"])
+sys.exit(0 if reported == actual else 1)
+PY
+then pass "P9 reported env_vars_count equals the written env size"
+else fail "P9 reported env_vars_count equals the written env size"
+fi
+
+# ------------------------------------------------- P6 self-collision case
+# An update run whose plugin list omits cogni-workspace must still keep the
+# three keys the script sets unconditionally. COGNI_WORKSPACE_ROOT wears the
+# generated shape, so a shape-only rule would delete the workspace's own root
+# pointer here.
+WS6="$TMPROOT/collide"
+seed_ws "$WS6"
+bash "$GEN" --target "$WS6" --plugins '[{"name":"cogni-trends","path":"/p/cogni-trends"}]' --update >/dev/null 2>&1
+assert_py "P6 unconditional workspace keys survive a run omitting cogni-workspace" "$WS6" \
+  'all(k in env for k in ("PROJECT_AGENTS_OPS_ROOT", "COGNI_WORKSPACE_ROOT", "COGNI_WORKSPACE_PYTHON_VENV"))'
+
+# ------------------------------------------------------------ Q1 init mode
+# Without --update the prune must be unreachable: the document is replaced, so
+# no prior key survives at all.
+WS1="$TMPROOT/init"
+seed_ws "$WS1"
+bash "$GEN" --target "$WS1" --plugins "$PLUGINS" >/dev/null 2>&1
+assert_py "Q1 init mode replaces the document, so no prior key survives" "$WS1" \
+  '"MY_OWN_VAR" not in env and "COGNI_VISUAL_ROOT" not in env'
+
+# ------------------------------------------------- Q2 malformed prior file
+# Assert BY SHAPE only — exit status and stream emptiness. The diagnostic comes
+# from python3, whose wording is localized, so grepping it would pass vacuously
+# on a non-English host.
+WS2="$TMPROOT/malformed"
+mkdir -p "$WS2/.claude"
+printf '%s' '{ this is not json' > "$WS2/.claude/settings.local.json"
+Q2_OUT="$TMPROOT/q2.out"; Q2_ERR="$TMPROOT/q2.err"
+if bash "$GEN" --target "$WS2" --plugins "$PLUGINS" --update > "$Q2_OUT" 2> "$Q2_ERR"; then
+  q2_rc=0
+else
+  q2_rc=1
+fi
+if [ "$q2_rc" -ne 0 ] && [ -s "$Q2_ERR" ] && ! grep -q 'success' "$Q2_OUT"; then
+  pass "Q2 malformed prior settings aborts non-zero with no success envelope"
+else
+  fail "Q2 malformed prior settings aborts non-zero with no success envelope"
+fi
+
+# ------------------------------------------- Q3 installed_plugins overwrite
+# Already correct on the base tree — locked here against regression.
+if WSDIR="$WS" python3 - <<'PY' >/dev/null 2>&1
+import json, os, sys
+cfg = json.load(open(os.path.join(os.environ["WSDIR"], ".workspace-config.json")))
+sys.exit(0 if sorted(cfg["installed_plugins"]) == ["cogni-knowledge", "cogni-trends"] else 1)
+PY
+then pass "Q3 installed_plugins equals the current plugin set exactly"
+else fail "Q3 installed_plugins equals the current plugin set exactly"
+fi
+
+# ----------------------------------------------------------- Q5 idempotency
+# A second consecutive --update must leave the env object identical. Only env
+# is compared: .workspace-config.json's updated_at legitimately changes.
+ENV_BEFORE="$TMPROOT/env-before.json"; ENV_AFTER="$TMPROOT/env-after.json"
+WSDIR="$WS" OUT="$ENV_BEFORE" python3 - <<'PY' 2>/dev/null
+import json, os
+env = json.load(open(os.path.join(os.environ["WSDIR"], ".claude", "settings.local.json")))["env"]
+json.dump(env, open(os.environ["OUT"], "w"), sort_keys=True)
+PY
+bash "$GEN" --target "$WS" --plugins "$PLUGINS" --update >/dev/null 2>&1
+WSDIR="$WS" OUT="$ENV_AFTER" python3 - <<'PY' 2>/dev/null
+import json, os
+env = json.load(open(os.path.join(os.environ["WSDIR"], ".claude", "settings.local.json")))["env"]
+json.dump(env, open(os.environ["OUT"], "w"), sort_keys=True)
+PY
+if cmp -s "$ENV_BEFORE" "$ENV_AFTER"; then
+  pass "Q5 a second consecutive update leaves the env object identical"
+else
+  fail "Q5 a second consecutive update leaves the env object identical"
+fi
+
+echo
+if [ "$failures" -eq 0 ]; then
+  echo "All generate-settings prune tests passed."
+  exit 0
+else
+  echo "$failures test(s) failed."
+  exit 1
+fi


### PR DESCRIPTION
Closes #1555.

## Summary

`generate-settings.sh --update` read-modify-wrote `settings.local.json` and carried over every pre-existing `env` key it had not regenerated. That carry-over is load-bearing for user keys — the file is the user's too — but it drew no line between a user key and one this same script had written for a plugin since retired. So `COGNI_VISUAL_ROOT`, `COGNI_NARRATIVE_ROOT` and their `_PLUGIN` twins survived every subsequent run, pointing at directories that no longer exist.

The carry-over now takes one of three arms:

```python
for k, v in settings.get("env", {}).items():
    if k in env:
        continue                     # regenerated this run — the fresh value wins
    m = GENERATED_KEY.fullmatch(k)
    if m and m.group(1) not in current_keyspaces:
        continue                     # ours, plugin has left the set — prune
    env[k] = v                       # not ours — preserve untouched, value included
```

The keep-set is **derived, not listed**. `current_keyspaces` accumulates the stem of the same `root_var` the per-plugin loop already builds, so there is no roster of retired names to hand-maintain and the next plugin removed needs no edit here.

## Two design points worth a reviewer's attention

**The three unconditional keys are spared by exact key identity, not by shape.** `PROJECT_AGENTS_OPS_ROOT`, `COGNI_WORKSPACE_ROOT` and `COGNI_WORKSPACE_PYTHON_VENV` are assigned before the update gate on every run, so arm 1 returns them before any shape test. Identity is *required* here, not merely convenient: `discover-plugins.sh` has no self-exclusion, so `cogni-workspace` reaches the per-plugin loop as an ordinary plugin and `COGNI_WORKSPACE_ROOT` is a shape a real plugin genuinely produces. A shape-only rule would delete the workspace's own root pointer for anyone who deselects `cogni-workspace` at the confirm step. Case `P6` pins exactly that run.

**The regex carries no `^`/`$` anchors.** The Python body sits in an *unquoted* `python3 << PYEOF` heredoc, where `$`, backticks and backslashes are live. `.fullmatch()` supplies the anchoring instead, leaving a pattern with no shell-live metacharacter at all.

## Deliberately not changed — each gets a regression-locking case instead

| Surface | Why no code change | Case |
|---|---|---|
| `.workspace-env.sh` | Regenerated wholesale from `env`, so pruning `env` clears the stale exports for free | `P8` |
| `env_vars_count` | Computed after the merge, so it already reports the post-prune count | `P9` |
| `.workspace-config.json` `installed_plugins[]` | Already a full overwrite from the current set, with no carry-over loop | `Q3` |
| Malformed prior JSON | The uncaught `json.load` still aborts non-zero under `set -euo pipefail`; kept fail-loud | `Q2` |
| Init mode | The prune sits inside the existing `update_mode and os.path.isfile(...)` gate, so it is unreachable without `--update` | `Q1` |

**On the issue's `installed_plugins[]` premise.** The issue reports that "the same residue exists in `.workspace-config.json` `installed_plugins[]`". It does not, as far as this script is concerned — the update branch does `config["installed_plugins"] = plugin_names`, a full overwrite with no carry-over loop, so it cannot strand an entry. Acceptance criterion 5 is therefore **already satisfied on `main`**; it is graded here by the presence of case `Q3`, not by a change to the config write.

## A judgement call

A plugin that is installed but supplied *without* a `path` writes no `_PLUGIN` key this run. Its previously-generated `_PLUGIN` key is **preserved**, not pruned, because its stem is still in the current set. This follows the issue's literal rule ("a key whose suffix maps to a plugin not in the current plugin set is removed") and errs toward preservation in a destructive operation. Case `Q4` pins it.

The corollary, stated plainly in the script comment so it is discoverable rather than surprising: a hand-added key that happens to wear the generated shape for an absent plugin *is* pruned. That is the intended cost of keying on the namespace, which the issue mandates explicitly over a name list.

## Test plan

New suite `cogni-workspace/tests/test-generate-settings-prune.sh` — 15 cases, hermetic (`mktemp -d` + `trap ... EXIT`), no network, argument-free. It drives the real script rather than re-implementing the predicate. Case `L1` is a liveness floor: a missing script fails the suite rather than letting every later assertion pass vacuously.

Verified on this branch:

- `bash cogni-workspace/tests/test-generate-settings-prune.sh` — 15/15 `PASS:`, exit 0
- `python3 scripts/run-plugin-tests.py` — full sweep, **127/127 passed, 0 failed**, new suite discovered and green
- `python3 scripts/check-result-line-plainness.py` — clean
- `python3 scripts/check-breadcrumbs.py` — clean, 0 findings
- `python3 scripts/check-version-bump.py` — `8 plugin(s) scanned, 0 touched, 0 violation(s)`
- `python3 scripts/check-mcp-tool-grant.py`, `python3 scripts/check-workflow-yaml.py` — both exit 0

Case `Q2` asserts the malformed-JSON abort **by shape only** — non-zero exit plus `[ -s "$err" ]` — never by grepping the Python traceback, which is localized and would pass vacuously on a non-English host. (Worth noting the local `grep` here is `ugrep 7.5.0`, which is precisely the class of foreign-tool variation that rule exists for.)

## Mutation recipe

Both recipes were **run on this branch and returned `guard_verified`**. Note the harness ships inside the cogni-service plugin — there is no `scripts/mutation-check.sh` at this repo root.

**Pruning half** — disable the prune; case `P1` must go red:

```bash
bash "$HOME/.claude/plugins/marketplaces/managed-service/cogni-service/scripts/mutation-check.sh" \
  --root . \
  --file cogni-workspace/scripts/generate-settings.sh \
  --expr 's/if m and m\.group\(1\) not in current_keyspaces:/if False and m.group(1) not in current_keyspaces:/' \
  --test 'bash cogni-workspace/tests/test-generate-settings-prune.sh' \
  --case P1
```

**Preservation half** — widen the prune to every carried-over key, destroying user settings; case `P4` must go red:

```bash
bash "$HOME/.claude/plugins/marketplaces/managed-service/cogni-service/scripts/mutation-check.sh" \
  --root . \
  --file cogni-workspace/scripts/generate-settings.sh \
  --expr 's/if m and m\.group\(1\) not in current_keyspaces:/if True:/' \
  --test 'bash cogni-workspace/tests/test-generate-settings-prune.sh' \
  --case P4
```

Both are plain literal substitutions with no `^`/`$` anchor, so no `/m` modifier is needed under the harness's `perl -0pi -e`. The substitution target stands alone on its own line and appears verbatim exactly once. Case ids are letter-prefixed and two characters, so none is a prefix of another under the harness's whole-token match. The second recipe also reds `Q4` if you want a third data point.

## Scope

The diff touches four paths, all inside the boundary the issue's last acceptance criterion draws: `cogni-workspace/scripts/generate-settings.sh`, the new suite, and the `manage-workspace` / `workspace-status` SKILL.md sentences the behaviour change makes inaccurate. No version field is touched — the post-merge workflow owns the bump.

## Follow-up issues

- #1559 — `cogni-workspace/README.md` line 178's Components-table row repeats the same incomplete `--update` description.

Filed rather than fixed here: `README.md` is not among the four paths the issue's scope criterion admits, so including it would put a path outside that predicate in the changed-file list.

**On `Closes` versus `Refs`.** `deferred[]` is non-empty, which mechanically implies a partial link. It is used as a full link deliberately: #1559 is an adjacent surface the issue's criteria explicitly exclude, and no acceptance criterion of #1555 is left undone by this PR. A partial link would strand a fully-satisfied issue open. Flagging the deviation rather than making it silently.

## Review notes

The pre-commit skill-quality gate returned `needs_revision` on both touched SKILL.md files. One finding was inside this diff and is fixed: the pruned-key notation in `manage-workspace` was ambiguous about whether `COGNI_*` and `_ROOT` formed one pattern or two families, and now spells the shapes out. The remainder are tagged `introduced_by_change: false` — pre-existing authoring observations this diff neither caused nor touched, recorded here rather than fixed:

- `manage-workspace` — the `desktop_config_key` labelling rule is stated at near-full length in both Init Mode step 5 and Update Mode step 5; the "never overwrite the workspace-root CLAUDE.md" caveat appears twice; the 44-line Init Mode step 5 MCP block is a relocate-to-`references/` candidate. Body is at 38.5% of cap.
- `workspace-status` — the MCP Servers check carries roughly a quarter of the body including a four-row state table, and the Theme drift subsection inlines a five-row table; both have existing `references/` files that would be natural homes. The check sequence is also numbered 1–5, 5.5, 6, where the fractional section encodes insertion history. Body is at 73.3% of cap.

Neither reviewer proposed a change to the three `workspace-status` status categories or the `Broken:` worked example, and both were left as-is by design: that skill reads *current* state, and a moved directory belonging to a still-installed plugin produces a broken var that pruning neither does nor should clear.