### PR TITLE
cogni-workspace: MCP install probe resolves by registry server name

### DIFF
--- a/cogni-workspace/skills/install-mcp/SKILL.md
+++ b/cogni-workspace/skills/install-mcp/SKILL.md
@@ -133,6 +133,11 @@ bash "${CLAUDE_PLUGIN_ROOT}/scripts/install-mcp.sh" \
   $WRAPPER_ARG
 ```
 
+`--name` becomes the directory the server is installed into, under `$CLAUDE_MCP_DIR`.
+Which registry key belongs here, how it differs from the one naming the host config
+entry, and what base `$CLAUDE_MCP_DIR` falls back to, are all stated once in
+`${CLAUDE_PLUGIN_ROOT}/skills/workspace-status/SKILL.md` section "6. MCP Servers".
+
 The script outputs JSON. On success, `data.action` is `installed` (fresh clone),
 `updated` (a `--force` refetch), `rebuilt` (already cloned but unbuilt, so the build
 reran) or `skipped` (already built). A failure carries no `action` at all — it reports

--- a/cogni-workspace/skills/workspace-dashboard/references/dashboard-sections.md
+++ b/cogni-workspace/skills/workspace-dashboard/references/dashboard-sections.md
@@ -44,7 +44,7 @@ Per-section reference for `workspace-dashboard`: data source, helper(s) reused, 
 
 **Data source**:
 - `<workspace-root>/cogni-workspace/references/mcp-git-registry.json` — declares each server (`type`, `repo`, `desktop_config_key`, `provides_tools[]`, `required_by[]`, platform-specific paths for native servers)
-- Install status check: existence of `~/.claude/mcp-servers/<desktop_config_key>/start.sh` for git-based servers; existence of the platform-specific binary path for native servers
+- Install status check: for git-based servers, existence of `~/.claude/mcp-servers/<name>/start.sh` (base overridable via `$CLAUDE_MCP_DIR`); for native servers, existence of the platform-specific binary path. What `<name>` is, and why it rather than `desktop_config_key`, is stated once in `skills/workspace-status/SKILL.md` section "6. MCP Servers"
 - Required shape: a top-level `servers` object whose values are themselves objects. A registry that parses but does not match it — root not an object, `servers` absent or not an object, or any entry not an object — is **unreadable**. This section then falls back to the same placeholder a missing registry gets, because either way there are no cards to draw; the Health Snapshot row is where the two are told apart.
 
 **Output**: card per server. Status pill (Installed / Missing / Manual). Type pill (git / native). Required-by chips (one per consuming plugin). For git-based: repo URL truncated. For native: platform path.

--- a/cogni-workspace/skills/workspace-dashboard/scripts/generate-dashboard.py
+++ b/cogni-workspace/skills/workspace-dashboard/scripts/generate-dashboard.py
@@ -506,11 +506,17 @@ def load_mcp_registry(workspace_root):
 
 
 def mcp_install_status(server):
-    """Heuristic: check whether the MCP appears installed locally."""
+    """Heuristic: check whether the MCP appears installed locally.
+
+    The git-type probe resolves the install directory from the registry `name`,
+    never `desktop_config_key`. Which key governs which artifact, and why the
+    installer is authoritative for the directory, is stated once in
+    skills/workspace-status/SKILL.md section "6. MCP Servers".
+    """
     server_type = server.get("type", "")
-    desktop_key = server.get("desktop_config_key", "")
     if server_type == "git":
-        candidate = os.path.expanduser(f"~/.claude/mcp-servers/{desktop_key}/start.sh")
+        name = server.get("name", "")
+        candidate = os.path.join(_mcp_base_dir(), name, "start.sh")
         return ("installed" if os.path.isfile(candidate) else "missing", candidate)
     if server_type == "native":
         platforms = server.get("platforms", {})
@@ -520,6 +526,23 @@ def mcp_install_status(server):
             return ("installed", cmd)
         return ("manual", cmd)
     return ("unknown", "")
+
+
+def _mcp_base_dir():
+    """Base directory holding installed git-type MCP servers.
+
+    Reuses the CLAUDE_MCP_DIR spelling install-mcp.sh already reads, so a test
+    can point the installer and this probe at one fixture tree without touching
+    $HOME. `or`, not a bare default, so an EMPTY value falls back exactly like
+    install-mcp.sh's ${CLAUDE_MCP_DIR:-...} rather than resolving to an empty
+    base — pinned by the empty-value case in tests/test-dashboard-mcp-counts.sh,
+    since the bare-default form passes every other case.
+
+    Not yet universal: patch-desktop-config.py reads the same variable with a
+    bare default and so does NOT fall back on empty (tracked in #1588), and
+    hooks/ensure-excalidraw-canvas.sh uses its own EXCALIDRAW_MCP_DIR spelling.
+    """
+    return os.environ.get("CLAUDE_MCP_DIR") or os.path.expanduser("~/.claude/mcp-servers")
 
 
 def _command_on_path(cmd):

--- a/cogni-workspace/skills/workspace-status/SKILL.md
+++ b/cogni-workspace/skills/workspace-status/SKILL.md
@@ -197,6 +197,11 @@ means it is not available. The **Install** column decides how a missing server i
   - the **install directory** — `$HOME/.claude/mcp-servers/mcp_excalidraw/start.sh`, named
     for the registry **server name**, not the config key
 
+    This is the canonical statement of the key-to-directory rule: the dashboard install
+    probe, `skills/workspace-dashboard/references/dashboard-sections.md` and
+    `skills/install-mcp` all point here rather than restating it. `$CLAUDE_MCP_DIR`, when
+    set to a non-empty value, replaces the `$HOME/.claude/mcp-servers` base.
+
   | Config entry (this host) | `start.sh` | State | Advise |
   |---|---|---|---|
   | absent | absent | never installed | route to `/cogni-workspace:install-mcp` |

--- a/cogni-workspace/tests/test-dashboard-mcp-counts.sh
+++ b/cogni-workspace/tests/test-dashboard-mcp-counts.sh
@@ -19,12 +19,14 @@
 # falsifier of the "0/0 forever" defect.
 #
 # SHAPE ONLY, NEVER HOST AVAILABILITY -- the same discipline as D9 in the sibling suite
-# test-dashboard-dependency-counts.sh. No case may depend on what is installed under
-# ~/.claude/mcp-servers. That is host-dependent, and on this repo's own live registry it is
-# also currently WRONG for an unrelated and separately-filed reason: an entry declares a
-# desktop_config_key that does not match its installed directory name, so a present server
-# reports `missing`. Fixtures therefore use entries whose status is deterministic on every
-# host: type "native" with no `platforms` key resolves to "manual", and type "git" with a
+# test-dashboard-dependency-counts.sh. No case may depend on what is installed under the
+# real ~/.claude/mcp-servers. That is host-dependent, so this suite exports CLAUDE_MCP_DIR to
+# an empty fixture tree under $TMPROOT before any case runs: the probe resolves its base from
+# that variable (the same spelling install-mcp.sh and patch-desktop-config.py honour), so no
+# case can reach the developer's live install directory and determinism is STRUCTURAL rather
+# than a naming convention. A case needing a populated base overrides the export explicitly
+# and restores it afterwards. Fixtures otherwise use entries whose status is deterministic on
+# every host: type "native" with no `platforms` key resolves to "manual", and type "git" with a
 # key that cannot exist resolves to "missing".
 #
 # Cases drive the PRODUCTION read path -- resolve_mcp_servers(root) against a real on-disk
@@ -50,6 +52,13 @@ SECTIONS="$WS_ROOT/skills/workspace-dashboard/references/dashboard-sections.md"
 TMPROOT="$(mktemp -d)"
 trap 'rm -rf "$TMPROOT"' EXIT
 
+# Every case probes an EMPTY fixture base by default, so no present or future case can read
+# the developer's live ~/.claude/mcp-servers. Cases that need a populated base export over
+# this and restore it immediately after their assertion.
+MCP_EMPTY="$TMPROOT/mcp-empty"
+mkdir -p "$MCP_EMPTY"
+export CLAUDE_MCP_DIR="$MCP_EMPTY"
+
 failures=0
 pass() { printf 'PASS: %s\n' "$1"; }
 fail() { printf 'FAIL: %s\n' "$1"; failures=$((failures + 1)); }
@@ -65,6 +74,17 @@ new_root() {
     printf '%s' "$2" > "$root/cogni-workspace/references/mcp-git-registry.json"
   fi
   printf '%s' "$root"
+}
+
+# new_mcp_base <name> <relpath-to-start.sh> -- build a temp MCP base directory containing
+# exactly one installed wrapper at <relpath>, and echo the base. Used by the cases that pin
+# which directory name the probe resolves; the file is touched, never executed.
+new_mcp_base() {
+  local name="$1" rel="$2"
+  local base="$TMPROOT/mcp-$name"
+  mkdir -p "$base/$(dirname "$rel")"
+  touch "$base/$rel"
+  printf '%s' "$base"
 }
 
 # assert_mcp "<label>" "<root>" "<python expr, True to pass>" -- the renderer is bound as `r`,
@@ -216,11 +236,68 @@ assert_resolve "M13 the repo's own registry is still a shape this reader accepts
 
 # --- M14: a registry whose servers are all absent still reports a real total. --
 # The direct analogue of the sibling's D2 and the strongest falsifier of "0/0 forever": a
-# reader rendering a constant 0/0 fails here on the TOTAL, not merely on the label. type "git"
-# with a key that cannot exist resolves to "missing" on every host, so this is deterministic.
-M14ROOT="$(new_root m14 '{"servers":{"alpha":{"type":"git","desktop_config_key":"zz-not-installed-alpha"},"beta":{"type":"git","desktop_config_key":"zz-not-installed-beta"}}}')"
+# reader rendering a constant 0/0 fails here on the TOTAL, not merely on the label. These
+# entries declare no name, so the probe falls back to their map keys and looks for alpha/ and
+# beta/ under the exported empty fixture base -- determinism comes from that base, not from
+# the spelling of the keys.
+M14ROOT="$(new_root m14 '{"servers":{"alpha":{"type":"git"},"beta":{"type":"git"}}}')"
 assert_mcp "M14 a fully-uninstalled registry reports a truthful two-server total" "$M14ROOT" \
   'status == "ok" and row["label"] != "ok" and row["summary"] == "0/2 installed"'
+
+# --- M15: the install directory is keyed on the registry name, not the config key. -------
+# The positive falsifier, and RED AT BASE: the base probe read desktop_config_key AND
+# hardcoded the real ~/.claude/mcp-servers, so it resolved to a path outside this fixture
+# entirely and reported the server "missing". The fixture declares a name that DIFFERS from
+# its desktop_config_key and installs the wrapper under the name only, so the two keys cannot
+# both be right. The hint is asserted by exact equality, never a substring: "fixture/start.sh"
+# is a substring of the name-keyed form and a containment check would pass against the wrong
+# path.
+M15BASE="$(new_mcp_base m15 mcp_fixture/start.sh)"
+M15ROOT="$(new_root m15 '{"servers":{"mcp_fixture":{"type":"git","name":"mcp_fixture","desktop_config_key":"fixture"}}}')"
+export CLAUDE_MCP_DIR="$M15BASE"
+assert_mcp "M15 a git server installs under its registry name, not its config key" "$M15ROOT" \
+  'status == "ok" and row["summary"] == "1/1 installed" and servers[0]["install_status"] == "installed" and servers[0]["install_hint"] == r.os.path.join(r.os.environ["CLAUDE_MCP_DIR"], "mcp_fixture", "start.sh")'
+export CLAUDE_MCP_DIR="$MCP_EMPTY"
+
+# --- M16: a directory named for the config key alone is NOT installed. -------------------
+# The negative twin of M15, and the reason M15 alone is insufficient: a fix that probes BOTH
+# <name>/ and <desktop_config_key>/ and accepts either would satisfy M15 while reintroducing a
+# false "installed". This base carries ONLY the config-key directory and no mcp_fixture/ at
+# all, so an either-path reader reports "installed" here and goes red. It needs its own base
+# AND its own root -- reusing M15's would leave mcp_fixture/start.sh present and the case
+# would assert nothing.
+M16BASE="$(new_mcp_base m16 fixture/start.sh)"
+M16ROOT="$(new_root m16 '{"servers":{"mcp_fixture":{"type":"git","name":"mcp_fixture","desktop_config_key":"fixture"}}}')"
+export CLAUDE_MCP_DIR="$M16BASE"
+assert_mcp "M16 a directory named for the config key alone does not count as installed" "$M16ROOT" \
+  'status == "ok" and row["label"] != "ok" and row["summary"] == "0/1 installed" and servers[0]["install_status"] == "missing"'
+export CLAUDE_MCP_DIR="$MCP_EMPTY"
+
+# --- M17: the sections reference documents the derivation the code actually uses. --------
+# The documentation twin, in the M11 style: two operands over the same file, both falsifiable
+# at base (the name form was absent, the desktop_config_key form present on the install-status
+# line). Without the negative operand a stale sentence could survive alongside a new one.
+if grep -qF 'mcp-servers/<name>/start.sh' "$SECTIONS" \
+   && ! grep -qF 'mcp-servers/<desktop_config_key>' "$SECTIONS"; then
+  pass "M17 the sections reference keys the install directory on the server name"
+else
+  fail "M17 the sections reference keys the install directory on the server name"
+  printf '%s\n' "  the install-status bullet must name <name>, not <desktop_config_key>"
+fi
+
+# --- M18: an EMPTY CLAUDE_MCP_DIR falls back to the default base. -----------------------
+# Without this case nothing distinguishes the probe's `or` form from a bare
+# os.environ.get(VAR, default): every other case exports a NON-empty base, so both spellings
+# are green across the suite and a future "consistency" tidy-up to the bare-default form --
+# the spelling patch-desktop-config.py still uses -- would silently reintroduce an empty base.
+# SHAPE ONLY: this asserts the derived PATH, never that anything is installed there. The name
+# cannot exist on any host, so the status is "missing" everywhere and the case turns purely on
+# where the probe decided to look.
+M18ROOT="$(new_root m18 '{"servers":{"zz-not-installed-fallback":{"type":"git"}}}')"
+export CLAUDE_MCP_DIR=""
+assert_mcp "M18 an empty CLAUDE_MCP_DIR falls back to the default base, not an empty one" "$M18ROOT" \
+  'servers[0]["install_hint"] == r.os.path.join(r.os.path.expanduser("~/.claude/mcp-servers"), "zz-not-installed-fallback", "start.sh")'
+export CLAUDE_MCP_DIR="$MCP_EMPTY"
 
 echo
 if [ "$failures" -eq 0 ]; then


### PR DESCRIPTION
Refs #1580.

## Summary

`mcp_install_status` in `cogni-workspace/skills/workspace-dashboard/scripts/generate-dashboard.py` now derives a git-type server's install directory from the registry **server name**, never `desktop_config_key`. The live `mcp_excalidraw` entry therefore probes `<base>/mcp_excalidraw/start.sh` and a correctly-installed server is reported `installed` instead of `missing`.

**Authoritative side: the installer.** The issue left the producer question open (registry key, installer, or probe?). It resolves to the probe being wrong:

| Site | Key used for the directory | Value |
|---|---|---|
| `scripts/install-mcp.sh:44` — `INSTALL_DIR="$MCP_BASE_DIR/$NAME"` (the producer) | registry `name` | `mcp_excalidraw` |
| `scripts/patch-desktop-config.py:105` — `resolve_wrapper_path(server["name"])` (sibling resolver, same question) | registry `name` | `mcp_excalidraw` |
| `skills/workspace-dashboard/SKILL.md:81`, `skills/workspace-status/references/mcp-registry.md:17` | registry `name` | `mcp_excalidraw` |
| `hooks/ensure-excalidraw-canvas.sh:29` | literal | `mcp_excalidraw` |
| **`generate-dashboard.py:513`** — the outlier | **`desktop_config_key`** | `excalidraw` |
| On disk | — | `mcp_excalidraw` |

**The registry is deliberately not touched.** `desktop_config_key` has a separate job — the host config entry, and hence the `mcp__excalidraw__*` tool namespace — and `tests/test-mcp-declaration-hygiene.sh` case **A2** pins its value (with its own recorded mutation recipe) while **A3** pins the `PreToolUse` matcher `mcp__excalidraw__.*`. Renaming it would have gone red on both and silently broken the shipped hook matcher. Those two cases passing is the control proving the fix was taken on the probe side.

**`CLAUDE_MCP_DIR` override.** AC bullet 3 asks for a fixture-tree regression case, but the probe hardcoded `~/.claude/mcp-servers` with no indirection — unlike `install-mcp.sh:13`, which already honours `CLAUDE_MCP_DIR`. The probe now reads the same variable, which is the mechanism the AC's own test requirement depends on. It uses `or`, not a bare default, so an **empty** value falls back exactly like `${CLAUDE_MCP_DIR:-...}`.

The install hint and the Health Snapshot `n/m installed` count both follow the probe for free — the hint is stored once by `resolve_mcp_servers` and re-read by `render_mcp`, and the count derives from the same `install_status` values.

## Regression coverage

Four new cases in `cogni-workspace/tests/test-dashboard-mcp-counts.sh`, each with its falsification evidence:

| Case | Pins | Evidence it is not vacuous |
|---|---|---|
| **M15** | a git server installs under its registry `name`, not its config key | **RED at base** — verified by running the new suite against an `origin/main` checkout |
| **M16** | a directory named for the config key alone is **not** installed | green at base, but **RED against an either-path mutant** (a fix probing both `<name>/` and `<desktop_config_key>/` passes M15 and fails here) — verified by injecting that mutant |
| **M17** | the sections reference names `<name>`, not `<desktop_config_key>` | **RED at base** — the positive operand was absent, the negative present |
| **M18** | an empty `CLAUDE_MCP_DIR` falls back to the default base | **RED against the bare-default mutant** — no other case distinguishes `or` from `os.environ.get(VAR, default)`, so a future "consistency" tidy-up would otherwise pass all 17 suites while reintroducing an empty base |

The suite now exports `CLAUDE_MCP_DIR` to an empty fixture base for **every** case, so its own SHAPE-ONLY discipline is structural rather than a naming convention. That also resolves M14, whose `alpha`/`beta` keys become the probed directory names once resolution moves off `desktop_config_key` — determinism no longer rests on those names being improbable. M14's now-inert `desktop_config_key` values were dropped.

## Test plan

- [x] `bash cogni-workspace/tests/test-dashboard-mcp-counts.sh` → exits 0; `PASS: M15`, `PASS: M16`, `PASS: M17`, `PASS: M18` present alongside M01–M14.
- [x] `bash cogni-workspace/tests/test-mcp-declaration-hygiene.sh` → 15 passed, 0 failed, with `PASS: A2` and `PASS: A3` present (the registry and hook matcher did not move).
- [x] `python3 scripts/run-plugin-tests.py --filter cogni-workspace` → **17 discovered, 17 passed, 0 failed**. The count is asserted explicitly: `--list` reports **17** suites, unchanged from base — this PR adds cases to an existing suite and creates no new suite file. (`0 failed` alone is green at base and discriminates nothing.)
- [x] `check-frontmatter.sh` → clean, 52 files scanned, 0 offenders.
- [x] `check-breadcrumbs.sh` → 9 offenders, **all pre-existing** in `skills/manage-themes/SKILL.md`, which this PR does not touch; the same 9 are present at base.
- [x] Zero surviving claims that the install directory is keyed on `desktop_config_key`: the two remaining occurrences in `generate-dashboard.py` are docstring prose, both non-path-constructing.

## Mutation recipe

```
bash "$HOME/.claude/plugins/marketplaces/managed-service/cogni-service/scripts/mutation-check.sh" \
  --root . \
  --file cogni-workspace/skills/workspace-dashboard/scripts/generate-dashboard.py \
  --expr 's/name = server\.get\("name", ""\)/name = server.get("desktop_config_key", "")/' \
  --test 'bash cogni-workspace/tests/test-dashboard-mcp-counts.sh' \
  --case M15
