### PR TITLE
cogni-consult: drop the retired cogni-visual export-route row

### DIFF
--- a/cogni-consult/README.md
+++ b/cogni-consult/README.md
@@ -232,8 +232,7 @@ cogni-consult/
 | Plugin | Required | Purpose |
 |--------|----------|---------|
 | cogni-knowledge | Yes | Bound once at setup (`plugin_refs.knowledge_base`) — the research spine every deliverable's evidence routes through |
-| cogni-workspace | No | Cross-session engagement discovery (`discover-projects.sh` delegates to its helper); `pick-theme` themes the `consult-dashboard` HTML (falls back to a built-in theme); consult-design-thinking routes the claims-correction cascade, and `submit-assumption-claim.py` submits assumption claims to `cogni-workspace:claims` for verification; consult-publish runs an optional `copywriter` polish pass before brief handoff |
-| cogni-visual / document-skills | No | Deliverable export (slides, documents) when a deliverable names an export route |
+| cogni-workspace | No | Cross-session engagement discovery (`discover-projects.sh` delegates to its helper); `pick-theme` themes the `consult-dashboard` HTML (falls back to a built-in theme); consult-design-thinking routes the claims-correction cascade, and `submit-assumption-claim.py` submits assumption claims to `cogni-workspace:claims` for verification; consult-publish runs an optional `copywriter` polish pass before brief handoff; opt-in local-render fallback for publish deliverables (`cogni-workspace:enrich-report` / `cogni-workspace:story-to-infographic`) — the standard `consult-publish` path builds every format as a consult-native brief and hands it to Claude Design to render, so no plugin sits on the standard export route |
 
 cogni-consult is standalone as an orchestrator — it structures the engagement, the WBS, and the design-thinking loops on its own. cogni-knowledge is the one required integration: without it, deliverable research has no compounding base.
 


### PR DESCRIPTION
Closes #1617.

## Summary

`cogni-consult/README.md`'s `## Dependencies` table named the retired plugin `cogni-visual` as a deliverable export route. That plugin is absent from `.claude-plugin/marketplace.json` `plugins[]`, is listed in `scripts/retired-plugins.json` `retired_prefixes[]`, and has no tree at the default branch — so the row pointed a reader at a plugin that no longer exists.

The row is deleted and its still-true subject folded into the existing `cogni-workspace` row as one appended clause. Base line 236 was the file's only `cogni-visual` occurrence, so `grep -n 'cogni-visual' cogni-consult/README.md` now returns nothing.

## Two decisions worth reading

**1. Merge-and-delete, not retarget-in-place.** `docs/audit-report.md:51` prescribes retargeting the row to `cogni-workspace / document-skills`. Not taken: `document-skills` is absent from `marketplace.json` `plugins[]` and no `*/skills/document-skills/SKILL.md` exists anywhere in the repo, which acceptance criterion 2 forbids. Base line 235 was **already** a `cogni-workspace` row, so folding the clause into it also avoids leaving two rows describing one dependency. The wording follows the plugin's own canonical `references/data-model.md:420`, which already carries this sentence for this relationship.

**2. The Purpose cell was rewritten, not just renamed.** The old text — "Deliverable export (slides, documents) when a deliverable names an export route" — was false beyond the retired name. `references/publish-routing.md` states that every format is built natively as a brief and that `cogni-workspace:enrich-report` / `story-to-infographic` are "an explicit opt-in local-render fallback only… no longer the standard path". The new clause says that, so removing a stale name does not leave a differently-false statement behind.

## AC4 — the guard is deliberately NOT widened, and here is the evidence

The `no-retired-plugin-name` case in `cogni-consult/tests/test_route_example_hygiene.sh` keeps its `skills/**/SKILL.md` scan.

