### PR TITLE
cogni-knowledge: give klib-01 a reachable PASS/FAIL pair

### DIFF
--- a/cogni-knowledge/tests/test_knowledge_lib.sh
+++ b/cogni-knowledge/tests/test_knowledge_lib.sh
@@ -28,12 +28,40 @@ SCRIPTS_DIR="$PLUGIN_ROOT/scripts"
 
 . "$(dirname "$0")/fixtures/test_helpers.sh"
 
+# Missing-script text for klib-01. The loop accumulates; the case is emitted
+# once, after it closes, under a fixed id. Initialized here because `set -u` is
+# on and the post-loop arms read it whether or not the loop ever appended to it.
+missing_scripts=""
+
 for f in _knowledge_lib.py candidate-store.py fetch-cache.py; do
   if [ ! -f "$SCRIPTS_DIR/$f" ]; then
-    red "FAIL: klib-01-$(case_slug "$f") $f not found at $SCRIPTS_DIR/$f"
-    exit 1
+    missing_scripts="$missing_scripts$f not found at $SCRIPTS_DIR/$f
+"
   fi
 done
+
+# klib-01 is emitted here, once, rather than per file inside the loop. In the
+# loop the id had to carry a per-file case_slug discriminator to stay unique per
+# emitted line, and the arm was fail-only with no else — so the id could never
+# print a green line, and a harness aimed at it read a clean run as
+# case_not_found instead of a verdict. A fixed id only becomes safe once the
+# emission leaves the loop, which is why this is a relocation and not a suffix
+# strip. The id stays the second whitespace-separated token, never colon-abutted.
+#
+# grade() below is the mechanism every other case in this file uses, and is
+# deliberately NOT reused here: it grades a tagged line out of $OUT from the
+# python subprocess this precondition must run BEFORE (that subprocess imports
+# the very scripts checked here), it folds into `errors`, which is not
+# initialized until just above it, and it is non-fatal — where this check must
+# abort. The exit stays fatal; it now reports every missing script rather than
+# only the first.
+if [ -z "$missing_scripts" ]; then
+  green "PASS: klib-01 all three library scripts present under $SCRIPTS_DIR"
+else
+  red "FAIL: klib-01 library script(s) missing under $SCRIPTS_DIR:"
+  printf '%s' "$missing_scripts" | sed 's/^/  /'
+  exit 1
+fi
 
 WORK=$(mktemp -d)
 trap 'rm -rf "$WORK"' EXIT


### PR DESCRIPTION
Refs #1582.

## Summary

`klib-01` was emitted only from a **FAIL arm inside** the three-script precondition loop, carrying a per-file `case_slug` discriminator and followed immediately by `exit 1`. No PASS counterpart existed anywhere in the file, so a green run emitted **no `klib-01` line at all** and `mutation-check.sh --case klib-01` returned `case_not_found` rather than a verdict — a guard no mutation run could falsify.

