### PR TITLE
cogni-knowledge: retire the CLAUDE.md forward-looking rollout clause

### DIFF
--- a/cogni-knowledge/CLAUDE.md
+++ b/cogni-knowledge/CLAUDE.md
@@ -241,7 +241,7 @@ Every result line a suite emits is addressed by its **first token**, so that tok
 - **Per line, not per case.** Uniqueness is a property of each **emitted result line**, not of the conceptual case. A block that can emit two failing lines needs two ids, even when its narrative calls them one case.
 - **Verification.** Check uniqueness by **running** the suite and grouping the emitted first tokens — never by grepping call sites. A grep cannot see a label interpolated at runtime, a line emitted from Python inside a heredoc, or a branch that did not run, and it counts commented-out call sites that never emit at all.
 
-A suite adopts the shape as its labels are written or converted; suites still carrying the old namespace-prefix labels are converted plugin-wide by a separate rollout.
+A suite adopts the shape as its labels are written or converted.
 
 ## Roadmap & shipped phases
 


### PR DESCRIPTION
Closes #1541.

## Summary

`cogni-knowledge/CLAUDE.md:244` no longer promises a future plugin-wide conversion rollout. The trailing clause — `; suites still carrying the old namespace-prefix labels are converted plugin-wide by a separate rollout` — is removed.

The sentence's first clause, **"A suite adopts the shape as its labels are written or converted."**, is **kept**. It is standing guidance for a newly written or newly edited suite, not a rollout promise, so deleting the whole sentence would have dropped live guidance along with the counterfactual claim. The line is *replaced* (one line out, one line in), so blank lines 243 and 245 never become adjacent and the file stays 248 lines.

**No past-tense restatement was substituted.** A restatement was permitted, but any "the suites have been converted" / "uniqueness is proven plugin-wide" wording would assert an empirical fact this prose-only diff does no work to establish — and the scheme's own `**Verification.**` rule (line 242) requires *running* suites rather than grepping. Retiring the promise without substituting a fresh claim is the conservative reading.

## Why this is safe to land now

The issue is gated on "once case-id conversion is plugin-wide". That gate is met, verified against this branch's base rather than taken from issue prose:

- #1498 ("close the sweep — apply the case-id scheme to every remaining suite and prove plugin-wide uniqueness") is CLOSED/COMPLETED via PR #1544.
- `git merge-base --is-ancestor bb71000 HEAD` exits 0 — the conversion is an ancestor of this branch, so the retirement asserts a completion that actually happened. A branch forked from an earlier base would satisfy every prose check while making the file lie.
- Zero result-line labels across the 78 `cogni-knowledge/tests/*.sh` suites still lead with a bare namespace-prefix first token.

## Scope

- **In:** exactly one hunk, in exactly one file, lying strictly between the `**Verification.**` bullet and the `## Roadmap & shipped phases` heading.
- **Out — `cogni-knowledge/tests/`:** the fence this issue exists to respect. The conversion PR's acceptance bar falsifies on any changed path outside that directory; this PR is the mirror-image commitment and touches nothing inside it.
- **Out — `cogni-knowledge/tests/README.md`:** its inbound reference (lines 99–100) cites the `**Shape.**` rule, not the retired sentence, and names no heading anchor or line number, so it stays correct unchanged. It already documents the scheme in completed tense.
- **Out — version bump:** `plugin.json` / `marketplace.json` untouched; the post-merge Version bump workflow owns that.
- **Out — `CHANGELOG.md`:** no CI gate demands a changelog line for a developer-guide prose fix.

## Verification

**The discriminating check** — red at base, green at head:

| Check | Result |
|---|---|
| `git diff --name-only origin/main...HEAD` | exactly one path: `cogni-knowledge/CLAUDE.md` |
| `git diff --unified=0 origin/main...HEAD` | exactly one hunk, `@@ -244 +244 @@`, one `-` line and one `+` line |
| Text between the `**Verification.**` bullet and the `## Roadmap` heading | no surviving forward-looking construction (`will be` / `is pending` / `are being converted` / `plugin-wide by`) |

Item 1 alone discharges the scope boundary, the no-version-touch item, and the tests/README.md-unchanged item. Item 2 is what proves the six rules and both headings survived byte-identical.

**Regression guards** (green at base too — they cannot be evidence the fix landed, and are reported as guards, not as the gate):

- Six rule bullets still present and named, **range-extracted between the two headings**: returns 6. Note the un-ranged `grep -c '^- \*\*'` over the whole file returns **10**, not 6 — the un-ranged form fails spuriously and would read as a broken fix.
- No run of two or more consecutive blank lines: 0.
- The still-true first clause survives exactly once.
- The 78 `cogni-knowledge/tests/*.sh` suites still pass.

### Why the obvious check here is vacuous

Recorded because a reviewer will otherwise reach for it. **Running the cogni-knowledge suites proves nothing about this diff.** No suite reads line 244 or the `### Test result-line case ids` section, and `tests/test_skill_contracts.sh` — the only suite naming `CLAUDE.md` at all — explicitly passes `--exclude=CLAUDE.md` (lines 406, 425). A green run is equally green at base.

Likewise, **do not gate on `grep -c 'separate rollout'`.** The issue-time acceptance contract names it the wrong check explicitly: a permitted past-tense restatement may legitimately retain those words. It happens to return 0 for this particular delete-the-clause fix, which is exactly what makes it a seductive trap — it grades the mechanism rather than the property.

## Token-scope disclosure

The Step 7.5 least-privilege preflight reported `status: over_scoped` — the runner token carries `gist`, `read:org` and `workflow` beyond the documented minimal posture (`repo` / `public_repo`), with `workflow` on the forbidden list. This is the fixed scope set of the GitHub CLI's own OAuth app (`gh auth login`), which cannot be narrowed from the runner side. The run proceeded under the operator-authorized `--allow-overscoped` flag (never the environment variable), and this note is the required disclosure. No workflow file is touched by this PR.