### PR TITLE
Retire live cogni-visual references from ecosystem-overview and six dependency tables

### DIFF
--- a/cogni-marketing/README.md
+++ b/cogni-marketing/README.md
@@ -187,7 +187,7 @@ cogni-marketing/
 |--------|----------|---------|
 | cogni-portfolio | Yes | Products, propositions, markets, competitors, solutions |
 | cogni-trends | Yes | Strategic themes (Handlungsfelder), trend data, claims |
-| cogni-visual | No | Slide decks and visual assets from content briefs |
+| cogni-workspace | No | Slide decks and visual assets from content briefs via `story-to-slides` / `story-to-web` |
 
 ## Contributing
 

--- a/cogni-portfolio/CLAUDE.md
+++ b/cogni-portfolio/CLAUDE.md
@@ -189,10 +189,9 @@ Research agents auto-log claims with source URLs and entity provenance (`entity_
 
 | Plugin | Direction | Mechanism |
 |--------|-----------|-----------|
-| cogni-workspace | bidirectional | portfolio-verify orchestrates claim verification and propagates corrections back to entity files; research agents auto-log claims with entity_ref provenance; portfolio-dashboard uses pick-theme for theme selection; portfolio-communicate reads the `narrative` skill's arc definitions for pitch structure |
+| cogni-workspace | bidirectional | portfolio-verify orchestrates claim verification and propagates corrections back to entity files; research agents auto-log claims with entity_ref provenance; portfolio-dashboard uses pick-theme for theme selection; portfolio-communicate reads the `narrative` skill's arc definitions for pitch structure; that output is in turn consumable by `story-to-slides` and `story-to-web`, and its markdown is enrichable via `enrich-report` (concept diagrams + charts) |
 | cogni-trends | bidirectional | trends-bridge imports solution templates, exports portfolio anchors |
 | document-skills | downstream | portfolio-ingest uses docx/pptx/xlsx readers; portfolio-communicate workbook uses XLSX writer |
-| cogni-visual | downstream | portfolio-communicate output consumable by story-to-slides, story-to-web; markdown output enrichable via enrich-report (concept diagrams + charts) |
 
 ## Key Conventions
 

--- a/cogni-portfolio/README.md
+++ b/cogni-portfolio/README.md
@@ -217,11 +217,10 @@ cogni-portfolio/
 
 | Plugin | Required | Purpose |
 |--------|----------|---------|
-| cogni-visual | No | Pitch output consumable by story-to-slides, story-to-web, and story-to-storyboard |
 | cogni-marketing | No | Customer narratives from portfolio-communicate are auto-discovered by marketing-setup for voice/messaging enrichment |
 | cogni-trends | No | Bidirectional TIPS integration via trends-bridge |
 | cogni-knowledge | No | Pitch arcs (technology-futures, strategic-foresight, trend-panorama, theme-thesis) in portfolio-communicate draw on cogni-knowledge research syntheses for evidence |
-| cogni-workspace | No | Theme selection for portfolio-dashboard via pick-theme; claim verification for research-backed assertions via portfolio-verify; the `narrative` skill's arc definitions shape the pitch use case, and `copywriter` audience tuning drives acronym-expansion depth |
+| cogni-workspace | No | Theme selection for portfolio-dashboard via pick-theme; claim verification for research-backed assertions via portfolio-verify; the `narrative` skill's arc definitions shape the pitch use case, and `copywriter` audience tuning drives acronym-expansion depth; pitch output consumable by `story-to-slides`, `story-to-web`, and `story-to-storyboard` |
 | cogni-sales | No | Downstream consumer — why-change pitch builds on portfolio features and propositions |
 | document-skills | No | Document ingestion (docx, pptx, xlsx, pdf) via portfolio-ingest; XLSX export via portfolio-communicate |
 

--- a/cogni-sales/CLAUDE.md
+++ b/cogni-sales/CLAUDE.md
@@ -82,8 +82,7 @@ Each phase has a **quality gate** — the orchestrator presents key findings to 
 |--------|----------|-----------|-----------|
 | cogni-portfolio | Yes | upstream | Products, features, propositions (IS/DOES/MEANS), solutions (pricing tiers), markets (TAM/SAM/SOM, revenue range), competitors, customers (reference accounts) |
 | cogni-trends | No | upstream | TIPS value-model themes, regulatory timelines, solution templates, gap analysis — enriches all 4 phases when available |
-| cogni-workspace | Yes | bidirectional | Upstream: the `narrative` skill's Corporate Visions arc definition + per-phase pattern files. Downstream: claims registered during research are verified by `cogni-workspace:claims`, and `copywriter` polishes final deliverables (`/copywrite sales-presentation.md`) |
-| cogni-visual | No | downstream | PPTX generation from sales presentation (`/pptx create sales-presentation.md`) |
+| cogni-workspace | Yes | bidirectional | Upstream: the `narrative` skill's Corporate Visions arc definition + per-phase pattern files. Downstream: claims registered during research are verified by `cogni-workspace:claims`, `copywriter` polishes final deliverables (`/copywrite sales-presentation.md`), and `story-to-slides` generates a PPTX from the sales presentation |
 
 ## Data Model
 

--- a/cogni-sales/README.md
+++ b/cogni-sales/README.md
@@ -155,8 +155,7 @@ cogni-sales/
 |--------|----------|---------|
 | cogni-portfolio | Yes | Products, features, propositions, solutions, markets, competitors, customers |
 | cogni-trends | No | TIPS strategic theme enrichment — value-modeler themes, regulatory timelines, gap analysis |
-| cogni-workspace | Yes | Corporate Visions story arc patterns from the `narrative` skill; source verification via `cogni-workspace:claims`; executive polish on final deliverables via `copywriter` |
-| cogni-visual | No | PPTX generation from sales presentation |
+| cogni-workspace | Yes | Corporate Visions story arc patterns from the `narrative` skill; source verification via `cogni-workspace:claims`; executive polish on final deliverables via `copywriter`; slide/PPTX generation from the sales presentation via `story-to-slides` |
 
 ## Contributing
 

--- a/cogni-trends/README.md
+++ b/cogni-trends/README.md
@@ -252,8 +252,7 @@ cogni-trends/
 | Plugin | Required | Purpose |
 |--------|----------|---------|
 | cogni-portfolio | No | Bidirectional integration via trends-bridge (portfolio context export, opportunity import) |
-| cogni-visual | No | Themed HTML report via enrich-report; Big Block diagrams from value-modeler solution networks |
-| cogni-workspace | No | Theme selection for trends-dashboard via pick-theme; citation verification via `cogni-workspace:claims`; the `narrative` skill's smarter-service arc drives the canonical report's theme-case writer and macro composer; `copywriter` applies executive polish with tone scoping |
+| cogni-workspace | No | Theme selection for trends-dashboard via pick-theme; citation verification via `cogni-workspace:claims`; the `narrative` skill's smarter-service arc drives the canonical report's theme-case writer and macro composer; `copywriter` applies executive polish with tone scoping; themed HTML report via `enrich-report`; Big Block diagrams from value-modeler solution networks |
 
 cogni-trends is standalone for trend scouting and reporting. Cross-plugin integrations add verification, narrative polish, portfolio mapping, and visual output.
 

--- a/docs/ecosystem-overview.md
+++ b/docs/ecosystem-overview.md
@@ -91,7 +91,7 @@ cogni-workspace (copywriter)
   → consumes: narrative output (auto-activated by arc_id frontmatter)
   → produces: polished document
 
-cogni-visual
+cogni-workspace (story-to-slides / story-to-web / story-to-storyboard / story-to-infographic)
   → consumes: polished narrative
   → produces: slide deck / journey map / web narrative / poster
 ```
@@ -137,7 +137,7 @@ cogni-consult (action-fields WBS)
   Per deliverable  → design-thinking loop (empathize→define→ideate→prototype→test)
                      research via the engagement's bound cogni-knowledge base
   Quality          → acting stakeholder personas challenge each deliverable
-  Hand-off         → deliverables feed the narrative skill, cogni-visual, cogni-sales
+  Hand-off         → deliverables feed the narrative and story-to-slides skills, cogni-sales
 ```
 
 For the entity-level diagram see [er-diagram.md](er-diagram.md).
@@ -150,7 +150,7 @@ All plugins depend on cogni-workspace for three shared concerns:
 
 **Environment variables.** `manage-workspace` generates `.claude/settings.local.json`, which Claude Code auto-injects at session start. Plugins resolve sibling plugin paths via these variables rather than hardcoding paths.
 
-**Theme management.** Visual plugins (cogni-visual, cogni-marketing, cogni-website) call the `pick-theme` skill from cogni-workspace to resolve a brand theme. Themes live in `{workspace}/cogni-workspace/themes/` and are shared across all plugins that produce HTML or visual output.
+**Theme management.** Visual-output plugins (cogni-marketing, cogni-website) call the `pick-theme` skill from cogni-workspace to resolve a brand theme, as do cogni-workspace's own rendering skills. Themes live in `{workspace}/cogni-workspace/themes/` and are shared across all plugins that produce HTML or visual output.
 
 **Session hooks.** cogni-workspace installs an `on-session-start.sh` hook that sources workspace environment variables and validates plugin availability each time a Claude Code session opens.
 
@@ -320,11 +320,11 @@ Seven end-to-end workflow guides document the cross-plugin pipelines:
 | Workflow | Pipeline | End deliverable |
 |----------|----------|-----------------|
 | [Research to Report](workflows/research-to-report.md) | cogni-knowledge → cogni-workspace (claims → copywriter) | Verified, polished research report |
-| [Portfolio to Pitch](workflows/portfolio-to-pitch.md) | cogni-portfolio → cogni-sales → cogni-visual | Sales presentation with slides |
+| [Portfolio to Pitch](workflows/portfolio-to-pitch.md) | cogni-portfolio → cogni-sales → cogni-workspace (story-to-slides) | Sales presentation with slides |
 | [Portfolio to Website](workflows/portfolio-to-website.md) | cogni-portfolio → cogni-workspace → cogni-website | Deployable multi-page customer website |
-| [Trends to Solutions](workflows/trends-to-solutions.md) | cogni-trends → cogni-portfolio (bridge) → cogni-visual | Ranked solutions with visual deliverables |
+| [Trends to Solutions](workflows/trends-to-solutions.md) | cogni-trends → cogni-portfolio (bridge) → cogni-workspace (story-to-slides / enrich-report) | Ranked solutions with visual deliverables |
 | [Consulting Engagement](workflows/consulting-engagement.md) | cogni-consult → cogni-knowledge (+ persona-gated deliverables) | Full consulting deliverable package |
-| [Content Pipeline](workflows/content-pipeline.md) | cogni-marketing → cogni-workspace → cogni-visual | Multi-channel marketing content |
+| [Content Pipeline](workflows/content-pipeline.md) | cogni-marketing → cogni-workspace (copywriter → story-to-slides / story-to-web) | Multi-channel marketing content |
 
 ---
 


### PR DESCRIPTION
Closes #1624

## Summary

Replaces every live `cogni-visual` reference in `docs/ecosystem-overview.md` and six plugin dependency tables with its live `cogni-workspace` successor, named down to the skill slug. `cogni-visual` is absent from `.claude-plugin/marketplace.json` `plugins[]` — its rendering skills were absorbed into `cogni-workspace`. Past-tense lineage prose is left untouched.

Seven files, +12 / −17.

## Scope decisions

- **Six ecosystem-overview sites, not the four tabulated.** The issue's Current-behavior table enumerates `docs/ecosystem-overview.md:140,323,325,327`. Two further sites fall inside **AC1's own falsifier** and are fixed here: line **94** is a bare `cogni-visual` **pipeline stage** in the Data Flow fence, and line **153** is a **prose line naming it as live** ("Visual plugins (cogni-visual, cogni-marketing, cogni-website) call the `pick-theme` skill"). AC1 is falsified by "a surviving `Pipeline` cell **or prose line naming it as live**", so shipping only the tabulated four would have left the criterion unmet on its own terms. `cogni-visual` occurred exactly 6 times in this file at base; all six are addressed and the file now holds zero.

- **Five of the six tables are merge-and-delete, not rename.** `cogni-sales/README.md`, `cogni-sales/CLAUDE.md`, `cogni-portfolio/README.md`, `cogni-portfolio/CLAUDE.md` and `cogni-trends/README.md` **already carried a `cogni-workspace` row in the same table**. A naive `cogni-visual` → `cogni-workspace` rename would therefore have produced a **duplicate-key table** — two rows claiming the same plugin with different `Required`/`Direction` values. Each retired row is instead deleted and its capability text folded into the surviving row's Purpose/Mechanism cell, so no information is lost (deletion was explicitly rejected in the issue's Alternatives considered). Each merged row keeps whatever `Required`/`Direction` the **existing** `cogni-workspace` row carried — the folded capability was optional on the retired row, so no `No → Yes` upgrade is implied.

- **`cogni-marketing/README.md` is the only plain rename** — its table carried no `cogni-workspace` row at all, so there was nothing to merge into and no duplicate-key risk.

- **Two sites needed a rewrite, not a substitution.** Line 153 would otherwise have read "cogni-workspace … call the `pick-theme` skill from cogni-workspace" — a plugin calling a skill from itself. The Content Pipeline row (327) would otherwise have read `cogni-marketing → cogni-workspace → cogni-workspace`, two indistinguishable hops.

- **Every replacement is grounded, not invented.** Each qualifier comes from the target's own self-description: `docs/workflows/portfolio-to-pitch.md:5`, `trends-to-solutions.md:3` (which literally states `→ cogni-workspace (story-to-slides / enrich-report)`), `content-pipeline.md:3`, `consulting-engagement.md:276`. Every named slug was verified to exist as `cogni-workspace/skills/<slug>/SKILL.md`, and `cogni-workspace` is present in `marketplace.json` `plugins[]`.

- **Deliberately untouched.** `cogni-consult/README.md:236` still carries a live row, but AC4 forbids touching it (tracked by #1617) — excluded by design, not overlooked. Also out: the `{source_dir}/cogni-visual/…` path literals in `cogni-workspace/skills/story-to-*/SKILL.md` (live on-disk directory names, AC5), `cogni-workspace/references/absorption-roadmap.md`, and the "Seven end-to-end workflow guides" heading above a six-row table — that is pre-existing drift (`docs/workflows/` holds seven files; the table is missing the `install-to-infographic` row), and the row count deliberately stays six.

- **No `plugin.json` is touched.** The patch bump is applied post-merge by the version-bump workflow.

## AC7 — decision on `cogni-workspace/CLAUDE.md:162,166,174`

**All three are deliberately LEFT UNCHANGED as past-tense lineage.** Each sits inside the adoption notes describing how the tree arrived: `:162` records that a kept test fixture was also an input to the former plugin's `story-to-web` eval (a CHANGELOG-recorded historical dependency), `:166` opens "Adopted from cogni-visual across the absorption stages, and now the only copy: the retirement stage deleted the source tree", and `:174` explains that a guard, on arrival, scans this plugin "rather than cogni-visual's tree". None presents `cogni-visual` as a live dependency, dispatch target or pipeline stage, so none falls in AC1/AC2's class — and **AC6 requires lineage prose be preserved**, so rewriting them would falsify a different criterion. `cogni-workspace/CLAUDE.md` is absent from the changed-file list.

## Open questions

- **Generator ownership — these surfaces can re-drift, and the fix cannot land in this repo.** `docs/ecosystem-overview.md` is a **generated output of the cogni-docs `doc-hub` skill** (`cogni-docs/skills/doc-hub/SKILL.md:124`; `references/doc-templates.md:707` names it as an output path), and the four README `## Dependencies` sections are classified **auto-generatable** in `cogni-docs/skills/doc-generate/references/preservation-rules.md:19` ("Cross-plugin reference scanning"). The two `CLAUDE.md` cross-plugin tables are *not* on that list (`doc-claude`, interactive-by-default). No in-file "do not edit" markers exist in any of the seven files, so a hand edit is the correct fix today — and `docs/audit-report.md:174` explicitly prescribes "Content correction, no `/doc-generate` pass" for this exact file set. But a future `/doc-hub` or `/doc-generate` run could re-emit `cogni-visual` and silently undo this PR **unless the generator's own source stops emitting it**. cogni-docs lives in the sibling `cogni-work/managed-service` repo, so that change cannot land here. **Should a follow-up be filed against `managed-service`?**

- **Should the Check-17 detector become enforcing for insight-wave CI?** This class was found by `doc-audit` Check 17, whose detector (`removed-plugin-refs.sh`) also lives in cogni-docs and is advisory — nothing in insight-wave CI blocks on it, so a regression is silent until someone runs an audit. Three options: **(a)** vendor a copy into `insight-wave/scripts/`, creating a second copy that will drift from its canonical home; **(b)** take a cross-repo plugin-install dependency in CI; **(c)** leave it advisory and accept periodic sweeps like this one. (a) and (b) additionally need a standing allowlist for the majority of raw findings that are legitimate. A second, insight-wave-side prose guard was evaluated and **rejected**: at base `cogni-visual` appears on 222 matching lines across 80 files, the large majority legitimate — lineage prose, the `{source_dir}/cogni-visual/…` path literals this issue itself carves out, wiki entity pages, and guard fixtures whose matching data *is* the literal — and the only design precise enough to be green after this PR is by construction blind to the real remaining defect at `cogni-consult/README.md:236`, whose cell is the compound `cogni-visual / document-skills`. Maintainer decision needed.

## Test plan — results

Baselines measured at `origin/main` c69e303d, so each check is non-vacuous.

- **AC1** — `grep -c cogni-visual docs/ecosystem-overview.md` → **0** (base 6). ✅
- **AC2** — same grep over the six table files → **0 each** (base 1 each, 6 total). ✅
- **Duplicate-key guard** — `grep -c '^| cogni-workspace ' <each of the six>` → **1 for every file**, never 2. ✅
- **AC3** — `cogni-workspace` present in `marketplace.json` `plugins[]`; `story-to-slides`, `story-to-web`, `story-to-storyboard`, `story-to-infographic`, `enrich-report`, `copywriter`, `pick-theme`, `narrative` all resolve to `cogni-workspace/skills/<slug>/SKILL.md`. ✅
- **AC3b** — `git diff | grep '^+' | grep -c 'cogni-visual:'` → **0**; `python3 scripts/check-external-dispatch.py` → 0 violations. ✅
- **AC4** — `cogni-consult/README.md` absent from the changed-file list (exactly 7 files changed). ✅
- **AC5** — no `cogni-workspace/skills/story-to-*` path in the changed-file list. ✅
- **AC6** — `cogni-workspace/CLAUDE.md` absent from the changed-file list. ✅
- **AC7** — recorded above. ✅
- **AC8** — `python3 scripts/run-plugin-tests.py` → **134 discovered, 134 passed, 0 failed** (non-zero discovered count, so not a vacuous 0-of-0). `python3 scripts/check-version-bump.py` → clean, **4 plugins touched, 0 violations**. ✅
- **Row count** — the Workflow Guides table still has exactly **6** data rows. ✅

> Note on the version-bump evidence: an initial run before the commit reported `plugins_touched: []` because its three-dot diff against `origin/main` saw an empty touched set — a vacuous green. The result above is the **post-commit** re-run, which genuinely resolves 4 touched plugins.

No `## Mutation recipe` section: the touched set is seven `.md` files with no `*/tests/test-*.sh` and no `*/scripts/check-*.sh`, so that gate is `not_applicable`.