### PR TITLE
wiki: correct the roster count across both trees

### DIFF
--- a/cogni-workspace/references/wiki-tree-reconciliation.md
+++ b/cogni-workspace/references/wiki-tree-reconciliation.md
@@ -493,13 +493,20 @@ table, this file becomes generated output and the guard question reopens on the 
 
 ## Observed, out of scope here
 
-Two current-state documents still assert an `11-plugin` roster: `cogni-workspace/wiki/wiki/pages/
-ecosystem-overview.md:13` and `wiki/wiki/index.md:9`. Neither is corrected here, and for different
-reasons. `ecosystem-overview` sits in the two-tree intersection, so a one-sided edit would break the
-byte-identity Decision 3 records across the shared pages. `wiki/index.md` is a tree-level page whose
-root twin lies outside this record's editable surface. Both belong to the repo-wide roster-count
-class already tracked against the root `CLAUDE.md`, not to the bundled-only sweep, so they are named
-here rather than re-filed.
+Four current-state documents asserted an `11-plugin` roster, not the two this section first named.
+The original pair cited one copy of each page and not its twin — the bundled
+`ecosystem-overview.md:13` and the root `index.md:9` — leaving the root `ecosystem-overview` copy
+and the bundled `index.md` copy unrecorded. None of the four was corrected by this record's own
+sweep, for the reasons given at the time: `ecosystem-overview` sits in the two-tree intersection,
+so a one-sided edit would break the byte-identity Decision 3 records across the shared pages, and
+`index.md` is a tree-level page whose root twin lay outside this record's editable surface.
+
+The class is now closed. All four sites were re-derived to `8-plugin` against
+`.claude-plugin/marketplace.json` in one change that edits both trees symmetrically, so the
+`ecosystem-overview` pair stays byte-identical and the substantive residual stays at the 11 lines
+Decision 2 records. The two `index.md` copies are edited on both sides and still differ from each
+other, so Decision 3's group-C divergence is preserved. The statement in the next section that no
+tree-level file is edited describes this record's own sweep, not every later change.
 
 ## Deliberately left standing
 

--- a/cogni-workspace/wiki/wiki/index.md
+++ b/cogni-workspace/wiki/wiki/index.md
@@ -6,7 +6,7 @@ This is the content catalog for **insight-wave**. Every wiki page is listed here
 
 ### Ecosystem
 
-- [[ecosystem-overview]] — insight-wave is an 11-plugin monorepo for consulting, sales, and marketing on Claude Code, Apache-2.0.
+- [[ecosystem-overview]] — insight-wave is an 8-plugin monorepo for consulting, sales, and marketing on Claude Code, Apache-2.0.
 - [[ecosystem-plugin-selection]] — Which plugin handles my task: the task-to-plugin routing table, what each plugin owns, and where to read more.
 - [[ecosystem-command-reference]] — How each plugin is invoked: the slash commands that exist, the skills behind them, and the naming patterns that make the list predictable.
 

