### PR TITLE
cogni-workspace: pin install-mcp.sh's CLAUDE_MCP_DIR fallback

### DIFF
--- a/cogni-workspace/tests/test-install-mcp-base.sh
+++ b/cogni-workspace/tests/test-install-mcp-base.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+# Regression test for the MCP base directory that install-mcp.sh resolves
+# (MCP_BASE_DIR at scripts/install-mcp.sh:13, and INSTALL_DIR derived from it at :44).
+#
+# Contract under test: the base override falls back to $HOME/.claude/mcp-servers when it is
+# unset OR set-but-empty, and is honoured verbatim otherwise. That is the same semantics as
+# patch-desktop-config.py's `or` form and the dashboard probe's. CLAUDE_MCP_DIR has three
+# readers -- scripts/install-mcp.sh:13, scripts/patch-desktop-config.py:86 and
+# skills/workspace-dashboard/scripts/generate-dashboard.py:544. The two Python ones are
+# pinned by tests/test-patch-desktop-config-mcp-base.sh (P03) and
+# tests/test-dashboard-mcp-counts.sh (M18). This bash one was the only site with no
+# discriminating case, so a "consistency" edit dropping the colon -- ${CLAUDE_MCP_DIR-...},
+# which fires only on UNSET -- had no red test anywhere in the tree. This suite is that test.
+#
+# ASSERT THE POSITIVE PATH, NEVER A NEGATIVE SHAPE. Every case below compares the resolved
+# location against a controlled fixture path by EQUALITY. A case phrased as "the path is not
+# empty" or "does not start with a bare slash" would be green against the colon-dropped form
+# and pin nothing -- the same rule the sibling suite's header states.
+#
+# DRIVE THE PRODUCTION READ PATH. Each case EXECUTES install-mcp.sh as a subprocess and reads
+# the install_dir the script itself prints. Re-implementing ${CLAUDE_MCP_DIR:-...} inside the
+# test, or grepping the script's source for the ":-" spelling, would never execute line 13:
+# the first is green against a mutated script, the second goes red on any harmless reformat.
+#
+# WHY THE "ALREADY INSTALLED" PATH IS THE ONLY HERMETIC SEAM. install-mcp.sh clones and
+# builds, and it has no --help or dry-run flag. Its only other early exit -- the missing-args
+# path at :37-41 -- prints no path at all, so it cannot pin a base. But with INSTALL_DIR/.git
+# present (:56 tests `[ -d ]` only, so an empty directory suffices), --force absent, and
+# INSTALL_DIR/dist present (:64 accepts dist OR build), the script prints
+# {"action":"skipped","install_dir":...} at :66 and exits 0 at :68 -- before `git clone` at
+# :75 and before the build at :81. $REPO is dereferenced only at :75 and :108, both past that
+# exit, which is why --repo takes a placeholder that is never resolved. No network, no git
+# binary, no npm, no credential.
+#
+# An INCIDENTAL branch is an adequate observation point here only because INSTALL_DIR is
+# SINGLY DERIVED, at :44, before any branching -- the skip print at :66, the rm -rf at :74,
+# the clone at :75, the cd at :80 and the metadata write at :104 all read that one
+# derivation. Observing it on the skip branch therefore observes all of them. A refactor that
+# computed INSTALL_DIR per branch would silently narrow this pin to the skip branch alone, so
+# check that premise before trusting these cases about any other path.
+#
+# SHAPE ONLY, NEVER HOST AVAILABILITY -- the same discipline as the two sibling suites. HOME
+# is overridden to a fixture tree for every invocation, so the default-base cases resolve
+# inside $TMPROOT and determinism is STRUCTURAL rather than a naming convention. Each case
+# also sets its own CLAUDE_MCP_DIR state on the line immediately before its invocation, so
+# nothing leaks between cases and an exported value from the developer's shell cannot decide
+# a result.
+#
+# ASSERT THE MUTANT'S DEATH BY SHAPE, NEVER BY ITS DIAGNOSTIC WORDING. Under the
+# colon-dropped mutant the empty-override run dies at `mkdir -p ""` (:53) under
+# `set -euo pipefail`, which is also what stops it reaching the `rm -rf "$INSTALL_DIR"` at
+# :74 with a root-level path. The message that failure prints is foreign coreutils output and
+# is locale-dependent, so no case may match its text -- a grep for the English fragment finds
+# nothing on a non-English host and the case would pass against the unfixed reader everywhere
+# except English-locale CI. Detection here is purely structural: empty or unparseable stdout
+# (I01-I03) and a non-zero exit status (I04). install-mcp.sh's own "skipped" literal is an
+# own-emitter string and is fair game.
+#
+# I04's ABSENCE CONJUNCT IS ORDER-DEPENDENT BY CONSTRUCTION. start.sh and .mcp-install.json
+# are absent only because every earlier case also took the skip path. A case that passed
+# --force (:57), or omitted the dist fixture, would fall through to the build at :81 and
+# create both -- turning I04 green for the wrong reason on a later run. No case may do either.
+#
+# Case ids are zero-padded to a uniform width so no id is a prefix of another: the mutation
+# harness matches --case as a whole token, and I1 vs I10 is that collision class.
+#
+# Paths are self-located from $0, never the working directory: the repo runner invokes suites
+# with cwd=<repo root> and the mutation harness with cwd=$ROOT, so a cwd-relative path here
+# would be a latent false result.
+#
+# `set -u` but deliberately NOT `set -e`: the mutant run exits non-zero by design, and the
+# suite has to survive it to report the case rather than aborting.
+#
+# stdlib-only: bash + python3, no pip deps, per the repo-wide script convention.
+#
+# Mutation recipe (recorded in the PR body; verdict guard_verified):
+#   mutation-check.sh --root . --file cogni-workspace/scripts/install-mcp.sh
+#     --expr 's/CLAUDE_MCP_DIR:-/CLAUDE_MCP_DIR-/'
+#     --test 'bash cogni-workspace/tests/test-install-mcp-base.sh' --case I03
+
+set -u
+HERE="$(cd "$(dirname "$0")" && pwd)"
+WS_ROOT="$(cd "$HERE/.." && pwd)"
+INSTALLER="$WS_ROOT/scripts/install-mcp.sh"
+TMPROOT="$(mktemp -d)"
+trap 'rm -rf "$TMPROOT"' EXIT
+
+# A fixture $HOME, a fixture non-default base, and an empty directory to run from. The .git
+# and dist directories are what put every invocation on the pre-clone skip path; they are
+# real directories because :56 and :64 test with `[ -d ]`, but they are empty -- no git
+# repository is initialised and nothing in them is ever read.
+FAKE_HOME="$TMPROOT/home"
+DEFAULT_BASE="$FAKE_HOME/.claude/mcp-servers"
+ALT_BASE="$TMPROOT/alt-base"
+EMPTY_CWD="$TMPROOT/empty-cwd"
+SRV="fixture-mcp-server"
+mkdir -p "$DEFAULT_BASE/$SRV/.git" "$DEFAULT_BASE/$SRV/dist" \
+         "$ALT_BASE/$SRV/.git" "$ALT_BASE/$SRV/dist" "$EMPTY_CWD"
+
+failures=0
+pass() { printf 'PASS: %s\n' "$1"; }
+fail() { printf 'FAIL: %s\n' "$1"; failures=$((failures + 1)); }
+
+# run_installer -- one invocation of the real script on its skip path, with HOME overridden
+# and CLAUDE_MCP_DIR inherited from whatever the calling case just set. stdout is returned;
+# stderr is discarded because the mutant writes a locale-dependent diagnostic there that no
+# case may read. The subshell propagates the script's exit status, so a caller can capture it.
+run_installer() {
+  ( cd "$EMPTY_CWD" && HOME="$FAKE_HOME" bash "$INSTALLER" \
+      --name "$SRV" --repo unused://fixture )
+}
+
+# json_field_is "<json>" "<key>" "<expected>" -- the suite's single definition of a
+# well-formed emission: the payload parses, carries a `data` object, and that object's <key>
+# equals <expected>. Empty or unparseable stdout therefore fails, which is the mutant's
+# signature. Both assertion sites go through this one predicate so that policy cannot drift
+# between them -- I04 exists to backstop I03, so it must not grade against a laxer parse than
+# the case it backstops.
+json_field_is() {
+  printf '%s' "$1" | python3 -c '
+import json, sys
+try:
+    data = json.load(sys.stdin)["data"]
+except Exception:
+    sys.exit(1)
+sys.exit(0 if data.get(sys.argv[1]) == sys.argv[2] else 1)
+' "$2" "$3"
+}
+
+# assert_install_dir "<label>" "<expected path>" -- the script exited 0 AND the install_dir
+# it printed equals the expected fixture path. The rc conjunct is in the helper rather than
+# in one case, so every case carries it: without it, a change that printed the right path and
+# then exited non-zero would leave I01 and I02 green. `rc` is captured on its own line
+# because `local out="$(...)"` would mask the substitution's status behind local's own.
+assert_install_dir() {
+  local label="$1" expected="$2" out rc
+  out="$(run_installer 2>/dev/null)"
+  rc=$?
+  if [ "$rc" -eq 0 ] && json_field_is "$out" install_dir "$expected"; then
+    pass "$label"
+  else
+    fail "$label"
+  fi
+}
+
+# --- I01: an UNSET override resolves under the default base. -----------------------------
+# The unset arm is pinned separately from the empty arm so the fix for one cannot regress the
+# other. The explicit unset is not redundant: anyone who has run install-mcp exports this
+# variable, and without it I01 would read that live base and fail on their machine.
+unset CLAUDE_MCP_DIR
+assert_install_dir "I01 an unset override resolves the install dir under the default base" \
+  "$DEFAULT_BASE/$SRV"
+
+# --- I02: a NON-EMPTY override replaces the base. ----------------------------------------
+export CLAUDE_MCP_DIR="$ALT_BASE"
+assert_install_dir "I02 a non-empty override resolves the install dir under that base" \
+  "$ALT_BASE/$SRV"
+
+# --- I03: an EMPTY override falls back to the default base. ------------------------------
+# The discriminating case, and the recorded mutation target. Against ${CLAUDE_MCP_DIR-...}
+# the base stays the empty string, the script dies before printing anything, and the equality
+# above cannot hold.
+export CLAUDE_MCP_DIR=""
+assert_install_dir "I03 an empty override falls back to the default base, not an empty one" \
+  "$DEFAULT_BASE/$SRV"
+
+# --- I04: the empty-override run took the SKIP path, and built nothing. -------------------
+# The anti-vacuity conjunct. Without it, I03's equality alone does not establish that the
+# observed install_dir came from the network-free seam rather than from a clone-and-build
+# that happened to land in the same place. Both arms carry the same leading id token so the
+# case stays addressable from the mutation harness on a green run.
+export CLAUDE_MCP_DIR=""
+# The label is bound once and used by both arms: the mutation harness matches --case I04 as
+# a whole token against the EMITTED line, and reads both the mutated (red) and restored
+# (green) runs, so an edit retitling one arm and not the other would leave the case
+# addressable on only one of the two.
+i04_label="I04 the empty-override run took the skip path and wrote no install artifacts"
+i04_out="$(run_installer 2>/dev/null)"
+i04_rc=$?
+if [ "$i04_rc" -eq 0 ] \
+  && json_field_is "$i04_out" action skipped \
+  && [ ! -e "$DEFAULT_BASE/$SRV/start.sh" ] \
+  && [ ! -e "$DEFAULT_BASE/$SRV/.mcp-install.json" ]; then
+  pass "$i04_label"
+else
+  fail "$i04_label"
+fi
+
+unset CLAUDE_MCP_DIR
+
+echo
+if [ "$failures" -eq 0 ]; then
+  echo "All install-mcp MCP-base tests passed."
+  exit 0
+else
+  echo "$failures test(s) failed."
+  exit 1
+fi


### PR DESCRIPTION
Closes #1592.

## Summary

Adds `cogni-workspace/tests/test-install-mcp-base.sh` — the first suite that executes `cogni-workspace/scripts/install-mcp.sh` as a subject. `CLAUDE_MCP_DIR` has three readers; the two Python ones were already pinned (`test-patch-desktop-config-mcp-base.sh` P03, `test-dashboard-mcp-counts.sh` M18), and this bash one was the only site where a colon-dropping edit — `${CLAUDE_MCP_DIR-...}`, which fires on **unset only** — had no red test anywhere in the tree.

`cogni-workspace/scripts/install-mcp.sh` is **not modified**. Line 13 stays byte-identical: this PR adds a pin, it never edits the thing being pinned.

### The seam

`install-mcp.sh` clones and builds and has no `--help` or dry-run flag. Its only other early exit — the missing-args path at `:37-41` — prints no path at all, so it cannot pin a base. The suite instead drives the script's own **pre-clone "already installed" exit**: with `INSTALL_DIR/.git` present (`:56` tests `[ -d ]` only, so an empty directory suffices), `--force` absent, and `INSTALL_DIR/dist` present (`:64` accepts `dist` or `build`), the script prints `{"action":"skipped","install_dir":...}` at `:66` and exits 0 at `:68` — before `git clone` at `:75` and before the build at `:81`. `$REPO` is dereferenced only at `:75` and `:108`, both past that exit, which is why `--repo` takes a placeholder that is never resolved.

So every assertion reads the `install_dir` **the script itself printed**. Nothing re-implements `${CLAUDE_MCP_DIR:-...}` in the test, and nothing greps the script's source for the `:-` spelling — the first would be green against a mutated script, the second would go red on any harmless reformat of line 13.

### The four cases

| id | override | asserts |
|---|---|---|
| `I01` | `unset` | resolves under the default fixture base |
| `I02` | `$ALT_BASE` | honoured verbatim |
| `I03` | `""` (set-but-empty) | falls back to the default base — **the discriminating case**, and the mutation target |
| `I04` | `""` | the run exited 0, reported `action: skipped`, and wrote neither `start.sh` nor `.mcp-install.json` — the anti-vacuity conjunct |

Every assertion is a **positive equality** against a controlled fixture path under an overridden `$HOME`. No negative or containment shapes.

`I04` exists because `I03`'s equality alone does not establish that the observed `install_dir` came from the network-free seam rather than from a clone-and-build that happened to land in the same place.

## Verification

All run in the branch worktree.

```
bash cogni-workspace/tests/test-install-mcp-base.sh
  PASS: I01 / I02 / I03 / I04   ->  rc 0

python3 scripts/run-plugin-tests.py --filter cogni-workspace
  total: 19   passed: 19   failed: 0      (18 suites at base + this one)

python3 scripts/check-case-id-pairing.py        ->  rc 0, 0 violations (132 files scanned)
python3 scripts/check-result-line-plainness.py  ->  rc 0, 0 violations (132 files scanned)
```

`git diff origin/main...HEAD -- cogni-workspace/scripts/install-mcp.sh` is empty, and `git diff --stat origin/main...HEAD` shows exactly one added file.

## Mutation recipe

```
bash "$HOME/.claude/plugins/marketplaces/managed-service/cogni-service/scripts/mutation-check.sh" \
  --root . \
  --file cogni-workspace/scripts/install-mcp.sh \
  --expr 's/CLAUDE_MCP_DIR:-/CLAUDE_MCP_DIR-/' \
  --test 'bash cogni-workspace/tests/test-install-mcp-base.sh' \
  --case I03
```

Verdict **`guard_verified`** — `mutated_result: red`, `restored_result: green`, replayed against this branch.

Notes, kept below the invocation so the recipe is the first command-position line in this section:

- The `--expr` reverts **the guarded property itself** — the empty-falling-back `:-` back to the unset-only `-` — which is precisely the pre-fix semantics the issue names. The target line is one this diff leaves byte-identical, which is correct here: the property being pinned lives at `install-mcp.sh:13` and this PR adds no production line to aim at.
- The search literal `CLAUDE_MCP_DIR:-` occurs **exactly once** in the file, and the replacement does not contain it, so the no-`/g` `perl -0pi` substitution is total rather than partial and the mutant cannot re-satisfy the pattern and stay green.
- **Per-case behaviour was observed directly under the mutant, not merely inferred from the harness verdict:**

  ```
  PASS: I01 an unset override resolves the install dir under the default base
  PASS: I02 a non-empty override resolves the install dir under that base
  FAIL: I03 an empty override falls back to the default base, not an empty one
  FAIL: I04 the empty-override run took the skip path and wrote no install artifacts
  ```

  `I01` and `I02` staying **green** under the mutation is the half that matters: it separates a real comparison from a suite that simply stopped parsing. `I04` reddens alongside `I03` because it shares the empty override — added signal, not noise.
- Under the mutant an empty `CLAUDE_MCP_DIR` survives as the base, so `mkdir -p ""` at `:53` fails under `set -euo pipefail`; the script exits non-zero printing nothing, and the positive equality cannot hold. That same early death is why the mutant never reaches the `rm -rf "$INSTALL_DIR"` at `:74` with a root-level path.
- Replay from the repo root, serially — not concurrently with a test sweep.

## Design constraints worth flagging to a reviewer

- **The mutant's death is asserted by shape, never by its diagnostic wording.** The `mkdir` failure message is foreign coreutils output and is locale-dependent, so matching its text would pass against the unfixed reader on every non-English host. Detection is structural only: empty/unparseable stdout (`I01`-`I03`) and a non-zero exit status (`I04`). The script's own `"skipped"` literal is an own-emitter string and is used.
- **`I04` carries both a pass and a fail arm under the same leading id token.** `check-case-id-pairing.py` grades inline emissions; helper-routed cases reach it as a bare `$1` and are not graded, so the one inline case has to be paired explicitly or the blocking CI job fails.
- **`I04` captures `$?` on the line immediately after its command substitution** — any intervening command would overwrite the status the case turns on.
- **`I04`'s absence conjunct is order-dependent by construction.** `start.sh` and `.mcp-install.json` are absent only because every earlier case also took the skip path. A case passing `--force`, or omitting the `dist` fixture, would fall through to the build and create both — turning `I04` green for the wrong reason. The header states this beside the assertion.
- **`set -u` but deliberately not `set -e`** — the mutant run exits non-zero by design and the suite has to survive it to report the case rather than aborting.

## Quality pass

Four parallel cleanup reviewers (reuse / simplification / efficiency / altitude) ran over the diff before commit. Efficiency returned clean. The other three produced four findings, all applied:

- **Reuse + simplification (same finding, deduped):** the two embedded `python3` probes hand-rolled the same envelope parse. They now share one `json_field_is` predicate. The cost was never line count — measured at ~0 — it was that the parse/compare policy (`unparseable stdout fails`, the mutant's own signature) existed in two independently-editable copies, so hardening one would leave **I04 grading against a laxer parse than the case it exists to backstop**.
- **Simplification:** `I04`'s 63-character label was written out twice, once per arm. It is now bound once. The harness reads both the mutated and the restored run, so an edit retitling one arm and not the other would leave the case addressable on only one of the two.
- **Altitude F1:** the header justified the incidental seam by hermeticity but omitted the property that actually makes it adequate — `INSTALL_DIR` is **singly derived** at `:44` before any branching, so observing it on the skip branch observes the clone, build and metadata paths too. Now stated, with the refactor that would invalidate it called out.
- **Altitude F3:** `assert_install_dir` discarded the exit status, so only `I04` carried an `rc == 0` conjunct. It is now in the helper, so every case has it — otherwise a change that printed the right path and then exited non-zero would leave `I01` and `I02` green.

One finding was taken in a different form than proposed, deliberately. Altitude **F2** asked the suite to adopt the sibling's predicate-parameterized helper (`assert_patcher "<label>" "<expected>" "<predicate>"`). Its stated cost — two copies of the parse block — is what the `json_field_is` extraction already removes. The sibling achieves that parameterization by expanding a predicate *string* into an unquoted heredoc; parameterizing by `argv` instead reaches the same generality without the string-expansion hazard, which is why that form was kept.

Two items were recorded and **not** acted on, both correctly out of this PR's fence:

- Hoisting the doctrine prose shared across suites into a `cogni-workspace/tests/README.md` — a repo-wide refactor touching every suite, and most of the value in these headers is site-specific adaptation rather than the shared sentences.
- A purpose-built no-network flag on `install-mcp.sh`. Adding production surface to a user-facing installer to serve one test is the wrong trade today — and the flag would itself need a pin. The trigger to revisit is a **second** hermetic case wanting the script, e.g. pinning `WRAPPER_PATH` (`:45`) or the wrapper-template resolution (`:48-50`), both observable only past the network work. At that point the skip-path approach gets replicated and a real seam earns its keep.

Every gate was re-run after the edits: suite 4/4 green, mutation `guard_verified`, `total: 19 / failed: 0`, both guards 0 violations, and `I01`/`I02` still green under the mutant.

## Scope

- **Included:** exactly one new file.
- **New suite rather than a case in a sibling:** `test-patch-desktop-config-mcp-base.sh` binds its subject to `patch-desktop-config.py` and `test-dashboard-mcp-counts.sh` to `generate-dashboard.py`. Neither invokes `install-mcp.sh` at all, so a case added there would never execute line 13 and would be vacuous by the same "drive the production read path" discipline both suites' headers insist on.
- **No registration anywhere:** `scripts/run-plugin-tests.py` discovers via two non-recursive globs, and `.github/workflows/lint.yml` runs `plugin-test-suites`, `case-id-pairing-guard` and `result-line-plainness-guard` unconditionally. CLAUDE.md documents both guards generically and enumerates no suite filenames.
- **Deliberately excluded**, per the issue's committed acceptance contract: `cogni-workspace/scripts/patch-desktop-config.py`, `cogni-workspace/skills/workspace-dashboard/**`, and any shared/unified MCP-base resolver. No sibling case is altered, renumbered or deleted, so the recorded `P03` and `M18` mutation targets keep their teeth.