### PR TITLE
docs/workflows: retarget retired-plugin routing to live plugins

### DIFF
--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -18,7 +18,6 @@ When both Claude Desktop (Cowork) and Claude Code are installed, they register c
 |--------|--------|---------|--------|
 | cogni-workspace | claims | cobrowse | Browser-based claim source co-browsing unavailable when Claude Code's native host is active — claim verification falls back to web fetch only |
 | cogni-workspace | cogni-issues | browser-based GitHub issue filing | Cannot file GitHub issues via browser automation — must use gh CLI or manual filing instead |
-| cogni-visual | zone-reviewer | browser-based visual review | Browser-based zone review for rendered visuals may fail silently when tools are missing |
 | cogni-workspace | manage-themes | website theme extraction via browser | Live website theme extraction requires browser automation — falls back to manual theme specification |
 
 **Workaround:** Toggle native messaging host configs by renaming the .json file for the unused product and restarting Chrome.

--- a/docs/workflows/consulting-engagement.md
+++ b/docs/workflows/consulting-engagement.md
@@ -35,8 +35,7 @@ The core difference from the classic approach:
 |-------------|-----|
 | cogni-consult installed | Orchestrates the engagement lifecycle |
 | cogni-knowledge installed | Required — the research spine bound at setup |
-| cogni-workspace / document-skills installed (optional) | Deliverable export when a deliverable names an export route |
-| cogni-workspace installed (optional) | Cross-session engagement discovery |
+| cogni-workspace / document-skills installed (optional) | Cross-session engagement discovery; also deliverable export when a deliverable names an export route |
 | Web access enabled | cogni-knowledge runs web research during the inverted pipeline |
 
 cogni-consult is standalone as an orchestrator. cogni-knowledge is the one required integration — without it, the compounding-research promise cannot be delivered.

--- a/docs/workflows/consulting-engagement.md
+++ b/docs/workflows/consulting-engagement.md
@@ -35,7 +35,7 @@ The core difference from the classic approach:
 |-------------|-----|
 | cogni-consult installed | Orchestrates the engagement lifecycle |
 | cogni-knowledge installed | Required — the research spine bound at setup |
-| cogni-visual / document-skills installed (optional) | Deliverable export when a deliverable names an export route |
+| cogni-workspace / document-skills installed (optional) | Deliverable export when a deliverable names an export route |
 | cogni-workspace installed (optional) | Cross-session engagement discovery |
 | Web access enabled | cogni-knowledge runs web research during the inverted pipeline |
 
@@ -274,7 +274,7 @@ One recommendation, not a menu. On confirmation, `consult-resume` dispatches the
 |-----------|---------------|-------------|
 | Single-field engagement | Derive one action field in scoping | Narrowly scoped advisory work |
 | Research-heavy engagement | Run `knowledge-ingest` with source documents before starting deliverables | Engagement topics with known prior art (reports, PDFs) |
-| Export a deliverable as slides | Name `cogni-visual` as the `producing_route` in the deliverable manifest | Deliverable is a client-facing presentation |
+| Export a deliverable as slides | Name `story-to-slides` as the `producing_route` in the deliverable manifest | Deliverable is a client-facing presentation |
 | Multilingual engagement | Set `language` at setup | DACH or other non-English stakeholder audiences |
 | Add a field mid-engagement | `consult-action-fields` add-field operation | Scope expands after an early deliverable reveals a gap |
 | Persona-first | Define and enrich personas before deliverable work begins | Client stakeholder landscape is complex and well-known |

--- a/docs/workflows/content-pipeline.md
+++ b/docs/workflows/content-pipeline.md
@@ -1,6 +1,6 @@
 # Content Pipeline
 
