### PR TITLE
cogni-workspace: dashboard Dependencies row reads the real check-dependencies shape

### DIFF
--- a/cogni-workspace/skills/workspace-dashboard/references/dashboard-sections.md
+++ b/cogni-workspace/skills/workspace-dashboard/references/dashboard-sections.md
@@ -77,7 +77,7 @@ This section is **read-only**. `audit-region-sources` is the dedicated coverage 
 - Environment vars: read `.claude/settings.local.json` `env` object, count how many resolve to existing paths
 - Plugins: count from Section 2
 - Themes: count from Section 3
-- Dependencies: invoke `<workspace-root>/cogni-workspace/scripts/check-dependencies.sh` and parse the JSON envelope (`data.required[]` and `data.optional[]`)
+- Dependencies: invoke `<workspace-root>/cogni-workspace/scripts/check-dependencies.sh` and partition `data.dependencies[]` (one entry per tool: `{name, available, required, version}`) on each entry's own `required` flag; `data.missing_required` / `data.missing_optional` carry the same misses as integers
 - MCPs: count from Section 4
 
 **Output**: one row per check. Each row: green/yellow/red dot, check name, one-line summary (e.g., "12 vars set, 0 missing"), and a "Run `/cogni-workspace:workspace-status` for details" pointer at the section foot.

--- a/cogni-workspace/skills/workspace-dashboard/scripts/generate-dashboard.py
+++ b/cogni-workspace/skills/workspace-dashboard/scripts/generate-dashboard.py
@@ -674,16 +674,19 @@ def _check_dependencies(workspace_root):
         if proc.returncode != 0 or not proc.stdout.strip():
             return ("warning", "check-dependencies.sh failed")
         payload = json.loads(proc.stdout)
-        data = payload.get("data", {})
-        required = data.get("required", {}) or {}
-        optional = data.get("optional", {}) or {}
-        req_ok = sum(1 for v in required.values() if v.get("available"))
-        req_total = len(required)
-        opt_ok = sum(1 for v in optional.values() if v.get("available"))
-        opt_total = len(optional)
+        data = payload.get("data", {}) if isinstance(payload, dict) else {}
+        deps = data.get("dependencies") if isinstance(data, dict) else None
+        entries = [d for d in deps if isinstance(d, dict)] if isinstance(deps, list) else []
+        if not entries:
+            return ("warning", "check-dependencies.sh reported no dependencies")
+        required = [d for d in entries if d.get("required")]
+        optional = [d for d in entries if not d.get("required")]
+        req_total, opt_total = len(required), len(optional)
+        req_ok = sum(1 for d in required if d.get("available"))
+        opt_ok = sum(1 for d in optional if d.get("available"))
         label = "ok" if req_ok == req_total else "danger"
         return (label, f"{req_ok}/{req_total} required, {opt_ok}/{opt_total} optional")
-    except (subprocess.SubprocessError, json.JSONDecodeError, OSError):
+    except (subprocess.SubprocessError, json.JSONDecodeError, AttributeError, TypeError, OSError):
         return ("warning", "check-dependencies.sh errored")
 
 