--- a/cogni-workspace/wiki/wiki/pages/arch-plugin-anatomy.md
+++ b/cogni-workspace/wiki/wiki/pages/arch-plugin-anatomy.md
@@ -29,7 +29,7 @@ How insight-wave plugins are structured on disk. Every plugin follows the same s
 └── README.md                     User-facing introduction
 ```
 
-Not every plugin uses every directory. cogni-marketing has no `scripts/`, only four plugins ship `hooks/`, cogni-workspace has `libraries/` alongside per-skill `references/`.
+Not every plugin uses every directory. cogni-marketing has no `scripts/`, only cogni-consult, cogni-portfolio and cogni-workspace ship `hooks/`, cogni-workspace has `libraries/` alongside per-skill `references/`.
 
 ## The four file kinds
 

--- a/cogni-workspace/wiki/wiki/pages/ecosystem-overview.md
+++ b/cogni-workspace/wiki/wiki/pages/ecosystem-overview.md
@@ -10,7 +10,7 @@ sources:
 status: stable
 ---
 
-insight-wave is an 11-plugin monorepo for consulting, sales, and marketing on Claude Code, Apache-2.0, with all plugins following the standard Claude Code plugin shape.
+insight-wave is an 8-plugin monorepo for consulting, sales, and marketing on Claude Code, Apache-2.0, with all plugins following the standard Claude Code plugin shape.
 
 ## Repository shape
 
@@ -28,7 +28,7 @@ Five conventions show up everywhere in the codebase:
 
 ## Plugin data flow
 
-Research output feeds the narrative and copywriting skills in [[plugin-cogni-workspace]], which in turn feed [[plugin-cogni-workspace]] rendering. [[plugin-cogni-trends]] and [[plugin-cogni-portfolio]] sit at the strategic core, dispatching to [[plugin-cogni-sales]] (Why Change pitches) and [[plugin-cogni-marketing]] (content engine). [[plugin-cogni-workspace]] is a foundational utility every plugin can rely on, and its claim verification cuts across every plugin that produces sourced assertions ([[concept-claims-propagation]], [[concept-claim-lifecycle]]). [[plugin-cogni-website]] assembles deployable static sites from upstream plugin output. The wiki engine running this very wiki is vendored inside cogni-knowledge. The trends ↔ portfolio bridge is the most complex bidirectional integration — see [[concept-trends-portfolio-bridge]].
+Research output — from cogni-knowledge bases, including the one each cogni-consult engagement binds at setup as its research spine — feeds the narrative and copywriting skills in [[plugin-cogni-workspace]], which in turn feed that same plugin's rendering skills. [[plugin-cogni-trends]] and [[plugin-cogni-portfolio]] sit at the strategic core, dispatching to [[plugin-cogni-sales]] (Why Change pitches) and [[plugin-cogni-marketing]] (content engine). [[plugin-cogni-workspace]] is a foundational utility every plugin can rely on, and its claim verification cuts across every plugin that produces sourced assertions ([[concept-claims-propagation]], [[concept-claim-lifecycle]]). [[plugin-cogni-website]] assembles deployable static sites from upstream plugin output. The wiki engine running this very wiki is vendored inside cogni-knowledge. The trends ↔ portfolio bridge is the most complex bidirectional integration — see [[concept-trends-portfolio-bridge]].
 
 ## Common workflows
 

--- a/wiki/wiki/index.md
+++ b/wiki/wiki/index.md
@@ -6,7 +6,7 @@ This is the content catalog for **insight-wave**. Every wiki page is listed here
 
 ### Ecosystem
 
-- [[ecosystem-overview]] — insight-wave is an 11-plugin monorepo for consulting, sales, and marketing on Claude Code, Apache-2.0.
+- [[ecosystem-overview]] — insight-wave is an 8-plugin monorepo for consulting, sales, and marketing on Claude Code, Apache-2.0.
 
 ### Architecture
 

--- a/wiki/wiki/pages/arch-plugin-anatomy.md
+++ b/wiki/wiki/pages/arch-plugin-anatomy.md
@@ -29,7 +29,7 @@ How insight-wave plugins are structured on disk. Every plugin follows the same s
 └── README.md                     User-facing introduction
 ```
 
-Not every plugin uses every directory. cogni-marketing has no `scripts/`, only four plugins ship `hooks/`, cogni-workspace has `libraries/` alongside per-skill `references/`.
+Not every plugin uses every directory. cogni-marketing has no `scripts/`, only cogni-consult, cogni-portfolio and cogni-workspace ship `hooks/`, cogni-workspace has `libraries/` alongside per-skill `references/`.
 
 ## The four file kinds
 

--- a/wiki/wiki/pages/ecosystem-overview.md
+++ b/wiki/wiki/pages/ecosystem-overview.md
@@ -10,7 +10,7 @@ sources:
 status: stable
 ---
 
-insight-wave is an 11-plugin monorepo for consulting, sales, and marketing on Claude Code, Apache-2.0, with all plugins following the standard Claude Code plugin shape.
+insight-wave is an 8-plugin monorepo for consulting, sales, and marketing on Claude Code, Apache-2.0, with all plugins following the standard Claude Code plugin shape.
 
 ## Repository shape
 
@@ -28,7 +28,7 @@ Five conventions show up everywhere in the codebase:
 
 ## Plugin data flow
 