-**Pipeline**: cogni-marketing (setup + content generation) → the `narrative` skill (story arc shaping, long-form only) → the `copywriter` skill (polish) → cogni-workspace (slides / web)
+**Pipeline**: cogni-marketing (setup + content generation) → the `narrative` skill (story arc shaping, long-form only) → the `copywriter` skill (polish) → the `story-to-slides` / `story-to-web` skills (slides / web)
 **Duration**: 2–6 hours for a complete content batch, depending on format count and polish depth
 **End deliverable**: A multi-channel marketing content package — polished articles, battle cards, email nurtures, and optionally a slide deck or web narrative
 
@@ -9,7 +9,7 @@ graph LR
     A[marketing-setup] -->|content-strategy.json| B[content generation]
     B -->|raw content pieces| N[the `narrative` skill]
     N -->|arc-shaped long-form| C[the `copywriter` skill]
-    C -->|polished content| D[cogni-workspace]
+    C -->|polished content| D[the `story-to-slides` / `story-to-web` skills]
     D -->|slides / web| E[Deliverable]
 ```
 

--- a/docs/workflows/content-pipeline.md
+++ b/docs/workflows/content-pipeline.md
@@ -1,6 +1,6 @@
 # Content Pipeline
 
-**Pipeline**: cogni-marketing (setup + content generation) → the `narrative` skill (story arc shaping, long-form only) → the `copywriter` skill (polish) → cogni-visual (slides / web)
+**Pipeline**: cogni-marketing (setup + content generation) → the `narrative` skill (story arc shaping, long-form only) → the `copywriter` skill (polish) → cogni-workspace (slides / web)
 **Duration**: 2–6 hours for a complete content batch, depending on format count and polish depth
 **End deliverable**: A multi-channel marketing content package — polished articles, battle cards, email nurtures, and optionally a slide deck or web narrative
 
@@ -9,7 +9,7 @@ graph LR
     A[marketing-setup] -->|content-strategy.json| B[content generation]
     B -->|raw content pieces| N[the `narrative` skill]
     N -->|arc-shaped long-form| C[the `copywriter` skill]
-    C -->|polished content| D[cogni-visual]
+    C -->|polished content| D[cogni-workspace]
     D -->|slides / web| E[Deliverable]
 ```
 
@@ -35,7 +35,7 @@ All content is sourced — each piece references the TIPS claims and portfolio p
 | cogni-trends installed | Provides strategic themes (Handlungsfelder) |
 | the `narrative` skill installed (optional) | Shapes long-form content with a story arc before polishing; required for thought-leadership / whitepaper / keynote formats |
 | the `copywriter` skill installed | Polishes generated content; reads `arc_id` frontmatter from narrative output for arc-aware polishing |
-| cogni-visual installed (optional) | Renders content to slides or web |
+| cogni-workspace installed (optional) | Renders content to slides or web |
 | Portfolio project initialized | cogni-marketing reads from cogni-portfolio |
 | TIPS project available (optional) | Required for strategy-connected content; generic themes are used otherwise |
 
