### PR TITLE
cogni-workspace guide: document the four absorbed rendering skills

### DIFF
--- a/docs/plugin-guide/cogni-workspace.md
+++ b/docs/plugin-guide/cogni-workspace.md
@@ -299,6 +299,39 @@ Two modes matter beyond ordinary polish:
 
 Commands: `/copywrite`, `/review-doc`.
 
+### `story-to-slides` — Turn a narrative into a presentation brief
+
+Absorbed from the retired cogni-visual plugin. Reads a narrative that already carries a story arc and re-architects its argument into slide-level messages: pyramid communication, one message per slide, assertion headlines, and speaker notes. The output is `presentation-brief.md`, written by default to `{source_dir}/cogni-visual/presentation-brief.md` and capped at `max_slides` (default 15), so a long narrative is consolidated rather than transcribed. The density rule is that the slide carries the anchor and the speaker notes carry the detail — content that exceeds a layout's physical capacity moves to the notes instead of being force-fit on the slide.
+
+The skill *creates* the brief; it does not render PowerPoint. Rendering is a separate step it guides you to at the end: attach the brief and the theme file in a claude.ai chat with the Anthropic PPTX skill (currently the recommended path), or render inside Claude Code via the `document-skills:pptx` skill, which cogni-workspace's own `pptx` *agent* wraps. There is no `pptx` skill in this plugin. Briefs carry no color fields — the renderer reads the theme directly.
+
+No slash command of its own — ask for a deck from a narrative, or invoke the skill by name.
+
+### `story-to-web` — Turn a narrative into a scrollable web brief
+
+Absorbed from the retired cogni-visual plugin. Decomposes a narrative into a scroll-driven section architecture and writes `web-brief.md`, by default to `{source_dir}/cogni-visual/web-brief.md`: a selected visual style guide, one message per section, assertion headlines, scroll-optimized copy, image prompts, and a CTA proposal (`conversion_goal` defaults to `consultation`, `max_sections` to 10). Sections alternate light and dark so each message lands before the next begins.
+
+As with `story-to-slides`, this is the briefing half only: the `web` agent renders the brief via Pencil MCP into a `.pen` file and then exports a self-contained HTML page from it, and the brief itself contains no color fields. It does not produce slides (`story-to-slides`), print storyboard posters (`story-to-storyboard`), or polished prose (`copywriter`).
+
+No slash command of its own — ask for a web narrative or a landing page built from a narrative document.
+
+### `story-to-infographic` — Distill a narrative into a single-page infographic
+
+Absorbed from the retired cogni-visual plugin. Extracts the three to five most impactful data points from a narrative, selects a layout, and writes `infographic-brief.md` (default `{source_dir}/cogni-visual/infographic-brief.md`) with content blocks under strict word limits plus icon prompts. The brief routes to one of two rendering families, picked by `style_preset`:
+
+- **Hand-drawn** — the `sketchnote` and `whiteboard` presets, rendered through `/render-infographic-handdrawn` into an `.excalidraw` scene.
+- **Editorial** — the `economist`, `editorial`, `data-viz` and `corporate` presets, rendered through `/render-infographic-editorial` into a `.pen` file.
+
+`/render-infographic` is the universal entry point: it reads the brief's `style_preset` and routes to the right family. Unlike the two skills above, this one renders by default — after writing the brief it auto-dispatches `/render-infographic` (pass `render: false` to produce the brief only). One constraint to respect: both hand-drawn render agents share a single Excalidraw MCP canvas, so hand-drawn renders must be serialized and never dispatched in parallel. Pencil-rendered editorial briefs are file-backed and can run alongside one Excalidraw render safely.
+
+### `enrich-report` — Turn a finished report into a visual deliverable
+
+Absorbed from the retired cogni-visual plugin. Post-processes an *already-written* markdown report into a self-contained themed HTML rendition — it never authors a new report from scratch, never creates slides, and never rewrites prose (that is `copywriter`). The layout follows the consulting-deliverable pattern: the report's executive summary, then a full-width editorial infographic distilled from the whole report, then the report body with sidebar navigation and sparse inline Chart.js charts and SVG concept diagrams. The infographic is where the data visualization concentrates; the body stays prose unless a visual genuinely aids a specific passage.
+
+One run always produces both HTML layouts: a scroll version at `{source_dir}/output/{stem}-enriched.html` and a paginated flipbook alongside it as `{stem}-enriched-flipbook.html`. On request via `formats`, PDF is derived from that HTML while DOCX is converted from the original markdown to keep the document structure clean. The source markdown is never touched, and a validation gate enforces preservation — the HTML must retain at least 80% of the source word count, with H2 and citation counts matching.
+
+Commands: `/enrich-report`.
+
 ---
 
 ## Integration Points


