### PR TITLE
cogni-consult: guard retired plugin names in README, CLAUDE.md and references

### DIFF
--- a/cogni-consult/tests/test_route_example_hygiene.sh
+++ b/cogni-consult/tests/test_route_example_hygiene.sh
@@ -10,15 +10,17 @@
 # colon: `PASS: goes-red: ...` would match neither pattern, and a recipe
 # recorded against this suite would return case_not_found instead of a verdict.
 #
-# Which mutation reddens which case. The recorded recipe in the pull request
-# drives the second one; the retired name it substitutes is deliberately not
+# Which mutation reddens which case. Two recipes are recorded in the pull
+# request — one drives the second case, one drives the fifth against the
+# plugin-root README.md; the retired names they substitute are deliberately not
 # spelled here, so this file introduces no new mention of a retired plugin.
 #   route-examples-found         deleting both `Route:` example lines
 #   route-example-slug-resolves  rewriting the route token to any prefix listed
 #                                in scripts/retired-plugins.json (the recorded recipe)
 #   route-example-non-default    rewriting the route token to consult-design-thinking
 #   route-example-parity         changing the route token at one site only
-#   no-retired-plugin-name       planting any retired prefix in a skill body
+#   no-retired-plugin-name       planting any retired prefix in any scanned body
+#                                (the recorded README recipe)
 #
 # RELATIONSHIP TO scripts/check-external-dispatch.py. That repo-level guard reads
 # the SAME registry and already scans this subject file, so this suite is not a
@@ -30,6 +32,19 @@
 # as a route" and "retired plugin name used as a directory" only exists near the
 # site, which is why this half of the property is guarded per-plugin here rather
 # than repo-wide there.
+#
+# DIRECTORY-VS-DISPATCH CARVE-OUT. Case 5 keeps the BARE-NAME match; the colon
+# anchor above cannot be reused here. The README row this case exists to catch
+# named a retired plugin in a Dependencies table with no colon at all, so a
+# colon-anchored match would be permanently green against exactly the content
+# the case guards — vacuous, and unfalsifiable by the recorded recipe. What is
+# excluded instead is an occurrence immediately followed by `/`: that is what a
+# filesystem path looks like, and a directory that happens to be named after a
+# retired plugin is not a route. The carve-out is load-bearing rather than
+# decorative — two sites in the scanned subject exercise it, the
+# `<prefix>/claims.json` path mentions in CLAUDE.md and in
+# references/publish-routing.md — so the case is green with it and red without
+# it, which is what the second recorded recipe falsifies.
 #
 # THE PREFIX FILTER MIRRORS THAT GUARD'S load_registry CONTRACT deliberately.
 # A colon-bearing entry would pass a bare truthiness filter and then be handed to
@@ -57,7 +72,24 @@
 #
 # SCOPE OF EACH CASE. Cases 1-4 pin the `Route:` note, which is defined in one
 # file, so they key on that file. Case 5's predicate is plugin-wide — a retired
-# name is wrong in any skill body — so it scans every skill in the plugin.
+# name is wrong in any authored prose the plugin ships — so it scans an
+# ENUMERATED subject: every `skills/**/SKILL.md`, the plugin-root `README.md`
+# and `CLAUDE.md`, and every `references/**/*.md`.
+#
+# What that subject leaves out, and why it is enumerated rather than globbed.
+# `scripts/` and `tests/` are excluded because no lexical carve-out clears them
+# on a CORRECT tree: one retired prefix is also a live workspace directory name,
+# and after the trailing-slash carve-out 11 legitimate occurrences across three
+# files still match — 8 of the form `mkdir -p "$VAR/<prefix>"`, where the path
+# separator precedes the name and the line ends right after it; 2 that assemble
+# the path across string-literal boundaries via `os.path.join`, so no separator
+# sits adjacent in the source at all; and 1 bare mention in a comment. Including
+# those trees would make the case permanently red against a correct tree, which
+# is the failure this enumeration exists to avoid. `agents/` and
+# `output-styles/` are authored prose too and are simply not covered yet.
+# A whole-tree glob over `$PLUGIN_DIR` is also deliberately avoided: engagement
+# directories live under `$PLUGIN_DIR/{slug}/`, so a glob would scan a user's
+# own engagement content as if it were plugin source.
 #
 # Each case below is gated only on its OWN predicate and emits exactly one
 # result line per run, so every `FAIL` arm has a reachable same-id green twin