This applies the collect-then-pair restructure already merged for `plain-emit-03`/`plain-emit-04` (`e5c3ac54`, PR #1583): the loop now only accumulates missing script names, and one fixed-id `if`/`else` after it emits exactly one arm. **A fixed id only becomes safe once the emission leaves the loop, which is why this is a relocation and not a suffix strip.**

`exit 1` stays fatal, and now names *every* missing script rather than only the first.

## Scope decisions

- **In:** `cogni-knowledge/tests/test_knowledge_lib.sh`, lines 31–36 only. One file, +30/−2.
- **`case_slug` is untouched** in `fixtures/test_helpers.sh`. It becomes unused *in this file* — intended — but stays live repo-wide: `test_migrate_layout.sh:136` pairs it correctly across both arms (`migrate-layout-10-$fslug` at :138 and :140). Verified green on this branch.
- **Two in-repo shapes fix an unpaired loop id, and this PR takes the second.** `test_migrate_layout.sh:136-143` keeps a per-iteration suffix and adds a green arm *inside* the loop; `test_plain_result_emitters.sh:112-193` accumulates and emits one fixed-id pair *after* it. `klib-01` is a **fatal** precondition — its FAIL arm ends in `exit 1` — so an in-loop green arm would emit up to three PASS lines for one precondition and would have to survive an early exit the migrate-layout case (which only increments `errors`) never faces.
- **`grade()` reuse was considered and rejected** (the reasoning is recorded in the code comment, not just here): it grades a tagged line out of `$OUT` from the python subprocess this precondition must run *before* — that subprocess imports the very scripts being checked — it folds into `errors`, which is not initialized until ~1300 lines lower, and it is non-fatal where this check must abort.
- **`01` is reused, never renumbered** (README rule 3). No `plugin.json` version moves — the post-merge workflow owns the bump.

## Test plan

| Check | Base `e79c4163` | This branch |
|---|---|---|
| `bash …/test_knowledge_lib.sh` exit code | 0 | 0 |
| `… \| awk '/^[ \t]*PASS:/{print $2}' \| grep -c '^klib-01$'` | **0** | **1** |
| Emitted PASS-id set | `klib-02` … `klib-42` | same **+ `klib-01`**, nothing removed |
| `… \| sort \| uniq -d` (duplicate ids) | empty | empty |
| `test_plain_result_emitters.sh` | green | green |
| `test_migrate_layout.sh` | green | green (3 × `migrate-layout-10-…`) |
| `python3 scripts/check-result-line-plainness.py` | 0 | 0 |
| `python3 scripts/run-plugin-tests.py` | — | **129/129 suites pass, rc 0** |
| `git diff --name-only origin/main` | — | exactly one path, under `cogni-knowledge/tests/` |

The duplicate-id check is **already empty at base**, so it is a non-regression guard only — never evidence the fix landed. The discriminating check is the `PASS: klib-01` count going 0 → 1.

**FAIL-arm transcript** (branch shape, two of three names mutated away):

```
FAIL: klib-01 library script(s) missing under …/cogni-knowledge/scripts:
  _knowledge_lib_ABSENT.py not found at …/cogni-knowledge/scripts/_knowledge_lib_ABSENT.py
  candidate-store_ABSENT.py not found at …/cogni-knowledge/scripts/candidate-store_ABSENT.py
```
exit code `1`; zero `PASS: klib-01` lines; zero `klib-02`+ lines (nothing below the precondition runs). Both missing names are reported — at base the loop aborted on the first.

## Mutation recipe

Run from the repo root:

```bash
bash "$HOME/.claude/plugins/marketplaces/managed-service/cogni-service/scripts/mutation-check.sh" --root . --file cogni-knowledge/tests/test_knowledge_lib.sh --expr 's/for f in _knowledge_lib\.py candidate-store\.py/for f in _knowledge_lib_ABSENT.py candidate-store_ABSENT.py/' --test 'bash cogni-knowledge/tests/test_knowledge_lib.sh' --case klib-01
```

**Recorded verdicts — the base-vs-branch delta is the evidence, since a recipe green at base pins nothing:**

- **This branch:** `guard_verified` (`mutated_result: red`, `restored_result: green`).
- **Base `origin/main` @ `e79c4163`, identical invocation:** `case_not_found` — *"no 'FAIL: klib-01' and no 'ok:/PASS: klib-01' line in the mutated test output."* Mutated, base emits `klib-01-knowledge-lib-absent-py` (the `case_slug` suffix), a different whole token; clean, base emits nothing for `klib-01` at all. **That contrast is the defect being closed.**

Three notes on the recipe's construction:

- **Two names are mutated, not one**, because the accumulation is the behaviour this PR introduces: base bails on the *first* miss, so only one name is ever reported; the branch accumulates and lists both. A one-name mutant would discriminate only the id, not the collect-then-pair change.
- **The `--expr` targets line 31, the loop header — a line this diff leaves byte-identical.** That is required here, not the usual unchanged-line-pin defect: the recipe must *also* replay at the base ref to produce the `case_not_found` half of the delta, and a mutant aimed at a line this PR introduces cannot exist at base at all (`mutation-check.sh` would return the `expr_no_op` hard error there instead of a verdict). Beyond that, the guarded property is a precondition over the three script *names*, and line 31 is the only place naming them.
- **The `for f in ` prefix confines the substitution to the loop header.** The three names recur in the python heredoc's `load(…)` calls; an unprefixed global rename would corrupt the imports and redden the mutated run for a second, unrelated reason.

## Follow-up issues

- **#1584** — cogni-knowledge: nothing mechanically detects a FAIL-only case id, so the class keeps being found by hand.

This class has now been hand-fixed twice (#1575, #1582), both off **manual censuses**. Two read-only passes during this resolve measured the population and posted it to #1584: ~81 single-file fail-only preconditions across ~50 suites, plus a third *loop* variant at `test_prose_density_contract.sh:24-29`. Building the detector is a new repo-root guard plus suite plus lint wiring — outside this issue's ids-and-gating remit, so it is filed rather than folded in.

## Open questions

- **`Refs` rather than `Closes`, deliberately — but #1582 is fully satisfied.** The pipeline passes `--partial` whenever `deferred[]` is non-empty, and this resolve filed #1584, so the link is mechanically `Refs`. All **eight** of #1582's acceptance criteria are met (table above). #1584 is a *new, separable* concern discovered during the work, not a piece of #1582 left undone — so **#1582 should be closed on merge**; it will not auto-close through this link.
- **Token-scope disclosure.** The Step 7.5 least-privilege gate reported `over_scoped`: the runner holds `gist`, `read:org`, `workflow` beyond the documented `repo` posture. The runner is on a `gho_` GitHub-CLI OAuth token whose scope set is fixed by the CLI's OAuth app and cannot be narrowed — the case the gate's own message names for opting out. Taken via the `--allow-overscoped` **flag** (not the env var), disclosed here per the standing convention.