### PR DESCRIPTION
Closes #1603.

## Summary

Adds four `### ` capability sections to `docs/plugin-guide/cogni-workspace.md` — `story-to-slides`, `story-to-web`, `story-to-infographic`, `enrich-report` — all four of which had **zero** occurrences in the guide at base despite shipping under `cogni-workspace/skills/`.

#1554 retargeted dead `../plugin-guide/cogni-visual.md` links onto this guide and annotated them as covering exactly these four skills. The links resolved, but the destination was silent on the reader's subject. This makes the destination true.

Each section follows the shape the two immediate neighbours set — `### \`narrative\`` (:263) and `### \`copywriter\`` (:289): an `Absorbed from the retired cogni-visual plugin.` lineage sentence, body prose, and a `Commands:` trailer **only** where a real command file exists. Purely additive to one file.

## Every claim is written from source, not from memory

That is the whole point of a documentation issue, so each section was drafted from the skill's own `SKILL.md` at base and then independently re-verified. The verification pass caught three defects in the first draft:

1. **A CommonMark rendering hazard.** The block's final line ``Commands: `/enrich-report`.`` would have abutted the existing `---` that closes the `## Capabilities` block. In CommonMark a `---` immediately after a text line makes that text a **setext H2** — so the insert would have silently produced a spurious `## Commands: /enrich-report.` heading and pushed the `enrich-report` section *outside* `## Capabilities`. Fixed with a mandated blank line; verified in the final file (line 333 text, 334 blank, 335 `---`).
2. **A false claim.** The draft said PDF *and* DOCX are derived from the enriched HTML. Source says DOCX is converted from the **original markdown**, to keep document structure clean; only PDF comes from the HTML.
3. **A contradicted count.** The draft called enrich-report's layout "three zones" while the skill's own heading reads *Two-Zone Architecture*.

Confirmed present in source rather than assumed: `max_slides` 15, `conversion_goal` `consultation`, `max_sections` 10, the three-to-five data points, the `render: false` parameter, the 80% word-count preservation gate, and all four default output paths.

**Two accuracy traps handled explicitly:**

- **`pptx` is an agent, not a skill.** `cogni-workspace/agents/pptx.md` exists; `cogni-workspace/skills/pptx/` does not. `story-to-slides`' own SKILL.md calls the renderer "the PPTX skill" (lines 4, 13) and "PPTX agent" (line 12) inconsistently — copying that phrasing would have documented a skill that does not exist. The section describes the render path as claude.ai with the Anthropic PPTX skill, or `document-skills:pptx` in Claude Code which the cogni-workspace `pptx` *agent* wraps, and says outright that this plugin has no `pptx` skill.
- **Renderer routing is stated in the source's own direction, not swapped:** hand-drawn (`sketchnote`, `whiteboard`) → `/render-infographic-handdrawn` → `.excalidraw`; editorial (`economist`, `editorial`, `data-viz`, `corporate`) → `/render-infographic-editorial` → `.pen`.
- **Provenance verified, not assumed.** `cogni-visual` appears verbatim in `scripts/retired-plugins.json` `retired_prefixes[]`, and git history (`--diff-filter=A`) shows all four `SKILL.md` files previously lived under `cogni-visual/skills/` before monorepo migration commit `6a61ebb` inlined them into `cogni-workspace/`.

## Scope decisions

**Included:** exactly the four skills the issue names.

**Deliberately excluded — and not held-back slices of this issue:**

