### PR TITLE
cogni-workspace: empty CLAUDE_MCP_DIR falls back to the default base

### DIFF
--- a/cogni-workspace/scripts/patch-desktop-config.py
+++ b/cogni-workspace/scripts/patch-desktop-config.py
@@ -74,8 +74,16 @@ def get_cli_config_path() -> Path:
 
 
 def resolve_wrapper_path(server_name: str) -> str | None:
-    """Find the installed wrapper script for a git-based MCP server."""
-    mcp_base = os.environ.get("CLAUDE_MCP_DIR", str(Path.home() / ".claude" / "mcp-servers"))
+    """Find the installed wrapper script for a git-based MCP server.
+
+    `or`, not a bare default: a bare default fires only on an UNSET override, so an
+    empty one resolves to a cwd-relative wrapper that never exists -- and the caller
+    below turns an unresolvable wrapper into a git server silently omitted from the
+    written config. No trimming, so a whitespace-only override is honoured verbatim.
+    The override rule itself is stated canonically in
+    skills/workspace-status/SKILL.md section "6. MCP Servers".
+    """
+    mcp_base = os.environ.get("CLAUDE_MCP_DIR") or str(Path.home() / ".claude" / "mcp-servers")
     wrapper = Path(mcp_base) / server_name / "start.sh"
     if wrapper.exists():
         return str(wrapper)

--- a/cogni-workspace/skills/workspace-dashboard/scripts/generate-dashboard.py
+++ b/cogni-workspace/skills/workspace-dashboard/scripts/generate-dashboard.py
@@ -538,9 +538,8 @@ def _mcp_base_dir():
     base — pinned by the empty-value case in tests/test-dashboard-mcp-counts.sh,
     since the bare-default form passes every other case.
 
