### PR TITLE
One capability taxonomy across README and ecosystem-overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,25 @@ Each plugin implements an established framework (Corporate Visions, Double Diamo
 
 ## What the plugins do
 
-8 plugins organized around nine capability areas. Each area handles a distinct part of the consulting-to-delivery workflow; plugins within an area share data formats and can be used independently or together.
+8 plugins organized around eight capability areas: one horizontal area — cogni-workspace, the shared workspace layer every other plugin builds on — and seven vertical areas, one per business-domain plugin, each keeping its own project lifecycle. Plugins share data formats and can be used independently or together.
+
+### Workspace Infrastructure
+
+[cogni-workspace](cogni-workspace/README.md) is the horizontal layer every other plugin builds on. It manages the shared foundation — environment variables, MCP server installation, theme management, plugin discovery, and workspace health. Runs dependency checks, discovers installed plugins, and generates shared settings. Includes Obsidian vault integration for browsable knowledge management. 19 skills and 7 agents.
+
+> "Initialize my insight-wave workspace and check plugin health"
+
+**Rendering.** The `story-to-slides`, `story-to-infographic`, `story-to-storyboard` and `story-to-web` skills transform narratives into visual formats: slide decks (11 layout types), scrollable web narratives, printed poster storyboards, and single-page infographics. Skills generate structured briefs; agents render them into .pptx, .excalidraw, .pen, or .html files. All visuals inherit brand identity from your workspace theme.
+
+> "Create a slide deck from the sales presentation, then enrich the trend report with charts and diagrams"
+
+**Narrative and executive copy.** The `narrative` skill transforms structured content into executive narratives using 11 story arc frameworks with quality scoring (0-100, A-F grades), and the `copywriter` skill polishes any document for executive readability using 7 messaging frameworks (BLUF, Pyramid, SCQA, STAR, PSB, FAB, Inverted Pyramid) with 5 parallel stakeholder personas to catch blind spots.
+
+**Source verification.** The `claims` skill verifies whether sourced claims match what their cited sources actually say — catching misquotations, unsupported conclusions, selective omissions, and stale data. Other plugins register claims during generation; cogni-workspace fetches each source and flags deviations for your review.
+
+> "Verify all claims in the trend report against their cited sources"
+
+→ [Plugin guide](docs/plugin-guide/cogni-workspace.md) · [Getting started](docs/workflows/install-to-infographic.md)
 
 ### Knowledge Management
 
@@ -47,7 +65,7 @@ Each plugin implements an established framework (Corporate Visions, Double Diamo
 
 ### Content Production
 
-[cogni-marketing](cogni-marketing/README.md) bridges portfolio propositions and trend themes into channel-ready content across 16 formats — blogs, LinkedIn articles, whitepapers, battle cards, email nurtures, video scripts, and more. A 3D content matrix (market x GTM path x content type) tracks coverage gaps. Narrative shaping and executive polish now live in [cogni-workspace](cogni-workspace/README.md): its `narrative` skill transforms structured content into executive narratives using 11 story arc frameworks with quality scoring (0-100, A-F grades), and its `copywriter` skill polishes any document for executive readability using 7 messaging frameworks (BLUF, Pyramid, SCQA, STAR, PSB, FAB, Inverted Pyramid) with 5 parallel stakeholder personas to catch blind spots. Together with cogni-marketing: 17 skills and 8 agents.
+[cogni-marketing](cogni-marketing/README.md) bridges portfolio propositions and trend themes into channel-ready content across 16 formats — blogs, LinkedIn articles, whitepapers, battle cards, email nurtures, video scripts, and more. A 3D content matrix (market x GTM path x content type) tracks coverage gaps. 11 skills and 3 agents.
 
 > "Generate thought leadership content for the AI automation theme across LinkedIn and blog formats"
 
@@ -61,14 +79,6 @@ Each plugin implements an established framework (Corporate Visions, Double Diamo
 
 → [Plugin guide](docs/plugin-guide/cogni-sales.md) · [Portfolio to Pitch workflow](docs/workflows/portfolio-to-pitch.md)
 
-### Visual Production
-
-A [cogni-workspace](cogni-workspace/README.md) capability (not a separate plugin): the `story-to-slides`, `story-to-infographic`, `story-to-storyboard` and `story-to-web` skills transform narratives into visual formats: slide decks (11 layout types), scrollable web narratives, printed poster storyboards, and single-page infographics. Skills generate structured briefs; agents render them into .pptx, .excalidraw, .pen, or .html files. All visuals inherit brand identity from your workspace theme.
-
-> "Create a slide deck from the sales presentation, then enrich the trend report with charts and diagrams"
-
-→ [Plugin guide](docs/plugin-guide/cogni-workspace.md)
-
 ### Website Generation
 
 [cogni-website](cogni-website/README.md) assembles multi-page customer websites from portfolio, marketing, trend, and research content produced by other plugins — outputting a deployable static site with shared navigation, theming, and responsive HTML. Service pages update in minutes as your portfolio model changes, staying consistent with your messaging and SEO-optimized. 6 skills and 3 agents.
@@ -76,24 +86,6 @@ A [cogni-workspace](cogni-workspace/README.md) capability (not a separate plugin
 > "Build a customer website from our portfolio and marketing content with a Pencil-rendered hero"
 
 → [Plugin guide](docs/plugin-guide/cogni-website.md) · [Portfolio to Website workflow](docs/workflows/portfolio-to-website.md)
-
-### Platform & Quality
-
-#### Workspace Foundation
-
-[cogni-workspace](cogni-workspace/README.md) manages the shared foundation — environment variables, MCP server installation, theme management, plugin discovery, and workspace health. Runs dependency checks, discovers installed plugins, and generates shared settings. Includes Obsidian vault integration for browsable knowledge management, and owns the cross-plugin claim-verification gate (see Source Verification below), plus story-arc narrative composition and executive copywriting. 19 skills and 7 agents.
-
-> "Initialize my insight-wave workspace and check plugin health"
-
-→ [Plugin guide](docs/plugin-guide/cogni-workspace.md) · [Getting started](docs/workflows/install-to-infographic.md)
-
-#### Source Verification
-
-A cogni-workspace capability (not a separate plugin): the `claims` skill verifies whether sourced claims match what their cited sources actually say — catching misquotations, unsupported conclusions, selective omissions, and stale data. Other plugins register claims during generation; cogni-workspace fetches each source and flags deviations for your review.
-
-> "Verify all claims in the trend report against their cited sources"
-
-→ [Plugin guide](docs/plugin-guide/cogni-workspace.md)
 
 Beyond the open-source plugins, cogni-works offers consulting services — plugin engineering for domain-specific workflows, managed deployment, and a partner certification program — through [cogni-work.ai](https://cogni-work.ai). Whether you run a consulting practice, a sales organization, or a marketing team, the site shows how these capabilities translate into managed workflows and onboarding for your team.
 
@@ -214,14 +206,14 @@ Plugins follow the [Claude Code plugin standard](https://code.claude.com/docs/en
 
 | Plugin | Capability | Skills | Agents | What it does |
 |--------|-----------|--------|--------|--------------|
-| [cogni-knowledge](cogni-knowledge/README.md) | Platform | 21 | 16 | Wiki-first research orchestrator — binds its own vendored wiki base to N research projects so findings compound across runs via a zero-network inverted pipeline |
-| [cogni-consult](cogni-consult/README.md) | Consulting | 9 | 4 | Action-fields-WBS consulting orchestrator with per-deliverable design thinking and acting stakeholder personas |
+| [cogni-knowledge](cogni-knowledge/README.md) | Knowledge Management | 21 | 16 | Wiki-first research orchestrator — binds its own vendored wiki base to N research projects so findings compound across runs via a zero-network inverted pipeline |
+| [cogni-consult](cogni-consult/README.md) | Consulting Orchestration | 9 | 4 | Action-fields-WBS consulting orchestrator with per-deliverable design thinking and acting stakeholder personas |
 | [cogni-trends](cogni-trends/README.md) | Trend Intelligence | 9 | 12 | TIPS trend scouting with bilingual DE/EN research, investment theme modeling, and reusable industry catalogs |
-| [cogni-portfolio](cogni-portfolio/README.md) | Portfolio | 21 | 20 | IS/DOES/MEANS portfolio positioning with eight industry taxonomies, competitive analysis, and market sizing |
-| [cogni-marketing](cogni-marketing/README.md) | Content | 11 | 3 | B2B marketing content engine — 16 formats across thought leadership, demand gen, lead gen, sales enablement, ABM |
-| [cogni-sales](cogni-sales/README.md) | Sales | 1 | 4 | Corporate Visions Why Change pitch generation for named customers or market segments |
-| [cogni-website](cogni-website/README.md) | Website | 6 | 3 | Multi-page customer websites from portfolio, marketing, and research content with shared navigation and theming |
-| [cogni-workspace](cogni-workspace/README.md) | Platform | 19 | 7 | Shared foundation — env vars, MCP installation, theme management, plugin discovery, workspace health, Obsidian integration, bundled wiki, claim verification, story-arc narrative, executive copywriting, and slide/infographic/storyboard/web rendering |
+| [cogni-portfolio](cogni-portfolio/README.md) | Portfolio Messaging | 21 | 20 | IS/DOES/MEANS portfolio positioning with eight industry taxonomies, competitive analysis, and market sizing |
+| [cogni-marketing](cogni-marketing/README.md) | Content Production | 11 | 3 | B2B marketing content engine — 16 formats across thought leadership, demand gen, lead gen, sales enablement, ABM |
+| [cogni-sales](cogni-sales/README.md) | Sales Pitches | 1 | 4 | Corporate Visions Why Change pitch generation for named customers or market segments |
+| [cogni-website](cogni-website/README.md) | Website Generation | 6 | 3 | Multi-page customer websites from portfolio, marketing, and research content with shared navigation and theming |
+| [cogni-workspace](cogni-workspace/README.md) | Workspace Infrastructure | 19 | 7 | Shared foundation — env vars, MCP installation, theme management, plugin discovery, workspace health, Obsidian integration, bundled wiki, claim verification, story-arc narrative, executive copywriting, and slide/infographic/storyboard/web rendering |
 
 **97 skills, 69 agents** across the 8 active plugins.
 

--- a/docs/ecosystem-overview.md
+++ b/docs/ecosystem-overview.md
@@ -8,50 +8,59 @@ For the canonical plugin descriptions, see the individual README files. For step
 
 ## Plugin Landscape
 
-The 8 plugins are grouped by the role they play in a typical engagement — the same set the root [`marketplace.json`](../.claude-plugin/marketplace.json) enumerates.
+The 8 plugins — the same set the root [`marketplace.json`](../.claude-plugin/marketplace.json) enumerates — are grouped into eight capability areas: one horizontal area (cogni-workspace, the shared workspace layer every other plugin builds on) and seven verticals, one per business-domain plugin, each keeping its own project lifecycle.
 
 ### Workspace Infrastructure
 
 | Plugin | What it does |
 |--------|-------------|
 | [cogni-workspace](../cogni-workspace/README.md) | Initializes the shared workspace: environment variables, plugin discovery, theme management, and Obsidian vault integration. The vertical business plugins consume the shared state it owns; each keeps its own project lifecycle. |
+| [cogni-workspace](../cogni-workspace/README.md) — `narrative` | Transforms research reports and structured content into executive narratives using 11 story arc frameworks and 8 narrative techniques. Includes a TIPS-native arc for trend panoramas, a theme-thesis arc for investment narratives, and a JTBD portfolio arc for buyer-job-centric portfolio narratives. |
+| [cogni-workspace](../cogni-workspace/README.md) — `copywriter` | Polishes documents using messaging frameworks (BLUF, Pyramid, SCQA, STAR, PSB, FAB, Inverted Pyramid). Runs parallel stakeholder persona reviews, readability optimization and JSON field polishing; the arc contract against the `narrative` skill is now asserted by `test-arc-reference-sync.sh` rather than audited by a skill. Translate-then-polish across DE/EN/FR/IT/PL/NL/ES. |
+| [cogni-workspace](../cogni-workspace/README.md) — `story-to-*` | Converts polished narratives and structured data into presentation briefs, slide decks, scrollable web narratives, poster storyboards, and single-page infographics. Supports Excalidraw, Pencil MCP, PPTX, and HTML rendering. |
+| [cogni-workspace](../cogni-workspace/README.md) — `claims` | Verifies sourced claims against their cited URLs, detecting misquotations, unsupported conclusions, and selective omissions. Runs as a review loop inside cogni-knowledge and is callable standalone on any document with citations. |
 
 Run `/manage-workspace` once per project directory before using any other plugin.
 
-Claim verification is a cogni-workspace capability, not a separate plugin: the `claims` skill verifies sourced claims against their cited URLs, detecting misquotations, unsupported conclusions, and selective omissions. It runs as a review loop inside cogni-knowledge and is callable standalone on any document with citations.
-
-### Research and Analysis
+### Knowledge Management
 
 | Plugin | What it does |
 |--------|-------------|
-| [cogni-trends](../cogni-trends/README.md) | Scouts industry trends using the Smarter Service Trendradar framework and bridges them to portfolio solutions via the TIPS content framework (Trends, Implications, Possibilities, Solutions). Produces CxO-ready trend reports with investment theme modeling. Bilingual (local + EN) research against per-market institutional authority sources across DACH/DE, FR, IT, ES, NL, PL plus UK/US. |
 | [cogni-knowledge](../cogni-knowledge/README.md) | Wiki-first research that compounds across runs. Binds each project to its own wiki knowledge base (the Karpathy-style engine is vendored in) so future runs read what prior runs filed before hitting the web. Inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification. See the [deep dive](plugin-guide/cogni-knowledge.md). |
 
 See [Research to Report workflow](workflows/research-to-report.md) for how research output moves downstream.
 
-### Strategy and Portfolio
+### Consulting Orchestration
+
+| Plugin | What it does |
+|--------|-------------|
+| [cogni-consult](../cogni-consult/README.md) | Orchestrates consulting engagements: action fields as the work-breakdown structure, a design-thinking loop per deliverable, acting stakeholder personas, and one cogni-knowledge base per engagement as the compounding research spine. See the [deep dive](plugin-guide/cogni-consult.md). |
+
+See the [Consulting Engagement workflow](workflows/consulting-engagement.md) for how cogni-consult coordinates the other plugins.
+
+### Trend Intelligence
+
+| Plugin | What it does |
+|--------|-------------|
+| [cogni-trends](../cogni-trends/README.md) | Scouts industry trends using the Smarter Service Trendradar framework and bridges them to portfolio solutions via the TIPS content framework (Trends, Implications, Possibilities, Solutions). Produces CxO-ready trend reports with investment theme modeling. Bilingual (local + EN) research against per-market institutional authority sources across DACH/DE, FR, IT, ES, NL, PL plus UK/US. |
+
+### Portfolio Messaging
 
 | Plugin | What it does |
 |--------|-------------|
 | [cogni-portfolio](../cogni-portfolio/README.md) | Structures product and service messaging using the IS/DOES/MEANS framework. Features are market-independent (IS). Advantages (DOES) and benefits (MEANS) are market-specific. Includes TAM/SAM/SOM sizing, competitor analysis, Lean Canvas bootstrapping, and eight industry taxonomies. |
-| [cogni-consult](../cogni-consult/README.md) | Orchestrates consulting engagements: action fields as the work-breakdown structure, a design-thinking loop per deliverable, acting stakeholder personas, and one cogni-knowledge base per engagement as the compounding research spine. See the [deep dive](plugin-guide/cogni-consult.md). |
-
-See the [Consulting Engagement workflow](workflows/consulting-engagement.md) for how cogni-consult coordinates the other plugins.
 
 ### Content Production
 
 | Plugin | What it does |
 |--------|-------------|
-| [cogni-workspace](../cogni-workspace/README.md) — `narrative` | Transforms research reports and structured content into executive narratives using 11 story arc frameworks and 8 narrative techniques. Includes a TIPS-native arc for trend panoramas, a theme-thesis arc for investment narratives, and a JTBD portfolio arc for buyer-job-centric portfolio narratives. |
-| [cogni-workspace](../cogni-workspace/README.md) — `copywriter` | Polishes documents using messaging frameworks (BLUF, Pyramid, SCQA, STAR, PSB, FAB, Inverted Pyramid). Runs parallel stakeholder persona reviews, readability optimization and JSON field polishing; the arc contract against the `narrative` skill is now asserted by `test-arc-reference-sync.sh` rather than audited by a skill. Translate-then-polish across DE/EN/FR/IT/PL/NL/ES. |
 | [cogni-marketing](../cogni-marketing/README.md) | Bridges cogni-trends strategic themes and cogni-portfolio propositions into channel-ready content across 16 formats — thought leadership, demand generation, lead generation, sales enablement, and ABM. Configurable brand voice; market-aware content across European and US/UK targets. |
-| [cogni-sales](../cogni-sales/README.md) | Generates B2B sales pitches using the Corporate Visions Why Change methodology. Supports named customer deals (deal-specific) and reusable segment pitches. Builds on cogni-portfolio data with optional TIPS strategic enrichment. Multilingual EN/DE/PT-BR. |
 
-### Visual Delivery
+### Sales Pitches
 
 | Plugin | What it does |
 |--------|-------------|
-| [cogni-workspace](../cogni-workspace/README.md) — `story-to-*` | Converts polished narratives and structured data into presentation briefs, slide decks, scrollable web narratives, poster storyboards, and single-page infographics. Supports Excalidraw, Pencil MCP, PPTX, and HTML rendering. |
+| [cogni-sales](../cogni-sales/README.md) | Generates B2B sales pitches using the Corporate Visions Why Change methodology. Supports named customer deals (deal-specific) and reusable segment pitches. Builds on cogni-portfolio data with optional TIPS strategic enrichment. Multilingual EN/DE/PT-BR. |
 
 ### Website Generation
 


### PR DESCRIPTION
Closes #1552.

## Summary

- Replaces README's nine capability areas and `docs/ecosystem-overview.md`'s six buckets with **one shared taxonomy of eight `###` headings**, identical in name and order in both files: `Workspace Infrastructure` (the horizontal layer) then `Knowledge Management`, `Consulting Orchestration`, `Trend Intelligence`, `Portfolio Messaging`, `Content Production`, `Sales Pitches`, `Website Generation`.
- Each of the 8 `marketplace.json` plugins is the subject of exactly one heading in each file. `cogni-workspace` is the sole member of `### Workspace Infrastructure`, which holds no vertical plugin — so the issue's central claim (one horizontal plugin, seven verticals) is now structural rather than prose-only.
- `### Visual Production` (README) and `### Visual Delivery` (ecosystem-overview) stop being top-level areas, and `#### Source Verification` stops being a peer of the workspace core. The `story-to-*` rendering, `narrative`/`copywriter` and `claims` capabilities are **relocated, not deleted** — bold lead-ins under the horizontal heading in README, table rows in ecosystem-overview.
- README's lead sentence names the horizontal/vertical split as the organising idea, and its area count is re-derived (`eight`, matching the live count of 8 `###` headings).
- README's `## Plugins at a glance` `Capability` column is re-drawn from the settled heading names, resolving the `Platform` collision that labelled both `cogni-knowledge` and `cogni-workspace` identically. **Skills/Agents columns and the `97 skills, 69 agents` rollup are byte-identical to base** — this is a taxonomy rename, not a recount.

## Evidence

Every acceptance-contract item was executed, not asserted:

```
# identical heading lists, name-for-name and position-for-position
diff <(awk '/^## What the plugins do$/{f=1;next} /^## Who this is for$/{f=0} f&&/^### /' README.md) \
     <(awk '/^## Plugin Landscape$/{f=1;next} /^## Data Flow$/{f=0} f&&/^### /' docs/ecosystem-overview.md)
# -> empty (identical)

# Skills/Agents columns unchanged vs base
diff <(git show origin/main:README.md | grep -E '^\| \[cogni-' | awk -F'|' '{print $2"|"$4"|"$5}') \
     <(grep -E '^\| \[cogni-' README.md | awk -F'|' '{print $2"|"$4"|"$5}')
# -> empty (byte-identical)

# scope predicate
git diff --name-only origin/main        # -> README.md, docs/ecosystem-overview.md
git diff --name-only origin/main | grep -c 'wiki/'   # -> 0
```

Also verified: 8 `###` headings per section with no `####` surviving in either; each roster plugin the subject of exactly one heading per file; `cogni-workspace` isolated under the horizontal heading in both; `story-to-*`, `narrative`, `copywriter` and `claims` all still described under it; every `Capability` cell verbatim equal to the heading its plugin sits under; the glance table still 8 rows; every prose roster count still `8` (#1551's fix preserved); all three `See … workflow` pointers and README's trailing cogni-works paragraph preserved.

**Full repo test sweep: 132/132 suites pass, 0 failed** (`python3 scripts/run-plugin-tests.py`).

## Scope decisions

- **Both files in one PR.** "Same heading names in the same order in both files" is unsatisfiable by editing one of them, and the `Capability` column can only be validated against a settled heading set. A one-file slice would ship an internally inconsistent half-taxonomy.
- **One heading per plugin (8 headings).** This makes "every roster plugin under exactly one heading" and "every `Capability` cell equals its plugin's heading" true *by construction* rather than by audit.
- **Sub-structure uses bold lead-ins, not `####` headings**, so the taxonomy is unambiguously the `###` level in both files.
- **A factually false claim was caught and removed during planning.** An earlier draft of the lead sentence said each vertical "owns its own `setup → resume → dashboard` arc". That is false at `origin/main` — `cogni-sales` ships exactly one skill, `cogni-website` has no dashboard skill, `cogni-trends` has no setup skill. The shipped wording is "each keeping its own project lifecycle", which reuses `docs/ecosystem-overview.md`'s own existing phrasing.
- **Untouched on purpose:** both `wiki/**` copies of ecosystem-overview (verified to be hand-maintained summary pages sharing *none* of these heading strings — a later child of epic #1354 owns them), `Cogni Work Design System/**` (a separate marketing artifact carrying its own stale, mutually inconsistent counts), and every plugin-roster count.

## Follow-up issues

- #1605 — `README.md` states cogni-workspace at **19 skills / 7 agents**; the plugin ships **26 / 26**. The `97 skills, 69 agents` rollup is the exact column sum of the stale row, so correcting the row requires recomputing the rollup in the same edit. The other seven roster rows were each checked against the tree and all agree, so the drift is isolated to cogni-workspace.

### Why this PR still links `Closes`, not `Refs`

`service-resolve` Step 8 mechanically passes `--partial` when `deferred[]` is non-empty, which would have shipped `Refs #1552`. That was deliberately **not** taken here, and the call is flagged so it is adjudicated rather than inherited.

The rule exists so that *this issue's own* dropped work cannot fall through to the `Closes` path. Nothing of #1552's scope was dropped — the opposite: **#1552's own acceptance contract forbids touching those figures**, requiring the glance table's Skills/Agents columns to stay byte-identical ("a taxonomy rename, not a recount"). Work an acceptance criterion explicitly fences out was never in scope to defer. Linking `Refs` on that basis would leave #1552 open behind a PR that fully satisfies it, adding a fifth `refs-only` strand to a board already carrying four.

## Operational disclosure

The Step 7.5 least-privilege token-scope gate returned `over_scoped` (exit 1) and was cleared with the **`--allow-overscoped` flag**, scoped to that single invocation (never the `COGNI_SERVICE_ALLOW_OVERSCOPED` env var, which leaks into nested `run-tests` and false-blocks `check-preflight`).

- `forbidden_scopes`: `["workflow"]`
- `extra_scopes`: `["gist", "read:org", "workflow"]`
- `observed_scopes`: `["gist", "read:org", "repo", "workflow"]`

This runner is a personal, dedicated machine operating against the operator's own repository, which is the condition `cogni-service/CLAUDE.md` §Operational hardening states for the opt-out, and the operator authorized this posture as standing policy. The gate's own status remains `over_scoped` — surfaced, not silenced. Re-scoping the runner to a fine-grained PAT would remove the standing exception and is still the better end state.

## Caveat on the automated gates

This is a **docs-only diff**, so the deterministic preflight instruments have nothing to examine — no touched `SKILL.md`, no `agents/*.md`, no `scripts/check-*.sh`, no `tests/test-*.sh`, no `plugin.json`. Their green is the *absence of evidence*, not evidence of correctness. Likewise CI's `plugin-test-suites` job runs the whole suite regardless of diff scope, but no suite reads either changed file, so it passes trivially and is not a regression guard here. The real evidence is the executed contract checks quoted under **Evidence** above.