### PR TITLE
cogni-workspace: normalize troubleshoot section 6 to its Scope Boundary

### DIFF
--- a/cogni-workspace/skills/troubleshoot/SKILL.md
+++ b/cogni-workspace/skills/troubleshoot/SKILL.md
@@ -159,10 +159,18 @@ Route each hit to `references/known-issues.md`, which carries the full remedy:
 
 ### 6. Common Misconfigurations
 
-- **Missing COGNI_WORKSPACE_ROOT**: Many plugins need this env var. Check
-  `.workspace-env.sh` exists and is sourced.
-- **GitHub CLI not authenticated**: Required for cogni-issues. Run `gh auth status`;
-  when authentication is missing, guide the user through `gh auth login`.
+Recognition patterns, not checks this skill runs — name the symptom, then route. Per
+the Scope Boundary above, workspace infrastructure is `workspace-status`'s to verify
+and `/manage-workspace`'s to repair.
+
+- **Missing COGNI_WORKSPACE_ROOT** — a plugin reports that shared resources (themes,
+  env vars) are unavailable, typically because the workspace was never initialized or
+  `.workspace-env.sh` is not sourced by the session hook. Route to `/workspace-status`
+  to diagnose and `/manage-workspace` to repair; `references/known-issues.md` carries
+  the entry "Missing COGNI_WORKSPACE_ROOT".
+- **GitHub CLI not authenticated** — the cogni-issues skill fails with an
+  authentication or login error. Route to `references/known-issues.md`, which carries
+  the remedy under "GitHub not logged in".
 - **PPTX rendering skill unavailable**: `document-skills:pptx` renders the story-to-slides
   brief and does not ship from this marketplace. Confirm the session provides it before
   dispatching the `pptx` agent; otherwise take story-to-slides Step 11, "Guide User to
@@ -179,7 +187,10 @@ summary table:
 | Plugin integrity | OK/WARN/FAIL | Any missing SKILL.md files |
 | State files | OK/WARN/FAIL | Any corrupted or stale files |
 | Dependencies | OK/WARN/FAIL | Any missing cross-plugin deps |
-| Environment | OK/WARN/FAIL | Key env vars and tools |
+| Environment | OK/WARN/FAIL | Observed only — route to `/workspace-status` |
+
+The Environment row is a routing signal, not a check this skill performs — report
+what the session already shows and hand the diagnosis to `/workspace-status`.
 
 ## Reference
 


### PR DESCRIPTION
Refs #1543.

## Summary

`skills/troubleshoot/SKILL.md` asserted one ownership rule in four places — the frontmatter `description`, the intro prose, the `## Scope Boundary` table, and the routing sentence beneath it — and then contradicted it twice further down. Section 6 instructed the reader to check `.workspace-env.sh` and run `gh auth status`; the Full Scan Mode table promised an `Environment | Key env vars and tools` row. A model reading top-to-bottom got a routing rule followed by instructions that break it.

Both surfaces are now **recognition-and-handoff**:

- **§6 gained a lead-in** stating the section names symptoms and routes rather than running checks, so the bullets no longer each have to re-justify stopping short of a repair.
- **`Missing COGNI_WORKSPACE_ROOT`** recognizes the symptom and routes to `/workspace-status` to diagnose and `/manage-workspace` to repair, citing the catalogue entry of the same name. This mirrors the shape `references/known-issues.md` already uses for that entry.
- **`GitHub CLI not authenticated`** recognizes the symptom and routes to `references/known-issues.md` → "GitHub not logged in", which carries the real `gh auth login` remedy. No bare `gh auth status` instruction survives in the skill body.
- **The PPTX bullet is byte-identical base** — `document-skills:pptx` availability is a plugin/skill-availability check this skill legitimately owns, and is not a Scope Boundary row.
- **The Full Scan `Environment` row is annotated, not deleted** — its Details cell now names the handoff target, and one sentence beneath the table explains that the row is a routing signal rather than a check this skill performs.

The direction is deliberate: section 6 is brought **up to** the boundary, never the boundary down to section 6. The `## Scope Boundary` table, the frontmatter description, the intro prose and the routing sentence are all untouched.

## Why `Refs` and not `Closes`