@@ -166,7 +198,8 @@ else
 fi
 
 # --- case 5: no-retired-plugin-name ------------------------------------------
-# No retired plugin prefix may appear in any skill body in this plugin, in a
+# No retired plugin prefix may appear in any scanned body in this plugin — skill
+# bodies, the plugin-root README.md and CLAUDE.md, and references/**/*.md — in a
 # Route: note or in prose. An unreadable, empty, or malformed registry fails
 # rather than passing silently.
 retired_prefixes="$(python3 -c '
@@ -187,22 +220,47 @@ for prefix in prefixes:
     print(prefix)
 ' "$RETIRED" 2>/dev/null || true)"
 
-skill_bodies="$(find "$PLUGIN_DIR/skills" -name SKILL.md -type f 2>/dev/null | sort)"
+# Every path derives from $PLUGIN_DIR, never a hardcoded one, so --root (above)
+# still redirects the whole subject. Keep this list and $scan_desc below in step.
+# The suite runs under `set -u` only — there is no `set -e` and no pipefail — so
+# a find over a missing directory is inert here; do not add `set -e` without
+# revisiting this.
+scan_desc='skills/**/SKILL.md, README.md, CLAUDE.md, references/**/*.md'
+scan_bodies="$({
+  find "$PLUGIN_DIR/skills" -name SKILL.md -type f
+  find "$PLUGIN_DIR/references" -name '*.md' -type f
+  [ -f "$PLUGIN_DIR/README.md" ] && printf '%s\n' "$PLUGIN_DIR/README.md"
+  [ -f "$PLUGIN_DIR/CLAUDE.md" ] && printf '%s\n' "$PLUGIN_DIR/CLAUDE.md"
+} 2>/dev/null | sort)"
+
+# A newly covered surface that has silently vanished must not read as success:
+# the scan would narrow back toward the pre-widening subject and still print
+# PASS. Each arm below names the missing surface. They stay in ONE if/elif chain
+# so the case still emits exactly one result line per run.
+missing_surface=""
+[ -f "$PLUGIN_DIR/README.md" ] || missing_surface="$missing_surface README.md"
+[ -f "$PLUGIN_DIR/CLAUDE.md" ] || missing_surface="$missing_surface CLAUDE.md"
+[ -d "$PLUGIN_DIR/references" ] || missing_surface="$missing_surface references/"
 
 if [ -z "$retired_prefixes" ]; then
   fail "no-retired-plugin-name" "no usable retired_prefixes[] readable from $RETIRED (vacuous scan)"
-elif [ -z "$skill_bodies" ]; then
-  fail "no-retired-plugin-name" "no SKILL.md found under $PLUGIN_DIR/skills (vacuous scan)"
+elif [ -n "$missing_surface" ]; then
+  fail "no-retired-plugin-name" "scanned surface(s) absent under $PLUGIN_DIR:$missing_surface (vacuous scan of a newly covered surface)"
+elif [ -z "$scan_bodies" ]; then
+  fail "no-retired-plugin-name" "no scannable body found under $PLUGIN_DIR ($scan_desc) (vacuous scan)"
 else
   present=""
   for prefix in $retired_prefixes; do
-    hits="$(printf '%s\n' "$skill_bodies" | while IFS= read -r body; do
-      grep -l -- "$prefix" "$body" 2>/dev/null || true
-    done)"
+    # Bare-name match minus the directory-path carve-out: an occurrence
+    # immediately followed by `/` is a filesystem path, not a route. See
+    # DIRECTORY-VS-DISPATCH CARVE-OUT in the header for why the colon anchor
+    # scripts/check-external-dispatch.py uses cannot be reused here.
+    hits="$(printf '%s\n' "$scan_bodies" | tr '\n' '\0' \
+      | xargs -0 grep -lE -- "$prefix"'([^/]|$)' 2>/dev/null || true)"
     [ -n "$hits" ] && present="$present $prefix"
   done
   if [ -n "$present" ]; then
