### PR TITLE
cogni-knowledge: make plain-emit-03/04 reachable on both arms

### DIFF
--- a/cogni-knowledge/tests/test_plain_result_emitters.sh
+++ b/cogni-knowledge/tests/test_plain_result_emitters.sh
@@ -109,6 +109,13 @@ fixtures_definers=0
 exercisers=0
 shape_errors=0
 
+# Offender text for plain-emit-03 / plain-emit-04. The loop accumulates; both
+# cases are emitted once, after it closes, under a fixed id. Initialized here
+# because `set -u` is on and the post-loop arms read these whether or not the
+# loop ever appended to them.
+pair_offenders=""
+plain_offenders=""
+
 for f in "$SCAN_ROOT"/*.sh "$SCAN_ROOT"/fixtures/*.sh; do
   [ -f "$f" ] || continue
 
@@ -145,17 +152,56 @@ for f in "$SCAN_ROOT"/*.sh "$SCAN_ROOT"/fixtures/*.sh; do
     esac
   done <<<"$defs"
 
+  # Accumulate only — the emission for both cases happens after the loop. The
+  # predicates and both shape_errors bumps are unchanged, so the fold below
+  # stays arithmetically identical. The file name moves into the message text,
+  # since the id no longer carries it. `${f##*/}` rather than $(basename "$f")
+  # because the name is now interpolated into an ASSIGNMENT: an assignment
+  # takes its exit status from the substitution, so under `set -e` a failing
+  # one would abort the run, where the `red "…"` argument it replaced would
+  # not have. Parameter expansion also forks nothing.
   if [ "$n_red" -ne 1 ] || [ "$n_green" -ne 1 ]; then
-    red "FAIL: plain-emit-03-$(case_slug "$(basename "$f")") defines red=$n_red green=$n_green (expected 1 each)"
+    pair_offenders="$pair_offenders${f##*/} defines red=$n_red green=$n_green (expected 1 each)
+"
     shape_errors=$((shape_errors + 1))
   elif [ "$n_plain" -ne 2 ]; then
-    red "FAIL: plain-emit-04-$(case_slug "$(basename "$f")") emitter bodies are not both the plain printf form"
-    printf '%s\n' "$defs" | sed 's/^/  /'
+    plain_offenders="$plain_offenders${f##*/}
+$defs
+"
     shape_errors=$((shape_errors + 1))
   fi
 done
 
 errors=$((errors + shape_errors))
+
+# plain-emit-03 / plain-emit-04 are emitted here, once, rather than per file
+# inside the loop. In the loop each id had to carry a per-file discriminator to
+# stay unique per emitted line, and the if/elif had no else — so neither id
+# could ever print a green line, and a harness aimed at either read a clean run
+# as case_not_found instead of a verdict. A fixed id only becomes safe once the
+# emission leaves the loop, which is why this is a relocation and not a suffix
+# strip. The id stays the second whitespace-separated token, never colon-abutted.
+#
+# Like the plain-emit-06 block below, neither FAIL arm increments errors: the
+# errors=$((errors + shape_errors)) fold above already counted every offending
+# file, and counting again would change the failure tally.
+if [ -z "$pair_offenders" ]; then
+  green "PASS: plain-emit-03 every emitter-defining file defines exactly one red and one green"
+else
+  red "FAIL: plain-emit-03 emitter-defining file(s) do not define exactly one red and one green:"
+  printf '%s' "$pair_offenders" | sed 's/^/  /'
+fi
+
+# Scoped to the files that cleared the pairing check: the elif above means a
+# pairing offender never reaches the n_plain check, so an unqualified "every
+# emitter body is plain" claim would be false on exactly the run where
+# plain-emit-03 is red.
+if [ -z "$plain_offenders" ]; then
+  green "PASS: plain-emit-04 both emitter bodies are the plain printf form in every file that cleared the pairing check above"
+else
+  red "FAIL: plain-emit-04 emitter-defining file(s) clearing the pairing check have bodies that are not both the plain printf form:"
+  printf '%s' "$plain_offenders" | sed 's/^/  /'
+fi
 
 # Liveness floor — a broken glob must fail loudly rather than pass vacuously.
 # 79 files exercise the contract today (1 defines the emitters — the shared


### PR DESCRIPTION
Closes #1575. Refs #1517.

## Summary

`plain-emit-03` and `plain-emit-04` were emitted only from FAIL arms **inside** the emitter-shape loop (`:149`, `:152`), each id carrying a per-file `case_slug` discriminator, and the `if`/`elif` had no `else`. Neither id could ever print a green line, so the mutation harness returned `case_not_found` instead of a verdict and both guards were unfalsifiable.

The loop now accumulates offender text into `pair_offenders` / `plain_offenders`, and each case is emitted **once, after the loop closes**, under a fixed id. A fixed id only becomes safe once emission leaves the loop — which is why this is a relocation and not the `#1517` suffix strip.

## Why placement is load-bearing, twice

- **After the loop's `done`.** The live population is 81 files with exactly **one** emitter-definer (`fixtures/test_helpers.sh`). An aggregate emitted *inside* the loop would print exactly once on today's tree and would therefore pass the `sort | uniq -d` census the acceptance criteria use — placement correctness cannot be established from output alone on this tree.
- **Above `plain-emit-06`.** That block's FAIL prose reads "see the plain-emit-03/plain-emit-04 lines above". Inserting between the `errors + shape_errors` fold and the `plain-emit-05` comment keeps it true without editing it.

Neither new FAIL arm increments `errors` — the fold already counted every offending file. Same rule the `plain-emit-06` block records in its own comment.

## Evidence

All measured on this branch; the base column is the falsifier each criterion names.