Widening it to the whole plugin tree goes **RED against the post-fix tree** — not merely the pre-fix one — on a *different* retired prefix. `cogni-claims` is in `retired_prefixes[]` **and** is simultaneously a live directory name (the workspace registry `cogni-claims/claims.json`). Under `cogni-consult/` it occurs as a legitimate filesystem path in:

- `CLAUDE.md:182`
- `references/publish-routing.md:298`
- `scripts/resolve-assumptions.py` (~8 sites)
- `scripts/submit-assumption-claim.py`
- `tests/test_resolve_assumptions.sh` (~20 lines)

Retiring the *plugin* did not move the *directory*. A naive widening would therefore fail permanently after this fix, so it could not be recorded as a mutation-verified guard at all. This is exactly the false-positive class the suite's own header (lines 23–32) already documents: the discriminator between "retired plugin named as a route" and "retired plugin name used as a directory" only exists near the site.

Making the widening viable needs a path-vs-dispatch carve-out, designed and falsified on its own. Filed as **#1630** with its own acceptance bar.

**No `## Mutation recipe` is owed** — the touched set is one file, `cogni-consult/README.md`. No `*/tests/test-*.sh`, no `*/scripts/check-*.sh`.

## Closes, not Refs — deliberate

`deferred[]` is non-empty (#1630, #1631), which normally routes a PR to `Refs`. `Closes` is correct here, because neither deferral is unmet scope of #1617:

- **#1630** is AC4's widening. AC4's own wording is *"If not widened, say why in the PR"* — declining with reasons **satisfies** the criterion rather than leaving it open. The widening was never required by this issue.
- **#1631** is pre-existing drift in `README.md:136`, outside this issue's stated scope (the Dependencies table row), and already asserted-against by `references/data-model.md:420` before this PR existed.

All four acceptance criteria are met by this diff, so `Refs` would strand the issue open with nothing left to do — a failure mode this board already carries five instances of.

## Deferred follow-ups

- **#1630** — widen the `no-retired-plugin-name` guard beyond `skills/**/SKILL.md` with a `cogni-claims` directory carve-out.
- **#1631** — `README.md:136` still names two `cogni-workspace` skills as the *standard* export route, contradicting `references/publish-routing.md`. Pre-existing; this PR joins the correct side rather than creating the conflict.

## Verification

| Check | Result |
|---|---|
| `grep -n 'cogni-visual' cogni-consult/README.md` (AC1) | no matches |
| Changed paths (contract item 8) | exactly `cogni-consult/README.md`; nothing under `docs/` or `scripts/` |
| Table shape (AC3) | header + separator + `cogni-knowledge` row unchanged; 2 data rows; every row 4 pipes / 3 columns |
| Row 235 fidelity (contract item 3) | every pre-existing clause byte-identical, including ``optional `copywriter` polish pass before brief handoff``; only delta is the appended clause |
| Exactly one `cogni-workspace` row (contract item 4) | 1 |
| Named slugs resolve (AC2) | `cogni-workspace/skills/enrich-report/SKILL.md`, `cogni-workspace/skills/story-to-infographic/SKILL.md`; `cogni-workspace` in `plugins[]` |
| `cogni-consult` test suite | 13 discovered / 13 passed / 0 failed, including `test_route_example_hygiene.sh` (guard untouched) |
| `plugin.json` version | untouched — the patch bump is post-merge |

## Gate honesty

Two pre-commit gates were **inert** on this diff rather than green, and are named here rather than reported as passes:

- **`/simplify` (code pass)** — inert. The diff is prose-only (one markdown table row); the reuse / simplification / efficiency / altitude angles have no code subject.
- **Prose simplify + skill-quality gates** — skipped by their own guards: no touched path matches `*/skills/*/SKILL.md` or `*/agents/*.md`.

Token-scope preflight was passed with the sanctioned `--allow-overscoped` flag: the runner uses the `gho_` GitHub CLI token, whose extra scopes (`gist`, `read:org`, `workflow`) are fixed by the CLI's OAuth app and cannot be narrowed.