-    fail "no-retired-plugin-name" "retired plugin prefix(es) present in a $PLUGIN_DIR skill body:$present"
+    fail "no-retired-plugin-name" "retired plugin prefix(es) present in a $PLUGIN_DIR scanned body ($scan_desc):$present"
   else
     pass "no-retired-plugin-name"
   fi

--- a/cogni-consult/tests/test_route_example_hygiene.sh
+++ b/cogni-consult/tests/test_route_example_hygiene.sh
@@ -221,7 +221,10 @@ for prefix in prefixes:
 ' "$RETIRED" 2>/dev/null || true)"
 
 # Every path derives from $PLUGIN_DIR, never a hardcoded one, so --root (above)
-# still redirects the whole subject. Keep this list and $scan_desc below in step.
+# still redirects the whole subject. A surface is registered in THREE places that
+# must stay in step: this list, $scan_desc below, and the $missing_surface vacuity
+# chain further down. Adding a surface to the first two but not the third is what
+# lets it silently vanish while the case still prints PASS.
 # The suite runs under `set -u` only — there is no `set -e` and no pipefail — so
 # a find over a missing directory is inert here; do not add `set -e` without
 # revisiting this.
@@ -242,22 +245,32 @@ scan_bodies="$({
 # Before the widening, an absent skills/ tree was caught by a dedicated
 # `-z "$skill_bodies"` test; once the subject grew, a bare emptiness test on the
 # whole set only fires when EVERY surface is empty, so an absent skills/ tree
-# would be absorbed by the other three and pass silently. It is tested against
-# the assembled subject rather than with another find, so it cannot drift from
-# what is actually scanned.
+# would be absorbed by the other three and pass silently.
+#
+# BOTH directory-glob arms — skills/ and references/ — are tested against the
+# ASSEMBLED SUBJECT ($scan_bodies), never with a second find and never with a
+# bare `-d`. A `-d` test asks whether the directory exists, which is a strictly
+# weaker question than whether the scan actually reaches anything inside it: a
+# directory left in place but emptied of its .md files passes `-d` while
+# contributing nothing to the subject, so the surface silently narrows and the
+# case still prints PASS. Testing the subject cannot drift from what is scanned.
+#
+# The README.md and CLAUDE.md arms are deliberately NOT of that shape and need
+# no conversion: each is a single file gated on `-f`, the identical test the
+# subject assembly above uses to admit it, so presence and inclusion-in-subject
+# are equivalent for them and no emptied-but-present shape exists.
 missing_surface=""
 printf '%s\n' "$scan_bodies" | grep -q '/skills/.*/SKILL\.md$' \
   || missing_surface="$missing_surface skills/**/SKILL.md"
 [ -f "$PLUGIN_DIR/README.md" ] || missing_surface="$missing_surface README.md"
 [ -f "$PLUGIN_DIR/CLAUDE.md" ] || missing_surface="$missing_surface CLAUDE.md"
-[ -d "$PLUGIN_DIR/references" ] || missing_surface="$missing_surface references/"
+printf '%s\n' "$scan_bodies" | grep -q '/references/.*\.md$' \
+  || missing_surface="$missing_surface references/**/*.md"
 
 if [ -z "$retired_prefixes" ]; then
   fail "no-retired-plugin-name" "no usable retired_prefixes[] readable from $RETIRED (vacuous scan)"
 elif [ -n "$missing_surface" ]; then
   fail "no-retired-plugin-name" "scanned surface(s) absent under $PLUGIN_DIR:$missing_surface (vacuous scan — the subject would silently narrow)"
-elif [ -z "$scan_bodies" ]; then
-  fail "no-retired-plugin-name" "no scannable body found under $PLUGIN_DIR ($scan_desc) (vacuous scan)"
 else
   present=""
   for prefix in $retired_prefixes; do

--- a/cogni-consult/tests/test_route_example_hygiene.sh
+++ b/cogni-consult/tests/test_route_example_hygiene.sh
@@ -233,11 +233,21 @@ scan_bodies="$({
   [ -f "$PLUGIN_DIR/CLAUDE.md" ] && printf '%s\n' "$PLUGIN_DIR/CLAUDE.md"
 } 2>/dev/null | sort)"
 