#1543's own acceptance criteria are fully satisfied by this diff. The link is `Refs` because the drain's partial-linkage rule fires deterministically on a non-empty `deferred[]` — one genuinely separate concern was found and filed (below) — not because the implementation is incomplete. #1543 can be closed on merge.

## Follow-up issues

- #1568 — the `## Scope Boundary` table credits `workspace-status` with `Dependency tool versions (node, gh, etc.)`, but `cogni-workspace/scripts/check-dependencies.sh` probes only jq, python3, curl, git, bc, and nothing in `workspace-status` checks gh **authentication** (the plugin's only gh-auth probe belongs to `cogni-issues`). That gap is precisely why this change routes the gh-auth arm to the catalogue rather than to `/workspace-status` — it routes *around* the gap rather than leaning on it, so no boundary assertion is weakened here. Correcting the row, or making the sibling's probe real, is a separate ownership decision that the issue-time acceptance contract explicitly excluded from this change.

## Review notes

The pre-commit skill-quality gate returned `needs_revision` with three findings, no structural issues. One was applied and two were skipped:

- **Applied (defect).** §6's second bullet closed with "take it from there rather than re-deriving it", which a reader could take as licence to apply the login remedy in-skill — the repair posture the lead-in had just assigned elsewhere — and it was not parallel to bullet 1's shape. Reworded to the same recognition → `Route to …` form. The reviewer's *suggested* target for that route — `/workspace-status`, "which owns session tooling" — was **rejected**: nothing in `workspace-status` probes gh authentication, so that handoff dead-ends, which the acceptance contract names as a failure. The real defect was fixed without adopting the false destination.
- **Skipped (preference).** Changing the Environment row's Status cell from `OK/WARN/FAIL` to `Observed` would make one row of five heterogeneous in a column every other row shares, for a row the note directly beneath already disarms.
- **Skipped (preference, `introduced_by_change: false`).** Pre-existing duplication between §3 and §5 over `.claude/cogni-help.local.md`. It lies in base lines 23–159, which the acceptance contract's minimal-diff discipline puts out of bounds for this change.

## Operational disclosure

`check-token-scope.sh --strict` reported the runner token **over-scoped** — extra scopes `gist`, `read:org`, `workflow` — against the documented least-privilege posture. This is the fixed scope set of the GitHub CLI OAuth (`gho_`) token and cannot be narrowed from the runner. Proceeded under the standing operator authorization via the `--allow-overscoped` flag, disclosed here rather than silently.

## Evidence

Run from the branch worktree:

- `python3 scripts/run-plugin-tests.py --filter cogni-workspace` → **15 discovered / 15 passed / 0 failed**, matching base. (The issue's AC says "14/14"; that count is stale — base measures 15/15, so the operative bar is no regression.)
- `grep -c '^| Environment |' cogni-workspace/skills/troubleshoot/SKILL.md` → `1`
- Full Scan table data rows (`OK/WARN/FAIL` within the section) → `5`
- `grep -c '^### [1-6]\.'` → `6`, contiguous, §6 still between §5 and `## Full Scan Mode`
- `grep -cE '#1543|#1539|#1467|PR #'` → `0` (no breadcrumb leakage)
- `grep -c 'CLAUDE_PLUGIN_ROOT'` → `0`, `grep -c 'cogni-help:'` → `0` (`test-relocated-skill-hygiene.sh` P1/P2 stay inert)
- `grep -c 'document-skills:pptx'` → `1` (PPTX bullet intact)
- `grep -c 'gh auth status'` → `0` in the skill body
- Both cited catalogue headings resolve: `## GitHub not logged in` (:45), `## Missing COGNI_WORKSPACE_ROOT` (:57)
- `evals/evals.json` untouched (`git diff --name-only origin/main -- .../evals/` → empty)
- `check-frontmatter.sh` → clean, 52 files scanned
- `check-breadcrumbs.sh` → 9 offenders, **all** in `skills/manage-themes/SKILL.md`, which this diff never touches; zero in `skills/troubleshoot/`. Pre-existing standing drift.
- `git diff --stat origin/main` → one file, +16/−5

No mutation recipe applies: the diff touches no `tests/test-*.sh` and no `scripts/check-*.sh`, and the mechanism under change is prose in a SKILL.md.