-Research output feeds the narrative and copywriting skills in [[plugin-cogni-workspace]], which in turn feed [[plugin-cogni-workspace]] rendering. [[plugin-cogni-trends]] and [[plugin-cogni-portfolio]] sit at the strategic core, dispatching to [[plugin-cogni-sales]] (Why Change pitches) and [[plugin-cogni-marketing]] (content engine). [[plugin-cogni-workspace]] is a foundational utility every plugin can rely on, and its claim verification cuts across every plugin that produces sourced assertions ([[concept-claims-propagation]], [[concept-claim-lifecycle]]). [[plugin-cogni-website]] assembles deployable static sites from upstream plugin output. The wiki engine running this very wiki is vendored inside cogni-knowledge. The trends ↔ portfolio bridge is the most complex bidirectional integration — see [[concept-trends-portfolio-bridge]].
+Research output — from cogni-knowledge bases, including the one each cogni-consult engagement binds at setup as its research spine — feeds the narrative and copywriting skills in [[plugin-cogni-workspace]], which in turn feed that same plugin's rendering skills. [[plugin-cogni-trends]] and [[plugin-cogni-portfolio]] sit at the strategic core, dispatching to [[plugin-cogni-sales]] (Why Change pitches) and [[plugin-cogni-marketing]] (content engine). [[plugin-cogni-workspace]] is a foundational utility every plugin can rely on, and its claim verification cuts across every plugin that produces sourced assertions ([[concept-claims-propagation]], [[concept-claim-lifecycle]]). [[plugin-cogni-website]] assembles deployable static sites from upstream plugin output. The wiki engine running this very wiki is vendored inside cogni-knowledge. The trends ↔ portfolio bridge is the most complex bidirectional integration — see [[concept-trends-portfolio-bridge]].
 
 ## Common workflows
 


### PR DESCRIPTION
Closes #1558.

## Summary

Corrects the stale `11-plugin` roster assertion at all **four** current-state sites — `wiki/wiki/index.md:9`, `cogni-workspace/wiki/wiki/index.md:9`, `wiki/wiki/pages/ecosystem-overview.md:13`, `cogni-workspace/wiki/wiki/pages/ecosystem-overview.md:13` — to **8**, re-derived from `.claude-plugin/marketplace.json` `plugins[]` rather than pinned from prose.

Three further changes, each inside the same path boundary:

- **`arch-plugin-anatomy.md:32` (both trees)** — said ``only four plugins ship `hooks/` `` where exactly **three** do. Measured, not assumed: `cogni-consult/hooks/`, `cogni-portfolio/hooks/`, `cogni-workspace/hooks/` are the complete set. It now names the three instead of counting them, so it does not re-rot on the next roster change. The same line's other two claims were re-verified and are true, so both are left exactly as written.
- **`ecosystem-overview.md` `## Plugin data flow` (both trees)** — the doubled self-referential `[[plugin-cogni-workspace]] … which in turn feed [[plugin-cogni-workspace]] rendering` construction is gone, and cogni-consult is named for the first time (0 occurrences at base). Both cogni-consult and cogni-knowledge appear as **bare prose**, never wikilinks: no `plugin-cogni-consult.md` or `plugin-cogni-knowledge.md` exists in either tree, so a wikilink would dangle and red W4/W5. The page's wikilink count goes 12 → 11 and every surviving link still resolves.
- **`cogni-workspace/references/wiki-tree-reconciliation.md`** — its `## Observed, out of scope here` section named these exact occurrences as deliberately-not-corrected. This change makes that false, so the section is refreshed to record the class closed — and to record that it was **four** sites, not the two it originally named (it cited one copy of each page and not its twin).

## The AC4 / AC5 deviation — stated explicitly

**`scripts/release-bundle-wiki.sh` was NOT run, in any mode. The vendored edits were mirrored by hand.** This deviates from the issue's "`cogni-workspace/wiki/**` → produced by the script, never hand-edited" instruction and from AC4/AC5 as literally worded. It is not a shortcut — running the script is the destructive option here:

- A **bare** run is not a plain write. It runs a pre-sync destruction gate first, classifies pending changes into `would_delete` / `would_overwrite`, and on a non-empty set emits a failure envelope and **exits 1 writing nothing**. The standing destructive inventory is 10 paths, so a bare run is inert.
- **`--force`** skips that gate and would **delete the seven bundled-only pages Decision 4 holds** — work owned by open #1402 and #1440 — and overwrite both `log.md` copies and both `.cogni-wiki/config.json` files, which Decision 5 and Decision 1 forbid. The record's own `## Rejected alternative — run the sync script and accept the deletions` already settled this.
- **`--check` is not a gate**: it always exits 0 and only reports `changes_pending`, which was already **11** at base. Decision 2 documents that residual as expected and says verbatim *"Do not gate on `changes_pending`."*