@@ -165,7 +165,7 @@ This runs 5 parallel reader personas (executive, technical, legal, marketing, en
 
 ### Step 5: Render to Visual Formats (Optional)
 
-Long-form polished content (whitepapers, thought leadership articles) can be rendered into slide decks or scrollable web narratives via cogni-visual.
+Long-form polished content (whitepapers, thought leadership articles) can be rendered into slide decks or scrollable web narratives via cogni-workspace.
 
 **For a slide deck:**
 
@@ -185,7 +185,7 @@ Turn the managed services thought leadership article into a scrollable web page
 Create a slide deck summarizing the full content batch for the DACH enterprise campaign
 ```
 
-cogni-visual reads the polished narrative, detects the story arc, maps content to slide layouts with assertion headlines and number plays, and produces a PPTX file via `document-skills:pptx`.
+cogni-workspace reads the polished narrative, detects the story arc, maps content to slide layouts with assertion headlines and number plays, and produces a PPTX file via `document-skills:pptx`.
 
 ## Organizing a Multi-Channel Campaign
 
@@ -229,8 +229,7 @@ Monitor coverage and progress via the dashboard:
 ## Related Guides
 
 - [cogni-marketing plugin guide](../plugin-guide/cogni-marketing.md)
-- [cogni-workspace plugin guide](../plugin-guide/cogni-workspace.md) — the `narrative` and `copywriter` skills
-- [cogni-visual plugin guide](../plugin-guide/cogni-visual.md)
+- [cogni-workspace plugin guide](../plugin-guide/cogni-workspace.md) — the `narrative`, `copywriter`, `story-to-slides`, and `story-to-web` skills
 - [cogni-portfolio plugin guide](../plugin-guide/cogni-portfolio.md)
 - [cogni-trends plugin guide](../plugin-guide/cogni-trends.md)
 - [Trends to Solutions workflow](./trends-to-solutions.md) — produces the TIPS themes that feed marketing content

--- a/docs/workflows/install-to-infographic.md
+++ b/docs/workflows/install-to-infographic.md
@@ -44,10 +44,8 @@ Install the full insight-wave plugin set — any workflow you pick from Step 5 c
 
 ```
 /plugin install cogni-workspace@insight-wave
-/plugin install cogni-workspace@insight-wave
 /plugin install cogni-trends@insight-wave
 /plugin install cogni-portfolio@insight-wave
-/plugin install cogni-visual@insight-wave
 /plugin install cogni-marketing@insight-wave
 /plugin install cogni-knowledge@insight-wave
 /plugin install cogni-sales@insight-wave

--- a/docs/workflows/portfolio-to-pitch.md
+++ b/docs/workflows/portfolio-to-pitch.md
@@ -209,7 +209,7 @@ Render the mid-market SaaS pitch as a slide deck
 Create a scrollable web version of the DACH manufacturing pitch
 ```
 
-These dispatch to `/story-to-slides` or `/story-to-web` inside cogni-visual, inheriting your workspace theme.
+These dispatch to `/story-to-slides` or `/story-to-web` inside cogni-workspace, inheriting your workspace theme.
 
 ### Optional — stakeholder visuals (shared)
 

--- a/docs/workflows/research-to-report.md
+++ b/docs/workflows/research-to-report.md
@@ -1,6 +1,6 @@
 # Research to Report
 
-**Pipeline**: cogni-knowledge → cogni-workspace (optional) → the `copywriter` skill → cogni-visual
+**Pipeline**: cogni-knowledge → cogni-workspace (optional) → the `copywriter` skill → the `story-to-infographic` / `enrich-report` skills
 **Duration**: 10 min – 4 hours (all options) depending on research depth, claims volume, and visual enrichment
 **End deliverable**: A verified, polished research report as themed HTML with data visualizations — plus an optional one-page infographic
 
@@ -8,7 +8,7 @@
 graph LR
     A[cogni-knowledge] -->|synthesis + cited sources| B[cogni-workspace]
     B -->|live-source re-check| C[the `copywriter` skill]
-    C -->|polished report| D[cogni-visual]
+    C -->|polished report| D[the `story-to-infographic` / `enrich-report` skills]
     D -->|infographic + enriched HTML| E[Deliverables]
 ```
 
@@ -20,8 +20,8 @@ A research report where every citation has been checked against its cited source
 - A structured synthesis with inline citations and a source registry, verified **zero-network** against each cited source's extracted claims (cogni-knowledge)
 - An optional **live-source re-check** that flags misquotations, unsupported conclusions, and stale data against the live source URLs (cogni-workspace, via `knowledge-refresh --resweep`)
 - An executive-polished document with strong structure, active voice, and readability scoring (the `copywriter` skill)
-- A single-page infographic distilling the 3–5 key data points (cogni-visual / story-to-infographic)
-- A themed HTML report with Chart.js visualizations, concept diagrams, and sidebar navigation (cogni-visual / enrich-report)
+- A single-page infographic distilling the 3–5 key data points (cogni-workspace / story-to-infographic)
+- A themed HTML report with Chart.js visualizations, concept diagrams, and sidebar navigation (cogni-workspace / enrich-report)
 
 This is the chain to use when the report will be read by decision-makers or shared externally and both accuracy and visual impact matter.
 
@@ -31,8 +31,7 @@ This is the chain to use when the report will be read by decision-makers or shar
 |-------------|-----|
 | cogni-knowledge installed | Wiki-first research orchestrator (vendors the Karpathy wiki engine) |
 | the `copywriter` skill installed | Applies messaging frameworks and readability polish |
-| cogni-visual installed | Produces infographic and enriched HTML |
-| cogni-workspace installed (optional) | Live-source re-check of cited claims via resweep |
+| cogni-workspace installed | Produces the infographic and enriched HTML (story-to-infographic, enrich-report); also the optional live-source re-check of cited claims via resweep |
 | Web access enabled | cogni-knowledge dispatches parallel web researchers during curate/fetch |
 
 ## Step-by-Step
@@ -167,7 +166,7 @@ This runs 5 parallel stakeholder personas (executive, technical, legal, marketin
 
 ### Step 4: Create an Infographic (Optional)
 
-Distill the polished report into a single-page visual summary using cogni-visual's story-to-infographic skill. This extracts the 3–5 most impactful data points and produces an infographic brief that auto-renders into a visual.
+Distill the polished report into a single-page visual summary using cogni-workspace's story-to-infographic skill. This extracts the 3–5 most impactful data points and produces an infographic brief that auto-renders into a visual.
 
 **Command**: `/story-to-infographic` or describe what you want
 
@@ -253,7 +252,5 @@ This matches the consulting deliverable pattern: executive one-pager up front, d
 ## Related Guides
 
 - [cogni-knowledge plugin guide](../plugin-guide/cogni-knowledge.md)
-- [cogni-workspace plugin guide](../plugin-guide/cogni-workspace.md)
-- [cogni-workspace plugin guide](../plugin-guide/cogni-workspace.md) — the `narrative` and `copywriter` skills
-- [cogni-visual plugin guide](../plugin-guide/cogni-visual.md)
+- [cogni-workspace plugin guide](../plugin-guide/cogni-workspace.md) — the `narrative`, `copywriter`, `story-to-infographic`, and `enrich-report` skills
 - [Consulting Engagement workflow](./consulting-engagement.md) — this pipeline runs inside a deliverable's design-thinking loop

--- a/docs/workflows/trends-to-solutions.md
+++ b/docs/workflows/trends-to-solutions.md
@@ -1,6 +1,6 @@
 # Trends to Solutions
 
-**Pipeline**: cogni-trends (trend-scout + value-modeler) → optional cogni-portfolio (trends-bridge) → cogni-visual (story-to-slides / enrich-report)
+**Pipeline**: cogni-trends (trend-scout + value-modeler) → optional cogni-portfolio (trends-bridge) → cogni-workspace (story-to-slides / enrich-report)
 **Duration**: 4–8 hours for a complete trends-to-solutions analysis
 **End deliverable**: Ranked solution blueprints with visual deliverables (slide deck or enriched HTML report)
 
@@ -32,7 +32,7 @@ This workflow is suited to strategy and advisory work where clients need to unde
 | Requirement | Why |
 |-------------|-----|
 | cogni-trends installed | Runs trend scouting and value modeling |
-| cogni-visual installed | Renders visual deliverables (slides, enriched reports) |
+| cogni-workspace installed | Renders visual deliverables (slides, enriched reports) |
 | Web access enabled | cogni-trends dispatches 32+ bilingual web searches |
 | cogni-portfolio installed (optional) | Required for Scenario B; enables product-anchored solution blueprints and the trends-bridge backflow |
 | cogni-portfolio project (optional) | Required for Scenario B; carries the products, features, and propositions that anchor blueprints |
@@ -154,7 +154,7 @@ This closes the loop: trend signals become portfolio mutations the team can buil
 
 ### Step 4: Produce Visual Deliverables (shared)
 
-Use cogni-visual to present the solution landscape visually. Both options work for either scenario; the underlying value-model JSON is the same shape.
+Use cogni-workspace to present the solution landscape visually. Both options work for either scenario; the underlying value-model JSON is the same shape.
 
 **Option A — Slide deck**: Run `story-to-slides` on a narrative derived from the value-modeler output to create an executive presentation.
 
@@ -193,7 +193,7 @@ Create a slide deck from the automotive investment themes narrative
 
 - [cogni-trends plugin guide](../plugin-guide/cogni-trends.md)
 - [cogni-portfolio plugin guide](../plugin-guide/cogni-portfolio.md) — see the `trends-bridge` section for authoritative reference on the bridge operations
-- [cogni-visual plugin guide](../plugin-guide/cogni-visual.md)
+- [cogni-workspace plugin guide](../plugin-guide/cogni-workspace.md)
 - [Consulting Engagement workflow](./consulting-engagement.md) — this pipeline runs inside the Discover and Develop phases
 - [Content Pipeline workflow](./content-pipeline.md) — trends output feeds marketing content generation
 - [Portfolio to Pitch workflow](./portfolio-to-pitch.md) — the portfolio side; pairs naturally with Scenario B


### PR DESCRIPTION
Closes #1554.

## Summary

The six `docs/workflows/*.md` guides and `docs/known-issues.md` still named `cogni-visual` — retired into `cogni-workspace` and absent from `.claude-plugin/marketplace.json` `plugins[].name`. A reader *executing* a guide was told to install a plugin that does not exist and sent to plugin-guide pages that 404, with no signal the guide was stale rather than their setup broken.

Every retired token is retargeted onto the live roster, and every skill named after the rewrite resolves to a real `SKILL.md` under `cogni-workspace/skills/`.

**7 files changed, not 8** — see decision 6.

## Scope decisions

**1. Three dead plugin-guide links — retargeted in text *and* href; folded, not duplicated.**
`docs/plugin-guide/cogni-visual.md` does not exist (the directory holds exactly the 8 live plugins); `cogni-workspace.md` does. So these links were already broken before this PR. Two of the three sit in a `## Related Guides` list that *already* carried a cogni-workspace bullet — `research-to-report.md:256`+`:257` and `content-pipeline.md:232` — so a mechanical swap would have emitted two or three bullets pointing at the same page. Both fold into the existing bullet's qualifier. `trends-to-solutions.md:196` has no existing bullet and is a plain retarget.

**2. Two prerequisite-table collisions — handled asymmetrically, on purpose.**
`research-to-report.md:34/:35` paired a **required** cogni-visual row with an **optional** cogni-workspace row; a swap would have told the reader one plugin is both. They merge into one required row whose Why-cell carries both purposes, with optionality attached to the *resweep use* rather than the install. `consulting-engagement.md:38/:39` are both already optional and their Requirement cells differ (`cogni-workspace / document-skills` vs plain `cogni-workspace`), so there is no contradiction to resolve — the rows stay separate and only the token changes. Merging there would have conflated deliverable export with cross-session engagement discovery.

**3. `install-to-infographic.md` — deleted, not swapped.**
Lines 46 and 47 were already a byte-identical duplicate `/plugin install cogni-workspace@insight-wave`, so swapping line 50 would have produced a **third** copy. The retired line and the pre-existing duplicate are both removed, leaving the block enumerating all eight `plugins[].name` entries exactly once. The prose at `:43` ("Start with `cogni-workspace` … then the rest") stays true — cogni-workspace remains first.

The title and the bare `/story-to-infographic` dispatches at `:100`/`:109`/`:117` are **not** touched. The issue calls this file "the sharpest case" on the theory its title is keyed to a moved capability, but `story-to-infographic` still exists under cogni-workspace and those dispatches already resolve — only the install line was broken.

**4. `known-issues.md:21` — row deleted.**
`zone-reviewer` occurs **exactly once in the entire repo**: this line. `cogni-visual` has no source tree left, so no absorbing plugin re-implemented it, and neither `review-brief` nor `narrative-review` is browser-based visual review. A plugin-cell-only swap would have shipped a row asserting cogni-workspace owns a `zone-reviewer` skill — roster-clean but naming a phantom capability, which is strictly worse than the status quo because it looks correct. The three surviving rows already cover this issue class for plugins that exist. The `1 open, 0 mitigated, 0 resolved` counter at `:3` counts KI **entries** (verified: exactly one `### KI-`), not table rows, so it stays accurate.

**5. `consulting-engagement.md:277` `producing_route` — category error fixed, not perpetuated.**
`cogni-consult/references/data-model.md:238` defines `producing_route` as naming the **skill** that produces the deliverable (default `consult-design-thinking`). `cogni-visual` was a *plugin* name in a skill-shaped field and was always wrong. Swapping it to `cogni-workspace` would have kept the category error with a live name, so the cell takes its correct value `story-to-slides` per the row's own context. The identical defect one row down at `:281` names the live plugin `cogni-knowledge`, carries no retired token, and is filed as #1602 rather than fixed here.

**6. `docs/claude-code-desktop.md` — empty diff, deliberately.**
The issue's inventory claims one occurrence in this file. A case-insensitive whole-file search for all seven names in `scripts/retired-plugins.json` returns **zero**. Its only `cogni-*` tokens are `cogni-workspace` (`:236`, live) and `cogni-docs` (`:6`, inside an HTML maintainer comment pointing at `cogni-docs/skills/doc-hub/references/doc-templates.md`). `cogni-docs` is not in the retired set and is not an insight-wave plugin at all — it belongs to the managed-service marketplace, so that is a correct cross-repo provenance pointer. "Fixing" it would have broken a working reference that the issue's own criteria would then have scored as a pass.

**7. Pipeline headers and mermaid nodes — no tautologies, no duplicate labels.**
`research-to-report.md` node `B` is already `cogni-workspace`, so relabelling node `D` to the same string would have rendered two identically-labelled boxes; `D` names the skills instead. Both fences verified to have zero duplicate node labels after the change.

## Two preserved references

- `research-to-report.md:67` — `.cogni-wiki/config.json` is a **live on-disk path**, not a dispatch: referenced across 92 files under `cogni-knowledge/`, documented at `cogni-knowledge/CLAUDE.md:19`, and `docs/plugin-guide/cogni-knowledge.md` describes `.cogni-knowledge/binding.json` as "a sibling to the wiki's `.cogni-wiki/config.json`". Preserved byte-identically; it never appears in the diff.
- `docs/claude-code-desktop.md` — untouched in full, per decision 6.

## On the acceptance criteria — four of seven are vacuous at base

Stated plainly so the reviewer does not read a green as evidence:

| AC | Status |
|---|---|
| 1 — colon-form `cogni-[a-z-]+:` tokens minus the roster | **Vacuous.** The eight in-scope files contain **zero** colon-form *retired* tokens at base. `consulting-engagement.md`'s 12 colon tokens are all `cogni-consult:` / `cogni-knowledge:`, both live. Residue is 0 before the change and 0 after. |
| 2 — every skill after a surviving dispatch token exists | **Vacuous** for the same reason. |
| 4 — `cogni-claims/` paths preserved | **Vacuous.** No `cogni-claims/` occurs in any in-scope file. |
| 6 — `run-plugin-tests.py` all green | **Vacuous as a grade.** No suite reads any of the eight files, so it is green at base and stays green for any docs-only diff — a no-regression signal, never evidence the rewrite is correct. |
| 3, 5, 7 | Substantive and satisfied. |

The bar that actually discriminates is the **bare-name** form over the `scripts/retired-plugins.json` prefix set — 23 lines across 7 files at base, 1 after (the preserved path). Evidence below is graded against that, not against AC1's stated command.

## Evidence

- `grep -rnE 'cogni-(visual|wiki|research|help|claims|narrative|copywriting)' docs/workflows/ docs/known-issues.md docs/claude-code-desktop.md` → **exactly one line**: `research-to-report.md:66` `.cogni-wiki/config.json` (the preserved path).
- `git diff --name-only origin/main` → 7 paths, all inside the AC7 fence, none excluded.
- `git diff --stat -- docs/claude-code-desktop.md` → empty.
- `git diff -- docs/workflows/research-to-report.md | grep -c 'cogni-wiki'` → **0** (preserved path byte-identical, not merely present).
- Every plugin name remaining in the changed files is in `plugins[].name`; the only non-roster `cogni-*` matches are the skill name `cogni-issues`, the org `cogni-work/`, and the deliberate historical note naming the archived `cogni-consulting` plugin — none of which is a retired-plugin dispatch.
- All six skills named in the diff resolve: `story-to-infographic`, `story-to-slides`, `story-to-web`, `enrich-report`, `narrative`, `copywriter`.
- Every `../plugin-guide/` href in the six guides resolves to an existing file; no `plugin-guide/cogni-visual.md` remains anywhere under `docs/workflows/`.
- No `## Related Guides` list contains two bullets with the same href (checked all four that have one).
- Install block = exactly the 8 live plugins, one each, cogni-workspace first.
- Both mermaid fences: zero duplicate node labels.
- `python3 scripts/run-plugin-tests.py` → **132/132 suites pass, 0 failed** (green at base too — see the AC table).

## Why `Closes` and not `Refs`

Two follow-ups were filed, but **neither is this issue's residual**, so `full_scope` stays true and the link is `Closes`:

- **#1602** names `cogni-knowledge`, which **is** in `plugins[].name` — it already satisfies this issue's AC1, and this issue's mapping is scoped to *retired* tokens.
- **#1603** targets `docs/plugin-guide/`, a path this issue's **AC7 explicitly excludes** from the diff. It was never in scope to defer.

The `--partial` rule exists so a dropped `full_scope` with *this issue's* work still deferred cannot reach the `Closes` path. Out-of-fence work an AC forbids touching was never in scope to defer, and flipping to `Refs` would manufacture another `refs_only_link` strand on a board already carrying four. Flagged explicitly so this is adjudicated rather than inherited.

## Follow-up issues

- #1602 — `producing_route` names a plugin where the data model requires a skill (`consulting-engagement.md:281`).
- #1603 — the cogni-workspace plugin guide documents none of the four absorbed rendering skills, yet this PR's retargeted links now send readers there for exactly those skills. Checked against #1557: that child is scoped to `doc-generate`'s structural sections and its own criteria treat hand-written prose as preserved and out of scope.

## Reviewer notes

- **No automated check grades this diff.** `check-external-dispatch.py` excludes `docs/` by design (docstring: "the doc mirror (prose, not a dispatch)"), `check-plugin-inventory.py` never reads `docs/` content and is not wired in `lint.yml`, and no bash suite reads any of these files. The preflight instrument set is likewise inert on a docs-only diff. **A green that examined nothing is the absence of evidence** — review rigor substitutes for gating here, which is why the evidence above is executed rather than asserted.
- **No `## Mutation recipe`** — the diff touches no `*/tests/test-*.sh` and no `*/scripts/check-*.sh`, so that check records `not_applicable`.
- **114 retired-name occurrences sit just outside this fence** (`docs/plugin-guide/` 49, `docs/architecture/` 23, `docs/audit-report.md` 20, `docs/relicensing/` 11, `docs/contributing/` 7, `docs/er-diagram.md` 4) — 4.4× the 26 inside it. Owned by siblings #1552 / #1553 / #1556 / #1557 / #1558 and deliberately untouched.
- **Two inventory entries in the issue are false positives** (decision 6, and the `.cogni-wiki` path counted within `research-to-report.md`'s tally of 8). Following the issue literally on either would have shipped a regression its own criteria would score as a pass.