### PR TITLE
docs: model the live roster in er-diagram and the architecture pages

### DIFF
--- a/docs/architecture/design-philosophy.md
+++ b/docs/architecture/design-philosophy.md
@@ -34,7 +34,7 @@ Each side stores a path to the other. The bridge skill resolves the reference at
 
 ## Progressive Disclosure
 
-Skills and agents load reference material only at the step that needs it. This pattern appears in cogni-visual, cogni-portfolio, cogni-knowledge, and cogni-consult consistently.
+Skills and agents load reference material only at the step that needs it. This pattern appears in cogni-workspace, cogni-portfolio, cogni-knowledge, and cogni-consult consistently.
 
 The motivation is context window management. A research report skill that loaded every reference file at startup would fill its context before the user's first sub-question was answered. Instead, each phase of the pipeline loads only what that phase requires:
 
@@ -43,7 +43,7 @@ The motivation is context window management. A research report skill that loaded
 - Phase 3: load the writer's style reference only when writing begins
 - Phase 4: load the reviewer's checklist only when reviewing begins
 
-cogni-visual's CLAUDE.md describes this directly: "Reference files are read only at the step that needs them, not all at once."
+The rule is simple: reference files are read only at the step that needs them, not all at once.
 
 The same principle applies to entity data. cogni-portfolio's `portfolio.json` is a lightweight manifest that stores entity counts and status flags — the full entity content lives in subdirectories and is read only when a skill actively works on that entity type. Browsing portfolio status costs almost nothing; deep research on a single feature loads only that feature's files.
 
@@ -72,14 +72,14 @@ cogni-workspace's claims engine uses UUID-v4 slugs (`claim-550e8400-...`) rather
 
 ## Brief-Based Rendering
 
-cogni-visual separates content specification from rendering. The pipeline has three stages:
+cogni-workspace's rendering skills separate content specification from rendering. The pipeline has three stages:
 
 ```
-cogni-workspace (narrative → copywriter) → cogni-visual
+cogni-workspace (narrative → copywriter) → cogni-workspace (rendering)
 (compose)         (polish)            (visualize)
 ```
 
-Between the compose/polish phase and the render phase, cogni-visual inserts a brief: a structured Markdown file with YAML frontmatter that describes what to render without describing how to render it.
+Between the compose/polish phase and the render phase, the rendering skills insert a brief: a structured Markdown file with YAML frontmatter that describes what to render without describing how to render it.
 
 A presentation brief lists slides with headlines, body copy, and CTA proposals. It does not specify colors, fonts, layout coordinates, or element types. An infographic brief lists content blocks with block types, headlines, and data points. It does not specify element composition or spatial relationships — those decisions belong to the rendering agents.
 
@@ -89,7 +89,7 @@ This separation has two practical benefits:
 
 2. The rendering agents can evolve independently. When rendering pipelines upgrade, existing briefs remain valid because brief formats make no assumptions about rendering technique.
 
-cogni-visual's CLAUDE.md: "Briefs are YAML frontmatter + Markdown. Frontmatter holds metadata (type, version, theme, arc_type, arc_id, confidence_score). Body holds the content specification."
+The brief contract: briefs are YAML frontmatter + Markdown. Frontmatter holds metadata (type, version, theme, arc_type, arc_id, confidence_score). Body holds the content specification.
 
 
 ---

