### PR TITLE
cogni-workspace: complete the --update description in components table

### DIFF
--- a/cogni-workspace/README.md
+++ b/cogni-workspace/README.md
@@ -175,7 +175,7 @@ State lives in two layers that other plugins consume. Configuration (env vars, t
 | `check-skill-names.sh` | script | Validates skill directory names against plugin.json manifest for consistency |
 | `check-workspace-python-deps.sh` | script | Fail-soft health check for optional Python packages in the workspace venv; reports per-package importability (`success` stays true) |
 | `discover-plugins.sh` | script | Scans marketplace cache for installed cogni-x plugins, returns JSON inventory |
-| `generate-settings.sh` | script | Generates settings files; supports `--update` to preserve custom env vars |
+| `generate-settings.sh` | script | Generates settings files; `--update` preserves custom env vars and prunes the ones it generated for plugins no longer in the list |
 | `install-mcp.sh` | script | Installs a git-based MCP server into `~/.claude/mcp-servers/` (clone, build, wrapper); outputs JSON with install and wrapper paths |
 | `install-workspace-deps.sh` | script | Provisions optional Python packages from `python-deps-registry.json` into an isolated venv at `~/.claude/workspace-python-venv/`; idempotent, `--force` reinstalls, JSON envelope |
 | `patch-desktop-config.py` | script | Merges git-installed MCP servers into the user's Claude Code (`~/.claude.json`) or Claude Desktop config from `mcp-git-registry.json`, preserving existing entries |


### PR DESCRIPTION
## Summary

`cogni-workspace/README.md` line 178 — the Components-table row for `generate-settings.sh` — still described `--update` as preservation only. Update mode also prunes the env keys the script itself generated (`COGNI_{SUFFIX}_ROOT` / `_PLUGIN`, `PLUGIN_{SUFFIX}_ROOT` / `_PLUGIN`) for plugins absent from the current plugin set, so the row told half the story.

This rewrites that one description cell so it states both halves. One line changed, nothing else.

The new cell text is byte-exact:

```
| `generate-settings.sh` | script | Generates settings files; `--update` preserves custom env vars and prunes the ones it generated for plugins no longer in the list |
```

Closes #1559

## Scope decisions

- **README only.** The parent change already corrected the script's own usage comment (`cogni-workspace/scripts/generate-settings.sh:7-8`) and the `manage-workspace` SKILL.md surface; verified at `origin/main` that `manage-workspace/SKILL.md:256-261` already carries the complete two-halves description. A **repo-wide** sweep (not just plugin-wide) confirms this row was the only remaining incomplete `--update` description in `insight-wave`: repo-root `README.md` and `CLAUDE.md` have zero hits for `generate-settings` or `--update`, no `docs/` page mentions either, and `workspace-status/SKILL.md` does not describe the flag at all.
- **No overclaim.** The removal clause is deliberately qualified to the keys the script *generated*. It does not say "all env vars", which would contradict the preservation half of the same sentence and misstate `scripts/generate-settings.sh:132-145`, where a key is pruned only when it matches the generated-key namespace and its stem has left `current_keyspaces`. It therefore also does not imply `PROJECT_AGENTS_OPS_ROOT`, `COGNI_WORKSPACE_ROOT` or `COGNI_WORKSPACE_PYTHON_VENV` are pruned — those are assigned unconditionally at lines 76-80 and always survive.
- **No version bump.** The bump is applied post-merge, not on the feature branch; no `plugin.json` or `marketplace.json` `version` is touched.
- **No label or usage-string work is owed.** This change registers nothing and alters no flag.
- **No table restructure.** The row keeps its three cells, byte-identical Component and Type cells, and its position between the `discover-plugins.sh` (177) and `install-mcp.sh` (179) rows. No escaped pipe is used — matching the house convention of that table, where no cell contains a literal or escaped pipe.
- **No test fixture added.** A `cogni-workspace/tests/` fixture is admitted by the acceptance contract but not required; no existing suite asserts on this row. No `## Mutation recipe` section is present because the diff touches no test (`*/tests/test-*.sh`) and no guard (`*/scripts/check-*.sh`) — that requirement does not apply here.

## Test plan

- [x] `git diff --numstat origin/main -- cogni-workspace/README.md` reports exactly `1	1	cogni-workspace/README.md`
- [x] `git diff --name-only origin/main` lists `cogni-workspace/README.md` and nothing else
- [x] `sed -n '177,179p' cogni-workspace/README.md` shows discover-plugins.sh, generate-settings.sh, install-mcp.sh in that order
- [x] `awk 'NR==178 {print gsub(/\|/, "|")}' cogni-workspace/README.md` prints `4` (three cells, one physical line)
- [x] Byte-exact full-line equality against the intended replacement line. This replaces an earlier draft check ("cell does not contain the word `all`"), which was **unsound** — a bare substring test for `all` also fires on `install`, `finally` and `actually`. Full-line equality subsumes both the `preserves custom env vars` and `prunes the ones it generated for plugins no longer in the list` substring assertions and any over-claim guard.
- [x] `python3 scripts/check-version-bump.py` reports neither `version-touched` nor `version-mirror-desync`
- [x] `git diff origin/main -- cogni-workspace/README.md | grep -c '^@@'` prints `1`
- [x] All 15 `cogni-workspace/tests/test-*.sh` suites pass on this branch (15 PASS / 0 FAIL)

## Disclosure — runner token scope

The Step 7.5 least-privilege check reports `over_scoped`: observed `[gist, read:org, repo, workflow]` against an allowed set of `[public_repo, repo]`, so `extra=[gist, read:org, workflow]` and `forbidden=[workflow]`. This is the default `gh auth login` (`gho_`) token, whose scope set is fixed by the GitHub CLI OAuth app and cannot be narrowed. The run proceeded under the sanctioned `--allow-overscoped` flag (never the environment variable), disclosed here per policy rather than blocking the handoff.