### PR TITLE
cogni-workspace: guard MCP Servers row against registry shape drift

### DIFF
--- a/cogni-workspace/skills/workspace-dashboard/references/dashboard-sections.md
+++ b/cogni-workspace/skills/workspace-dashboard/references/dashboard-sections.md
@@ -45,6 +45,7 @@ Per-section reference for `workspace-dashboard`: data source, helper(s) reused, 
 **Data source**:
 - `<workspace-root>/cogni-workspace/references/mcp-git-registry.json` — declares each server (`type`, `repo`, `desktop_config_key`, `provides_tools[]`, `required_by[]`, platform-specific paths for native servers)
 - Install status check: existence of `~/.claude/mcp-servers/<desktop_config_key>/start.sh` for git-based servers; existence of the platform-specific binary path for native servers
+- Required shape: a top-level `servers` object whose values are themselves objects. A registry that parses but does not match it — root not an object, `servers` absent or not an object, or any entry not an object — is **unreadable**. This section then falls back to the same placeholder a missing registry gets, because either way there are no cards to draw; the Health Snapshot row is where the two are told apart.
 
 **Output**: card per server. Status pill (Installed / Missing / Manual). Type pill (git / native). Required-by chips (one per consuming plugin). For git-based: repo URL truncated. For native: platform path.
 
@@ -78,7 +79,7 @@ This section is **read-only**. `audit-region-sources` is the dedicated coverage 
 - Plugins: count from Section 2
 - Themes: count from Section 3
 - Dependencies: invoke `<workspace-root>/cogni-workspace/scripts/check-dependencies.sh` and partition `data.dependencies[]` (one entry per tool: `{name, available, required, version}`) on each entry's own `required` flag; `data.missing_required` / `data.missing_optional` carry the same misses as integers
-- MCPs: count from Section 4
+- MCPs: read the `servers` object from `<workspace-root>/cogni-workspace/references/mcp-git-registry.json` and partition its entries on each entry's own resolved install status. The row renders exactly one of four summaries: `registry not found` (file absent, unparseable, or a literal JSON null), `registry unreadable` (parses, but not the required shape above), `no servers configured` (`servers` present and empty), or `<installed>/<total> installed[, <n> manual]`. All three zero-server states are non-`ok`, so the row can never report a green `0/0` — a count comparison both sides satisfy at zero is not evidence of health.
 
 **Output**: one row per check. Each row: green/yellow/red dot, check name, one-line summary (e.g., "12 vars set, 0 missing"), and a "Run `/cogni-workspace:workspace-status` for details" pointer at the section foot.
 