-# A newly covered surface that has silently vanished must not read as success:
-# the scan would narrow back toward the pre-widening subject and still print
-# PASS. Each arm below names the missing surface. They stay in ONE if/elif chain
-# so the case still emits exactly one result line per run.
+# A surface that has silently vanished must not read as success: the scan would
+# narrow back toward a smaller subject and still print PASS. Each arm below names
+# the missing surface. They stay in ONE if/elif chain so the case still emits
+# exactly one result line per run.
+#
+# The skills/ arm covers the ORIGINAL subject and is not optional bookkeeping.
+# Before the widening, an absent skills/ tree was caught by a dedicated
+# `-z "$skill_bodies"` test; once the subject grew, a bare emptiness test on the
+# whole set only fires when EVERY surface is empty, so an absent skills/ tree
+# would be absorbed by the other three and pass silently. It is tested against
+# the assembled subject rather than with another find, so it cannot drift from
+# what is actually scanned.
 missing_surface=""
+printf '%s\n' "$scan_bodies" | grep -q '/skills/.*/SKILL\.md$' \
+  || missing_surface="$missing_surface skills/**/SKILL.md"
 [ -f "$PLUGIN_DIR/README.md" ] || missing_surface="$missing_surface README.md"
 [ -f "$PLUGIN_DIR/CLAUDE.md" ] || missing_surface="$missing_surface CLAUDE.md"
 [ -d "$PLUGIN_DIR/references" ] || missing_surface="$missing_surface references/"
@@ -245,7 +255,7 @@ missing_surface=""
 if [ -z "$retired_prefixes" ]; then
   fail "no-retired-plugin-name" "no usable retired_prefixes[] readable from $RETIRED (vacuous scan)"
 elif [ -n "$missing_surface" ]; then
-  fail "no-retired-plugin-name" "scanned surface(s) absent under $PLUGIN_DIR:$missing_surface (vacuous scan of a newly covered surface)"
+  fail "no-retired-plugin-name" "scanned surface(s) absent under $PLUGIN_DIR:$missing_surface (vacuous scan — the subject would silently narrow)"
 elif [ -z "$scan_bodies" ]; then
   fail "no-retired-plugin-name" "no scannable body found under $PLUGIN_DIR ($scan_desc) (vacuous scan)"
 else


### PR DESCRIPTION
Closes #1630.

## Summary

Widen case 5 (`no-retired-plugin-name`) in `cogni-consult/tests/test_route_example_hygiene.sh` from `skills/**/SKILL.md` alone to the plugin's authored prose surfaces — `skills/**/SKILL.md` + plugin-root `README.md` + plugin-root `CLAUDE.md` + `references/**/*.md` (37 files at this base, up from 9). Every path derives from `$PLUGIN_DIR`, never hardcoded, so `--root` still redirects the whole subject.

**Bare-name matching is kept, deliberately.** The obvious move is to reuse the colon anchor (`<prefix>:`) that `scripts/check-external-dispatch.py` and `cogni-workspace/tests/test-relocated-skill-hygiene.sh` both use — it has zero false positives on this corpus. It is the wrong answer here. The line #1617 removed from this README was:

```
| cogni-visual / document-skills | No | Deliverable export (slides, documents) when a deliverable names an export route |
```

A **bare** name, no colon. A colon-anchored match would be permanently green against exactly the content this case exists to catch — vacuous, and it would make the issue's AC3 ("demonstrably RED against the pre-#1617 README content") unsatisfiable.

**The carve-out is instead a trailing-slash exclusion** — an occurrence immediately followed by `/` is a filesystem path, not a route. It is load-bearing rather than decorative: two sites in the widened subject exercise it, `cogni-consult/CLAUDE.md:182` and `cogni-consult/references/publish-routing.md:298`, both `cogni-claims/claims.json`. Remove the carve-out and the case goes red on those two; that is falsification F1 below.

**The vacuity guard covers every surface — including the original one.** An absent `README.md`, `CLAUDE.md`, `references/`, **or `skills/**/SKILL.md`** FAILs the case naming the missing surface, rather than silently narrowing the scan and still printing PASS.

That last arm was a **regression this PR introduced and then fixed** — see "Caught in self-review" below.

