### PR TITLE
docs: Variations table names a skill, not a plugin, as producing_route

### DIFF
--- a/docs/workflows/consulting-engagement.md
+++ b/docs/workflows/consulting-engagement.md
@@ -277,7 +277,7 @@ One recommendation, not a menu. On confirmation, `consult-resume` dispatches the
 | Multilingual engagement | Set `language` at setup | DACH or other non-English stakeholder audiences |
 | Add a field mid-engagement | `consult-action-fields` add-field operation | Scope expands after an early deliverable reveals a gap |
 | Persona-first | Define and enrich personas before deliverable work begins | Client stakeholder landscape is complex and well-known |
-| Research report as a deliverable | Route through cogni-knowledge as the `producing_route` | The deliverable is a standalone research report rather than a consulting artifact |
+| Research report as a deliverable | Name `knowledge-run` as the `producing_route` in the deliverable manifest | The deliverable is a standalone research report rather than a consulting artifact |
 
 ## Common Pitfalls
 


### PR DESCRIPTION
Closes #1602.

## Summary

- `docs/workflows/consulting-engagement.md` — the **"Research report as a deliverable"** row of the `## Variations` table read *"Route through cogni-knowledge as the `producing_route`"*. `cogni-knowledge` is a **plugin** name, but `cogni-consult/references/data-model.md:238-239` defines `producing_route` as naming the **skill** that produces the deliverable. A reader copying that value into a deliverable manifest wrote a value the field does not accept.
- The row now reads *"Name `knowledge-run` as the `producing_route` in the deliverable manifest"*, mirroring the already-corrected sibling row for `story-to-slides` verbatim in shape.
- One cell, one line. `git diff --stat` is `1 file changed, 1 insertion(+), 1 deletion(-)`.

## Scope decisions

### Which skill: `knowledge-run`, not `knowledge-compose`

Both candidates resolve to a real `cogni-knowledge/skills/<name>/SKILL.md` and both satisfy every acceptance criterion, so this is a judgement call and it is stated here rather than left implicit.

**`knowledge-run` is the correct route** on the field's own semantics. `producing_route` names the skill that *produces the deliverable*, and its default `consult-design-thinking` is a whole end-to-end loop dispatched once. `knowledge-run`'s own `description:` frontmatter is the structural analogue — *"Drive the cogni-knowledge inverted pipeline end-to-end for ONE fresh topic in a single invocation … depositing a freshly-composed, claim-verified synthesis into the bound wiki with no per-phase manual dispatch."* One dispatch, one finished deliverable. It also matches this row's own **When to use** column — *"the deliverable is a standalone research report"* — and standalone means starting from nothing, which is exactly `knowledge-run`'s `--topic` fresh-start contract.

**`knowledge-compose` was considered and rejected.** Its own SKILL.md scopes it to Phase 5: it *requires* `plan.json` and `ingest-manifest.json` from Phases 1–4 to already exist, and it lands an **unverified** `draft-vN.md` that `knowledge-verify` and `knowledge-finalize` must still follow. A route that cannot run from a standing start, and whose output is not the finished artifact, does not produce the deliverable.

Contrary evidence, weighed and recorded rather than suppressed: `docs/workflows/research-to-report.md` names `/knowledge-compose` as that workflow's slash-command entry point, and line 295 of this very file cross-links that guide. That mention is an *interactive command* nudge, not a `producing_route` value.

### `Closes`, not `Refs` — a deliberate deviation from the mechanical rule