- **The two Related-Guides annotations** (`docs/workflows/research-to-report.md:255`, `docs/workflows/content-pipeline.md:232`) are **not edited**. Both already name only skills drawn from this set of four. AC4 is satisfied by making the guide *true*, not by deleting rendering-skill names from the annotations — that deletion is the cheapest fix that passes the stated falsifier while inverting the issue's own Motivation. The diff touches no file under `docs/workflows/`.
- **`render-html-slides`, `story-to-storyboard`, `review-brief`** also ship undocumented under `cogni-workspace/skills/`, but the issue names exactly four skills and its AC3 is one-directional (documented ⇒ exists, not exists ⇒ documented). `story-to-storyboard` appears in one passing clause quoted from `story-to-web`'s own description and gets no section of its own. Documenting those three is sibling work.
- **No fenced invocation examples.** Neither model section carries one. And three of these four skills have **no slash command at all**: `cogni-workspace/commands/` contains `enrich-report.md` but no `story-to-slides.md`, `story-to-web.md` or `story-to-infographic.md`. Only `enrich-report` gets a `Commands:` trailer — inventing `/story-to-slides` would have documented a command that does not exist.
- **No plugin tree, manifest, script or test change.** The diff is confined to `docs/**`; no `.claude-plugin/**` manifest and no `version` field is touched (the post-merge workflow owns the bump).

**No links added.** The diff introduces zero markdown links, so the dead `cogni-visual.md` link class #1554 retired cannot recur. The `{source_dir}/cogni-visual/…` strings are code-span default output paths quoted from each skill's Parameters table, not links.

## Verification

Every gating item was executed against the branch, with each falsifier first confirmed **red at base** — a falsifier already green at base grades nothing.

| Check | Result |
|---|---|
| All four names present (0 for each at base) | `story-to-slides` 2, `story-to-web` 1, `story-to-infographic` 1, `enrich-report` 2 |
| Four own `### ` headings, none folded | 4, at lines 302 / 310 / 318 / 327 |
| Placement strictly inside `## Capabilities` | `## Capabilities` 83 … headings 302–327 … `## Integration Points` 337 |
| Additive only — deletions in diff | 0 |
| All eleven base capability headings survive | all present; top-level `##` count 9 → 9 |
| Every name presented as a skill resolves to `cogni-workspace/skills/<name>/SKILL.md` | all resolve; `skills/pptx` correctly absent and never called a skill |
| Lineage prefix real | 4 lineage sentences; `cogni-visual` present in `retired_prefixes[]` |
| Links added | 0 |
| Annotations untouched | 0 files touched under `docs/workflows/`; both lines still name their rendering skills |
| Scope boundary | `git diff --name-only` → `docs/plugin-guide/cogni-workspace.md` only |

Repo guards all green on the branch: `check-breadcrumbs.py`, `check-external-dispatch.py`, `check-plugin-inventory.py`, `check-attribution-path-integrity.py` (rc=0 each).

**No behavioural test and no `## Mutation recipe`** — and their absence is not an oversight. No deterministic guard in this repo scans `docs/`: `check-external-dispatch.py` excludes `docs/` by design (`EXCLUDE_TOPLEVEL`), `check-breadcrumbs.py` globs only `*/skills/*/SKILL.md` and `*/agents/*.md`, and no `tests/` suite covers `docs/plugin-guide`. The diff touches no `tests/**` or `scripts/**` path, so there is no guard to mutate. The achievable bar is the grep-anchored table above.

## Open questions

None blocking. Two disclosures for the reviewer:

- **Runner token is over-scoped.** `check-token-scope.sh --strict` reports `over_scoped` with `extra_scopes: [gist, read:org, workflow]` and `forbidden_scopes: [workflow]`. This is the standing `gho_` `gh auth login` token whose scope set is fixed by the GitHub CLI OAuth app and cannot be narrowed; the documented `--allow-overscoped` flag was taken (never the env var) and is disclosed here rather than buried. Mitigating fact specific to this PR: the diff touches exactly one path under `docs/` and no `.github/workflows/**` path, so the forbidden `workflow` scope is unexercised by this change.
- **The issue's own AC3 is green at base.** "Every skill the guide documents resolves to an existing directory" already held before this change (all eleven headed skills resolved). It is therefore a regression guard over the four new sections, not a defect this PR fixes — it must not be read as evidence of work done. It is satisfied, and was independently re-checked above.