**Header corrections.** A `DIRECTORY-VS-DISPATCH CARVE-OUT` paragraph is added beside the existing colon rationale; the `SCOPE OF EACH CASE` paragraph — which asserted case 5 "scans every skill in the plugin" — is rewritten to the real subject with the exclusions and their measured reason; the case-map row and the recorded-recipe paragraph are updated. The file still spells no retired prefix literally (`grep -cE 'cogni-(wiki|research|help|claims|narrative|copywriting|visual)'` → `0`), so it does not trip its own widened guard.

## Mutation recipe

```
bash ~/.claude/plugins/cache/managed-service/cogni-service/0.0.456/scripts/mutation-check.sh \
  --root . \
  --file cogni-consult/README.md \
  --expr 's/\| cogni-workspace \| No \|/| cogni-visual | No |/' \
  --test 'bash cogni-consult/tests/test_route_example_hygiene.sh' \
  --case no-retired-plugin-name
```

```
bash ~/.claude/plugins/cache/managed-service/cogni-service/0.0.456/scripts/mutation-check.sh \
  --root . \
  --file cogni-consult/references/publish-routing.md \
  --expr 's/cogni-claims\/claims.json/cogni-claims claims.json/' \
  --test 'bash cogni-consult/tests/test_route_example_hygiene.sh' \
  --case no-retired-plugin-name
```

Replay both from the repo root, **serially** — they share a snapshot root, so let each restore before starting the next.

The first arm is the one the issue's AC3/AC5 ask for: `--file` is `cogni-consult/README.md`, a surface this change **newly** covers, so the recipe could not have gone red before the widening. `| cogni-workspace | No |` occurs exactly once in that file (line 235, the `## Dependencies` table), so the substitution can never be an `expr_no_op`, and the mutant reproduces the pre-#1617 shape: a bare retired plugin name in a README dependencies row.

The second arm proves the `references/` half of the subject is really scanned **and** that the carve-out is what keeps that site green — it deletes only the `/`, turning a path mention into a bare one. `cogni-claims` occurs exactly once in that file (line 298).

There is no in-repo copy of the shared harness. `cogni-consult/scripts/mutation-check.sh` and `cogni-portfolio/scripts/mutation-check.sh` are a **different instrument** — no-arg, exit-code-classifying, accepting none of these five flags — so do not point the recipe at either. If that version directory is gone, use the newest under the same parent; everything after the path is version-independent.

## Falsification performed

Each probe was run against a scratch copy of the plugin tree; `→` is the observed case-5 line.

| # | mutation | expected | observed |
|---|---|---|---|
| F0 | none (base) | PASS | `PASS: no-retired-plugin-name` |
| F1 | carve-out removed (`grep -lF`, bare) | FAIL | `FAIL: … cogni-claims` — **carve-out is load-bearing** |
| F2 | `references/` dropped from subject, then `publish-routing.md` mutated | PASS | `PASS` — the mutation alone is not what reddens F3 |
| F3 | `references/` in subject, same mutation | FAIL | `FAIL: … cogni-claims` — **second arm genuinely grades `references/`** |
| F4 | bare retired name planted in `README.md` | FAIL | `FAIL: … cogni-visual` — primary arm |
| F5 | `README.md` removed | FAIL naming it | `FAIL: … scanned surface(s) absent …: README.md (vacuous scan — the subject would silently narrow)` |
| F5b | `CLAUDE.md` removed | FAIL naming it | `FAIL: … scanned surface(s) absent …: CLAUDE.md (…)` |
| F5c | `references/` removed | FAIL naming it | `FAIL: … scanned surface(s) absent …: references/**/*.md (…)` |
| F5d | `references/` present but emptied of `*.md` | FAIL naming it | `FAIL: … scanned surface(s) absent …: references/**/*.md (…)` — the emptied-but-present shape; **PASSes at `f043c216`**, which is what makes this arm's fix decisive rather than merely green |
| F8 | `skills/` removed | FAIL naming it | `FAIL: … scanned surface(s) absent …: skills/**/SKILL.md (…)` — the regression, post-fix |
| F8b | `skills/` present but emptied of `SKILL.md` | FAIL naming it | same — matches base's `-z "$skill_bodies"` semantics exactly |
| F6 | restored | PASS | `PASS: no-retired-plugin-name` |
| F7 | whole tree copied under a path containing a space | PASS | `PASS` — the `xargs -0` form is space-safe |

