### PR TITLE
README: recount cogni-workspace to 26 skills / 26 agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Each plugin implements an established framework (Corporate Visions, Double Diamo
 
 ### Workspace Infrastructure
 
-[cogni-workspace](cogni-workspace/README.md) is the horizontal layer every other plugin builds on. It manages the shared foundation — environment variables, MCP server installation, theme management, plugin discovery, and workspace health. Runs dependency checks, discovers installed plugins, and generates shared settings. Includes Obsidian vault integration for browsable knowledge management. 19 skills and 7 agents.
+[cogni-workspace](cogni-workspace/README.md) is the horizontal layer every other plugin builds on. It manages the shared foundation — environment variables, MCP server installation, theme management, plugin discovery, and workspace health. Runs dependency checks, discovers installed plugins, and generates shared settings. Includes Obsidian vault integration for browsable knowledge management. 26 skills and 26 agents.
 
 > "Initialize my insight-wave workspace and check plugin health"
 
@@ -213,9 +213,9 @@ Plugins follow the [Claude Code plugin standard](https://code.claude.com/docs/en
 | [cogni-marketing](cogni-marketing/README.md) | Content Production | 11 | 3 | B2B marketing content engine — 16 formats across thought leadership, demand gen, lead gen, sales enablement, ABM |
 | [cogni-sales](cogni-sales/README.md) | Sales Pitches | 1 | 4 | Corporate Visions Why Change pitch generation for named customers or market segments |
 | [cogni-website](cogni-website/README.md) | Website Generation | 6 | 3 | Multi-page customer websites from portfolio, marketing, and research content with shared navigation and theming |
-| [cogni-workspace](cogni-workspace/README.md) | Workspace Infrastructure | 19 | 7 | Shared foundation — env vars, MCP installation, theme management, plugin discovery, workspace health, Obsidian integration, bundled wiki, claim verification, story-arc narrative, executive copywriting, and slide/infographic/storyboard/web rendering |
+| [cogni-workspace](cogni-workspace/README.md) | Workspace Infrastructure | 26 | 26 | Shared foundation — env vars, MCP installation, theme management, plugin discovery, workspace health, Obsidian integration, bundled wiki, claim verification, story-arc narrative, executive copywriting, and slide/infographic/storyboard/web rendering |
 
-**97 skills, 69 agents** across the 8 active plugins.
+**104 skills, 88 agents** across the 8 active plugins.
 
 See [Cross-Plugin Data Flow](docs/er-diagram.md) for how data flows between plugins, or browse the [full documentation](docs/ecosystem-overview.md).
 


### PR DESCRIPTION
Closes #1605.

## Summary
- `README.md` cogni-workspace prose paragraph (under `### Workspace Infrastructure`): `19 skills and 7 agents.` -> `26 skills and 26 agents.`
- `## Plugins at a glance` cogni-workspace row: `| 19 | 7 |` -> `| 26 | 26 |`.
- Rollup sentence re-derived from the corrected column sums (not pinned to a literal): `**97 skills, 69 agents**` -> `**104 skills, 88 agents**` — skills 21+9+9+21+11+1+6+26 = 104, agents 16+4+12+20+3+4+3+26 = 88.

## Scope decisions
- **Included:** the three stale surfaces in `README.md`, which move together. The old rollup 97/69 is the exact column sum of the stale table, so correcting the row without recomputing the rollup would restate the same understatement as a headline number.
- **The recount was applied to all eight roster plugins (AC 5), not just cogni-workspace.** cogni-knowledge 21/16, cogni-consult 9/4, cogni-trends 9/12, cogni-portfolio 21/20, cogni-marketing 11/3, cogni-sales 1/4, cogni-website 6/3 were each re-derived from the live tree at the merge base and already agree — in both their prose paragraph and their glance row — so they are a verified zero-line diff, not an unchecked assumption.
- **Excluded — no other surface carries these figures.** `git grep -n -E '19 skills and 7 agents'` returns exactly one hit tree-wide (`README.md`); `CONTRIBUTING.md`, `CLAUDE.md` and `docs/**` were checked individually and carry none. No follow-up issue is warranted, so this closes the issue outright.
- **Excluded by construction:** the diff touches no file under any plugin tree (`cogni-*/**`), nor `docs/**`, `wiki/**`, `assets/**`, `.claude-plugin/**`, and no `plugin.json` (the version bump is owned by the post-merge workflow).
- **Untouched on purpose:** the plugin-*count* figures — `8 Apache-2.0 plugins`, `8 plugins organized around eight capability areas`, `(8 plugins)`, and the rollup's trailing `across the 8 active plugins.` — are a different metric settled by #1551. The #1552 taxonomy (the `### ` heading set and order, and the `Capability` column values) is byte-identical.
- **Two regression vectors avoided** by editing the three sites by hand rather than running a plural-shaped find-and-replace: cogni-sales uses the singular `1 skill and 4 agents` (a plural regex either misses it or regresses it to `1 skills`), and the cogni-portfolio paragraph carries a second, already-correct count clause (`21 skills handle the full positioning lifecycle...`) besides its closing `21 skills and 20 agents.`
- **Anchoring:** every edit is anchored on file content, never on a line number — the line numbers cited in the issue body (`:84` / `:224` / `:226`) are stale against the merge base, where the real sites are 18 / 216 / 218.

## Base moved mid-plan
The plan was validated against `origin/main` = `9641d935`; the branch forked from `e662dbdb` after #1612 merged during planning. Re-validated before editing: #1612 touched only `docs/**`, `README.md` is byte-identical across the move, all three anchors and all five guard strings still occur exactly once, and every live count is unchanged. The plan held without amendment.

## Test plan — all executed, all green
The rollup falsifier is **not green at base**: the awk column sum prints `97 69` at the merge base and `104 88` on this branch, so it genuinely grades the change rather than passing either way.

- [x] `git diff --name-only origin/main...HEAD` prints exactly `README.md` and nothing else.
- [x] `grep -cF '19 skills and 7 agents' README.md` -> `0`.
- [x] `grep -cF '26 skills and 26 agents' README.md` -> `1`, in the cogni-workspace paragraph under `### Workspace Infrastructure`.
- [x] `grep -cF '| [cogni-workspace](cogni-workspace/README.md) | Workspace Infrastructure | 26 | 26 |' README.md` -> `1`.
- [x] `grep -cF '**104 skills, 88 agents** across the 8 active plugins.' README.md` -> `1`.
- [x] Rollup equals the column sums, re-derived rather than trusted: `awk -F'|' '/^\| \[cogni-/ {s+=$4; a+=$5} END {print s, a}' README.md` -> `104 88` (and `97 69` at base). The pattern matches exactly the 8 data rows and nothing else.
- [x] Every row equals the live tree: for each `plugins[].name` in `.claude-plugin/marketplace.json`, the `Skills`/`Agents` cells match `git ls-tree` counts of `<name>/skills/*/SKILL.md` and `<name>/agents/*.md` — 21/16, 9/4, 9/12, 21/20, 11/3, 1/4, 6/3, 26/26. All eight pass.
- [x] Singular not regressed: `grep -cF '1 skill and 4 agents' README.md` -> `1`, and `grep -cE '(^|[^0-9])1 skills' README.md` -> `0` (digit-boundary anchored, so `21 skills` correctly does not trip it).
- [x] cogni-portfolio's second clause survives: `grep -cF '21 skills handle the full positioning lifecycle' README.md` -> `1`.
- [x] Taxonomy undisturbed: `git diff -U0 -- README.md | grep -cE '^[+-]### '` -> `0`, and the `### ` heading count is 14 on both sides.
- [x] Plugin-count figures undisturbed: `8 Apache-2.0 plugins`, `8 plugins organized around eight capability areas` and `across the 8 active plugins.` each still occur exactly once.
- [x] The cogni-workspace row's literal em dash (U+2014) survives the cell-scoped edit.
- [x] Diff size sanity: `git diff --numstat` -> `3	3	README.md`.

## Reviewer note — instrument coverage
No deterministic repo gate adjudicates a README count, and `check-preflight.sh` skips every instrument on a repo-level, docs-only touched set. Grading here is a static read plus re-derivation; a green, instrument-free preflight is **not** evidence the numbers are right. The awk column-sum check above is the one falsifier that actually distinguishes base from branch.