This PR carries a filed follow-up (#1609), and the mechanical `PARTIAL_FLAG` rule would set `--partial` (→ `Refs #1602`) on any non-empty `deferred[]`. That rule exists to guarantee a **partial** PR never auto-closes its parent. This PR is not partial:

- `full_scope` is `true`, and **every acceptance criterion of #1602 is satisfied by this diff** (verification below).
- #1609 is not a slice of #1602 held back. It is a *different plugin's* `skills/` file, which #1602's **own committed scope boundary explicitly forbids this PR from touching**, and which no acceptance criterion of #1602 covers.
- The committed issue-time contract's item 12 requires `Closes #1602` in as many words: *"the PR closes the issue rather than merely referencing it … nothing in it is deferred to a sibling issue or to epic #1354."*

Flagging it here so the deviation is adjudicated rather than discovered.

### The data model is unchanged — AC3 grades no edit

`cogni-consult/references/data-model.md:238-239` still defines `producing_route` as naming the skill, byte-identical to what the issue quotes. AC3's conditional branch (*"if the data model has since changed, the row is reconciled to whichever definition is current"*) therefore does not fire. The definition is correct and the table row was the side that was wrong; no reconciliation edit was needed and none was made. **AC3 is already satisfied at base and grades no change** — it is an invariant here, not coverage.

### No token-wide replace

At `origin/main` the file carries **13 occurrences** of the token `cogni-knowledge` across **12 lines**. Excluding the target row, **12 occurrences across 11 lines** — 3, 18, 28, 37, 39, 41, 47, 78, 284, 294, 295 (line 294 carries two: link text and link target) — are legitimate references to the plugin. Line 78 is a machine-readable `Skill: cogni-knowledge:knowledge-setup` dispatch directive; 294/295 are Related Guides links. A `sed s/cogni-knowledge/…/g` would corrupt all of them. This edit is a single-cell replace and the diff is exactly one changed line.

### Deliberately out of scope

- **`cogni-consult/skills/consult-action-fields/SKILL.md`** names the *retired* plugin `cogni-visual` as a `producing_route` in three places (`:117`, `:131`, `:197`) — a worse instance of the identical defect, in the skill that actually writes `producing_route` into a real `field.json`. Outside this issue's acceptance criteria and forbidden by its committed scope boundary. **Filed as #1609** rather than left as PR-body prose — the exact evaporation failure that caused #1602 itself to be filed.
- `docs/plugin-guide/cogni-consult.md:112` describes `producing_route` generically with no literal value. Verified — nothing to correct there.
- No `plugin.json` `version` is touched; the bump is post-merge.

### No regression guard exists, and none is added

Confirmed three ways: `producing_route` appears only in prose, reference files, `field.json` examples and `cogni-consult/tests/test_deliverable_graph.sh` fixtures (which hardcode `consult-design-thinking` and never read from `docs/`); `.github/workflows/lint.yml`'s external-dispatch guard scopes itself to `*/skills/*/SKILL.md`, `*/agents/*.md`, `*/commands/*.md` and `*/hooks/**`, so `docs/workflows/**` is out of its scope (re-run repo-wide on this branch: `files_affected: 0`); and the one test mentioning `consulting-engagement` (`cogni-workspace/tests/test-wiki-bare-name-roster.sh:970`) builds a **synthetic fixture** and never reads the real file. CI cannot catch a future drift of this row. Stated so the gap is visible rather than assumed closed.

## Verification — read this before trusting any green

**A green preflight proves nothing here.** This is a docs-only, repository-level touched set in **no plugin tree**, so `check-preflight.sh` resolves to no applicable plugin and skips every instrument; `check-frontmatter.sh`, `check-breadcrumbs.sh` and `check-structure-all.sh` never see the changed file. `check-breadcrumbs.sh` in particular scans only `skills/**/SKILL.md` and `agents/*.md`, so it is **inert** on this diff — the no-breadcrumb property below was confirmed by reading the added line, not by a gate. Every check below is manual by necessity.

Run at the branch head:

- **Diff shape** — `git diff --stat origin/main` → `1 file changed, 1 insertion(+), 1 deletion(-)`. ✅
- **AC1** (row names no plugin) — the route cell names `` `knowledge-run` ``; checked against `[p['name'] for p in marketplace.json['plugins']]` = `cogni-knowledge, cogni-consult, cogni-workspace, cogni-trends, cogni-portfolio, cogni-marketing, cogni-sales, cogni-website`. No match. ✅
- **AC2** (named skill resolves) — `cogni-knowledge/skills/knowledge-run/SKILL.md` is present. ✅
- **AC2, intent** — that file's `description:` describes depositing a *claim-verified synthesis*, i.e. it genuinely produces a report. A slug that merely existed (`knowledge-dashboard`) would pass the AC's literal falsifier while being wrong; this one passes on substance. ✅
- **AC3** (data model unmoved) — `git diff origin/main -- cogni-consult/references/data-model.md` is empty; the definition still reads *"names the skill that produces the deliverable"*. ✅ (invariant, grades no change)
- **AC4** (no remaining bare-plugin route) — every row of the table at `:274`–`:280` checked against `plugins[].name`: zero matches. Row 275's `knowledge-ingest` is a dispatch instruction, not a `producing_route`, and is unchanged. ✅
- **No collateral rename** — `cogni-knowledge` occurrence count went 13 → 12, exactly the one corrected cell; the diff shows exactly one `-`/`+` pair. ✅
- **No breadcrumb** — the added line carries no `#N` or PR reference; `Closes #1602` is in the **commit message**, not the edited prose. ✅
- **Table well-formed** — the row keeps four `|` delimiters, matching its siblings. ✅

## Follow-up issues

- #1609 — cogni-consult: `consult-action-fields` names the retired plugin `cogni-visual` as a `producing_route`

## Operational disclosure

The Step 7.5 least-privilege token check reported `over_scoped`: observed `gist, read:org, repo, workflow`; extra `gist, read:org, workflow`; forbidden `workflow`. That is the fixed scope set of the GitHub CLI OAuth (`gho_`) token, which cannot be narrowed. The run proceeded under the documented `--allow-overscoped` flag (never the env var), disclosed here per standing policy.