### PR TITLE
cogni-knowledge: rule 7 — both case arms reachable and own-gated

### DIFF
--- a/cogni-knowledge/tests/README.md
+++ b/cogni-knowledge/tests/README.md
@@ -71,7 +71,7 @@ same-named `cogni-portfolio/scripts/mutation-check.sh` and
 `cogni-consult/scripts/mutation-check.sh` are different, bespoke scripts and are
 not this harness.
 
-Six rules follow from how it matches:
+Seven rules follow from how it matches:
 
 1. **An id is unique within its suite.** Two cases sharing one id cannot be told
    apart, so neither is addressable.
@@ -144,6 +144,32 @@ Six rules follow from how it matches:
    Empty output is clean; anything printed is a collision. One limitation: a
    passing run emits only the green arms, so once those are clean, pair each red
    arm's id by reading the source.
+
+7. **Both arms of a case must be reachable, and each is gated only on that
+   case's own predicate.** Rule 5 gives the two arms one id; this one keeps both
+   of them printable. An arm the case's own predicate cannot reach is
+   addressable in name only — `--case <id>` reports `case_not_found` instead of
+   a verdict, and the guard it was meant to check proves nothing. Three shapes
+   recur here. The plainest is a fail-only check with no `else`, which can never
+   print green. The second chains a case onto a *different* case's condition
+   with `elif`, so the branch is evaluated only when that earlier condition took
+   the other path, and the state satisfying both prints neither arm. The third
+   gates a PASS on a suite-wide accumulator such as the shared `errors` counter,
+   which unrelated earlier checks increment — any one of them silences this
+   case. For a multi-file scan, collect then pair: accumulate offenders into one
+   variable during the loop, then gate a single same-id `if`/`else` on that
+   variable after the loop closes (`plain-emit-03` in
+   `test_plain_result_emitters.sh` is the resident model). The one legitimate
+   single arm is a preflight guard with no green state worth reporting — a
+   not-found check that aborts, where execution does not continue so a PASS
+   could never print. Aborting alone does not earn the exemption: a preflight
+   whose subject can legitimately be intact still owes a PASS twin, as `klib-01`
+   in `test_knowledge_lib.sh` shows, pairing one with a fatal `exit`.
+
+   Reachability is invisible in a green run: only the arms that fired appear.
+   Force each branch — a fixture, or an argument-driven scan root that makes the
+   red arm fire — or point `mutation-check.sh --case <id>` at it and let the
+   reverted guard do the forcing.
 
 How the harness classifies a line, precisely: it matches the id as a **whole
 token** (so `--case P1` never matches a `P10` line), keys red on a `FAIL:` line


### PR DESCRIPTION
Closes #1576. Refs #1517.

## Summary

Adds **rule 7** to `cogni-knowledge/tests/README.md` §"Case ids on result lines", recording the property #1517 and #1582 each fixed in code but never wrote down: both arms of a case must be **reachable**, and each arm gated only on that case's own predicate. Rule 5 already forces the two arms to share an id — it says nothing about whether either can print.

The rule names the three shapes that satisfy rules 1–6 and still leave `--case <id>` reporting `case_not_found`, the collect-then-pair remedy, the one legitimate single-arm exception, and how to verify reachability at all. The section lead-in flips from "Six rules follow" to "Seven".

## Scope decisions

- **Documentation only.** One file, `.md`, under `cogni-knowledge/tests/`. No `.sh`, `.py`, `.json` or `.yml`; no manifest and no `version` value in the diff.
- **The issue's own line coordinates are deliberately not transcribed.** #1517 merged and moved both sites: `test_plain_result_emitters.sh:164-169` now holds the *corrected* accumulator and `test_skill_contracts.sh:298` now reads `_wiki_dispatch_hits=0`. Rule 7 therefore carries **no** `<file>.sh:<line>` coordinate at all — it names resident models by case id and suite only, which stays true as the files move.
- **`Closes`, not `Refs`** — see "On the linkage" below.
- **No test, fixture, or `## Mutation recipe`.** The diff touches no `test-*.sh` / `check-*.sh` (the touched-set predicate the preflight mutation-recipe gate keys on), and this README has zero programmatic readers: `run-plugin-tests.py` globs `cogni-knowledge/tests/*.sh` directly, and all 25 in-repo references are prose citations in test headers. There is nothing to guard.