@@ -90,6 +91,7 @@ The dashboard intentionally does **not** re-implement the diagnostic depth of `w
 - **`discover-plugins.sh` fails**: fall back to glob mode and add a yellow note in Section 7's Plugins line.
 - **Theme parsing fails**: render the card with a "unparseable theme" badge and skip swatches.
 - **MCP registry missing**: skip Section 4 entirely with a placeholder note.
+- **MCP registry shape drift**: a registry that parses but does not match the required shape renders Section 4's placeholder and a non-`ok` Health Snapshot row naming which state it is. The run still exits 0 and still writes the HTML, per the rule below — a malformed registry must degrade, never abort before the page exists.
 - **Missing market catalogs**: render the matrix with empty columns for the missing plugins.
 
 In every failure mode the script must still produce *some* HTML — never error out without writing the file. The user's first question after a failure should be answerable by opening the dashboard.

--- a/cogni-workspace/skills/workspace-dashboard/scripts/generate-dashboard.py
+++ b/cogni-workspace/skills/workspace-dashboard/scripts/generate-dashboard.py
@@ -531,6 +531,54 @@ def _command_on_path(cmd):
     return False
 
 
+# Every registry state that is not a countable list of servers. Kept beside the resolver
+# that produces the statuses so the two cannot drift apart.
+MCP_NON_OK_SUMMARY = {
+    "missing": "registry not found",
+    "malformed": "registry unreadable",
+    "empty": "no servers configured",
+}
+
+
+def resolve_mcp_servers(workspace_root):
+    """Resolve the MCP registry into dashboard rows plus a status naming what was found.
+
+    Returns (servers, status) with status one of "missing" / "malformed" / "empty" / "ok".
+    The states themselves are documented in references/dashboard-sections.md; three
+    properties here are contracts a caller must not break:
+
+    - The "missing" test is an IDENTITY test, never a truthiness test. A falsy-but-present
+      body (`[]`, `""`, `0`, `false`) is malformed, not absent, and reporting it as absent
+      is the same class of bug this function exists to close.
+    - "malformed" returns None (not []) for the server list, so `render_mcp`'s existing
+      two branches stay correct without change.
+    - One bad entry makes the whole registry malformed rather than being skipped. A partial
+      count read from a file the reader does not understand is the failure being fixed, so
+      degrading loudly beats reporting a subset as if it were the whole.
+    """
+    registry = load_mcp_registry(workspace_root)
+    if registry is None:
+        return (None, "missing")
+    if not isinstance(registry, dict):
+        return (None, "malformed")
+    declared = registry.get("servers")
+    if not isinstance(declared, dict):
+        return (None, "malformed")
+    if not declared:
+        return ([], "empty")
+    servers = []
+    for key, server in declared.items():
+        if not isinstance(server, dict):
+            return (None, "malformed")
+        entry = dict(server)
+        entry["name"] = entry.get("name", key)
+        status, hint = mcp_install_status(entry)
+        entry["install_status"] = status
+        entry["install_hint"] = hint
+        servers.append(entry)
+    return (servers, "ok")
+
+
 # ---------------------------------------------------------------------------
 # Markets matrix
 # ---------------------------------------------------------------------------
@@ -609,7 +657,7 @@ def load_hooks(workspace_root):
 # Health snapshot
 # ---------------------------------------------------------------------------
 
-def health_snapshot(workspace_root, foundation, plugins, themes, mcp_servers):
+def health_snapshot(workspace_root, foundation, plugins, themes, mcp_servers, mcp_status):
     """Build a 6-row snapshot mirroring workspace-status categories."""
     found_required_ok = all(f["exists"] for f in foundation if f["required"])
     foundation_label = (
@@ -644,16 +692,23 @@ def health_snapshot(workspace_root, foundation, plugins, themes, mcp_servers):
 
     deps_label, deps_summary = _check_dependencies(workspace_root)
 
-    mcp_summary = ""
-    if mcp_servers is None:
+    # Keyed on the registry status, never on the server count. A count comparison is what
+    # reported a green row for a registry the dashboard could not read: with nothing to count,
+    # `installed + manual == total` is `0 == 0` and holds forever. The count arm below is
+    # therefore reachable only on "ok" WITH entries, so an empty list or a status this
+    # function does not recognize degrades instead of falling through to a count.
+    if mcp_status in MCP_NON_OK_SUMMARY:
         mcp_label = "warning"
-        mcp_summary = "registry not found"
-    else:
+        mcp_summary = MCP_NON_OK_SUMMARY[mcp_status]
+    elif mcp_status == "ok" and mcp_servers:
         installed = sum(1 for s in mcp_servers if s.get("install_status") == "installed")
         total = len(mcp_servers)
         manual = sum(1 for s in mcp_servers if s.get("install_status") == "manual")
         mcp_label = "ok" if installed + manual == total else "warning"
         mcp_summary = f"{installed}/{total} installed" + (f", {manual} manual" if manual else "")
+    else:
+        mcp_label = "warning"
+        mcp_summary = MCP_NON_OK_SUMMARY["malformed"]
 
     return [
         {"name": "Foundation", "label": foundation_label, "summary": foundation_summary},
@@ -1236,22 +1291,12 @@ def main():
     plugins = discover_plugins(workspace_root, mode)
     themes = discover_themes(workspace_root)
 
-    registry = load_mcp_registry(workspace_root)
-    mcp_servers = None
-    if registry:
-        mcp_servers = []
-        for key, server in registry.get("servers", {}).items():
-            entry = dict(server)
-            entry["name"] = entry.get("name", key)
-            status, hint = mcp_install_status(entry)
-            entry["install_status"] = status
-            entry["install_hint"] = hint
-            mcp_servers.append(entry)
+    mcp_servers, mcp_status = resolve_mcp_servers(workspace_root)
 
     markets_meta, market_sets, market_files = load_market_matrix(workspace_root)
     hooks_rows = load_hooks(workspace_root)
     snapshot = health_snapshot(workspace_root, foundation_files(workspace_root),
-                               plugins, themes, mcp_servers)
+                               plugins, themes, mcp_servers, mcp_status)
 
     html_doc = render_html(
         workspace_root=workspace_root,

--- a/cogni-workspace/tests/test-dashboard-mcp-counts.sh
+++ b/cogni-workspace/tests/test-dashboard-mcp-counts.sh
@@ -1,0 +1,232 @@
+#!/usr/bin/env bash
+# Regression test for the workspace-dashboard Health Snapshot's MCP Servers row
+# (resolve_mcp_servers + health_snapshot's MCP arm in
+# skills/workspace-dashboard/scripts/generate-dashboard.py).
+#
+# Contract under test: the row's status is derived from what the MCP registry actually
+# CONTAINS, not from a count comparison that both sides can satisfy at zero. The registry is
+# a cross-file producer (references/mcp-git-registry.json) whose shape nothing else verifies,
+# so every way it can drift has to reach a distinguishable non-ok row:
+#
+#   registry not found      no file, unparseable, or a literal JSON null
+#   registry unreadable     parsed, but not the shape this dashboard reads
+#   no servers configured   `servers` present, well-formed, and empty
+#   n/m installed           at least one entry
+#
+# The row must be FALSIFIABLE. A reader that renders a constant "0/0 installed" satisfies any
+# label-only assertion, so the healthy directions below pin the TOTAL as well: M14 asserts
+# 0/2 (not 0/0) for a registry whose servers are all absent, which is the single strongest
+# falsifier of the "0/0 forever" defect.
+#
+# SHAPE ONLY, NEVER HOST AVAILABILITY -- the same discipline as D9 in the sibling suite
+# test-dashboard-dependency-counts.sh. No case may depend on what is installed under
+# ~/.claude/mcp-servers. That is host-dependent, and on this repo's own live registry it is
+# also currently WRONG for an unrelated and separately-filed reason: an entry declares a
+# desktop_config_key that does not match its installed directory name, so a present server
+# reports `missing`. Fixtures therefore use entries whose status is deterministic on every
+# host: type "native" with no `platforms` key resolves to "manual", and type "git" with a
+# key that cannot exist resolves to "missing".
+#
+# Cases drive the PRODUCTION read path -- resolve_mcp_servers(root) against a real on-disk
+# fixture, or the CLI end to end. Hand-building the server list and calling health_snapshot
+# directly would never execute the registry read and would stay green against the unfixed
+# reader, which is exactly the vacuity this suite exists to avoid.
+#
+# Case ids are zero-padded to a uniform width so no id is a prefix of another: the mutation
+# harness matches --case as a whole token, and M1 vs M10 is that collision class.
+#
+# Paths are self-located from $0, never the working directory: the repo runner invokes suites
+# with cwd=<repo root> and the mutation harness with cwd=$ROOT, so a cwd-relative path here
+# would be a latent false result.
+#
+# stdlib-only: bash + python3, no pip deps, per the repo-wide script convention.
+
+set -u
+HERE="$(cd "$(dirname "$0")" && pwd)"
+WS_ROOT="$(cd "$HERE/.." && pwd)"
+REPO_ROOT="$(cd "$WS_ROOT/.." && pwd)"
+RENDERER="$WS_ROOT/skills/workspace-dashboard/scripts/generate-dashboard.py"
+SECTIONS="$WS_ROOT/skills/workspace-dashboard/references/dashboard-sections.md"
+TMPROOT="$(mktemp -d)"
+trap 'rm -rf "$TMPROOT"' EXIT
+
+failures=0
+pass() { printf 'PASS: %s\n' "$1"; }
+fail() { printf 'FAIL: %s\n' "$1"; failures=$((failures + 1)); }
+
+# new_root <name> [json] -- build a temp workspace root holding a registry at the exact
+# relative path load_mcp_registry derives, and echo the root. Omit the json argument to build
+# a root with NO registry file at all.
+new_root() {
+  local name="$1"
+  local root="$TMPROOT/$name"
+  mkdir -p "$root/cogni-workspace/references"
+  if [ "$#" -ge 2 ]; then
+    printf '%s' "$2" > "$root/cogni-workspace/references/mcp-git-registry.json"
+  fi
+  printf '%s' "$root"
+}
+
+# assert_mcp "<label>" "<root>" "<python expr, True to pass>" -- the renderer is bound as `r`,
+# resolve_mcp_servers' return as `servers` / `status`, and the MCP row dict as `row`. A raised
+# exception exits the driver non-zero, so "does not raise" is asserted by the case passing.
+assert_mcp() {
+  local label="$1" root="$2" expr="$3"
+  if python3 - "$RENDERER" "$root" <<PY
+import importlib.util, sys
+def _load(name, path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    m = importlib.util.module_from_spec(spec); spec.loader.exec_module(m); return m
+r = _load("r", sys.argv[1])
+root = sys.argv[2]
+servers, status = r.resolve_mcp_servers(root)
+snapshot = r.health_snapshot(root, r.foundation_files(root), [], [], servers, status)
+row = [x for x in snapshot if x["name"] == "MCP Servers"][0]
+sys.exit(0 if ($expr) else 1)
+PY
+  then pass "$label"; else fail "$label"; fi
+}
+
+# assert_resolve "<label>" "<root>" "<python expr>" -- the resolver alone, with `servers` and
+# `status` bound. Separate from assert_mcp because health_snapshot also builds the Dependencies
+# row, which shells out to check-dependencies.sh whenever that script exists: a no-op on a temp
+# fixture that has none, but a real subprocess on a case pointed at the repo root.
+assert_resolve() {
+  local label="$1" root="$2" expr="$3"
+  if python3 - "$RENDERER" "$root" <<PY
+import importlib.util, sys
+def _load(name, path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    m = importlib.util.module_from_spec(spec); spec.loader.exec_module(m); return m
+r = _load("r", sys.argv[1])
+servers, status = r.resolve_mcp_servers(sys.argv[2])
+sys.exit(0 if ($expr) else 1)
+PY
+  then pass "$label"; else fail "$label"; fi
+}
+
+# assert_cli "<label>" "<root>" <needle>... -- render the root through the real CLI and assert
+# the page. A needle prefixed with '!' must be ABSENT. Every case asserts the same baseline:
+# exit 0, a non-empty HTML file, and no traceback on stderr. That baseline is the point -- the
+# malformed shapes below all RAISED before this fix, writing no HTML and printing no JSON,
+# which contradicts the whole-file guarantee in references/dashboard-sections.md ("never error
+# out without writing the file"). One helper, so the invocation and that baseline are a single
+# edit and no case can quietly drop the traceback check by merging stderr into stdout.
+assert_cli() {
+  local label="$1" root="$2"; shift 2
+  local out="$root/out.html" err="$root/err.txt" needle ok=1
+  python3 "$RENDERER" "$root" --output "$out" >/dev/null 2>"$err" || ok=0
+  [ -s "$out" ] || ok=0
+  if grep -qF 'Traceback' "$err"; then ok=0; fi
+  for needle in "$@"; do
+    case "$needle" in
+      '!'*) if grep -qF -- "${needle#!}" "$out"; then ok=0; fi ;;
+      *)    grep -qF -- "$needle" "$out" || ok=0 ;;
+    esac
+  done
+  if [ "$ok" -eq 1 ]; then pass "$label"; else fail "$label"; fi
+}
+
+# --- M01: healthy, and deterministic on every host. --------------------------
+# type "native" with no `platforms` key resolves to ("manual", "") everywhere, so both
+# operands are exact. Asserting the label alone would pass against a constant-0/0 reader.
+M01ROOT="$(new_root m01 '{"version":"1.0.0","servers":{"alpha":{"type":"native"},"beta":{"type":"native"}}}')"
+assert_mcp "M01 well-formed registry renders ok with a truthful non-zero total" "$M01ROOT" \
+  'status == "ok" and len(servers) == 2 and row["label"] == "ok" and row["summary"] == "0/2 installed, 2 manual"'
+
+# --- M02: THE discriminating case, and the recorded mutation --case target. ---
+# The issue's own repro: `servers` renamed, so the registry parses but declares nothing this
+# reader understands. Three operands in ONE case, so the recorded mutation flips exactly this
+# case; the third is the one the mutation falsifies.
+M02ROOT="$(new_root m02 '{"version":"1.0.0","description":"x","server_list":{"alpha":{"type":"native"}}}')"
+assert_mcp "M02 shape-drifted registry renders non-ok and never 0/0 installed" "$M02ROOT" \
+  'row["label"] != "ok" and row["summary"] != "0/0 installed" and row["summary"] == "registry unreadable"'
+
+# --- M03: explicitly empty, which is well-formed but still not health. -------
+M03ROOT="$(new_root m03 '{"version":"1.0.0","servers":{}}')"
+assert_mcp "M03 registry declaring zero servers renders non-ok" "$M03ROOT" \
+  'status == "empty" and row["label"] != "ok" and row["summary"] == "no servers configured"'
+
+# --- M04: the pre-existing missing path, pinned so the refactor cannot move it. --
+M04ROOT="$(new_root m04)"
+assert_mcp "M04 absent registry file still renders the registry-not-found row" "$M04ROOT" \
+  'status == "missing" and servers is None and row["label"] == "warning" and row["summary"] == "registry not found"'
+
+# (No M05: pairwise distinctness of the three non-ok summaries is entailed by M02, M03 and M04
+# each asserting its own exact literal, so a separate case adds no falsifier. The id is left
+# unused rather than renumbering, which would invalidate the recorded mutation --case.)
+
+# --- M06-M08: the shapes that used to RAISE now degrade, end to end. ---------
+M06ROOT="$(new_root m06 '[1,2]')"
+assert_cli "M06 a registry whose root is not an object degrades without raising" "$M06ROOT" 'health-dot warning'
+
+M07ROOT="$(new_root m07 '{"servers":[1,2]}')"
+assert_cli "M07 a servers key holding a list degrades without raising" "$M07ROOT" 'health-dot warning'
+
+M08ROOT="$(new_root m08 '{"servers":{"alpha":"not-a-mapping"}}')"
+assert_cli "M08 a non-mapping server entry degrades without raising" "$M08ROOT" 'health-dot warning'
+
+# --- M09: no-regression for the missing path, through the real renderer. -----
+# M04 stops at the private function; this pins that render_mcp's placeholder still reaches the
+# page. A fix that collapsed the None and [] states into one sentinel would lose it.
+assert_cli "M09 absent registry still emits the Section 4 placeholder and a non-ok dot" \
+  "$M04ROOT" 'MCP registry not found in this workspace.' 'health-dot warning'
+
+# --- M10: the drifted fixture, end to end through the real renderer. ---------
+# Two operands like the sibling's D10: the negative alone would pass against an empty or
+# never-written page. "Green dot forever" is a property of the rendered page, so it is
+# asserted there and not only at the function boundary.
+assert_cli "M10 rendered page shows the drift summary and never a 0/0 count" \
+  "$M02ROOT" 'registry unreadable' 'health-dot warning' '!0/0 installed'
+
+# --- M11: the documentation twin describes the states the code emits. -------
+# Positive and negative, whole-file: a second mention of the old model elsewhere would let the
+# next reader re-derive the bug from the docs. grep -F, the strings carry no metacharacters.
+m11_ok=1
+for needle in 'registry not found' 'registry unreadable' 'no servers configured' 'installed'; do
+  grep -qF "$needle" "$SECTIONS" || m11_ok=0
+done
+if grep -qF -e '- MCPs: count from Section 4' "$SECTIONS"; then m11_ok=0; fi
+if [ "$m11_ok" -eq 1 ]; then
+  pass "M11 sections reference documents the four rendered states"
+else
+  fail "M11 sections reference documents the four rendered states"
+fi
+
+# --- M12: the unguarded inline read has not come back. -----------------------
+# Asserted as an ABSENCE only. The presence of a particular call spelling is deliberately not
+# asserted: that pins an implementation detail a rename would falsely red, while the behaviour
+# it stands for is already covered by M06-M08. The needle is the WHOLE loop line, not the bare
+# registry.get("servers", {}) substring, because the recorded mutation reintroduces that
+# substring and would otherwise make this case's failure indistinguishable from the mutation's
+# own footprint.
+if grep -qF 'for key, server in registry.get("servers", {}).items()' "$RENDERER"; then
+  fail "M12 the unguarded inline registry read is absent from the renderer"
+else
+  pass "M12 the unguarded inline registry read is absent from the renderer"
+fi
+
+# --- M13: the live registry's own shape, pinned from the consumer side. ------
+# The counterpart of the sibling's D9. SHAPE ONLY: the installed COUNT is deliberately not
+# asserted, because it depends on what the host has installed. What this pins is that the
+# repo's real registry is still one this reader classifies `ok` -- which is the whole of what
+# this change could break for the shipped file.
+assert_resolve "M13 the repo's own registry is still a shape this reader accepts" "$REPO_ROOT" \
+  'status == "ok" and servers is not None and len(servers) > 0'
+
+# --- M14: a registry whose servers are all absent still reports a real total. --
+# The direct analogue of the sibling's D2 and the strongest falsifier of "0/0 forever": a
+# reader rendering a constant 0/0 fails here on the TOTAL, not merely on the label. type "git"
+# with a key that cannot exist resolves to "missing" on every host, so this is deterministic.
+M14ROOT="$(new_root m14 '{"servers":{"alpha":{"type":"git","desktop_config_key":"zz-not-installed-alpha"},"beta":{"type":"git","desktop_config_key":"zz-not-installed-beta"}}}')"
+assert_mcp "M14 a fully-uninstalled registry reports a truthful two-server total" "$M14ROOT" \
+  'status == "ok" and row["label"] != "ok" and row["summary"] == "0/2 installed"'
+
+echo
+if [ "$failures" -eq 0 ]; then
+  echo "All dashboard MCP-count tests passed."
+  exit 0
+else
+  echo "$failures test(s) failed."
+  exit 1
+fi


### PR DESCRIPTION
Refs #1578.

## Summary

The Health Snapshot's MCP Servers row built `mcp_servers` from `registry.get("servers", {})` — a
defaulted read of a cross-file producer whose shape nothing verified. A registry that parsed but
carried no `servers` key yielded `[]`, not `None`, so the `mcp_servers is None` guard was bypassed
and `installed + manual == total` became a permanent `0 == 0`. The row rendered `0/0 installed`
under a green dot.

- New `resolve_mcp_servers(workspace_root)` returns `(servers, status)` over four states —
  `missing` / `malformed` / `empty` / `ok`.
- `health_snapshot`'s MCP arm branches on that status. The count arm is reachable **only** on
  `ok` with entries, so an empty list or an unrecognized status degrades instead of falling
  through to a count. Three distinguishable non-ok summaries: `registry not found`,
  `registry unreadable`, `no servers configured`.
- The registry test is `is None`, not a truthiness test. The old `if registry:` masked a
  falsy-but-present body (`[]`, `""`, `0`, `false`) as a missing file — the same bug class one
  step over.
- Three shapes that previously **raised** now degrade: a non-dict root, `servers` holding a list,
  and a non-mapping entry. All three raised *before* `render_html` and the file write, so the CLI
  exited 1 having written no HTML and printed no JSON — contradicting `dashboard-sections.md`'s
  "never error out without writing the file".
- New suite `cogni-workspace/tests/test-dashboard-mcp-counts.sh` (M01–M14, M05 intentionally
  unused). Suite count 16 → 17.
- Doc twin updated in three places; §7's MCP line was `- MCPs: count from Section 4`, naming no
  field, no shape and no partition rule.

## Evidence

| check | result |
|---|---|
| `run-plugin-tests.py --filter cogni-workspace` | **17 discovered / 17 passed / 0 failed** (base: 16/16/0) |
| new suite against the **base** renderer | `rc=1` (red) |
| new suite against this branch | `rc=0` (green) |
| mutation replay (below) | `guard_verified` |

The suite-count rise is the load-bearing assertion, not `0 failed` — the baseline is already
`0 failed`, so that alone is green at base and discriminates nothing.

## Mutation recipe

```
bash "$HOME/.claude/plugins/marketplaces/managed-service/cogni-service/scripts/mutation-check.sh" --root . --file cogni-workspace/skills/workspace-dashboard/scripts/generate-dashboard.py --expr 's/declared = registry\.get\("servers"\)/declared = registry.get("servers", {})/' --test 'bash cogni-workspace/tests/test-dashboard-mcp-counts.sh' --case M02
```

Recorded verdict on replay: `guard_verified` — `mutated_result: red` (M02), `restored_result:
green`, tree clean afterwards. Replayed again after the final edit to the renderer.

Three notes for whoever replays it:

- **The mutated line is one this diff introduces.** `declared = registry.get("servers")` is new
  code inside `resolve_mcp_servers`; the string it mutates *to* is the old inline read this PR
  deletes. Reverting it restores the exact pre-fix semantics — a missing `servers` key defaults
  to `{}`, classifies `empty` rather than `malformed`, and M02's
  `summary == "registry unreadable"` operand goes red.
- **The harness is cogni-service's, not this repo's.** The two same-named
  `scripts/mutation-check.sh` files here (`cogni-consult/`, `cogni-portfolio/`) are bespoke
  zero-argument harnesses that accept none of these flags. The unversioned marketplace path above
  was resolved on the authoring host and is byte-identical to the loaded copy; the version-pinned
  `cache/managed-service/cogni-service/<version>/` paths lag the marketplace.
- The `--expr` is fed to `perl -0pi`, never sed, and is deliberately non-global:
  `registry.get("servers"` occurs exactly once in the file both before and after this change.

## Scope decisions

**Acceptance criterion 3 is false at base — graded as a shape assertion, not as its literal text.**
The issue asks that the live registry "still renders `2/2 installed` with an `ok` label". Executed
against `origin/main` with no changes applied, it already renders `1/2 installed` + `warning`: the
registry declares `desktop_config_key: "excalidraw"` while the installed directory is
`mcp_excalidraw/`, so `mcp_install_status` probes a path that does not exist. The criterion is
both host-dependent and currently false for a reason this issue explicitly excludes — filed as
#1580. **Grading note:** a contract item restating AC-3 verbatim cannot be met by a `2/2 installed`
grep, and could not be met by any change inside this issue's scope. M13 discharges its intent the
way the sibling suite's D9 discharges its emitter contract: shape only, never host availability.

**`render_mcp` is unchanged, and `malformed` deliberately collapses onto `servers is None`** —
the "deliberately collapsed with a stated reason" branch of acceptance criterion 2, taken at the
one surface where there are no cards to draw either way. The Health Snapshot row is where the
states are told apart, because that is the surface that made the false claim.

**`health_snapshot`'s sixth parameter is required, with no default.** Verified repo-wide at
`origin/main`: `:1253` is the only caller and no suite or script calls it directly. A default
would let a future caller silently reintroduce the unguarded path.

**No shared zero-count helper.** #1573 fixed the same class for the Dependencies row. Two
instances is not enough to factor; a third would be — the issue says so and this honours it.

**No `plugin.json` version bump** — the patch bump is applied post-merge.

## Open questions

- **Section 4's placeholder now states something false for a malformed registry.** Because
  `malformed` reuses `servers is None`, `render_mcp` emits *"MCP registry not found in this
  workspace."* — but the file **is** there, and the remedy is to repair it, not create it. The
  page contradicts itself: the health row says `registry unreadable` while Section 4 says the file
  is absent. Fixing it means threading the status into `render_mcp` and selecting the string,
  which is a one-line change to a function whose call site this PR already touches — but it
  changes behaviour the plan and the committed contract both fixed as out of scope, so it was
  deliberately **not** applied here. Worth a maintainer's call on whether to fold it in or file it.
- **The stdout JSON still collapses all four states to `0`** (`"mcp_servers": len(mcp_servers) if
  mcp_servers else 0`). That key is the CLI contract documented in
  `skills/workspace-dashboard/SKILL.md`, outside this issue's scope boundary — but it means a
  machine consumer still reads the false-health signal the HTML row just stopped emitting.
- **Two other readers of the same registry remain unguarded** —
  `cogni-workspace/scripts/patch-desktop-config.py` and
  `cogni-workspace/tests/test-mcp-declaration-hygiene.sh` both do the same bare
  `registry.get("servers", {})`, and nothing validates the file producer-side. The repo now has
  one hardened reader and two soft ones, and no single place stating what the registry's shape is.

## Disclosure

The runner token is **over-scoped** relative to the documented least-privilege posture —
`check-token-scope.sh --strict` reports `status: over_scoped`, extra scopes `gist`, `read:org`,
`workflow`. This is the fixed scope set of the GitHub CLI OAuth (`gho_`) token and cannot be
narrowed; the run proceeded under the authorized `--allow-overscoped` flag, disclosed here per
policy.

## Follow-up issues

- #1580 — the MCP install probe resolves the wrong directory when `desktop_config_key` differs
  from the installed directory name.