```

Verdict: **`guard_verified`** — executed against this branch, `mutated_result: red`, `restored_result: green`. The expression reverts exactly the guarded property (which registry key the git-type probe resolves the install directory from), which is the pre-fix behaviour. The search literal occurs **exactly once** after the fix and **zero** times at base (`server.get("name"` and `name = server.get` are both absent at base; `entry.get("name", key)` at `resolve_mcp_servers` is a different string and does not collide), so the no-`/g` `perl -0pi` substitution is total rather than partial. Replay from the repo root, serially — not concurrently with a test sweep.

## Scope decisions

**Deliberately excluded:**
- `references/mcp-git-registry.json` — identity fields left byte-identical (see A2/A3 above).
- `scripts/install-mcp.sh`, `scripts/patch-desktop-config.py`, `hooks/*.json`, every `plugin.json` `version` — untouched; the post-merge workflow owns version bumps.
- No `--mcp-dir` CLI flag: `CLAUDE_MCP_DIR` is already the ecosystem spelling, and a flag would be a second spelling of one concept.
- `hooks/ensure-excalidraw-canvas.sh` uses its own `EXCALIDRAW_MCP_DIR` spelling — pre-existing, out of scope, noted in the probe docstring so the "one spelling" claim is not overstated.

## Follow-up issues

- #1588 — `patch-desktop-config.py:78` reads `CLAUDE_MCP_DIR` with a **bare default**, so an empty value yields an empty base path, diverging from `install-mcp.sh:13` and from the `or` form this PR gives the probe. A different consumer with a different symptom (the `start.sh` path written into the host config entry), and this issue's committed acceptance contract explicitly excludes any observable change to that file — so it is filed rather than folded in. The duplicate gate ran against 254 candidates and returned `unique`.

## Review notes

Both touched `SKILL.md` files went through the pre-commit skill-quality gate. One finding was **introduced by this change and has been fixed**: the `install-mcp` pointer sentence originally carried `(default ~/.claude/mcp-servers)`, a second copy of a value the canonical block owns — and it had already drifted, since "default" glosses the canonical statement's "when set to a non-empty value". It now defers that fact to the pointer instead. The remaining findings are annotated, not acted on:

- `workspace-status/SKILL.md` — the canonicity paragraph enumerates its three inbound pointers, a list that must be edited if a fourth surface starts pointing there. Reported `severity: low`, `category: preference`, `opt_out: true`; the reviewer's own recommendation was to annotate rather than apply, since editing the exact region the acceptance contract grades adds re-review risk for three words of maintainer-facing prose.
- `workspace-status/SKILL.md` — section "6. MCP Servers" carries ~73 lines of deep troubleshooting reference loaded on every invocation; `references/mcp-registry.md` would be the natural home. Pre-existing (`introduced_by_change: false`), body at 74% of a 22500-char cap, so no size breach.
- `workspace-status/SKILL.md` — the seven checks are numbered 1–5, 5.5, 6; renumbering is not safe to apply mechanically because sibling surfaces cite check numbers. Pre-existing.
- `install-mcp/SKILL.md` — the resolved `description` measures ~990 chars against the 1024-char platform cap (~96.5%). `check-frontmatter.sh` reports it clean, so it is under cap, but the next trigger phrase added would breach it. Pre-existing.

## Operational disclosure

`check-token-scope.sh --strict` reported `over_scoped` (extra scopes: `gist`, `read:org`, `workflow`) — the fixed scope set of the GitHub CLI OAuth (`gho_`) token, which cannot be narrowed. Proceeded under the `--allow-overscoped` flag per standing operator authorization, disclosed here rather than silently.

## Open questions

The committed acceptance contract recorded one escalation, classified `avoidable` / `insufficient_coverage` (not a blocker, surfaced for the record): the issue's plan-time acceptance criteria are narrower than a base-grounded regeneration. Three gating properties were absent from them and were added to the contract instead — nothing forbade an either-path fallback (now M16), nothing pinned the registry's identity fields (now the A2/A3 control), and bullet 3 presupposed a base-directory override the base code did not provide (now `CLAUDE_MCP_DIR`).