F2/F3 is the pair that matters: it separates "the mutation reddens the case" from "the case reddens *because that surface is in the subject*". Without F2, F3 alone would not distinguish the two.

Every probe was re-run after the cleanup pass below, and both recorded recipes re-replayed to `guard_verified` against the final code — a quality pass must not be allowed to quietly hollow out the guard it is tidying.

## Cleanup pass

Three changes from the pre-commit quality review, none behavioral:

1. **Removed a dead `grep -v '^$'` filter and the comment justifying it** — the comment claimed a skipped optional file "would otherwise contribute an empty record", which is false: when `[ -f … ]` fails the `printf` never runs, so nothing is emitted at all. Measured 0 empty records in every configuration. A false mechanism written into a comment outlives the line it defends, and this block is expected to be edited again.
2. **Bound the surface list once as `$scan_desc`** instead of spelling it verbatim in two `fail` messages, which could silently drift from the enumeration they describe.
3. **Batched the match** from one `grep` per (prefix, file) pair to one per prefix via `tr '\n' '\0' | xargs -0`: **259 process spawns → 7**, suite time 0.41s → 0.11s. Per-prefix attribution is unaffected — it comes from the loop variable, never from `grep`, so the failure message still names which prefix was found. `xargs -0` rather than word-splitting because `$PLUGIN_DIR` is caller-supplied via `--root` and may contain spaces (F7 covers this).
4. **Keyed the `references/**/*.md` vacuity arm on the assembled subject** (revision `a38ebaca`, closing the review verdict's one non-waived major, contract item 4). It read `[ -d "$PLUGIN_DIR/references" ]` — directory presence, a strictly weaker question than whether the scan reaches anything inside. Emptying `references/` of every `.md` while leaving the directory in place passed `-d` and still printed PASS (F5d). Now mirrors the `skills/` arm. The `README.md`/`CLAUDE.md` arms are deliberately **not** converted: each is a single file gated on `-f`, the identical test the subject assembly uses to admit it, so presence and inclusion-in-subject are equivalent and no emptied-but-present shape exists for them.
5. **Removed the unreachable `elif [ -z "$scan_bodies" ]` arm** (same revision). An empty subject necessarily fails the `skills/` grep, so `$missing_surface` is non-empty and the preceding arm always wins — verified against a plugin root stripped of all four surfaces, which names all four and never prints `no scannable body found`. A vacuity arm that can never fire is unfalsifiable, the same green-gate class this case exists to catch; its diagnostic is subsumed by the arm that does fire, which additionally names *which* surfaces vanished. This restores the merge base's 3-fail-site shape.
6. **Named the third surface-registration site.** The coupling note said to keep "this list and `$scan_desc`" in step — two sites, but a surface is registered in **three**: the `find` list, `$scan_desc`, and the `$missing_surface` chain. Registering a surface in the first two but not the third is exactly what lets it vanish silently.

A single `grep` with an alternation over all 7 prefixes was considered and rejected: `-l` reports which *file* matched, never which *alternative*, so it would cost the per-prefix attribution the failure message depends on.

One portability note, since CI is `ubuntu-latest` and this was developed on macOS: BSD and GNU `xargs` disagree on empty input — BSD skips, GNU runs the command once with no file operand, which would make `grep` read stdin. That divergence is unreachable here, because `$missing_surface` is non-empty whenever `$scan_bodies` is empty (an empty subject cannot match the `skills/` arm's grep), so the preceding `fail` arm always wins and the `else` branch — and therefore `xargs` — is only ever reached with at least one file. No `-r` is used, as it is a GNU extension the BSD build does not carry.

## Caught in self-review

The first version of this change **silently weakened an existing guard while widening it**, and the pre-handoff self-grade against the issue-time contract caught it.

Base had a dedicated vacuity arm, `elif [ -z "$skill_bodies" ]` — an absent `skills/` tree failed the case by name. Replacing that with a single emptiness test over the *whole* widened set meant it only fired when **every** surface was empty, so a missing `skills/` tree was absorbed by the other three and passed silently. Measured directly, deleting `skills/` and leaving the rest:

| | result |
|---|---|
| `origin/main` (base) | `FAIL: … no SKILL.md found under …/skills (vacuous scan)` |
| this branch, before the fix | `PASS: no-retired-plugin-name` |

A widening that quietly drops coverage of the surface it started from is worse than not widening at all, and nothing else in the pipeline would have caught it: the widened case was green, all 134 suites were green, and both mutation recipes returned `guard_verified` — because none of them exercises an absent `skills/` tree.

The fix adds a `skills/**/SKILL.md` arm to the same `missing_surface` chain, tested against the **assembled subject** (`grep -q '/skills/.*/SKILL\.md$'`) rather than with a second `find`, so it cannot drift from what is actually scanned and costs no extra I/O. F8/F8b above are its falsifiers; F8b confirms it reproduces base's semantics for a `skills/` directory that exists but holds no `SKILL.md`.

## Scope decisions

**Why three surfaces and not just `README.md`.** A README-only widening satisfies the issue's AC1 while making **AC2 vacuous** — `cogni-consult/README.md` holds zero occurrences of all seven prefixes, so AC2's own falsifier ("any hit on the `cogni-claims/` directory-path sites") could never fire and the carve-out would guard nothing. `CLAUDE.md` and `references/**/*.md` bring in the two real path sites, which is what makes the carve-out falsifiable in both directions.

**Why `scripts/` and `tests/` are excluded — measured, not assumed.** Of the 44 `cogni-claims` occurrences under `cogni-consult/`, 42 live in those two trees and no lexical carve-out clears them:

| discriminator | residue still red |
|---|---|
| followed by `/` | 11 |
| adjacent to `/` on either side | 3 |

The 11 break down as **8** `mkdir -p "$PROJn/cogni-claims"` in `tests/test_resolve_assumptions.sh` (separator *precedes* the name, line ends right after it), **2** assembled across string-literal boundaries via `os.path.join` (`scripts/resolve-assumptions.py:370`, `scripts/submit-assumption-claim.py:198`) where no separator is adjacent in the source at all, and **1** genuine bare mention in a comment (`tests/test_resolve_assumptions.sh:449`). Including these trees would make the case permanently red on a correct tree.

> The issue's Motivation, and this PR's own triage comment, both asserted these occurrences were uniformly path-shaped. That was false and is [corrected on the issue](https://github.com/cogni-work/insight-wave/issues/1630#issuecomment-5426196976): 44 total, 33 slash-followed, 11 not. The design above is built on the corrected measurement.

**Why the subject is enumerated, not globbed.** Engagement directories live under `cogni-consult/{slug}/` (`CLAUDE.md:162`), so a `find "$PLUGIN_DIR" -name '*.md'` would scan a user's own engagement content as if it were plugin source.

**Not touched:** `.claude-plugin/plugin.json` — the post-merge workflow owns the version bump.

## Test plan

- [x] `bash cogni-consult/tests/test_route_example_hygiene.sh` → five `PASS:` lines, exit 0
- [x] `bash cogni-consult/tests/test_route_example_hygiene.sh --root cogni-consult` → identical output (confirms the new subjects follow `--root`)
- [x] Full repo suite via `python3 scripts/run-plugin-tests.py` — 134/134 pass, `failed: 0` (re-run after the cleanup pass)
- [x] `python3 scripts/check-external-dispatch.py` → clean, `files_affected: 0`
- [x] Suite file spells no retired prefix literally → `0`
- [x] Both mutation-recipe arms replayed → `guard_verified` (re-replayed after the regression fix)

## Follow-up issues

- #1636 — extend the same scan to `agents/*.md` and `output-styles/*.md`, the two authored prose surfaces still uncovered. Both measured clean at this base under the bare match and the carve-out. This sits **outside** #1630's acceptance criteria (which ask for "at minimum the plugin-root README.md"), so all seven of them are delivered here and the link stays `Closes`, not `Refs`.

## Review notes

`check-preflight.sh`'s mutation-recipe check selects subjects by the glob `*/tests/test-*.sh` (hyphen); this suite is `test_route_example_hygiene.sh` (underscore), so that check records `not_applicable` and **the recorded recipe is ungated**. A green preflight is not evidence about it — it was replayed by hand, with the results in the falsification table above. The same naming mismatch makes cogni-service's `run-tests.sh` floor inert for this plugin; insight-wave's own `scripts/run-plugin-tests.py` globs `*/tests/*.sh` name-agnostically and does run this suite.

