### PR TITLE
Align every plugin-count statement and prose roster with the marketplace roster

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
     "email": "stephan@cogni-work.ai"
   },
   "metadata": {
-    "description": "Insight-wave is an 11-plugin ecosystem for Claude Code that turns consulting, research, portfolio, and communication workflows into AI-assisted, bilingual (EN/DE) pipelines — trend scouting, portfolio messaging, narrative transformation, visual deliverables, sales enablement, claim verification, knowledge management, wiki-first research, and end-to-end consulting orchestration.",
+    "description": "Insight-wave is an 8-plugin ecosystem for Claude Code that turns consulting, research, portfolio, and communication workflows into AI-assisted, bilingual (EN/DE) pipelines — trend scouting, portfolio messaging, sales enablement, knowledge management, wiki-first research, and end-to-end consulting orchestration, with narrative transformation, visual deliverables, and claim verification as cogni-workspace capabilities.",
     "version": "1.0.4"
   },
   "plugins": [

--- a/CLA.md
+++ b/CLA.md
@@ -7,14 +7,13 @@ Thank you for your interest in contributing to insight-wave core plugins. This C
 - cogni-workspace
 - cogni-trends
 - cogni-portfolio
-- cogni-visual
 - cogni-marketing
 - cogni-sales
 - cogni-consult
 - cogni-knowledge
 - cogni-website
 
-_This list mirrors the core plugins in [`.claude-plugin/marketplace.json`](.claude-plugin/marketplace.json) (11 plugins); update both together when the roster changes._
+_This list mirrors the core plugins in [`.claude-plugin/marketplace.json`](.claude-plugin/marketplace.json) (8 plugins); update both together when the roster changes._
 
 This Agreement does **not** apply to third-party community plugins published on the insight-wave marketplace. See [MARKETPLACE_TERMS.md](MARKETPLACE_TERMS.md) for community plugin terms.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,12 +1,12 @@
 # insight-wave
 
-11-plugin monorepo for consulting, sales, and marketing on Claude Code. Apache-2.0. All plugins follow the Claude Code plugin standard.
+8-plugin monorepo for consulting, sales, and marketing on Claude Code. Apache-2.0. All plugins follow the Claude Code plugin standard. The roster and its count are single-sourced from `.claude-plugin/marketplace.json` `plugins[]` — when the roster changes, update every count stated elsewhere in this repo from it.
 
 ## Repo Structure
 
 ```
 insight-wave/
-├── .claude-plugin/marketplace.json    Marketplace manifest (11 plugins)
+├── .claude-plugin/marketplace.json    Marketplace manifest (8 plugins)
 ├── cogni-{name}/                      Each plugin directory
 │   ├── .claude-plugin/plugin.json     Plugin manifest (name, version, description)
 │   ├── README.md                      Plugin documentation (IS/DOES/MEANS messaging)
@@ -125,7 +125,7 @@ Key integration patterns:
 
 - Plugin version lives in `.claude-plugin/plugin.json` `version` field (semver), mirrored on the plugin's entry in the repo-root `.claude-plugin/marketplace.json` — Claude Desktop reads the marketplace copy for update detection, so the two must always agree
 - `.github/workflows/cogni-version-bump.yml` owns the bump. On every push to `main` it patch-increments each plugin the merge touched, editing **both** manifests in one `bump(...)` commit. `scripts/apply-version-bump.py` does the edit; nothing is written unless the rewritten JSON re-parses and differs *only* in the intended version values
-- A feature branch that still touches a version reintroduces the merge-conflict class the post-merge move eliminated: when every PR bumped at authoring time, the instant one PR merged, every other open PR's version lines became a textual conflict. insight-wave had it worse than a one-manifest-per-plugin repo, because marketplace.json is a single file all 11 plugins share — so the conflict was repo-wide, not per-plugin
+- A feature branch that still touches a version reintroduces the merge-conflict class the post-merge move eliminated: when every PR bumped at authoring time, the instant one PR merged, every other open PR's version lines became a textual conflict. insight-wave had it worse than a one-manifest-per-plugin repo, because marketplace.json is a single file all 8 plugins share — so the conflict was repo-wide, not per-plugin
 - `scripts/check-version-bump.py` enforces this at PR time (CI: "Version-bump gate" in `.github/workflows/lint.yml`). It flags `version-touched` on any version change vs the fork point, and `version-mirror-desync` whenever plugin.json and marketplace.json disagree. Fix a `version-touched` finding by reverting the version line in **both** files
 - The auto-bump is patch-only and structurally cannot cross a maturity boundary, so `maturity` and the maturity keyword in `keywords[]` are never touched by it. **Boundary crossings stay human** — make them on a `bump/…` branch, which the PR-time gate exempts
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,7 +77,7 @@ python3 scripts/check-breadcrumbs.py --update-baseline
 
 **Do not bump a plugin version in your branch.** Every plugin's version lives in two places — `<plugin>/.claude-plugin/plugin.json` and the plugin's entry in the repo-root `.claude-plugin/marketplace.json` — and the `Version bump` workflow advances both, automatically, on merge to `main`, for each plugin your PR actually touched.
 
-The bump moved post-merge because that version line was the canonical merge-conflict class: when every PR bumped at authoring time, the instant one PR merged, every other open PR's version lines conflicted. Since `marketplace.json` is a single file shared by all 11 plugins, that conflict was repo-wide rather than per-plugin.
+The bump moved post-merge because that version line was the canonical merge-conflict class: when every PR bumped at authoring time, the instant one PR merged, every other open PR's version lines conflicted. Since `marketplace.json` is a single file shared by all 8 plugins, that conflict was repo-wide rather than per-plugin.
 
 The CI `Lint` workflow runs `scripts/check-version-bump.py` on every PR and fails on:
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # insight-wave
 
-Open-source plugins for consulting, sales, and marketing on [Claude Code](https://claude.ai/code). 12 Apache-2.0 plugins that automate the research-heavy, methodology-driven work behind B2B deliverables — trend scouting, portfolio positioning, sales pitches, content creation, visual production, website generation, knowledge management, and source verification.
+Open-source plugins for consulting, sales, and marketing on [Claude Code](https://claude.ai/code). 8 Apache-2.0 plugins that automate the research-heavy, methodology-driven work behind B2B deliverables — trend scouting, portfolio positioning, sales pitches, content creation, visual production, website generation, knowledge management, and source verification.
 
 Each plugin implements an established framework (Corporate Visions, Double Diamond, TIPS, IS/DOES/MEANS) rather than general-purpose text generation. Outputs include inline citations, structured data models, and quality gates. Every deliverable follows a reproducible methodology you can inspect and override.
 
@@ -11,7 +11,7 @@ Each plugin implements an established framework (Corporate Visions, Double Diamo
 
 ## What the plugins do
 
-9 plugins organized around nine capability areas. Each area handles a distinct part of the consulting-to-delivery workflow; plugins within an area share data formats and can be used independently or together.
+8 plugins organized around nine capability areas. Each area handles a distinct part of the consulting-to-delivery workflow; plugins within an area share data formats and can be used independently or together.
 
 ### Knowledge Management
 
@@ -63,11 +63,11 @@ Each plugin implements an established framework (Corporate Visions, Double Diamo
 
 ### Visual Production
 
-[cogni-visual](cogni-visual/README.md) transforms narratives into visual formats: slide decks (11 layout types), scrollable web narratives, printed poster storyboards, and single-page infographics. Skills generate structured briefs; agents render them into .pptx, .excalidraw, .pen, or .html files. All visuals inherit brand identity from your workspace theme.
+A [cogni-workspace](cogni-workspace/README.md) capability (not a separate plugin): the `story-to-slides`, `story-to-infographic`, `story-to-storyboard` and `story-to-web` skills transform narratives into visual formats: slide decks (11 layout types), scrollable web narratives, printed poster storyboards, and single-page infographics. Skills generate structured briefs; agents render them into .pptx, .excalidraw, .pen, or .html files. All visuals inherit brand identity from your workspace theme.
 
 > "Create a slide deck from the sales presentation, then enrich the trend report with charts and diagrams"
 
-→ [Plugin guide](docs/plugin-guide/cogni-visual.md)
+→ [Plugin guide](docs/plugin-guide/cogni-workspace.md)
 
 ### Website Generation
 
@@ -181,7 +181,7 @@ The workplace combines Claude Code with [Obsidian](https://obsidian.md/) for per
 ```
 insight-wave/
 ├── .claude-plugin/
-│   └── marketplace.json                    # Marketplace manifest (9 plugins)
+│   └── marketplace.json                    # Marketplace manifest (8 plugins)
 ├── docs/                                   # User documentation
 │   ├── getting-started.md                  # Forwarder → workflows/install-to-infographic.md
 │   ├── ecosystem-overview.md               # Plugin landscape and data flow
@@ -195,7 +195,6 @@ insight-wave/
 ├── cogni-portfolio/                        # Portfolio messaging & planning
 ├── cogni-sales/                            # B2B sales pitch generation
 ├── cogni-trends/                           # Trend scouting & reporting
-├── cogni-visual/                           # Visual deliverables
 ├── cogni-website/                          # Multi-page customer websites
 ├── cogni-workspace/                        # Workspace orchestrator
 ├── cogni-portfolio-evals/                  # Eval harness (not a marketplace plugin)
@@ -221,11 +220,10 @@ Plugins follow the [Claude Code plugin standard](https://code.claude.com/docs/en
 | [cogni-portfolio](cogni-portfolio/README.md) | Portfolio | 21 | 20 | IS/DOES/MEANS portfolio positioning with eight industry taxonomies, competitive analysis, and market sizing |
 | [cogni-marketing](cogni-marketing/README.md) | Content | 11 | 3 | B2B marketing content engine — 16 formats across thought leadership, demand gen, lead gen, sales enablement, ABM |
 | [cogni-sales](cogni-sales/README.md) | Sales | 1 | 4 | Corporate Visions Why Change pitch generation for named customers or market segments |
-| [cogni-visual](cogni-visual/README.md) | Visual | 7 | 19 | Slide decks, infographics, web narratives, poster storyboards, and report enrichment from narratives |
 | [cogni-website](cogni-website/README.md) | Website | 6 | 3 | Multi-page customer websites from portfolio, marketing, and research content with shared navigation and theming |
-| [cogni-workspace](cogni-workspace/README.md) | Platform | 19 | 7 | Shared foundation — env vars, MCP installation, theme management, plugin discovery, workspace health, Obsidian integration, bundled wiki, claim verification, story-arc narrative and executive copywriting |
+| [cogni-workspace](cogni-workspace/README.md) | Platform | 19 | 7 | Shared foundation — env vars, MCP installation, theme management, plugin discovery, workspace health, Obsidian integration, bundled wiki, claim verification, story-arc narrative, executive copywriting, and slide/infographic/storyboard/web rendering |
 
-**104 skills, 88 agents** across the 9 active plugins.
+**97 skills, 69 agents** across the 8 active plugins.
 
 See [Cross-Plugin Data Flow](docs/er-diagram.md) for how data flows between plugins, or browse the [full documentation](docs/ecosystem-overview.md).
 

--- a/cogni-workspace/references/absorption-roadmap.md
+++ b/cogni-workspace/references/absorption-roadmap.md
@@ -52,7 +52,8 @@ derived against, when the repo-root `.claude-plugin/marketplace.json` registered
 them. Rows are kept as the historical record of why each plugin scored as it did;
 they are not re-scored as plugins retire, so read the table against the
 absorption-status ledger below rather than as a current roster. `cogni-claims` has since been absorbed
-into cogni-workspace, leaving 11 registered plugins. A further top-level directory,
+into cogni-workspace; the marketplace now registers 8 plugins — read the
+absorption-status ledger below for the current state. A further top-level directory,
 `cogni-portfolio-evals/`, ships no `.claude-plugin/plugin.json` — it is an eval
 harness, not a plugin, and is correctly outside this table.
 

--- a/cogni-workspace/references/wiki-tree-reconciliation.md
+++ b/cogni-workspace/references/wiki-tree-reconciliation.md
@@ -196,7 +196,8 @@ for the same reason in reverse: it links `[[lint-2026-04-20]]`, a root-only page
 
 Measured at execution, the two copies differed on **four** description/intro lines, not the five
 recorded here. Three resolved root-wins: the `### Skills` and `### Agents` preambles (the bundle
-asserted "across all 11 plugins", which the nine-plugin marketplace roster contradicts) and the
+asserted "across all 11 plugins", which the marketplace roster contradicts — it registered
+nine plugins when this reconciliation ran and registers eight today) and the
 `skill-cogni-portfolio-propositions` bullet (the bundle still carried the terse stub, matching the
 stub page group A replaced).
 

--- a/cogni-workspace/themes/cogni-work/components/deck/index.html
+++ b/cogni-workspace/themes/cogni-work/components/deck/index.html
@@ -123,7 +123,7 @@
     <div class="agenda-grid">
       <div class="n">01</div><div class="t">The challenge<span class="sub">Why knowledge work is broken for professional teams</span></div>
       <div class="n">02</div><div class="t">The opportunity<span class="sub">What methodology-first automation unlocks</span></div>
-      <div class="n">03</div><div class="t">Our approach<span class="sub">14 plugins, four capability areas, one foundation</span></div>
+      <div class="n">03</div><div class="t">Our approach<span class="sub">8 plugins, four capability areas, one foundation</span></div>
       <div class="n">04</div><div class="t">What's next<span class="sub">Getting started and the partner program</span></div>
     </div>
     <div class="footer">

--- a/docs/architecture/loop-health-map.md
+++ b/docs/architecture/loop-health-map.md
@@ -19,11 +19,13 @@ rubric: it is what makes a flagged finding credible.
   this" section below restates the five moves, the anti-pattern map, and the
   severity policy — this map is self-contained and re-sweepable without
   cogni-service installed.
-- **Scope:** all 9 plugins in this repo's marketplace — cogni-consult,
+- **Scope:** all 8 plugins in this repo's marketplace — cogni-consult,
   cogni-knowledge, cogni-marketing, cogni-portfolio, cogni-sales, cogni-trends,
-  cogni-visual, cogni-website, cogni-workspace. The loops formerly surveyed under
+  cogni-website, cogni-workspace. The loops formerly surveyed under
   cogni-narrative and cogni-copywriting are now cogni-workspace skills and are
-  listed under it.
+  listed under it. cogni-visual has since been absorbed into cogni-workspace as
+  well; loops 7 and 8 below are still recorded under their pre-absorption
+  `cogni-visual/` source paths.
 - **Nature:** read-only. This map is a data artifact; it changes no loop and
   proposes no specific code edits. Any targeted hardening of a flagged loop is
   a further, evidence-gated concern — decided from this baseline, not

--- a/docs/ecosystem-overview.md
+++ b/docs/ecosystem-overview.md
@@ -1,6 +1,6 @@
 # Ecosystem Overview
 
-insight-wave is a monorepo of 11 Claude Code plugins that cover the full consulting and B2B content pipeline: from raw research through strategy, content production, visual delivery, and website generation. This document describes how the plugins are organized, how data moves between them, and what infrastructure they share.
+insight-wave is a monorepo of 8 Claude Code plugins that cover the full consulting and B2B content pipeline: from raw research through strategy, content production, visual delivery, and website generation. This document describes how the plugins are organized, how data moves between them, and what infrastructure they share.
 
 For the canonical plugin descriptions, see the individual README files. For step-by-step workflows, see [docs/workflows/](workflows/).
 
@@ -8,7 +8,7 @@ For the canonical plugin descriptions, see the individual README files. For step
 
 ## Plugin Landscape
 
-The 9 plugins are grouped by the role they play in a typical engagement — the same set the root [`marketplace.json`](../.claude-plugin/marketplace.json) enumerates.
+The 8 plugins are grouped by the role they play in a typical engagement — the same set the root [`marketplace.json`](../.claude-plugin/marketplace.json) enumerates.
 
 ### Workspace Infrastructure
 
@@ -51,7 +51,7 @@ See the [Consulting Engagement workflow](workflows/consulting-engagement.md) for
 
 | Plugin | What it does |
 |--------|-------------|
-| [cogni-visual](../cogni-visual/README.md) | Converts polished narratives and structured data into presentation briefs, slide decks, scrollable web narratives, poster storyboards, and single-page infographics. Supports Excalidraw, Pencil MCP, PPTX, and HTML rendering. |
+| [cogni-workspace](../cogni-workspace/README.md) — `story-to-*` | Converts polished narratives and structured data into presentation briefs, slide decks, scrollable web narratives, poster storyboards, and single-page infographics. Supports Excalidraw, Pencil MCP, PPTX, and HTML rendering. |
 
 ### Website Generation
 


### PR DESCRIPTION
Closes #1551.

The tree was already correct — `.claude-plugin/marketplace.json` `plugins[]` enumerates the right roster. Only the prose describing it had drifted, into four mutually inconsistent numbers (9 / 11 / 12 / 14), each restatement written against a different snapshot and none derived from the manifest. Live roster: **8** — cogni-knowledge, cogni-consult, cogni-workspace, cogni-trends, cogni-portfolio, cogni-marketing, cogni-sales, cogni-website.

## Summary

- **13 count sites** now state the live roster length. **Three were not in the issue's table**: `README.md:3` (12), `docs/ecosystem-overview.md:3` (11 — contradicting `:11`'s "The 9 plugins" eight lines below it *in the same file*), and `README.md:228` ("**104 skills, 88 agents** across the 9 active plugins"), which every prior sweep missed because the word "active" sits between the digit and the noun.
- **`cogni-visual` dropped from all six prose rosters** — the issue named two. Added: README's repo tree (`:198`, which drew a `cogni-visual/` directory that **does not exist**), README's glance table (`:224`), `CLA.md:7-15` (whose own `:17` declares it a mirror of `plugins[]`), and `docs/ecosystem-overview.md:54`.
- Its still-live capabilities are **rehomed, not deleted**, onto cogni-workspace — which verifiably owns them (`story-to-slides`, `story-to-infographic`, `story-to-storyboard`, `story-to-web`, `render-html-slides`, `enrich-report`) — in the idiom each file already uses for cogni-narrative and cogni-copywriting.
- `README.md:70`'s plugin-guide link pointed at `docs/plugin-guide/cogni-visual.md`, **which does not exist** — a broken link on base. Repointed to the cogni-workspace guide, matching the file's own Source Verification precedent at `:96`.

