### PR TITLE
deployment-guide: one install command, roster rebuilt from the live manifest

### DIFF
--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -136,17 +136,15 @@ Plugins give Claude the tools to do insight-wave work — building portfolios, w
 
    **What you'll see:** a confirmation message that the marketplace was added.
 
-2. **Install the core plugins you need.** Start with these three:
+2. **Install the core plugin.** Start with cogni-workspace — it carries the shared workspace, themes, and MCP setup the other plugins build on:
 
    ```
    /plugin install cogni-workspace@insight-wave
-   /plugin install cogni-portfolio@insight-wave
-   /plugin install cogni-visual@insight-wave
    ```
 
-   Paste them one at a time, waiting for each to finish. Each install takes 5–15 seconds.
+   Paste it and wait for it to finish. The install takes 5–15 seconds.
 
-3. **Browse everything available** by pasting `/plugin` and pressing Enter — a menu shows every plugin in the marketplace with a short description. Install others as you need them (cogni-sales, cogni-trends, cogni-knowledge, cogni-consult, cogni-workspace, cogni-marketing, cogni-website).
+3. **Browse everything available** by pasting `/plugin` and pressing Enter — a menu shows every plugin in the marketplace with a short description. Install others as you need them (cogni-knowledge, cogni-consult, cogni-trends, cogni-portfolio, cogni-marketing, cogni-sales, cogni-website).
 
 4. **If this doesn't work:** the most common cause is that Claude Code lost its internet connection. Close and reopen the terminal, then re-run `/plugin marketplace add`. If the marketplace URL says "not reachable," ask your IT team to allowlist `github.com` and `raw.githubusercontent.com`.
 


### PR DESCRIPTION
Closes #1550.

## Summary

Step 2 of `### Install the insight-wave plugins` told readers to paste three install commands. The third — `/plugin install cogni-visual@insight-wave` — names a plugin retired into `cogni-workspace` and absent from `.claude-plugin/marketplace.json` `plugins[]`, so it **errors on the first page of the onboarding path**, with no signal to the reader whether the instruction is stale or their environment is broken.

- The step collapses from three commands to **one**. The retired line is removed entirely; `cogni-visual` no longer appears anywhere in the file.
- The single surviving command is `/plugin install cogni-workspace@insight-wave` — chosen by **necessity, not preference**. cogni-visual's capability was absorbed into cogni-workspace, *and* the immediately following section (`### Turn on MCP servers`) instructs `/install-mcp`, which cogni-workspace provides (`cogni-workspace/skills/install-mcp/SKILL.md`). Naming any other plugin would strand that section.
- The follow-on sentence drops its plural for singular agreement while keeping the `5–15 seconds` timing statement, en dash (U+2013) intact — that is the file's convention for numeric ranges.
- Step 3's browse roster is rebuilt as `plugins[]` **minus the installed name**, in manifest array order. This fixes two base defects at once: `cogni-workspace` was listed although step 2 installs it, and `cogni-portfolio` was missing entirely.

Step 2 is edited **in place, never deleted**, so the ordered-list markers stay contiguous 1./2./3./4. and steps 3 and 4 survive.

## Verification against the issue-time contract

The acceptance contract was derived at triage (before this branch existed) and posted on #1550. **All 14 gating items were executed against the head tree, not argued:**

| Item | Check | Result |
|---|---|---|
| 1, 2 | changed-file list within the deployment-guide surface; manifest not modified | `docs/deployment-guide.md` only |
| 3 | both `###` headings survive, adjacent and in order | 127 → 153 |
| 4 | `/plugin marketplace add cogni-work/insight-wave` survives | 1 occurrence |
| 5 | exactly one `/plugin install ` line between the headings | **1** (base: 3) |
| 6 | it names cogni-workspace | confirmed |
| 7 | zero `cogni-visual` file-wide | **0** (base: 1) |
| 8 | every install name present in `plugins[].name` | subset holds |
| 9 | `Start with these three` / `Paste them one at a time` gone | 0 / 0 |
| 10 | `5–15 seconds` retained with en dash | present; bytes `e2 80 93` confirmed by `od` |
| 11 | roster **set-equals** `plugins[]` minus installed | 7 names, exact set equality, order matches manifest |
| 12 | install ∩ roster empty; roster ⊆ `plugins[]` | both hold |
| 13 | steps 3 and 4 survive; markers contiguous | `1 2 3 4` |
| 14 | no test/mutation recipe expected (prose in a docs file) | none added — see below |