-    Not yet universal: patch-desktop-config.py reads the same variable with a
-    bare default and so does NOT fall back on empty (tracked in #1588), and
-    hooks/ensure-excalidraw-canvas.sh uses its own EXCALIDRAW_MCP_DIR spelling.
+    hooks/ensure-excalidraw-canvas.sh uses its own EXCALIDRAW_MCP_DIR spelling --
+    a separate variable, not this one.
     """
     return os.environ.get("CLAUDE_MCP_DIR") or os.path.expanduser("~/.claude/mcp-servers")
 

--- a/cogni-workspace/tests/test-dashboard-mcp-counts.sh
+++ b/cogni-workspace/tests/test-dashboard-mcp-counts.sh
@@ -288,8 +288,9 @@ fi
 # --- M18: an EMPTY CLAUDE_MCP_DIR falls back to the default base. -----------------------
 # Without this case nothing distinguishes the probe's `or` form from a bare
 # os.environ.get(VAR, default): every other case exports a NON-empty base, so both spellings
-# are green across the suite and a future "consistency" tidy-up to the bare-default form --
-# the spelling patch-desktop-config.py still uses -- would silently reintroduce an empty base.
+# are green across the suite and a future "consistency" tidy-up to the bare-default form
+# would silently reintroduce an empty base. The sibling reader patch-desktop-config.py is
+# pinned the same way by tests/test-patch-desktop-config-mcp-base.sh.
 # SHAPE ONLY: this asserts the derived PATH, never that anything is installed there. The name
 # cannot exist on any host, so the status is "missing" everywhere and the case turns purely on
 # where the probe decided to look.

--- a/cogni-workspace/tests/test-patch-desktop-config-mcp-base.sh
+++ b/cogni-workspace/tests/test-patch-desktop-config-mcp-base.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# Regression test for the MCP base directory that patch-desktop-config.py resolves
+# (resolve_wrapper_path + build_mcp_entry's git branch in scripts/patch-desktop-config.py).
+#
+# Contract under test: the base override falls back to $HOME/.claude/mcp-servers when it is
+# unset OR set-but-empty, and is honoured VERBATIM otherwise -- including a whitespace-only
+# value. That is the same semantics as install-mcp.sh's ${...:-...} and the dashboard probe's
+# `or` form; neither trims, so this reader must not either. A bare os.environ.get(VAR, default)
+# fires only on unset, and the empty case is what it gets wrong.
+#
+# The empty case is SILENT, which is why it needs its own pin: an empty base makes
+# Path(mcp_base)/name/"start.sh" a CWD-RELATIVE path, resolve_wrapper_path is exists()-gated
+# so it returns None, and build_mcp_entry's git branch returns None in turn -- an installed
+# server just vanishes from the written config with no error anywhere.
+#
+# ASSERT THE POSITIVE PATH, NEVER A NEGATIVE SHAPE. The broken value is the relative
+# "<name>/start.sh", never an absolute "/<name>/start.sh", so a case phrased as "not
+# /<name>/" would be green against the unfixed reader and pin nothing. Every case below
+# compares against a controlled fixture path by equality.
+#
+# SHAPE ONLY, NEVER HOST AVAILABILITY -- the same discipline as the sibling suite
+# test-dashboard-mcp-counts.sh. No case may depend on what is installed under the real
+# ~/.claude/mcp-servers: $HOME is overridden to a fixture tree for every case, so the
+# default-base cases resolve inside $TMPROOT and determinism is STRUCTURAL rather than a
+# naming convention. Each case also runs with cwd pinned to an empty fixture directory,
+# because the broken value is cwd-relative -- a stray directory under the runner's working
+# directory would otherwise decide the result.
+#
+# Cases drive the PRODUCTION read path -- the real module is loaded and its own functions
+# called. Re-implementing the resolution expression in the test, or hand-building an entry
+# and asserting on that, would never execute the changed line and would stay green against
+# the unfixed reader, which is exactly the vacuity this suite exists to avoid.
+#
+# Case ids are zero-padded to a uniform width so no id is a prefix of another: the mutation
+# harness matches --case as a whole token, and P1 vs P10 is that collision class.
+#
+# Paths are self-located from $0, never the working directory: the repo runner invokes suites
+# with cwd=<repo root> and the mutation harness with cwd=$ROOT, so a cwd-relative path here
+# would be a latent false result.
+#
+# stdlib-only: bash + python3, no pip deps, per the repo-wide script convention.
+
+set -u
+HERE="$(cd "$(dirname "$0")" && pwd)"
+WS_ROOT="$(cd "$HERE/.." && pwd)"
+PATCHER="$WS_ROOT/scripts/patch-desktop-config.py"
+TMPROOT="$(mktemp -d)"
+trap 'rm -rf "$TMPROOT"' EXIT
+
+# A fixture $HOME, a fixture non-default base, and an empty directory to run from. The two
+# wrapper files are REAL because resolve_wrapper_path is exists()-gated -- a case that only
+# sets the environment would be red at every revision, not just the broken one. They are
+# touched, never executed.
+FAKE_HOME="$TMPROOT/home"
+DEFAULT_BASE="$FAKE_HOME/.claude/mcp-servers"
+ALT_BASE="$TMPROOT/alt-base"
+EMPTY_CWD="$TMPROOT/empty-cwd"
+SRV="fixture-git-server"
+mkdir -p "$DEFAULT_BASE/$SRV" "$ALT_BASE/$SRV" "$EMPTY_CWD"
+touch "$DEFAULT_BASE/$SRV/start.sh" "$ALT_BASE/$SRV/start.sh"
+
+failures=0
+pass() { printf 'PASS: %s\n' "$1"; }
+fail() { printf 'FAIL: %s\n' "$1"; failures=$((failures + 1)); }
+
+# assert_patcher "<label>" "<expected path>" "<python expr, True to pass>" -- the module is
+# bound as `p`, the server name as `name`, and the expected path as `expected`. The heredoc
+# delimiter is unquoted so $expr expands, so the body carries no other $, backtick or
+# backslash sequence. HOME is set per-invocation rather than exported once, so nothing here
+# can leak into the rest of the suite.
+assert_patcher() {
+  local label="$1" expected="$2" expr="$3"
+  if ( cd "$EMPTY_CWD" && HOME="$FAKE_HOME" python3 - "$PATCHER" "$SRV" "$expected" <<PY
+import importlib.util, os, sys
+
+def _load(name, path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    m = importlib.util.module_from_spec(spec); spec.loader.exec_module(m); return m
+
+p = _load("p", sys.argv[1])
+name = sys.argv[2]
+expected = sys.argv[3]
+resolved = p.resolve_wrapper_path(name)
+sys.exit(0 if ($expr) else 1)
+PY
+  ); then pass "$label"; else fail "$label"; fi
+}
+
+# --- P01: an UNSET override resolves under the default base. ----------------------------
+# The unset arm is pinned separately from the empty arm so the fix for one cannot regress
+# the other. The explicit unset is not redundant: anyone who has run install-mcp exports
+# this variable, and without it P01 would read that live base and fail on their machine.
+unset CLAUDE_MCP_DIR
+assert_patcher "P01 an unset override resolves the wrapper under the default base" \
+  "$DEFAULT_BASE/$SRV/start.sh" \
+  'resolved == expected'
+
+# --- P02: a NON-EMPTY override replaces the base. ----------------------------------------
+export CLAUDE_MCP_DIR="$ALT_BASE"
+assert_patcher "P02 a non-empty override resolves the wrapper under that base" \
+  "$ALT_BASE/$SRV/start.sh" \
+  'resolved == expected'
+
+# --- P03: an EMPTY override falls back to the default base. ------------------------------
+# The discriminating case. Against a bare os.environ.get(VAR, default) the base is the empty
+# string, so the wrapper is the cwd-relative "fixture-git-server/start.sh"; cwd is the empty
+# fixture directory, nothing creates that path there, and resolve_wrapper_path returns None.
+export CLAUDE_MCP_DIR=""
+assert_patcher "P03 an empty override falls back to the default base, not an empty one" \
+  "$DEFAULT_BASE/$SRV/start.sh" \
+  'resolved == expected'
+
+# --- P04: a WHITESPACE-ONLY override stays SET. ------------------------------------------
+# Green both before and after the fix -- it pins an invariant, not the change. Neither
+# ${...:-...} nor `or` trims, so a .strip() added here would make this reader fall back where
+# its two siblings do not, and this case is what goes red for it. The exists() conjunct is
+# the anti-vacuity half: without it, `resolved is None` would also hold if the default
+# fixture were simply missing.
+export CLAUDE_MCP_DIR=" "
+assert_patcher "P04 a whitespace-only override stays set and does not fall back" \
+  "$DEFAULT_BASE/$SRV/start.sh" \
+  'resolved is None and os.path.exists(expected)'
+
+# --- P05: an EMPTY override still yields an entry, rather than omitting the server. -------
+# The user-visible symptom, end to end: the git branch of build_mcp_entry returns None for an
+# unresolvable wrapper, so the server disappears from the written config. Asserting the whole
+# entry pins the omission rather than the resolution alone.
+export CLAUDE_MCP_DIR=""
+assert_patcher "P05 an empty override still yields a git server entry rather than omitting it" \
+  "$DEFAULT_BASE/$SRV/start.sh" \
+  'p.build_mcp_entry({"type": "git", "name": name}, "cli") == {"type": "stdio", "command": "bash", "args": [expected], "env": {}}'
+
+unset CLAUDE_MCP_DIR
+
+echo
+if [ "$failures" -eq 0 ]; then
+  echo "All patch-desktop-config MCP-base tests passed."
+  exit 0
+else
+  echo "$failures test(s) failed."
+  exit 1
+fi


### PR DESCRIPTION
Closes #1588.

## Summary

`cogni-workspace/scripts/patch-desktop-config.py` resolved the MCP base with `os.environ.get("CLAUDE_MCP_DIR", <default>)`. A bare default fires only on an **unset** variable, so a set-but-**empty** override yielded `""`. It was the only one of the three readers of that variable without empty-fallback; `install-mcp.sh:13` uses `${CLAUDE_MCP_DIR:-...}` and `generate-dashboard.py:545` uses `or`.

The symptom was silent. `resolve_wrapper_path` is `Path.exists()`-gated, so it returned `None`; `build_mcp_entry`'s git branch returns `None` for an unresolvable wrapper; the installed server simply vanished from the config written into `~/.claude.json` / `claude_desktop_config.json`, with no error anywhere.

## Two corrections to the issue's own framing

Both were found by executing the premises against base, and both change what a correct test must assert.

**1. The bad path is *relative*, not absolute.** The issue states the empty base builds `/<name>/start.sh`, and its acceptance criterion 2 asks the regression case to assert the resolved path is *"not `/<name>/`"*. `pathlib` treats an empty segment as no segment:

```
Path('') / 'gitsrv' / 'start.sh'  ->  'gitsrv/start.sh'   (is_absolute() == False)
```

Under the bug the path is therefore **cwd-relative**, and a *"not `/<name>/`"* falsifier would have been **green at base for the wrong reason** — pinning nothing. Every case here asserts the **positive** property instead (the return value equals a controlled fixture path) and pins cwd to an empty directory, so a stray relative path under the runner's working directory cannot produce a false pass.

**2. No documentation change is needed.** `skills/workspace-status/SKILL.md:202-203` already reads "`$CLAUDE_MCP_DIR`, when set to a **non-empty** value, replaces the `$HOME/.claude/mcp-servers` base" — the canonical statement was ahead of the implementation, not behind it. This fix makes the code match the doc; editing the doc would have been redundant.

## Changes

| Path | Change |
|---|---|
| `cogni-workspace/scripts/patch-desktop-config.py` | `os.environ.get(VAR, default)` → `os.environ.get(VAR) or ...`. No `.strip()`. |
| `cogni-workspace/tests/test-patch-desktop-config-mcp-base.sh` | **New** suite, P01–P05. |
| `cogni-workspace/skills/workspace-dashboard/scripts/generate-dashboard.py` | Docstring only — the expression at `:545` is byte-identical. |
| `cogni-workspace/tests/test-dashboard-mcp-counts.sh` | Comment only, M18 preamble. |

The two prose edits remove claims that this fix makes false. `generate-dashboard.py:541-543` said patch-desktop-config.py "does NOT fall back on empty (tracked in #1588)"; `test-dashboard-mcp-counts.sh:292` called the bare-default form "the spelling patch-desktop-config.py still uses". Line `:25` of that suite is deliberately **untouched** — it is a claim about the variable *name*, which stays true.

## Test design

| id | override | asserts | base | head |
|----|----------|---------|------|------|
| P01 | unset | resolved == `$HOME/.claude/mcp-servers/<srv>/start.sh` | green | green |
| P02 | non-empty | resolved == `$ALT_BASE/<srv>/start.sh` | green | green |
| P03 | `""` | resolved == `$HOME/.claude/mcp-servers/<srv>/start.sh` | **RED** | green |
| P04 | `" "` | `resolved is None and os.path.exists(expected)` | green | green |
| P05 | `""` | `build_mcp_entry(...)` yields the entry, not `None` | **RED** | green |

Three properties are load-bearing:

- **`$HOME` is overridden per invocation and cwd is pinned to an empty fixture dir**, so no case can read the developer's real `~/.claude/mcp-servers` or turn on the runner's working directory. Determinism is structural, not a naming convention.
- **A real `start.sh` is created at each controlled base.** `resolve_wrapper_path` is `exists()`-gated, so a case that only set the environment would be red at *head* too.
- **P04 pins an invariant, not the fix.** It is green before and after, and goes **red** under a `.strip()` — verified by running the suite against a `.strip()` variant. That matters because `.strip()` looks like a tidier fix but would make this reader diverge from both siblings, neither of which trims.

## Evidence

**New suite at head** — 5/5 PASS, rc=0.

**New suite at base** — replayable from a clean checkout, no stash and no dev state:

```
git worktree add --detach /tmp/base-1588 origin/main
cp cogni-workspace/tests/test-patch-desktop-config-mcp-base.sh /tmp/base-1588/cogni-workspace/tests/
cd /tmp/base-1588 && bash cogni-workspace/tests/test-patch-desktop-config-mcp-base.sh; echo "rc=$?"
```

Recorded output (the suite file is byte-identical to the one shipped here):

```
PASS: P01 an unset override resolves the wrapper under the default base
PASS: P02 a non-empty override resolves the wrapper under that base
FAIL: P03 an empty override falls back to the default base, not an empty one
PASS: P04 a whitespace-only override stays set and does not fall back
FAIL: P05 an empty override still yields a git server entry rather than omitting it

2 test(s) failed.
rc=1
```

**Other checks**

| Command | Result |
|---|---|
| `bash cogni-workspace/tests/test-dashboard-mcp-counts.sh` | rc=0, M18 green |
| `python3 scripts/run-plugin-tests.py --filter cogni-workspace --list` | total **18** (17 at base + 1 new) |
| `python3 scripts/run-plugin-tests.py --filter cogni-workspace` | total 18, **passed 18, failed 0** |
| `python3 scripts/check-case-id-pairing.py` | rc=0 |
| `python3 scripts/check-result-line-plainness.py` | rc=0 |
| `python3 scripts/check-breadcrumbs.py` | rc=0 |

`#1588` occurred exactly once repo-wide (`generate-dashboard.py:542`); removing it leaves no orphan breadcrumb, and the diff introduces no issue number.

## Mutation recipe

```
bash "$HOME/.claude/plugins/marketplaces/managed-service/cogni-service/scripts/mutation-check.sh" \
  --root . \
  --file cogni-workspace/scripts/patch-desktop-config.py \
  --expr 's{get\("CLAUDE_MCP_DIR"\) or str\(Path\.home\(\) / "\.claude" / "mcp-servers"\)}{get("CLAUDE_MCP_DIR", str(Path.home() / ".claude" / "mcp-servers"))}' \
  --test 'bash cogni-workspace/tests/test-patch-desktop-config-mcp-base.sh' \
  --case P03
```

Verdict **`guard_verified`** — `mutated_result: red`, `restored_result: green`, replayed against this branch.

Notes, kept below the invocation so the recipe is the first command-position line in this section:

- The `--expr` reverts **the fixed property itself** — the empty-falsy `or` back to the bare default — leaving that line byte-identical to base, so the mutated state is exactly the bug.
- The search literal occurs **exactly once** after the fix and **zero** times at base. `CLAUDE_MCP_DIR` appears only once in the whole file (the docstring deliberately does not repeat the token), so the no-`/g` `perl -0pi` substitution is total rather than partial.
- Replay from the repo root, serially — not concurrently with a test sweep.

## Quality pass

A pre-commit review over the diff returned clean on reuse, efficiency and altitude, and one finding on simplification which is applied here: the first draft's docstring claimed "all three readers of the override agree", which would have planted in `patch-desktop-config.py` the very cross-file claim that forced the `generate-dashboard.py` edit in this PR. It also asserted it was deferring to the canonical statement in the same breath as restating it. Both were cut; `generate-dashboard.py` now simply stops asserting a sibling's behaviour rather than asserting a fresher version of it.

Worth recording for the next reader: **unifying the three resolvers behind one shared function was considered and deliberately rejected.** `install-mcp.sh` is bash and unreachable from Python by construction, so unification would collapse three spellings to two, not one. The two Python spellings are provably equivalent — `Path.home()` is implemented as `expanduser("~")`. And the only cross-directory import precedent in this tree (`generate-dashboard.py:38-52`) is fail-soft with a `try/except` returning `None`; base resolution is not fail-soft, so each consumer would need a local fallback inside its `except` arm — reintroducing the duplicated literal in a branch no test exercises. The per-site discriminating test is the cheaper and more falsifiable guard.

Incidentally, the fix is also a small performance win: `os.environ.get(VAR, default)` evaluates its default **eagerly**, so `Path.home()` ran on every call even when the override was set. The `or` form short-circuits it (~3.34 µs → ~0.16 µs per call on the override-set path).

## Follow-up issues

- #1592 — `install-mcp.sh`'s `CLAUDE_MCP_DIR` fallback is the only one of the three readers with no executable pin. Its expression is already correct; what is missing is a red-at-base test. Filed rather than folded in because it needs a network-avoidance seam for a script that clones and builds.

## Disclosure — token scope

The runner token is over-scoped against the documented least-privilege posture (`extra scopes: gist, read:org, workflow`), and this run took the `--allow-overscoped` opt-out. It is a `gho_` token from a standard `gh auth login`, whose scope set is fixed by the GitHub CLI OAuth app and cannot be narrowed. Disclosed per the operator's standing instruction.

## Open questions

None.