## Three corrections made during the pre-commit quality pass

The first draft of rule 7 was revised before commit. All three were confirmed against the tree, not argued:

1. **The exemption was drawn on the wrong axis, and would have licensed reverting a fix merged this morning.** The draft exempted "a preflight guard that aborts the run — a not-found check whose red arm `continue`s, since 'file not found' has no meaningful PASS twin." But `klib-01` in `test_knowledge_lib.sh` is exactly that shape — a not-found preflight whose red arm `exit 1`s — and it *does* carry a PASS twin, added by #1582 / PR #1585 (merged 04:25Z today) precisely to close this defect class. Aborting and having a meaningful green state are independent. The rule now exempts on "no green state worth reporting" and says outright that aborting alone does not earn the exemption, citing `klib-01` as the counter-example.
2. **"An arm no input state can reach" was a stricter test than either named shape, and self-contradictory.** Neither shape produces an arm *no* state reaches — and the rule's own closing note tells the author to force the arm with a fixture, which is impossible for a genuinely unreachable arm. Narrowed to "an arm the case's own predicate cannot reach".
3. **The `elif` explanation was polarity-bound and backwards for this repo's actual chains.** "Evaluated only when the earlier test already failed" is wrong for the dominant failure-predicated shape (`if [ "$n_red" -ne 1 ]; then … elif …`), where the `elif` runs when the earlier check *passed*. Reworded polarity-free: "only when that earlier condition took the other path".

A fourth finding — that the fail-only-with-no-`else` shape was omitted, though it is the shape both resident rationale comments actually name and the dominant emission form in this corpus — was folded in as the first of the three named shapes.

## On the linkage: why `Closes` and not `--partial`

Follow-up #1586 was filed from this work, but the plan's `deferred[]` is empty and `full_scope` is true. #1586 is newly-discovered *separate* scope (a `CLAUDE.md` clause, outside this change's scope boundary), not deferred scope from #1576's ask. All five of #1576's acceptance criteria are satisfied by this diff, so linking with `Refs` would leave a fully-satisfied issue open with nothing left to do. Flagging the call explicitly so the reviewer can overrule it rather than infer it.

## Follow-up issues

- **#1586** — cogni-knowledge: CLAUDE.md's case-id section has no reachability clause, so the summary tier teaches only half of rule 7. `CLAUDE.md` §"Test result-line case ids" mirrors five of the six README rules; reachability gets no bullet, and `CLAUDE.md` is the surface an author actually has loaded. Out of scope here (contract item 14 admits only `.md` under `cogni-knowledge/tests/`).

## Verification

| Check | Result |
|---|---|
| `grep -c '^7\. '` | `1` at HEAD, empty at base |
| Ordering: rule 6 / rule 7 / harness paragraph | 135 / 148 / 174 |
| `grep -c 'Six rules follow'` | `0`; lead-in at :74 reads "Seven" |
| Stale coordinates (`:164`, `:169`, `:298`, any `.sh:<N>`) in rule-7 span | `0` |
| Bare stem `skill-contracts-84` quoted as `--case`-addressable | `0` |
| Rule-7 span length | 26 lines (rule 5 is 16; cap 32) |
| Removed lines in the whole diff | **1** — the lead-in only |
| Changed paths | `cogni-knowledge/tests/README.md` only |
| Tabs / trailing whitespace introduced | `0` |
| `test_plain_result_emitters.sh` | rc=0, 7 PASS / 0 FAIL |
| `test_skill_contracts.sh` | rc=0, 113 PASS / 0 FAIL |
| `test_knowledge_lib.sh` | rc=0, 42 PASS / 0 FAIL |

## Disclosure

The runner token is **over-scoped** relative to the documented least-privilege posture — `extra_scopes: gist, read:org, workflow`, of which `workflow` is `forbidden`. This is the fixed scope set of the GitHub CLI OAuth (`gho_`) token and cannot be narrowed from the CLI side. Accepted via the `--allow-overscoped` **flag** (not the environment variable) per the standing operator decision, and disclosed here as that decision requires.