All six CI lint guards were also run on the branch and exit 0: breadcrumbs, external-dispatch, result-line-plainness, case-id-pairing, mcp-tool-grant, version-bump (8 plugins scanned, **0 touched**).

**On item 14 and the absence of a test.** No test, CI workflow, or guard script in this repo reads `docs/deployment-guide.md`, `/plugin install` lines, or docs-roster consistency. `scripts/check-plugin-inventory.py` reads only the manifest and top-level plugin dirs. `scripts/check-external-dispatch.py` — the retired-plugin sweep, whose registry *does* list `cogni-visual` — excludes `docs/` structurally in both `EXCLUDE_SEGMENTS` and `EXCLUDE_TOPLEVEL`, and matches only the colon form `cogni-visual:`, never the `@insight-wave` install shape. So the achievable bar is the string/count/set assertions above, and the absence of a test artifact is not a coverage gap here.

**A note for the reviewer on preflight.** This is a docs-only touched set, so the preflight instrument set resolves to `no_applicable_checks` (exit 0). That green is **not** evidence about this change — it means the instruments never examined anything. The table above is the evidence.

## Scope decisions

- **Not modified: `.claude-plugin/marketplace.json`.** It is the roster of record and is correct; the guide is what drifted. Re-admitting `cogni-visual` to make stale prose true would invert the source of truth and re-ship a retired plugin.
- **Linked with `Closes`, not `Refs`** — see the first open question below for why.

## Open questions

Both are **non-holding** (`kind: avoidable`). Neither gates this PR.

1. **The same failing command survives one file over.** `docs/workflows/install-to-infographic.md:50` carries the identical `/plugin install cogni-visual@insight-wave`, plus a duplicated `cogni-workspace` at lines 46/47. It is **out of this issue's fence** — #1550's AC4 restricts the diff to `docs/deployment-guide.md`. It is already owned by sibling **#1554**, whose affected-components list names that file and whose own AC4 fences its diff to six `docs/workflows/*.md` + `docs/known-issues.md` + `docs/claude-code-desktop.md`, explicitly excluding this file. #1554's body calls it "the same class of failure as the deployment-guide install, spread across six more pages". The partition is deliberate — flagging it so it reads as such rather than as an oversight. **This is why no follow-up issue was filed and why this PR links with `Closes #1550`:** the one deferred entry the refine pass proposed resolved to an already-open canonical, and nothing of #1550's *own* scope is deferred. A reviewer who disagrees should say so — the alternative would leave #1550 open behind a merged PR.
2. **The plan-time acceptance criteria were under-specified.** The issue's four ACs leave three gating holes the derived 14-item bar closes: AC3 bounded the roster only by "at most once" and "no name the install step covers", so gutting the roster to two names would have passed all four while contradicting the issue body — the derived bar requires exact set equality; no AC required the `5–15 seconds` statement to survive, though the issue body asks for it; and no AC pinned *which* plugin the single command names, though the next section's `/install-mcp` strands on any other choice. Recorded as a measurement of AC quality, not a defect in this change.
3. **No guard couples docs install commands to the manifest.** Nothing in this repo would catch this class re-breaking. The durable fix — assert every `/plugin install <name>@insight-wave` under `docs/**` names a live `plugins[].name` — lands in `scripts/` and `.github/workflows/`, which this issue's scope fence puts out of bounds. Worth a follow-up issue; deliberately not opened here to avoid pre-empting a maintainer's call on guard scope.
4. **Unrelated, untouched:** `docs/deployment-guide.md:7` points readers at `/doc-deploy` in the `cogni-docs` plugin, which is not in this repo's marketplace (`cogni-docs` lives in the sibling `managed-service` repo). Pre-existing, outside the install step, and not in this issue's named change set.