So AC4's "no reported diff" and AC5's "reproducible by re-running the script" cannot both hold alongside AC2 and AC3. The satisfiable property — and what this PR delivers — is that **the substantive residual does not grow**: it is still exactly the 11 lines Decision 2 enumerates, with **no new line for `ecosystem-overview.md` or `arch-plugin-anatomy.md`**, because every shared-page edit landed identically on both sides.

## Evidence

All five guard suites green (they were green at base too — they are **regression guards here, not falsifiers**; the load-bearing falsifier is the count itself):

```
rc=0  cogni-workspace/tests/test-wiki-tree-parity.sh          All wiki-tree-parity tests passed. (12 cases)
rc=0  cogni-workspace/tests/test-wiki-bare-name-roster.sh     All wiki-bare-name-roster tests passed.
rc=0  cogni-workspace/tests/test-wiki-namespace-sync.sh       All wiki-namespace-sync tests passed.
rc=0  cogni-workspace/tests/test-layering-claim-reconciled.sh All layering-claim tests passed.
rc=0  tests/test_release_bundle_wiki.sh                       All release-bundle-wiki gate checks passed.
```

Mechanical checks at head:

- `rsync -anci --delete wiki/ cogni-workspace/wiki/` (attribute-only lines filtered) → **11 lines**, byte-for-byte the set Decision 2 enumerates: 7 `*deleting` for the Decision-4 pages, plus `.cogni-wiki/config.json`, `wiki/index.md`, `wiki/log.md`, `wiki/pages/lint-2026-04-20.md`. **0** lines mention `ecosystem-overview` or `arch-plugin-anatomy`.
- `cmp -s` silent on both shared pairs (`ecosystem-overview.md`, `arch-plugin-anatomy.md`) — byte-identity preserved.
- The two `index.md` copies still **differ**: root keeps `### Maintenance` + `[[lint-2026-04-20]]`, bundled keeps `[[ecosystem-plugin-selection]]` / `[[ecosystem-command-reference]]`. Decision 3 group-C divergence intact.
- `entries_count` untouched: root **124**, bundled **130** (Decision 1 — they are supposed to differ).
- `git diff --diff-filter=AD` prints nothing — **no page created or deleted in either tree**, the decisive proof `--force` was not used.
- Count sweep `grep -rniE '(eleven|[0-9]{1,2})[ -]plugins?'` over both trees leaves hits only in `wiki/wiki/log.md`, `cogni-workspace/wiki/wiki/log.md` and `wiki/wiki/pages/lint-2026-04-20.md` — all dated history, untouched per Decision 5 — plus the four newly-corrected `8-plugin` lines.
- `python3 -c "…len(marketplace.json plugins[])"` → **8**, matching every corrected sentence.

**No `## Mutation recipe` is owed** — the diff touches no `*/tests/test-*.sh` and no `*/scripts/check-*.sh`. It is seven markdown files.

## Open questions

Neither blocks this change; both are recorded for a maintainer.

1. **AC3 undercounts its own protected set.** It says "the **five** Decision-4 bundled-only wiki pages". Decision 4 is titled *"the **7** bundled-only pages are held pending a maintainer ruling"* and tables seven. This PR graded against **seven** — all seven are byte-identical to base. Worth correcting the issue text so the next child does not inherit the undercount.
2. **The issue's "never hand-edited" framing should be corrected.** As above, it is unexecutable against the current tree, and following it literally would execute a maintainer decision (#1402) that was deliberately reserved. The next child in this epic will hit the same instruction.

One judgment call worth a reviewer's eye: `## Deliberately left standing` in the decisions record asserts "None of the four tree-level wiki files … is edited". This PR edits both `index.md` files. That sentence is read as a record of *that sweep*, so it is left untouched, and the closing sentence of the refreshed `## Observed` block says so explicitly rather than widening the edit.

## Not done, deliberately

`## Common workflows` ("Five cross-plugin pipelines have dedicated wiki pages") is left byte-identical in both trees. It is true of the root tree (5 `workflow-*` pages) and false of the bundled tree (9, because four Decision-4 held pages are workflow pages). It is a **workflow-page** count, not a roster count, so it is outside this issue's sweep — and it is entangled with the Decision-4 ruling #1402 owns.