--- a/cogni-workspace/tests/test-dashboard-dependency-counts.sh
+++ b/cogni-workspace/tests/test-dashboard-dependency-counts.sh
@@ -1,0 +1,210 @@
+#!/usr/bin/env bash
+# Regression test for the workspace-dashboard Health Snapshot's Dependencies row
+# (_check_dependencies in skills/workspace-dashboard/scripts/generate-dashboard.py).
+#
+# Contract under test: the row's counts are derived from the payload
+# check-dependencies.sh actually emits — data.dependencies[], one entry per tool,
+# each {name, available, required, version} — partitioned on each entry's own
+# `required` flag. The row must be FALSIFIABLE: a required tool reporting
+# available:false has to surface a non-ok label and a truthful n/m with n < m.
+# A row that renders a constant count is the defect this suite exists to catch,
+# so the all-present direction is pinned to NON-ZERO totals as well: asserting
+# only "ok" would pass against a permanently-0/0 reader.
+#
+# Every case drives the real renderer against a STUB emitter under its own temp
+# root. That is deliberate and not a convenience: jq and python3 are present on
+# any dev or CI host, so a case running the real script would render "2/2
+# required, ok" and stay green against the broken reader too. No production seam
+# is needed — _check_dependencies derives its script path from its own
+# workspace_root argument, so pointing it at a temp tree is sufficient.
+#
+# Paths are self-located from $0, never the working directory: the repo runner
+# invokes suites with cwd=<repo root> and the mutation harness with cwd=$ROOT,
+# so a cwd-relative path here would be a latent false result.
+#
+# stdlib-only: bash + python3, no pip deps, per the repo-wide script convention.
+
+set -u
+HERE="$(cd "$(dirname "$0")" && pwd)"
+WS_ROOT="$(cd "$HERE/.." && pwd)"
+RENDERER="$WS_ROOT/skills/workspace-dashboard/scripts/generate-dashboard.py"
+SECTIONS="$WS_ROOT/skills/workspace-dashboard/references/dashboard-sections.md"
+EMITTER="$WS_ROOT/scripts/check-dependencies.sh"
+TMPROOT="$(mktemp -d)"
+trap 'rm -rf "$TMPROOT"' EXIT
+
+failures=0
+pass() { printf 'PASS: %s\n' "$1"; }
+fail() { printf 'FAIL: %s\n' "$1"; failures=$((failures + 1)); }
+
+# new_root <name> — build a temp workspace root holding a stub emitter at the
+# exact relative path _check_dependencies derives, and echo the root.
+new_root() {
+  local name="$1"
+  local root="$TMPROOT/$name"
+  mkdir -p "$root/cogni-workspace/scripts"
+  cat > "$root/cogni-workspace/scripts/check-dependencies.sh" <<STUB
+#!/usr/bin/env bash
+cat "$root/fixture.json"
+STUB
+  printf '%s' "$root"
+}
+
+# assert_dep "<label>" "<root>" "<python expr, True to pass>" — the renderer is
+# bound as \`r\` and the returned tuple as \`res\`. A raised exception exits the
+# driver non-zero, so "does not raise" is asserted by the case passing at all.
+assert_dep() {
+  local label="$1" root="$2" expr="$3"
+  if python3 - "$RENDERER" "$root" <<PY
+import importlib.util, sys
+def _load(name, path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    m = importlib.util.module_from_spec(spec); spec.loader.exec_module(m); return m
+r = _load("r", sys.argv[1])
+res = r._check_dependencies(sys.argv[2])
+sys.exit(0 if ($expr) else 1)
+PY
+  then pass "$label"; else fail "$label"; fi
+}
+
+# assert_degrades "<label>" "<root>" — a malformed payload must come back as a
+# warning tuple rather than raising. One definition, so tightening the
+# degradation contract is a single edit rather than three that can diverge.
+assert_degrades() {
+  assert_dep "$1" "$2" 'isinstance(res, tuple) and len(res) == 2 and res[0] == "warning"'
+}
+
+# --- D1: all present. --------------------------------------------------------
+D1ROOT="$(new_root d1)"
+cat > "$D1ROOT/fixture.json" <<'JSON'
+{"success": true, "data": {"dependencies": [
+  {"name": "jq", "available": true, "required": true, "version": "jq-1.7.1"},
+  {"name": "python3", "available": true, "required": true, "version": "Python 3.14.2"},
+  {"name": "curl", "available": true, "required": false, "version": "curl 8.7.1"},
+  {"name": "git", "available": true, "required": false, "version": "git 2.50.1"},
+  {"name": "bc", "available": true, "required": false, "version": "bc 7.0.3"}
+], "missing_required": 0, "missing_optional": 0}}
+JSON
+assert_dep "D1 all present renders ok with truthful non-zero totals" "$D1ROOT" \
+  'res[0] == "ok" and res[1] == "2/2 required, 3/3 optional"'
+
+# --- D2: THE discriminating case, and the recorded mutation --case target. ---
+# Both operands are asserted, which is what a constant renderer cannot satisfy.
+D2ROOT="$(new_root d2)"
+cat > "$D2ROOT/fixture.json" <<'JSON'
+{"success": false, "data": {"dependencies": [
+  {"name": "jq", "available": false, "required": true, "version": null},
+  {"name": "python3", "available": true, "required": true, "version": "Python 3.14.2"},
+  {"name": "curl", "available": true, "required": false, "version": "curl 8.7.1"},
+  {"name": "git", "available": true, "required": false, "version": "git 2.50.1"},
+  {"name": "bc", "available": true, "required": false, "version": "bc 7.0.3"}
+], "missing_required": 1, "missing_optional": 0}}
+JSON
+assert_dep "D2 absent required tool renders non-ok with a truthful n of m" "$D2ROOT" \
+  'res[0] != "ok" and res[1] == "1/2 required, 3/3 optional"'
+
+# --- D3: an optional tool is absent. Required side is whole, so still ok. ----
+D3ROOT="$(new_root d3)"
+cat > "$D3ROOT/fixture.json" <<'JSON'
+{"success": true, "data": {"dependencies": [
+  {"name": "jq", "available": true, "required": true, "version": "jq-1.7.1"},
+  {"name": "python3", "available": true, "required": true, "version": "Python 3.14.2"},
+  {"name": "curl", "available": true, "required": false, "version": "curl 8.7.1"},
+  {"name": "git", "available": false, "required": false, "version": null},
+  {"name": "bc", "available": true, "required": false, "version": "bc 7.0.3"}
+], "missing_required": 0, "missing_optional": 1}}
+JSON
+assert_dep "D3 absent optional tool stays ok and counts the optional miss" "$D3ROOT" \
+  'res[0] == "ok" and res[1] == "2/2 required, 2/3 optional"'
+
+# --- D4-D6: malformed payloads DEGRADE, they do not raise. -------------------
+# The old reader could not raise because .get(..., {}) defaulted; the new read
+# has to earn that back. An exception here exits the driver non-zero and fails
+# the case, so "returns a 2-tuple without raising" is what is being asserted.
+D4ROOT="$(new_root d4)"
+cat > "$D4ROOT/fixture.json" <<'JSON'
+{"success": true, "data": {"missing_required": 0, "missing_optional": 0}}
+JSON
+assert_degrades "D4 absent dependencies key degrades to a warning tuple" "$D4ROOT"
+
+D5ROOT="$(new_root d5)"
+cat > "$D5ROOT/fixture.json" <<'JSON'
+{"success": true, "data": {"dependencies": {"jq": {"available": true, "required": true}}}}
+JSON
+assert_degrades "D5 dependencies as a mapping degrades to a warning tuple" "$D5ROOT"
+
+D6ROOT="$(new_root d6)"
+cat > "$D6ROOT/fixture.json" <<'JSON'
+{"success": true, "data": {"dependencies": ["jq", null, "python3"]}}
+JSON
+assert_degrades "D6 non-mapping dependency entries degrade to a warning tuple" "$D6ROOT"
+
+# --- D7: the wrong-key reads are gone from the renderer entirely. ------------
+# grep -F, because both needles carry regex metacharacters.
+if grep -qF 'data.get("required"' "$RENDERER" || grep -qF 'data.get("optional"' "$RENDERER"; then
+  fail "D7 renderer no longer reads the keys the emitter never sets"
+else
+  pass "D7 renderer no longer reads the keys the emitter never sets"
+fi
+
+# --- D8: the documentation twin no longer describes the wrong shape. ---------
+# Whole-file, not just the one edited line: a second mention elsewhere would let
+# the next reader re-derive the bug from the docs.
+if grep -qE 'data\.required|data\.optional' "$SECTIONS"; then
+  fail "D8 sections reference documents the emitted shape"
+elif grep -qF 'data.dependencies[]' "$SECTIONS"; then
+  pass "D8 sections reference documents the emitted shape"
+else
+  fail "D8 sections reference documents the emitted shape"
+fi
+
+# --- D9: the emitter's own contract, pinned from the consumer side. ----------
+# SHAPE ONLY, never availability. The real script's last statement is its
+# heredoc, so it exits 0 on every host; a runner missing jq or bc merely flips an
+# entry's `available`, which is why an availability assertion here would be
+# environment-fragile while a shape assertion is not.
+if python3 - "$EMITTER" <<'PY'
+import json, subprocess, sys
+proc = subprocess.run(["bash", sys.argv[1]], capture_output=True, text=True, timeout=30)
+if proc.returncode != 0 or not proc.stdout.strip():
+    sys.exit(1)
+data = json.loads(proc.stdout).get("data", {})
+deps = data.get("dependencies")
+ok = (
+    isinstance(deps, list)
+    and len(deps) > 0
+    and all(isinstance(d, dict) and {"name", "available", "required"} <= set(d) for d in deps)
+    and any(d["required"] for d in deps)
+    and any(not d["required"] for d in deps)
+    and isinstance(data.get("missing_required"), int)
+    and isinstance(data.get("missing_optional"), int)
+)
+sys.exit(0 if ok else 1)
+PY
+then pass "D9 emitter still emits the shape this reader depends on"
+else fail "D9 emitter still emits the shape this reader depends on"; fi
+
+# --- D10: the same fixture, end to end through the real renderer. ------------
+# D1-D6 stop at the private function, which leaves two links unpinned: that
+# health_snapshot still calls it, and that the label reaches the dot's CSS
+# class. "Green dot forever" is a property of the rendered page, so one case
+# asserts it there. Reuses D2's root, so no new fixture is needed.
+D10OUT="$D2ROOT/out.html"
+if python3 "$RENDERER" "$D2ROOT" --output "$D10OUT" >"$TMPROOT/d10-render.json" 2>"$TMPROOT/d10-render.err"; then
+  if grep -qF '1/2 required, 3/3 optional' "$D10OUT" && grep -qF 'health-dot danger' "$D10OUT"; then
+    pass "D10 rendered page shows the truthful count and a non-ok dot"
+  else
+    fail "D10 rendered page shows the truthful count and a non-ok dot"
+  fi
+else
+  fail "D10 rendered page shows the truthful count and a non-ok dot"
+fi
+
+echo
+if [ "$failures" -eq 0 ]; then
+  echo "All dashboard dependency-count tests passed."
+  exit 0
+else
+  echo "$failures test(s) failed."
+  exit 1
+fi


### PR DESCRIPTION
Closes #1573.

## Summary

The Health Snapshot's Dependencies row read `data.required` / `data.optional` — keys `check-dependencies.sh` never emits. Because both reads used `.get(..., {})`, they resolved to `{}` silently, `req_total` and `req_ok` were both `0`, and the status expression `label = "ok" if req_ok == req_total else "danger"` was a permanent `0 == 0`. The row rendered `0/0 required, 0/0 optional` behind a green dot on every machine, including one missing both required tools. That silence is why it went unnoticed.

`_check_dependencies` now partitions `data.dependencies[]` on each entry's own `required` flag, matching the `sum(1 for x in ... if pred)` / `f"{ok}/{total} <noun>"` idiom the sibling rows in the same function already use.

**Shape guards are part of the fix, not padding.** The old form *could not* raise — the `.get` defaults saw to that — and `references/dashboard-sections.md:87-95` binds the renderer to still produce *some* HTML in every failure mode. The new read has to earn that back: an absent `dependencies` key, a non-list value there, or non-dict entries would each raise `AttributeError`/`TypeError`, and neither is caught by the existing `except` tuple. So the read is `isinstance`-guarded *and* the tuple widened — two layers, deliberately, because trading a silent wrong answer for a hard render crash would not be a fix.

`dashboard-sections.md:80` restated the same wrong shape and would have re-seeded the bug from the docs, so it moves in the same commit.

## Scope decisions

- **Included:** both readers the issue names (one defect class), the exception-surface hardening the changed read forces, and coverage that makes the fix falsifiable.
- **Excluded by the issue's own constraint:** `cogni-workspace/scripts/check-dependencies.sh` keeps its emitted shape byte-for-byte, and `skills/workspace-status/SKILL.md` §5 — which reads it correctly today — is untouched. A repo-wide search confirmed `_check_dependencies` is the *only* programmatic consumer; every other mention is prose that names no key shape. `git diff --stat origin/main` reports zero changed lines in both.
- **No production seam was added.** `_check_dependencies(workspace_root)` already derives its script path from its own argument, so the suite points it at a temp tree holding a stub emitter. No injection hook, no test-only branch in production code.
- **No `plugin.json` version bump** — the post-merge workflow owns it.

## Test plan

All measured, not asserted:

- `python3 scripts/run-plugin-tests.py --filter cogni-workspace` → **`total 16, passed 16, failed 0`** (base measures 15/15; the 16th is the new suite). This command is **green at base**, so it is a regression guard only — it cannot distinguish a correct fix from no fix, and is not offered as evidence the defect is fixed.
- `bash cogni-workspace/tests/test-dashboard-dependency-counts.sh` → 10/10 `PASS`.
- **The suite run against the base commit → 9 of 10 RED.** This is the real evidence. `origin/main` was materialised into a scratch tree, the suite dropped in unchanged, and every behavioural case failed against the old reader. The tenth, `D9`, is correctly green at base: it pins the *emitter's* contract, which this PR deliberately does not touch.
- `python3 scripts/check-result-line-plainness.py` → exit 0 (the suite's `printf` emitters carry no escape literal, which would otherwise defeat the mutation harness's own `FAIL:` match).

The discriminating case is **D2**: a required tool at `available: false` must produce a non-`ok` label **and** a truthful `1/2 required`. Both operands are asserted, which is precisely what a still-constant renderer cannot satisfy. **D1** pins the other direction with *non-zero* totals, so a renderer that swapped one constant for another (`0/0` + `danger`) fails too — a zero-total assertion would be vacuity of the same family as the bug. **D10** carries the assertion up to the rendered page, where "green dot forever" actually lives, closing the two links a function-level test leaves open: that `health_snapshot` still calls the function, and that the label reaches the dot's CSS class.

## Mutation recipe

```
bash "$HOME/.claude/plugins/marketplaces/managed-service/cogni-service/scripts/mutation-check.sh" --root . --file cogni-workspace/skills/workspace-dashboard/scripts/generate-dashboard.py --expr 's/label = "ok" if req_ok == req_total else "danger"/label = "ok"/' --test 'bash cogni-workspace/tests/test-dashboard-dependency-counts.sh' --case D2
```

Replayed from the repository root. **Recorded verdict: `guard_verified`** — `mutated_result: red`, `restored_result: green`, tree clean afterwards and the commit untouched.

Two notes for whoever replays it. The harness path is not `scripts/mutation-check.sh`: **that file does not exist in this repository.** The two same-named files here (`cogni-consult/`, `cogni-portfolio/`) are bespoke hard-coded harnesses that accept none of these flags — the flag-taking one ships with cogni-service in `managed-service`, which is why the installed-plugin path is recorded. And the `--expr` is fed to `perl -0pi`, never sed or ERE; it is non-global because that string occurs exactly once in the file, which is also why `label = "ok" if req_ok == req_total else "danger"` and the return line under it were deliberately left byte-identical by this change.

## Follow-up issues

- **#1578** — `workspace-dashboard`'s MCP Servers row renders a permanent `0/0 installed (ok)` when the registry's shape drifts.

Same defect class as this issue, different row and different producer (an on-disk JSON registry rather than a subprocess envelope), **reproduced by execution** rather than suspected. It is filed rather than folded in because this issue's committed acceptance contract fences the change to the Dependencies row — widening the diff would have broken the scope boundary this PR is graded against. A survey of all six Health Snapshot rows found it is the *only* exposed sibling, which is also why no shared "guard the empty side before an `X == Y` comparison" helper is proposed yet: at two instances that costs more indirection than it buys.

## Open questions

None blocking.

**Disclosure — runner token scope.** The Step 7.5 least-privilege preflight reports `over_scoped`: observed `[gist, read:org, repo, workflow]` against an allowed set of `[public_repo, repo]`, extra `[gist, read:org, workflow]`. This is the fixed scope set of the GitHub CLI's own OAuth app (`gho_` token), which cannot be narrowed from here. The run proceeded under the `--allow-overscoped` flag per the standing operator decision, and it is disclosed here rather than passed silently.