### PR TITLE
cogni-consult: fix retired-plugin route example + add guard

### DIFF
--- a/cogni-consult/skills/consult-action-fields/SKILL.md
+++ b/cogni-consult/skills/consult-action-fields/SKILL.md
@@ -114,7 +114,7 @@ deliverables in manifest order:
 | portfolio-fit | — (keine Deliverables geplant) | | | |
 | go-to-market | ⚠ field.json nicht lesbar (siehe Warnungen) | | | |
 
-Route: gtm-onepager · cogni-visual
+Route: gtm-onepager · narrative-adapt
 ```
 
 That is a German session. `Deliverable` and `Framework` are the same token in
@@ -128,7 +128,7 @@ cased per `references/user-facing-output.md` (c) note 4. A `complete` or
 `Route` is not a column: when a deliverable's `producing_route` differs from
 the default `consult-design-thinking`, note it beneath the table, never a
 sixth cell: `Route: <deliverable> · <producing_route>`, e.g.
-`Route: gtm-onepager · cogni-visual`.
+`Route: gtm-onepager · narrative-adapt`.
 
 An English session renders the same table: header
 `| Action field | Deliverable | Status | Framework | Persona review |`, values
@@ -194,8 +194,9 @@ field's `field.json` once, appending all agreed entries, each shaped:
 
 `producing_route` names the skill that will produce the deliverable —
 default `consult-design-thinking`; use another route only when the
-consultant names one (e.g. a direct `cogni-visual` export of an existing
-artifact). `persona_review` tracks the acting-persona challenge pass:
+consultant names one (e.g. a direct `narrative-adapt` one-pager built
+from an existing artifact). `persona_review` tracks the acting-persona
+challenge pass:
 `pending` → `in-progress` → `complete`. Both fields are manifest metadata —
 recommend the route, never dispatch it from here. `chosen_framework` records
 the deliverable's structuring framework and is selected per
@@ -241,10 +242,9 @@ Two skips keep the auto-wire safe and silent:
   silently — there is no gate target.
 
 The auto-wired edge is the same `{action_field, deliverable}` coordinate as any
-other dependency below (no new schema, no new field type — a field is a solution
-field positionally, by its slug), and it is covered by the same `validate`
-mandate at the end of this step — run the validator once after planning, not a
-second time for the auto-wire.
+other dependency below (no new schema, no new field type), and it is covered by
+the same `validate` mandate at the end of this step — run the validator once
+after planning, not a second time for the auto-wire.
 
 Write the auto-wired edge once, when the solution field's deliverables are first
 planned. On a re-run over an already-planned solution field, if a deliverable
@@ -290,11 +290,11 @@ declarations. Do not close the session with an unresolved `validate` failure
 when dependencies were declared this session.
 
 When planning surfaces a research-heavy deliverable, note that its evidence
-will run through the engagement's bound knowledge base per
-`$CLAUDE_PLUGIN_ROOT/references/research-routing.md`, with syntheses landing
-in this field's `research/` directory
-(`action-fields/<field-slug>/research/<topic-slug>.md`) — the producing
-route reads them from there.
+runs through the engagement's bound knowledge base per
+`$CLAUDE_PLUGIN_ROOT/references/research-routing.md` — never raw web search —
+with syntheses landing in this field's `research/` directory
+(`action-fields/<field-slug>/research/<topic-slug>.md`), which the producing
+route reads.
 
 Removing or renaming a deliverable is also an `Edit` of `field.json` — but
 never silently drop an entry whose `state` is not `pending`; started work is
@@ -391,7 +391,5 @@ markdown artifact lands under the field directory either way.
   survive; root `updated` changes only when `action_fields[]` itself does.
 - **Slug discipline**: `action_fields[]` holds kebab-case slug strings only —
   `engagement-status.sh` rejects non-string entries as malformed.
-- **Research routing**: deliverable research always runs through the
-  engagement's bound knowledge base per
-  `$CLAUDE_PLUGIN_ROOT/references/research-routing.md` — never raw web
-  search; this skill plans the work, the producing route runs the research.
+- **Research routing**: this skill plans the work; the producing route runs
+  the research through the bound knowledge base (step 4).

--- a/cogni-consult/tests/test_route_example_hygiene.sh
+++ b/cogni-consult/tests/test_route_example_hygiene.sh
@@ -10,12 +10,15 @@
 # colon: `PASS: goes-red: ...` would match neither pattern, and a recipe
 # recorded against this suite would return case_not_found instead of a verdict.
 #
-# Which mutation reddens which case:
+# Which mutation reddens which case. The recorded recipe in the pull request
+# drives the second one; the retired name it substitutes is deliberately not
+# spelled here, so this file introduces no new mention of a retired plugin.
 #   route-examples-found         deleting both `Route:` example lines
-#   route-example-slug-resolves  s/narrative-adapt/cogni-visual/g  (the recorded recipe)
-#   route-example-non-default    s/narrative-adapt/consult-design-thinking/g
+#   route-example-slug-resolves  rewriting the route token to any prefix listed
+#                                in scripts/retired-plugins.json (the recorded recipe)
+#   route-example-non-default    rewriting the route token to consult-design-thinking
 #   route-example-parity         changing the route token at one site only
-#   no-retired-plugin-name       reintroducing any prefix from retired-plugins.json
+#   no-retired-plugin-name       planting any retired prefix in a skill body
 #
 # RELATIONSHIP TO scripts/check-external-dispatch.py. That repo-level guard reads
 # the SAME registry and already scans this subject file, so this suite is not a

--- a/cogni-consult/tests/test_route_example_hygiene.sh
+++ b/cogni-consult/tests/test_route_example_hygiene.sh
@@ -1,0 +1,208 @@
+#!/usr/bin/env bash
+# Guard: the `Route:` worked examples in consult-action-fields name a real,
+# live skill slug — never a plugin name, never a retired one, never the default.
+#
+# Label vocabulary is the shape every suite in this directory carries. The
+# shared mutation harness classifies a case by matching `FAIL: <case>` (red) and
+# `ok: <case>` / `PASS: <case>` (green), each requiring whitespace or
+# end-of-line immediately after the case token. So a case id is a single
+# whitespace-free token and any detail is separated with " - ", never a glued
+# colon: `PASS: goes-red: ...` would match neither pattern, and a recipe
+# recorded against this suite would return case_not_found instead of a verdict.
+#
+# Which mutation reddens which case:
+#   route-examples-found         deleting both `Route:` example lines
+#   route-example-slug-resolves  s/narrative-adapt/cogni-visual/g  (the recorded recipe)
+#   route-example-non-default    s/narrative-adapt/consult-design-thinking/g
+#   route-example-parity         changing the route token at one site only
+#   no-retired-plugin-name       reintroducing any prefix from retired-plugins.json
+#
+# RELATIONSHIP TO scripts/check-external-dispatch.py. That repo-level guard reads
+# the SAME registry and already scans this subject file, so this suite is not a
+# second copy of it — it fills a gap the colon in that guard's pattern leaves
+# open. It compiles `\b(?:<prefix>):`, matching only colon-bearing dispatch
+# tokens, because the colon is what separates a dispatch from a noun or a
+# filesystem path; widening it to bare names would flag ~100 legitimate prose
+# and path mentions repo-wide. The discriminator between "retired plugin named
+# as a route" and "retired plugin name used as a directory" only exists near the
+# site, which is why this half of the property is guarded per-plugin here rather
+# than repo-wide there.
+#
+# THE PREFIX FILTER MIRRORS THAT GUARD'S load_registry CONTRACT deliberately.
+# A colon-bearing entry would pass a bare truthiness filter and then be handed to
+# a `grep` that could never match the bare-name form this case exists for — case
+# 5 would keep printing PASS while guarding nothing. Rejecting those entries here
+# keeps the vacuity visible rather than silent.
+#
+# EXTRACTION SCOPE. The extraction class deliberately excludes `<` and `>`, so
+# the placeholder shape line `Route: <deliverable> · <producing_route>` is NOT
+# collected. Widening the class to admit it would make the resolution case
+# permanently red against correct text, since a placeholder resolves nowhere.
+#
+# THE TWO FIELDS ARE NOT THE SAME KIND OF TOKEN. Each example is
+# `<deliverable> · <producing_route>`; only the SECOND field is a skill slug.
+# The first is a deliverable id — `gtm-onepager` resolves to no
+# `*/skills/gtm-onepager/SKILL.md` anywhere — so cases 2 and 3 key on the second
+# field alone. A case resolving both tokens would be red even after a correct
+# fix, and this guard would block its own change.
+#
+# RESOLUTION IS MARKETPLACE-ANCHORED ON PURPOSE. Case 2 resolves a slug against
+# the plugins the manifest lists, not against whatever `*/skills/` trees happen
+# to sit on disk. "Published" is the stronger claim and the one a reader of the
+# example depends on: a route naming a real directory in an unlisted tree is
+# still a route nobody can run. Do not simplify it to a glob.
+#
+# SCOPE OF EACH CASE. Cases 1-4 pin the `Route:` note, which is defined in one
+# file, so they key on that file. Case 5's predicate is plugin-wide — a retired
+# name is wrong in any skill body — so it scans every skill in the plugin.
+#
+# Each case below is gated only on its OWN predicate and emits exactly one
+# result line per run, so every `FAIL` arm has a reachable same-id green twin
+# (cogni-knowledge/tests/README.md rule 7). Cases that iterate accumulate a
+# per-case flag and report after the loop rather than emitting per iteration.
+
+set -u
+
+TESTS_DIR="$(cd "$(dirname "$0")" && pwd)"
+PLUGIN_DIR="$(cd "$TESTS_DIR/.." && pwd)"
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --root) PLUGIN_DIR="$2"; shift 2 ;;
+    *) echo "unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+REPO_ROOT="$(cd "$PLUGIN_DIR/.." && pwd)"
+SUBJECT="$PLUGIN_DIR/skills/consult-action-fields/SKILL.md"
+MARKETPLACE="$REPO_ROOT/.claude-plugin/marketplace.json"
+RETIRED="$REPO_ROOT/scripts/retired-plugins.json"
+
+failures=0
+pass() { printf 'PASS: %s\n' "$1"; }
+fail() { printf 'FAIL: %s - %s\n' "$1" "$2" >&2; failures=$((failures + 1)); }
+
+# The separator is U+00B7 MIDDLE DOT, matching the table cells it sits beside.
+examples="$(grep -o 'Route: [A-Za-z0-9._-]* · [A-Za-z0-9._-]*' "$SUBJECT" 2>/dev/null || true)"
+example_count="$(printf '%s\n' "$examples" | grep -c .)"
+
+# Second field of each example — the producing_route slug.
+route_tokens="$(printf '%s\n' "$examples" | sed 's/.* · //')"
+
+# --- case 1: route-examples-found --------------------------------------------
+# A vacuous scan must never read as success: with nothing extracted, cases 2-4
+# would each pass by checking an empty set.
+if [ "$example_count" -ge 2 ]; then
+  pass "route-examples-found"
+else
+  fail "route-examples-found" "expected at least 2 Route: examples in $SUBJECT, found $example_count (vacuous scan)"
+fi
+
+# --- case 2: route-example-slug-resolves -------------------------------------
+# Every route token resolves to a real skill under a marketplace-listed plugin.
+plugin_dirs="$(python3 -c '
+import json, sys
+with open(sys.argv[1], encoding="utf-8") as fh:
+    data = json.load(fh)
+for entry in data.get("plugins", []):
+    source = entry.get("source")
+    if not isinstance(source, str):
+        continue
+    cleaned = source.strip()
+    if cleaned.startswith("./"):
+        cleaned = cleaned[2:]
+    cleaned = cleaned.rstrip("/")
+    # Reject anything the repo-relative join below could not honour.
+    if not cleaned or cleaned.startswith("/") or ":" in cleaned or ".." in cleaned:
+        continue
+    print(cleaned)
+' "$MARKETPLACE" 2>/dev/null || true)"
+
+if [ -z "$plugin_dirs" ]; then
+  fail "route-example-slug-resolves" "no usable plugins[].source entries readable from $MARKETPLACE"
+else
+  unresolved=""
+  for token in $route_tokens; do
+    found=0
+    for plugin in $plugin_dirs; do
+      if [ -f "$REPO_ROOT/$plugin/skills/$token/SKILL.md" ]; then
+        found=1
+        break
+      fi
+    done
+    [ "$found" -eq 1 ] || unresolved="$unresolved $token"
+  done
+  if [ -n "$unresolved" ]; then
+    fail "route-example-slug-resolves" "route token(s) resolve to no */skills/<slug>/SKILL.md under any marketplace-listed plugin:$unresolved"
+  else
+    pass "route-example-slug-resolves"
+  fi
+fi
+
+# --- case 3: route-example-non-default ---------------------------------------
+# The Route: note is written only when producing_route DIFFERS from the default,
+# so an example naming the default contradicts its own stated precondition.
+defaulted=""
+for token in $route_tokens; do
+  [ "$token" = "consult-design-thinking" ] && defaulted="$defaulted $token"
+done
+if [ -n "$defaulted" ]; then
+  fail "route-example-non-default" "Route: example names the default producing_route, which the note's own precondition excludes:$defaulted"
+else
+  pass "route-example-non-default"
+fi
+
+# --- case 4: route-example-parity --------------------------------------------
+# The German render and the English convention example are defined as the same
+# unlocalized Route: note line, so every extracted example must be identical.
+# `-le 1` not `-eq 1`: an empty set is case 1's finding to report, not this one's.
+if [ "$(printf '%s\n' "$examples" | sort -u | grep -c .)" -le 1 ]; then
+  pass "route-example-parity"
+else
+  fail "route-example-parity" "Route: examples diverge; every occurrence must render identically to '$(printf '%s\n' "$examples" | head -n 1)'"
+fi
+
+# --- case 5: no-retired-plugin-name ------------------------------------------
+# No retired plugin prefix may appear in any skill body in this plugin, in a
+# Route: note or in prose. An unreadable, empty, or malformed registry fails
+# rather than passing silently.
+retired_prefixes="$(python3 -c '
+import json, sys
+with open(sys.argv[1], encoding="utf-8") as fh:
+    data = json.load(fh)
+prefixes = data.get("retired_prefixes")
+if not isinstance(prefixes, list):
+    sys.exit(1)
+for prefix in prefixes:
+    # Mirrors load_registry in scripts/check-external-dispatch.py: a blank,
+    # padded, or colon-bearing entry cannot match the bare-name form this case
+    # checks, so dropping it silently would make the case vacuous.
+    if not isinstance(prefix, str) or not prefix.strip():
+        sys.exit(1)
+    if prefix != prefix.strip() or ":" in prefix:
+        sys.exit(1)
+    print(prefix)
+' "$RETIRED" 2>/dev/null || true)"
+
+skill_bodies="$(find "$PLUGIN_DIR/skills" -name SKILL.md -type f 2>/dev/null | sort)"
+
+if [ -z "$retired_prefixes" ]; then
+  fail "no-retired-plugin-name" "no usable retired_prefixes[] readable from $RETIRED (vacuous scan)"
+elif [ -z "$skill_bodies" ]; then
+  fail "no-retired-plugin-name" "no SKILL.md found under $PLUGIN_DIR/skills (vacuous scan)"
+else
+  present=""
+  for prefix in $retired_prefixes; do
+    hits="$(printf '%s\n' "$skill_bodies" | while IFS= read -r body; do
+      grep -l -- "$prefix" "$body" 2>/dev/null || true
+    done)"
+    [ -n "$hits" ] && present="$present $prefix"
+  done
+  if [ -n "$present" ]; then
+    fail "no-retired-plugin-name" "retired plugin prefix(es) present in a $PLUGIN_DIR skill body:$present"
+  else
+    pass "no-retired-plugin-name"
+  fi
+fi
+
+[ "$failures" = "0" ]


### PR DESCRIPTION
Closes #1609.

## Summary
- `cogni-consult/skills/consult-action-fields/SKILL.md`: the three sites that presented the **retired** plugin `cogni-visual` as a `producing_route` value — `:117` (fenced German render), `:131` (English convention example), `:197` (contract prose) — now name the live skill slug `narrative-adapt`. It is a **bare slug**, never a `<plugin>:<skill>` dispatch token: this file records and recommends the route and never dispatches it. Those three were the only occurrences of any retired prefix in the file.
- `narrative-adapt` resolves at `cogni-workspace/skills/narrative-adapt/SKILL.md` under the marketplace-listed `cogni-workspace` plugin, and documents `--format one-pager`, so the `gtm-onepager` worked example stays coherent and the value stays non-default (the `Route:` note is written only when `producing_route` differs from `consult-design-thinking`).
- `:117` and `:131` carry a byte-identical `Route: gtm-onepager · narrative-adapt`, U+00B7 separator intact, preserving the unlocalized-parity contract the file states at `:137`.
- New guard `cogni-consult/tests/test_route_example_hygiene.sh`, auto-discovered by `scripts/run-plugin-tests.py`'s `*/tests/*.sh` glob and therefore run by the `plugin-test-suites` CI job. Five cases, each mutation-falsifiable — see the recipe below.

## Scope decisions
- **In scope:** the three sites, plus one regression guard. Nothing today catches a retired plugin name re-entering a `Route:` example — `scripts/check-external-dispatch.py` compiles `\b(?:<prefix>):`, so it matches only **colon-bearing** dispatch tokens and cannot see these bare-name sites; no existing fixture exercises a non-default `producing_route`.
- **The guard resolves only the route field.** Each example is `<deliverable> · <producing_route>`; only the second field is a skill slug. `gtm-onepager` is a deliverable id that resolves to no `skills/` tree anywhere, so a case resolving both tokens would be red even after a correct fix — the guard would have blocked its own PR. Cases 2 and 3 key on the second field alone.
- **Case 5 is plugin-scoped, cases 1-4 are file-scoped.** The `Route:` note is defined in one file, so its cases key on that file. "No retired plugin name" is a plugin-wide property, so case 5 scans every `skills/**/SKILL.md` in cogni-consult (green today, and falsifiable — planting a retired name in a *different* skill reddens it).
- **Widening `check-external-dispatch.py` to bare names was considered and rejected**, measured rather than assumed: dropping its mandatory colon produces **101 new hit lines across 34 files**, essentially all legitimate — `cogni-claims/claims.json` is a live on-disk path threaded through five skills, `${CLAUDE_PLUGIN_ROOT}/wiki/...` is a bundled config dir, and the rest is absorption history. The colon is the guard's entire semantic (dispatch token vs. noun/path). Widening would need ~100 allow-markers and would convert a guard whose docstring explicitly rejects the ratchet model into exactly that. The defect class is repo-wide but the discriminator is not, so a plugin-scoped guard is the right shape.
- **Out of scope, deliberately untouched:** `.claude-plugin/marketplace.json`; `cogni-consult/references/data-model.md` (the fix conforms to its definition rather than amending it); and `scripts/retired-plugins.json` — it already lists `cogni-visual`, so editing it would be a vacuous remedy and is **not** claimed as the fix here. See "Known non-change" below.
- **Which AC arm:** arm 1 (a real skill slug) over arm 2 (route-agnostic rewrite). `:117` is a *literal rendered-output* sample; a placeholder there — or deleting the `Route:` line from both sites — would strip the only worked example of a non-default route and make the parity contract at `:137` vacuous. The cost of arm 1 is a maintainer confirmation, recorded under **Open questions**.
- No `plugin.json` version line is touched: the patch bump is applied post-merge.
- Behaviour is unchanged: `producing_route` is still manifest metadata this skill records and recommends, never dispatches.

## Prose-simplify pass
The unit sits at ~90% of its complexity-scaled cap, so the net-growth budget applied and the fix had grown it (19079 → 19099 chars). A prose pass folded two genuine restatements to land at **18930**, below base:
- the solution-field-by-slug parenthetical in the auto-wire recap — the operative definition survives at `:219-220` ("any field whose slug is **not** `diagnostic-as-is`");
- the research-routing rule, stated twice — "never raw web search" and its `$CLAUDE_PLUGIN_ROOT/references/research-routing.md` pointer are now stated once at the step-4 point of use, with the Important Notes bullet reduced to the plans-vs-runs ownership line.

Both folds were verified to drop no instruction.

## Review notes
Two **pre-existing** path-form inconsistencies were flagged by the skill-quality review on lines this diff does not touch. They are `introduced_by_change: false` and `category: preference`, and are **annotated rather than fixed**, to keep an unrelated cleanup from riding along inside a focused three-token change:
- `:126` writes `references/user-facing-output.md` bare, while `:51` and `:55` prefix the same file with `$CLAUDE_PLUGIN_ROOT/`. Mildly load-bearing, because this skill also uses genuinely engagement-relative paths, so a bare `references/...` reads as resolvable against the engagement directory.
- `:148` names `deliverable-graph.py <engagement-dir> refresh-order` without interpreter or path, while `:284` and `:336` use the full `python3 $CLAUDE_PLUGIN_ROOT/scripts/deliverable-graph.py` form.

Two findings from the author's own contract self-grade were **fixed** rather than annotated, since both were mechanical and landed in files this change already touches:
- the recorded mutation recipe was not replayable as written — `--file` is resolved relative to `--root`, so the recorded `cogni-consult/skills/…` became `cogni-consult/cogni-consult/skills/…` and died at exit 2. Corrected to the root-relative form and re-verified by replay.
- the new guard's header comment spelled the literal retired name while documenting its own falsifying mutation, which tripped the contract's "no new `cogni-visual` mention anywhere in the diff" item. The comment now refers to `scripts/retired-plugins.json` instead, so neither changed file contains the token.

## Instrument coverage note
`check-preflight.sh` returned clean, but two of its arms were **structurally inert against this repo** and that is worth stating rather than reading as coverage: `run-tests` skipped with `no_suites_at_base` and `mutation-recipe` skipped with `not_applicable`, both because the cogni-service instruments glob `*/tests/test-*.sh` (hyphen) while every suite in this repo — all 12 in cogni-consult, and the new one — is named `test_*.sh` (underscore). So neither the test suites nor the recorded recipe were machine-validated by that gate. Both were verified by hand instead: `python3 scripts/run-plugin-tests.py` is 134/134, and the recipe above was replayed to `guard_verified`.

## Known non-change
`scripts/retired-plugins.json`'s `_comment` says its prefixes are "read by scripts/check-external-dispatch.py". With this PR a second reader exists (the new suite's case 5). The comment's operative instruction — "to retire another plugin, add its prefix here, that is the whole change" — remains true, since both readers pick it up automatically. The file is left out of this diff deliberately rather than re-touched; the new suite's header documents the relationship from the other direction.

## Test plan
- [x] `grep -n 'cogni-visual' cogni-consult/skills/consult-action-fields/SKILL.md` prints nothing.
- [x] `:117` and `:131` carry the byte-identical `Route: gtm-onepager · narrative-adapt`; separator verified as U+00B7.
- [x] `cogni-workspace/skills/narrative-adapt/SKILL.md` exists and `cogni-workspace` is in `.claude-plugin/marketplace.json` `plugins[]`.
- [x] `bash cogni-consult/tests/test_route_example_hygiene.sh` exits 0 with five `PASS:` lines.
- [x] `python3 scripts/run-plugin-tests.py` — **134/134 suites pass** (was 133 at base; the new suite is discovered).
- [x] `python3 scripts/check-result-line-plainness.py`, `check-case-id-pairing.py`, `check-external-dispatch.py` all exit 0.
- [x] Each of the five cases verified RED under its own mutation and GREEN after restore.

## Mutation recipe

```
bash ~/.claude/plugins/marketplaces/managed-service/cogni-service/scripts/mutation-check.sh --root cogni-consult --file skills/consult-action-fields/SKILL.md --expr 's/narrative-adapt/cogni-visual/g' --test 'bash tests/test_route_example_hygiene.sh' --case route-example-slug-resolves
```

Replay from the repository root. `--file` is resolved **relative to `--root`** (`mutation-check.sh:202-203` joins them), so it is `skills/…`, not `cogni-consult/skills/…`. `--test` runs with cwd=`cogni-consult`, and the suite self-locates from `$0`, so the root-relative `tests/…` path resolves and `REPO_ROOT` still reaches `.claude-plugin/marketplace.json`. Verified by replay: `verdict: guard_verified`, `mutated_result: red`, `restored_result: green`. The mutation reverts all three sites to the retired name; `route-example-slug-resolves` then goes RED because `cogni-visual` resolves to no `*/skills/<slug>/SKILL.md` under any marketplace-listed plugin, and GREEN again after restore.

The other four cases were verified the same way: `route-example-non-default` under `s/narrative-adapt/consult-design-thinking/g`; `route-example-parity` by changing the route token at one site only; `route-examples-found` by removing both example lines; `no-retired-plugin-name` by planting a retired name in a different skill in the plugin.

## Follow-up issues
- #1617 — `cogni-consult/README.md:236` lists `cogni-visual` as a deliverable export route. Same defect class, same plugin, but explicitly outside this issue's scope of `skills/consult-action-fields/SKILL.md`, and outside the new guard's reach (a plugin-root README is under neither `check-external-dispatch.py`'s dispatch-colon pattern nor case 5's `skills/**` scan). Filed as sibling work rather than folded in.

## Open questions
- **Confirm the replacement route slug.** `cogni-visual` is retired with no tree, so no successor is derivable mechanically — the issue flags this as a maintainer decision. This PR ships `narrative-adapt` because it is the only verified candidate whose own SKILL.md documents *both* a one-pager output and adaptation of an **existing** artifact, matching the `gtm-onepager` example and the `:197` phrasing simultaneously. Verified alternatives, judged weaker fits: `story-to-web` (a direct successor of a retired cogni-visual skill, but web output rather than a one-pager), `cogni-marketing/sales-enablement` (supports `one-pager`, but pulls a consulting deliverable into the marketing plugin), `cogni-workspace/copywriter`. If a different route is intended it is a one-token swap at three sites, and the new guard verifies any replacement resolves.

## Operational disclosure
The runner's token is a `gho_` GitHub CLI OAuth token, whose scope set (`gist, read:org, repo, workflow`) is fixed by the CLI's OAuth app and cannot be narrowed. `check-token-scope.sh --strict` therefore reports `over_scoped` with `workflow` forbidden; the run took the script's own sanctioned `--allow-overscoped` flag (never the environment variable) to proceed. Disclosed here rather than left in a session log.