--- a/docs/architecture/er-diagram.md
+++ b/docs/architecture/er-diagram.md
@@ -13,7 +13,7 @@ horizontal   cogni-workspace  (shared workspace state: themes, env vars, discove
 ─────────────────────────────────────────────────────────────────────────────────
 vertical     Orchestration   cogni-consult
              Data            cogni-portfolio  cogni-trends  cogni-knowledge  cogni-workspace
-             Output          cogni-workspace (narrative + copywriter)  cogni-visual
+             Output          cogni-workspace (narrative + copywriter + rendering)
                              cogni-sales      cogni-marketing
 ```
 
@@ -42,7 +42,7 @@ vertical     Orchestration   cogni-consult
 | cogni-sales | PitchLog, BuyingCenter, PhaseDeliverable | JSON + Markdown per phase |
 | cogni-marketing | MarketingProject, ContentStrategy, ContentPiece, Campaign, Calendar | JSON + Markdown with YAML frontmatter |
 | cogni-workspace (`narrative`) | Narrative (arc_id, sections, techniques) | Markdown with YAML frontmatter |
-| cogni-visual | Brief (YAML frontmatter + Markdown body) | Per-deliverable brief files |
+| cogni-workspace (rendering) | Brief (YAML frontmatter + Markdown body) | Per-deliverable brief files |
 | cogni-workspace | Theme, WorkspaceConfig, VaultConfig | Markdown (theme.md) + JSON |
 | cogni-consult | Engagement (consult-project.json), ActionField (field.json), Persona | JSON + Markdown |
 
@@ -72,10 +72,10 @@ Downstream plugins read YAML frontmatter fields from files produced by upstream 
 
 | Field | Set by | Read by | Purpose |
 |-------|-------|--------|---------|
-| `arc_id` | cogni-workspace (`narrative`) | cogni-workspace (`copywriter`), cogni-visual | Arc type for arc-aware polishing and visual theme selection |
-| `theme_path` | cogni-workspace | cogni-visual | Path to the active theme file |
+| `arc_id` | cogni-workspace (`narrative`) | cogni-workspace (`copywriter`, rendering) | Arc type for arc-aware polishing and visual theme selection |
+| `theme_path` | cogni-workspace | cogni-workspace (rendering) | Path to the active theme file |
 | `portfolio_path` | cogni-portfolio | cogni-sales, cogni-marketing, cogni-trends | Path to the project directory |
-| `arc_type` | cogni-visual (from arc_id mapping) | rendering agents | Visual arc type from libraries/arc-taxonomy.md |
+| `arc_type` | cogni-workspace (from arc_id mapping) | rendering agents | Visual arc type from libraries/arc-taxonomy.md |
 
 ---
 

--- a/docs/architecture/loop-health-map.md
+++ b/docs/architecture/loop-health-map.md
@@ -23,9 +23,9 @@ rubric: it is what makes a flagged finding credible.
   cogni-knowledge, cogni-marketing, cogni-portfolio, cogni-sales, cogni-trends,
   cogni-website, cogni-workspace. The loops formerly surveyed under
   cogni-narrative and cogni-copywriting are now cogni-workspace skills and are
-  listed under it. The rendering loops now owned by cogni-workspace — loops 7
-  and 8 below — are recorded under their current `cogni-workspace/` source
-  paths.
+  listed under it. cogni-visual has since been absorbed into cogni-workspace as
+  well; loops 7 and 8 below have been re-pointed to their current
+  `cogni-workspace/` source paths.
 - **Nature:** read-only. This map is a data artifact; it changes no loop and
   proposes no specific code edits. Any targeted hardening of a flagged loop is
   a further, evidence-gated concern — decided from this baseline, not

--- a/docs/architecture/loop-health-map.md
+++ b/docs/architecture/loop-health-map.md
@@ -23,9 +23,9 @@ rubric: it is what makes a flagged finding credible.
   cogni-knowledge, cogni-marketing, cogni-portfolio, cogni-sales, cogni-trends,
   cogni-website, cogni-workspace. The loops formerly surveyed under
   cogni-narrative and cogni-copywriting are now cogni-workspace skills and are
-  listed under it. cogni-visual has since been absorbed into cogni-workspace as
-  well; loops 7 and 8 below are still recorded under their pre-absorption
-  `cogni-visual/` source paths.
+  listed under it. The rendering loops now owned by cogni-workspace — loops 7
+  and 8 below — are recorded under their current `cogni-workspace/` source
+  paths.
 - **Nature:** read-only. This map is a data artifact; it changes no loop and
   proposes no specific code edits. Any targeted hardening of a flagged loop is
   a further, evidence-gated concern — decided from this baseline, not
@@ -70,8 +70,8 @@ hands-off.
 | 4 | verify-trend-report reviewer→revisor loop | `cogni-trends/skills/verify-trend-report/SKILL.md` | No | ✅ Clean pass *(rubric exemplar)* | — |
 | 5 | compete stakeholder-review auto-rewrite loop | `cogni-portfolio/skills/compete/SKILL.md` | No | ✅ Clean pass | — |
 | 6 | propositions ordered quality-gate chain | `cogni-portfolio/skills/propositions/SKILL.md` | No | ✅ Clean pass | — |
-| 7 | review-brief assessor verdict loop | `cogni-visual/skills/review-brief/SKILL.md` | No | ✅ Clean pass | — |
-| 8 | story-to-slides stakeholder-review loop (story-to-* family) | `cogni-visual/skills/story-to-slides/SKILL.md` | No | ✅ Clean pass | — |
+| 7 | review-brief assessor verdict loop | `cogni-workspace/skills/review-brief/SKILL.md` | No | ✅ Clean pass | — |
+| 8 | story-to-slides stakeholder-review loop (story-to-* family) | `cogni-workspace/skills/story-to-slides/SKILL.md` | No | ✅ Clean pass | — |
 | 9 | why-change assess-revise-reassess loop | `cogni-sales/skills/why-change/SKILL.md` | No | ✅ Clean pass | — |
 | 10 | copy-reader persona review + auto-improvement | `cogni-workspace/skills/copy-reader/SKILL.md` | No (but agent-callable) | ⚠ 1 major | nodding (Verification) |
 | 11 | consult-design-thinking DT stage machine | `cogni-consult/skills/consult-design-thinking/SKILL.md`, `cogni-consult/scripts/dt-stage-advance.sh` | No | ⚠ 1 advisory-minor | nodding-adjacent (Verification) |
@@ -251,7 +251,7 @@ bracketed by user checkpoints).
 
 ## Loop 7 — review-brief assessor verdict loop
 
-**Source:** `cogni-visual/skills/review-brief/SKILL.md`.
+**Source:** `cogni-workspace/skills/review-brief/SKILL.md`.
 **Unattended?** No — standalone interactive review; `auto_improve` defaults to
 `false`.
 
@@ -271,7 +271,7 @@ bracketed by user checkpoints).
 
 ## Loop 8 — story-to-slides stakeholder-review loop (story-to-* family)
 
-**Source:** `cogni-visual/skills/story-to-slides/SKILL.md` (Step 9b),
+**Source:** `cogni-workspace/skills/story-to-slides/SKILL.md` (Step 9b),
 representative of the story-to-infographic / story-to-storyboard /
 story-to-web siblings, which integrate the same `brief-review-assessor` loop
 per the plugin's shared `stakeholder_review` convention.
@@ -470,7 +470,7 @@ publish steps are all human checkpoints).
 
 **Anti-pattern:** nodding (Verification skipped on the revise leg — the flow that produces the edited deliverable also grades it).
 **Evidence location:** `cogni-workspace/skills/copy-reader/SKILL.md :: Step 5 ("Apply Auto-Improvement Loop")` — edits are applied in the orchestrator's context and validated only deterministically (charset, citation count, protected content), with no re-dispatch of any persona agent; and `:: Step 6 ("Report Results")` — the user-facing report template asserts post-improvement score effects ("raised Executive score to 88", "raised End-user score to 95") that no evaluator re-measured, and the JSON contract for "agent/skill callers" carries `overall_score` + `improvements_applied` downstream on the same unverified basis.
-**Why major, not minor:** this is the rubric's priority case and it is statically confirmable — there is no dispatch between the edit-write and the accept/report, and the report's score-delta claims are structurally unmeasurable in the flow as written. `AUTO_IMPROVE` defaults to `true`, so the self-graded improvement pass is the default path, including when other skills invoke copy-reader programmatically. Mitigations that keep it from being worse (fresh-context *initial* grading, deterministic guardrails with revert-to-backup, an interactive human reading the report in the common case) are real but do not close the gap the rubric targets: bad edits are laundered past the only quality gate with asserted-not-measured scores. The healthy contrast is in this same repo: `cogni-visual/skills/review-brief/SKILL.md :: Step 5` re-launches its assessor after applying improvements. A follow-up could look at re-grading applied edits (or reporting only pre-improvement scores) — evidence-gated, out of this sweep's scope.
+**Why major, not minor:** this is the rubric's priority case and it is statically confirmable — there is no dispatch between the edit-write and the accept/report, and the report's score-delta claims are structurally unmeasurable in the flow as written. `AUTO_IMPROVE` defaults to `true`, so the self-graded improvement pass is the default path, including when other skills invoke copy-reader programmatically. Mitigations that keep it from being worse (fresh-context *initial* grading, deterministic guardrails with revert-to-backup, an interactive human reading the report in the common case) are real but do not close the gap the rubric targets: bad edits are laundered past the only quality gate with asserted-not-measured scores. The healthy contrast is in this same repo: `cogni-workspace/skills/review-brief/SKILL.md :: Step 5` re-launches its assessor after applying improvements. A follow-up could look at re-grading applied edits (or reporting only pre-improvement scores) — evidence-gated, out of this sweep's scope.
 
 <a id="f2"></a>
 ### F2 — consult-design-thinking · nodding-adjacent (Verification) · advisory minor

--- a/docs/architecture/plugin-anatomy.md
+++ b/docs/architecture/plugin-anatomy.md
@@ -35,7 +35,7 @@ A fully featured plugin looks like this:
 └── README.md                    # User-facing introduction
 ```
 
-Not every plugin uses every directory. cogni-marketing and cogni-website have no `scripts/` directory. cogni-visual has a `libraries/` directory (shared reference material loaded by multiple agents) rather than per-skill `references/` subdirectories.
+Not every plugin uses every directory. cogni-marketing and cogni-website have no `scripts/` directory. cogni-workspace has a `libraries/` directory (shared reference material loaded by multiple agents) alongside its per-skill `references/` subdirectories.
 
 ---
 

--- a/docs/er-diagram.md
+++ b/docs/er-diagram.md
@@ -24,7 +24,7 @@ graph LR
     subgraph Output["Output Layer"]
         NA[cogni-workspace narrative<br/>arc-driven narratives]
         CW[cogni-workspace copywriter<br/>polished documents]
-        VI[cogni-visual<br/>slides, web, storyboard<br/>infographic, enrich-report]
+        RN[cogni-workspace rendering<br/>slides, web, storyboard<br/>infographic, enrich-report]
         SA[cogni-sales<br/>pitches, proposals]
         MK[cogni-marketing<br/>content, campaigns<br/>calendars]
     end
@@ -34,10 +34,10 @@ graph LR
     DM -->|dispatches discover/develop| TI
     DM -->|dispatches discover/develop/deliver| PF
     DM -->|dispatches define/deliver| CL
-    DM -->|dispatches export| VI
+    DM -->|dispatches export| RN
 
     %% Shared workspace → consumers
-    WS -.->|themes| VI
+    WS -.->|themes| RN
     WS -.->|env vars| PF
     WS -.->|env vars| TI
 
@@ -57,13 +57,13 @@ graph LR
 
     %% TIPS → Output
     TI -->|themes, Handlungsfelder| MK
-    TI -->|value-modeler output| VI
+    TI -->|value-modeler output| RN
 
     %% Narrative pipeline
     NA -->|arc output| CW
     NA -->|arc patterns| SA
-    NA -->|narratives| VI
-    CW -->|polished content| VI
+    NA -->|narratives| RN
+    CW -->|polished content| RN
 
     %% Teacher (standalone, not shown — teaches all plugins)
 ```
@@ -78,11 +78,11 @@ graph LR
 | **cogni-workspace** | ClaimRecord, DeviationRecord, ResolutionRecord | JSON in `cogni-claims/` directory | Receives claims from all data-layer plugins. Status: unverified → verified/deviated → resolved |
 | **cogni-sales** | PitchLog, BuyingCenter, PhaseDeliverable (research.json + narrative.md) | JSON + Markdown per phase | Consumes portfolio propositions + narrative arc patterns. Registers claims |
 | **cogni-marketing** | MarketingProject, ContentStrategy, ContentPiece, Campaign, Calendar | JSON + Markdown with YAML frontmatter | Consumes portfolio propositions + TIPS themes. 16 content formats |
-| **cogni-workspace** (`narrative`) | Narrative (arc_id, sections, techniques) | Markdown with YAML frontmatter | Consumed by Visual, the `copywriter` skill, and Sales via `arc_id` frontmatter |
+| **cogni-workspace** (`narrative`) | Narrative (arc_id, sections, techniques) | Markdown with YAML frontmatter | Consumed by the rendering skills, the `copywriter` skill, and Sales via `arc_id` frontmatter |
 | **cogni-workspace** (`copywriter`) | (no persistent entities) | In-place document modification | Detects `arc_id` frontmatter for arc-aware polishing |
-| **cogni-visual** | Brief (YAML frontmatter + Markdown body) | Per-deliverable brief files | Reads theme from cogni-workspace. Reads narrative via `arc_id` |
+| **cogni-workspace** (rendering) | Brief (YAML frontmatter + Markdown body) | Per-deliverable brief files | Reads the active theme. Reads narrative via `arc_id` |
 | **cogni-workspace** | Theme, WorkspaceConfig, VaultConfig, TerminalProfile | Markdown (theme.md) + JSON (settings, `.obsidian/` configs) | Theme files consumed by all visual plugins. Env vars consumed by all plugins. Obsidian browsing layer for all plugin outputs |
-| **cogni-consult** | Engagement (consult-project.json), ActionField (field.json), Deliverable state, Persona, ExecutionLog, MethodLog, DecisionLog | JSON state files + Obsidian-browsable Markdown deliverables in `action-fields/{field}/` | Binds one cogni-knowledge base per engagement as the research spine; deliverables feed the `narrative` skill, cogni-visual, cogni-sales |
+| **cogni-consult** | Engagement (consult-project.json), ActionField (field.json), Deliverable state, Persona, ExecutionLog, MethodLog, DecisionLog | JSON state files + Obsidian-browsable Markdown deliverables in `action-fields/{field}/` | Binds one cogni-knowledge base per engagement as the research spine; deliverables feed the `narrative` skill, cogni-workspace rendering, cogni-sales |
 
 ## Cross-Plugin Bridge Files
 


### PR DESCRIPTION
Closes #1553.

## Summary

Five hand-maintained architecture pages still modelled the pre-absorption ecosystem. They are not cogni-docs-generated, so no regeneration run corrects them.

- **`docs/er-diagram.md`** — the Mermaid `VI[cogni-visual…]` node becomes `RN[cogni-workspace rendering…]` with all five edges re-pointed; the L83 data-contract row is **rewritten, not deleted** (`Brief` survives); L85's consumer list and L81's bare `Visual` are re-attributed.
- **`docs/architecture/er-diagram.md`** — the ASCII group diagram's Output column, the Key-Entity-Types owner, and three frontmatter-contract cells move to cogni-workspace.
- **`docs/architecture/design-philosophy.md`** — L37/L75/L78/L82 rehomed; the two `cogni-visual's CLAUDE.md` citations keep their substance but lose their attribution (see Scope decisions).
- **`docs/architecture/loop-health-map.md`** — the five `cogni-visual/skills/…` citations become `cogni-workspace/skills/…` (both targets verified present), and the passage describing them as pre-absorption paths is updated in the same pass **while keeping the absorption marker itself** (`f7aede88`, per the maintainer ruling below).
- **`docs/architecture/plugin-anatomy.md`** — L38 rehomed, with `rather than` → `alongside`.

No `plugin.json` version is touched — the bump is post-merge.

## The issue's occurrence table is a hypothesis — and it partly holds

Verified at `f8acea35`, counting only the nine retired names the issue enumerates:

| File | Issue claims | Actual |
|---|---|---|
| `docs/er-diagram.md` | 4 | 4 ✅ |
| `docs/architecture/er-diagram.md` | 8 | 8 ✅ |
| `docs/architecture/design-philosophy.md` | 9 | 9 ✅ |
| `docs/architecture/plugin-anatomy.md` | 1 | 1 ✅ |
| `docs/architecture/loop-health-map.md` | 7 | **9** ⚠️ |

Four of five are exact; `loop-health-map.md` undercounts by two. But the raw count is not the work: of 31 occurrences, **7 were already correct and are untouched**, ~15 needed re-attribution, and 9 in `loop-health-map.md` were source-path citations.

`VI` **is** edge-referenced, as the issue claims — 5 edges. The AC3 breakage risk was real, not hypothetical. Only `docs/er-diagram.md` contains a Mermaid block at all, so **AC3 is vacuously satisfied for the other four files** — worth knowing so the check is not mistaken for five checks.

## Scope decisions

**(a) The VI node — relabelled, not folded.** The issue's prose asks for the node to be "folded into the cogni-workspace node". Taken literally that turns `WS -.->|themes| VI` into the self-edge `WS -.-> WS` and drags an Output-layer capability into the Foundation-layer node. The same diagram already carries `NA[cogni-workspace narrative]`, `CW[cogni-workspace copywriter]` and `CL[cogni-workspace …]` as separate capability-suffixed nodes, so a distinct node is the shape this file established. No acceptance criterion forces either shape and AC3 holds under both. **Where the Desired-behavior prose and a criterion disagree, the criteria govern.**

**(b) Both `CLAUDE.md` citations de-quoted, never re-attributed.** No CLAUDE.md in the repo contains either quoted string, so a one-token `cogni-visual` → `cogni-workspace` swap on those two lines would have **fabricated a citation**. Both sentences keep their full substance as the document's own prose.

Two rationales offered for this decision during planning were checked and **found false**, and are corrected here rather than shipped: the L46 rule is *not* undocumented — it lives, already roster-corrected, at `wiki/wiki/pages/concept-progressive-disclosure.md:17` — and the cited wiki pages are *not* divergent from their vendored twins (byte-identical, sha `79d0df08`). Those pages also independently corroborate this PR: `concept-progressive-disclosure.md:17` states the L37 roster as exactly "cogni-workspace, cogni-portfolio, cogni-knowledge, and cogni-consult", and `concept-brief-based-rendering.md:13/:18` give the same intra-plugin pipeline. Neither names `cogni-visual`.

**(c) `loop-health-map.md` — path clause re-pointed, archival marker kept.** The five path citations are rewritten because both targets genuinely resolve under `cogni-workspace/`. That makes the file's own "still recorded under their pre-absorption `cogni-visual/` source paths" sentence false, so it is updated in the same pass rather than left as a stale explanation. The first commit rewrote the whole passage and dropped the standalone absorption fact with it; `f7aede88` restores it, so the Scope bullet now reads *"cogni-visual has since been absorbed into cogni-workspace as well; loops 7 and 8 below **have been re-pointed to** their current `cogni-workspace/` source paths."* That keeps the paragraph symmetric with the surviving cogni-narrative/cogni-copywriting clause beside it, and keeps the dated artifact explicit that the citations were corrected *after* the 2026-07-07 sweep rather than presenting post-absorption paths as what that sweep read. **Untouched:** the L22–25 count/roster (owned by closed child #1551), the `Swept: 2026-07-07` date, the loop numbering, the totals block, every per-loop verdict, and the `f1`/`f2`/`f3` anchors with their inbound links.

**(d) `plugin-anatomy.md`'s `rather than` → `alongside` is forced, not optional scope.** cogni-workspace has **both** a plugin-level `libraries/` (17 files) and per-skill `references/` (201 files across 17 skills), so a bare owner swap would have shipped a false claim.

**(e) Deliberately preserved byte-identical** — the three `cogni-claims/` **paths** (the discriminator is the colon; no `cogni-claims:` dispatch token exists anywhere in these files), and the four archival `archived cogni-consulting` sentences.

**(f) `cogni-service` and `cogni-portfolio-evals` untouched.** Both are absent from `plugins[].name` and so are flagged by AC1's mechanical falsifier, and both are **correct as written** — `cogni-service` is an external plugin the file itself explains is not one of this repo's plugins, and `cogni-portfolio-evals/` is a real repo-root directory. This is the call sibling #1554 made for `.cogni-wiki/config.json`.

## Evidence

| Criterion | Result |
|---|---|
| AC1 — no retired token as a dispatch/ownership reference | ✅ **0** `cogni-visual` survivors across the five files |
| AC2 — only the two allowed residual forms | ✅ **0** `cogni-claims:` colon-form tokens; the 3 `cogni-claims/` paths byte-identical |
| AC3 — every Mermaid graph resolves | ✅ 22 edge lines parsed individually, **0 undefined operands, 0 self-edges**; `VI` count 0; `RN` defined *and* edge-referenced; the five capability words survive in the node label |
| AC4 — table owners + entity-name set | ✅ 18 rows base and head; entity-name set **identical**; `Brief` survives; **0** owners outside the roster |
| AC5 — `python3 scripts/run-plugin-tests.py` | ✅ **133/133 passed, rc=0** at `f7aede88` — identical to the pre-change baseline measured on `origin/main` |
| AC6 — diff touches only the five files | ✅ exactly those five, 30 insertions / 30 deletions across two commits |

## Rulings — settled, nothing open

All three questions this PR carried are decided. **No escalation remains.**

1. **AC2's allowed form vs. its own falsifier — the falsifier governs.** The criterion allowed "an explicitly dated historical sentence" but fired only on "an undated **present-tense** sentence"; five correct references sat between the two tests. Ruled: an explicit archival marker (`archived`, `formerly`, `has since been absorbed`, `pre-absorption`) suffices, **a date is not required**, and none may be invented where the files do not carry one. AC1's roster subtraction likewise does not reach `cogni-service` or `cogni-portfolio-evals`, both correct as written. Both rulings are written back into **#1553's body** as allowed forms (b) and (c) — not left in a comment a gate cannot read — with the rationale in [this comment](https://github.com/cogni-work/insight-wave/issues/1553#issuecomment-5406499714).

2. **The gate's held finding (contract item 7) — resolved in code.** The first commit's passage rewrite dropped the cogni-visual absorption marker as a side effect of the item-18-licensed path re-pointing. Ruled: restore the marker, re-point only the path clause — the reviewer's own suggested fix, applied at `f7aede88` (3 insertions / 3 deletions, one file).

3. **The `VI` → `RN` node shape and the two de-quoted citations stand as authored.** Both were graded satisfied by both perspectives; the literal fold produces a `WS -.-> WS` self-edge, and no CLAUDE.md in this repo contains either quoted string, so re-attribution would have fabricated a citation.

## Notes

- `/simplify` and the prose pass were no-ops: the diff is 29 added lines of Markdown prose, tables and diagram labels across five `.md` files, with no code and no `SKILL.md` / `agents/*.md` in scope.
- Token-scope preflight reported `over_scoped` (`workflow` extra) on the standard `gh auth login` token, whose scope set is fixed by the CLI OAuth app; taken via the documented `--allow-overscoped` flag and disclosed rather than silently passed.