| Check | Base (`50373ead`) | This branch |
|---|---|---|
| Suite exit code | `rc=0` | `rc=0` |
| `PASS:` census | `01 02 05 06 07` — **03/04 absent** | `01 02 03 04 05 06 07` |
| Duplicate ids (`sort \| uniq -d`) | empty | empty |
| `check-result-line-plainness.py` | clean | clean |
| Full sweep `run-plugin-tests.py` | — | **129/129 passed, 0 failed** |
| Touched paths | — | `cogni-knowledge/tests/test_plain_result_emitters.sh` only |

**Both FAIL arms were exercised**, not just the PASS arms. `SCAN_ROOT` is `${1:-$TESTS_DIR}`, so a crafted two-offender population drives both without touching the real tree:

```
FAIL: plain-emit-03 emitter-defining file(s) do not define exactly one red and one green:
  a_pair_offender.sh defines red=1 green=0 (expected 1 each)
FAIL: plain-emit-04 emitter-defining file(s) clearing the pairing check have bodies that are not both the plain printf form:
  b_plain_offender.sh
  red()   { echo "$1"; }
  green() { echo "$1"; }
```

That run reported **4** failures = `plain-emit-05` + `plain-emit-07` + `shape_errors`(2) — confirming the two new FAIL arms did not double-count `errors`.

## Mutation recipe

```
bash "$HOME/.claude/plugins/marketplaces/managed-service/cogni-service/scripts/mutation-check.sh" --root . --file cogni-knowledge/tests/fixtures/test_helpers.sh --expr 's/^red\(\)/red ()/m' --test 'bash cogni-knowledge/tests/test_plain_result_emitters.sh' --case plain-emit-03
```

```
bash "$HOME/.claude/plugins/marketplaces/managed-service/cogni-service/scripts/mutation-check.sh" --root . --file cogni-knowledge/tests/fixtures/test_helpers.sh --expr 's/red\(\)   \{ printf \x27%s\\n\x27/red()   { printf "%s\\n"/' --test 'bash cogni-knowledge/tests/test_plain_result_emitters.sh' --case plain-emit-04
```

Both `guard_verified` (`mutated_result: red`, `restored_result: green`, tree clean afterwards), replayed after the final edit.

Four notes for whoever replays them:

- **Both return `case_not_found` at `origin/main` and `guard_verified` here.** That base-vs-branch delta *is* the evidence — it is exactly the falsifier #1575 names, and it is what shows the recipes pin what this PR changed rather than an already-green line. Verified in a throwaway detached worktree at `50373ead`.
- **Neither mutation removes the fixture from the definer population**, which is what would make a recipe vacuous. `red ()` is still valid bash and every suite sourcing the helper keeps working, but `grep -E '^(red|green)\(\)'` no longer matches it, so `defs` holds the `green()` line alone — still non-empty, the file stays a definer, the per-file tally still runs, and `plain-emit-03` fires with `red=0 green=1`.
- **`--expr` is fed to `perl -0pi`, not sed or ERE.** Both are non-global and anchored; the second keys on `red()` plus **three** spaces, which the `green()` line's single space cannot match.
- **The harness is not `scripts/mutation-check.sh` — that path does not exist in this repo.** The two same-named files here (`cogni-consult/`, `cogni-portfolio/`) are bespoke and accept none of these flags. Same convention as `cogni-knowledge/tests/README.md:67-72`.

## Scope decisions

- `fixtures/test_helpers.sh` is **byte-unchanged**. This PR removes the file's last two `case_slug` call sites, but the helper is not orphaned — `test_knowledge_lib.sh` and `test_migrate_layout.sh` still use it, and `test_migrate_layout.sh:136` is a *correct* both-arms use.
- The `n_red` / `n_green` / `n_plain` predicates, both `shape_errors` bumps, and the fold are unchanged, so the failure tally is arithmetically identical for any tree.
- `plain-emit-04`'s PASS claim is **scoped to the population actually checked** — the `elif` means a pairing offender never reaches the `n_plain` check, so an unqualified "every emitter body is plain" would be false on exactly the run where `plain-emit-03` is red.
- No `plugin.json` version value moves; the patch bump is applied post-merge.

## Open questions

**1. Full-scope vs `--partial` — please sanity-check this call.** The plan carries a non-empty `deferred[]`, which mechanically suggests `--partial` (`Refs`). I opened this as full-scope (`Closes #1575`) because every one of #1575's acceptance criteria is verified green above, and the deferred item is a **distinct defect in a different file** — filed as #1582 with its own acceptance bar — not a slice of #1575's scope. The commit message already carries `Closes #1575`; since squash-merge concatenates commit messages and this repo forbids force-push, that link is fixed and re-opening as `--partial` would leave the PR body contradicting its own squash message. If you disagree, the remedy is to reopen #1575 after merge rather than to bounce this PR.

**2. Token-scope opt-out, disclosed.** The Step 7.5 preflight reported `over_scoped` — extra scopes `gist`, `read:org`, `workflow` (`workflow` is on the forbidden list). This is the fixed scope set of the GitHub CLI OAuth (`gho_`) token and cannot be narrowed. Run under the authorized `--allow-overscoped` **flag** (exit 0), disclosed here per standing policy.

## Follow-up issues

- **#1582** — `cogni-knowledge: klib-01 is a FAIL-only per-file id, so the test_knowledge_lib precondition can never report green`.

Worth flagging beyond the filing: **it falsifies #1575's own premise.** #1575 states these two were "the last split-case-id instances left in cogni-knowledge after #1517". A census run during planning found `test_knowledge_lib.sh:31-36` still emitting `klib-01-$(case_slug "$f")` from a FAIL-only arm with `exit 1` and no PASS counterpart — `klib-01` occurs exactly once at `origin/main`. Its remedy differs materially (the arm must abort after emitting), so it is a separate PR rather than fragmentation.