### PR TITLE
cogni-knowledge: state the real 3-argument assert_grep form in tests/README.md

### DIFF
--- a/cogni-knowledge/tests/README.md
+++ b/cogni-knowledge/tests/README.md
@@ -43,7 +43,10 @@ via `trap rm -rf "$WORK" EXIT`.
   them, so a `PASS:`/`FAIL:` label stays machine-parsable — plain, never
   wrapped in an escape sequence and never chosen by an environment probe.
   `test_plain_result_emitters.sh` holds this shape.
-- `assert_grep <pattern> <description>` for contract-level SKILL.md checks.
+- `assert_grep <pattern> <file> <description>` for contract-level SKILL.md
+  checks. `assert_not_grep <pattern> <file> <description>` is its inverted
+  counterpart — same three arguments, but it fails when the pattern IS
+  present.
 - `assert_grep_f` / `assert_not_grep_f` are the fixed-string (`grep -qF`)
   counterparts. Reach for them whenever the pattern is a literal carrying
   `[`, `]`, `.` or `*` — a wikilink, a glob, a path. `assert_grep` reads such


### PR DESCRIPTION
## Summary

`cogni-knowledge/tests/README.md`'s `## Convention` bullet documented
`assert_grep <pattern> <description>` — a two-argument signature the shared fixture has never had.
`cogni-knowledge/tests/fixtures/test_helpers.sh` binds three positionals
(`local pattern="$1" file="$2" description="$3"`, at :34, :48, :76 and :90).

An author following the README lands on a call that binds the description into `$2` and leaves `$3`
unset — under `set -u` that aborts the suite, and without it the assertion reads the wrong file.

This states the actual three-argument form and names the symmetric sibling `assert_not_grep`, which
the bullet list omitted entirely, by its failure condition rather than the weaker
"asserts the pattern is absent".

Documentation only. One file, 4 insertions, 1 deletion.

## What did not move, deliberately

- **`fixtures/test_helpers.sh` is untouched.** Its header lines 3-8 narrate the *historical*
  cogni-wiki `(pattern, description)` form and immediately supersede it. That is provenance prose
  about another plugin's retired helper, not a live signature claim — and all four of its own header
  comments already read `PATTERN FILE DESCRIPTION`.
- **The adjacent `assert_grep_f` / `assert_not_grep_f` bullet is verbatim.** It deliberately carries
  no arity claim, so the list stays internally consistent without touching it.
- **No version value moves.** The post-merge workflow owns the bump.

## Evidence

| Acceptance criterion | Evidence |
|---|---|
| `## Convention` bullet states the 3-arg form `assert_grep <pattern> <file> <description>` | Bullet text, whole on one line |
| `assert_not_grep` named in the same bullet list with its own 3-arg form | Bullet text, whole on one line |
| No behaviour change to `fixtures/test_helpers.sh` | That file's diff is empty — the diff touches one file |
| Full cogni-knowledge suite stays green | `python3 scripts/run-plugin-tests.py --filter knowledge` → **78/78 passed, rc=0** |

Repo-wide residue for the two-argument signature notation went **1 → 0**: the base
(`6623f429`) returned exactly one hit, `cogni-knowledge/tests/README.md:46`.

The four invariants the committed contract grades directly all hold: neither signature is split by
the line wrap, the `## Convention` list keeps exactly 7 top-level bullets (heading at :38,
`## Case ids on result lines` now at :59), no bracketed-optional or defaulted-argument notation, and
absence semantics are phrased as the failure condition.

## Provenance — resumed strand

A prior drain claimed #1535 at 2026-08-20T20:08:37Z and died before committing: no commit, no pushed
branch, no PR, only an uncommitted edit in a local worktree. This run resumed it after a liveness
check (claim age 605 min against a 90-minute TTL, `claim-status` verdict `stale`, newest dirty-file
mtime 556 min old, and no process holding the worktree).

`origin/main` had advanced from `bf46b4d4` to `6623f429` in the meantime, so the recorded plan's six
pre-flight checks were **re-run against the current base** rather than trusted, and the branch was
fast-forwarded to it before committing. All six pass; the plan itself is unchanged. Re-validation
record: https://github.com/cogni-work/insight-wave/issues/1535#issuecomment-5365930094

## Operational disclosure

`check-token-scope.sh --strict` reports `over_scoped` on this runner: the token carries
`gist`, `read:org` and `workflow` beyond the documented minimal posture. This is the fixed scope set
of the GitHub CLI OAuth app's `gho_` token, which cannot be narrowed in place. The run proceeded
under the **`--allow-overscoped` flag** (not the environment variable), per the standing operator
ruling, and discloses it here rather than blocking the handoff.

Closes #1535