## Two structural decisions

**Capability-area headings are preserved, contents rehomed.** README carries exactly the nine `###` areas its `:14` claims, and ecosystem-overview exactly the six buckets #1552's title names. Deleting a heading would leave eight areas under a line asserting nine — a contradiction inside this diff — and would silently pre-empt #1552. Both taxonomies are unchanged, so #1552 inherits the structure it was filed against.

**`README.md:228` is re-summed, not re-derived.** The nine rows summed to exactly 104 / 88 on base, so the line was table-consistent. Removing cogni-visual's row (7 / 19) makes it **97 skills, 69 agents**. The invariant preserved is "the line equals its table" — these are not fresh counts of actual skill/agent files, and re-deriving them is out of scope since they are not plugin-count statements.

## Deliberately untouched — none of these is an AC-2 miss

- Capability-**area** numbers ("nine capability areas", the deck's "four capability areas") — **#1552**, open and unmerged.
- `loop-health-map.md`'s per-loop `cogni-visual/skills/…` source citations (`:73`, `:74`, `:254`, `:274`, `:473`) — evidence citations in a dated survey, **#1553**'s charter. The scope sentence says so explicitly rather than claiming those loops are already "listed under" cogni-workspace, which the file's own body would contradict four lines later.
- `loop-health-map.md:100` "1 plugin assessed-empty" — tallies plugins *this sweep* found loop-empty, not the roster. Renumbering it would falsify a measurement.
- `docs/ecosystem-overview.md`'s data-flow block, hand-off/theme prose and workflow-routing table — **#1553** / **#1554**.
- **Four protected historical/quoted statements, all verified byte-identical after the edit**: `absorption-roadmap.md:49-52` (dated 12-plugin scoring snapshot), `absorption-roadmap.md:360` (a verbatim quotation of a wiki page inside that document's own findings table), `wiki-tree-reconciliation.md:199`'s quoted `"across all 11 plugins"`, and `:496` (describes AC-7-excluded wiki trees; still accurate).

## Evidence

Baseline captured **before** any edit, so a green result means something:

| Criterion | Base | Branch |
|---|---|---|
| AC 1/2 grep falsifier | **RED** (16 count violations + stale-name hits) | **GREEN** — only the four protected sites remain non-8 |
| AC 3 JSON parse + `plugins[]` byte-identical | — | ✅ parses; `plugins[]` identical; exactly one `metadata.description` line changed |
| AC 4 `test_check_plugin_inventory.sh` | rc 0 | **rc 0** |
| AC 5 `run-plugin-tests.py` | 132/132 | **132/132** (incl. `test-wiki-bare-name-roster.sh`, `test-wiki-tree-parity.sh`) |
| AC 6 `check-version-bump.py` | 0 touched | **0 touched, 0 violations** |
| AC 7 changed-file list | — | ✅ exactly the ten allowlisted paths |

AC 4/5/6 were **already green on base**, so they demonstrate "broke nothing", not "fixed something" — the issue says as much for AC 4. The AC 1/2 falsifier is the criterion that actually discriminates, which is why it was confirmed red at base first.

**Test coupling checked**: `test-wiki-tree-parity.sh` check (c) substring-searches `wiki-tree-reconciliation.md` for page stems. The edit is confined to one clause, the paragraph is not re-flowed, and `skill-cogni-portfolio-propositions` remains whole on its own line.

## Follow-up issues

- **#1600** — `CONTRIBUTING.md`'s Apache-2.0 core-plugin list diverges from the roster in *both* directions (names `cogni-visual` and the archived `cogni-consulting`; omits `cogni-knowledge` and `cogni-website`). Not fixed here: it accompanies no count, carries no mirror declaration, and its correct membership rule is a licensing decision this issue does not answer.

## Open questions

1. **Confirm the heading-preservation reroute.** This PR keeps `### Visual Production` / `### Visual Delivery` and rehomes their contents, leaving the taxonomies at nine and six for #1552. The alternative — collapsing them to eight and five and letting #1552 rebuild — is defensible but pre-empts that issue. Is preserving them the intent?
2. **Does the Apache-2.0 core-plugin list in `CONTRIBUTING.md:9-16` follow the marketplace roster?** Filed as #1600. It also raises a question this issue cannot settle: what Apache-2.0 coverage an *archived* plugin retains.

## Process disclosures

- The Step 4c.5 refine pass was dispatched with a path to the picked plan that **was never written**, so it ran without its stated input and its output matched the *rejected* plan's shape. Its findings were therefore treated as claims to verify rather than as a refinement: all six load-bearing factual claims were independently confirmed against `origin/main`, and Step 4d then passed **39/39** on every anchor and current-behavior string. The plan was adopted on that verification.
- The Step 7.5 token-scope gate exits **1** under `--strict`: the `gh auth login` OAuth token carries `workflow`, `gist` and `read:org` beyond the documented minimum, and its scope set is fixed by the GitHub CLI OAuth app. Proceeded with the documented `--allow-overscoped` flag.