### PR TITLE
cogni-portfolio: unslash two unresolvable consumers on registry L43

### DIFF
--- a/cogni-portfolio/skills/portfolio-communicate/references/use-case-registry.md
+++ b/cogni-portfolio/skills/portfolio-communicate/references/use-case-registry.md
@@ -40,7 +40,7 @@ Each scope produces a main component of a portfolio-driven website, driven by a 
 
 **Deprecated scopes (v1):** The `overview` / `market` / `customer` scopes from the previous version are replaced by `home` / (dropped) / `persona`. The old `market/*.md` files are no longer generated — their content was redundant with persona pages and had no role in a standard website IA. Existing market files from past runs are left on disk and not automatically migrated; regenerating with scope=`all` simply stops producing them.
 
-**Downstream pipeline:** Each output file carries `arc_id` in frontmatter so it is directly consumable by downstream cogni-workspace skills — `/story-to-web` for pages, `/story-to-slides` for deck versions — **with no intermediate `/narrative` pass**. Optionally run `/copywrite` on any file before rendering for extra prose polish.
+**Downstream pipeline:** Each output file carries `arc_id` in frontmatter so it is directly consumable by downstream cogni-workspace skills — `story-to-web` for pages, `story-to-slides` for deck versions — **with no intermediate `/narrative` pass**. Optionally run `/copywrite` on any file before rendering for extra prose polish.
 
 ---
 


### PR DESCRIPTION
Closes #1633.

## Summary

Line 43 of `cogni-portfolio/skills/portfolio-communicate/references/use-case-registry.md` wrote two downstream consumers as slash commands that do not resolve. **No `commands/story-to-web.md` or `commands/story-to-slides.md` exists anywhere in the repo** — both exist only as skills (`cogni-workspace/skills/story-to-{web,slides}/SKILL.md`). A skill directory is not a user-invocable slash command.

The fix is a **two-character deletion**: drop the `/` inside each of the two existing backtick pairs.

```diff
-... downstream cogni-workspace skills — `/story-to-web` for pages, `/story-to-slides` for deck versions — ...
+... downstream cogni-workspace skills — `story-to-web` for pages, `story-to-slides` for deck versions — ...
```

`/copywrite` and `/narrative` keep their slashes — both resolve (`cogni-workspace/commands/copywrite.md`, `cogni-workspace/commands/narrative.md`). This is specifically a `story-to-*` problem, not a general slash-token problem.

## The parent's premise was wrong, and this PR does not inherit it

#1627 (merged as PR #1634) edited this very line and asserted these two **do** resolve "because they exist as `SKILL.md`". The issue asked the picker to confirm that independently rather than inherit it. Verified at `origin/main`:

| Token on line 43 | `*/commands/<name>.md` | `*/skills/<name>/SKILL.md` | Verdict |
|---|---|---|---|
| `/story-to-web` | — none — | `cogni-workspace/skills/story-to-web/` | slash form wrong |
| `/story-to-slides` | — none — | `cogni-workspace/skills/story-to-slides/` | slash form wrong |
| `/copywrite` | `cogni-workspace/commands/copywrite.md` | — | correct, slash kept |
| `/narrative` | `cogni-workspace/commands/narrative.md` | — | correct, slash kept |

## Why a two-character deletion and not a rewrite

The first-pass plan proposed rewriting the clause to `the `story-to-web` skill for pages, …`. That was rejected at refine for two reasons:

1. **The committed contract's item 8 is already satisfied without it.** Its falsifier is a *conjunction* — "strips the slashes **but leaves the names unattributed and kind-less**". The governing clause `directly consumable by downstream cogni-workspace skills` already supplies both the attribution and the kind. The rewrite would also have said "skill" three times in one clause, against a repo precedent (`cogni-portfolio/CLAUDE.md:192`, `README.md:223`) that uses the wrapper zero times.
2. **A whole-line retype carried an unguarded corruption hazard.** Line 43 is 332 chars and contains **U+2014 EM DASH** characters. Retyping risks emitting `--` or U+2013 — and **no acceptance-contract item would catch it**: `--numstat` would still read `1	1`, and items 3, 6 and 9 would all still pass. A two-character deletion cannot introduce the drift.

A byte-identity falsifier was run to prove the em-dashes survived:

```
diff <(sed -n '43p' $FILE) \
     <(git show origin/main:$FILE | sed -n '43p' | sed 's|`/story-to-|`story-to-|g')
```
→ empty.

## Verification — 24/24 contract items, partitioned

Graded against the triage-time contract committed on #1633 **before** this branch existed.

**Change-proving (4)** — these fail at base and pass on the branch:
- Line 43 `/story-to-*` count: base **2** → branch **0**
- Both consumers still named bare (`story-to-web`, `story-to-slides`), each with a matching skill
- Every surviving slash token on line 43 resolves to a command file (`/narrative`, `/copywrite`)
- File-wide `/story-to-*` count: base **7** → branch **5** (a drop of exactly 2, all on line 43)

**Preservation / scope guards (5)** — these pass by inaction, and are *not* evidence the fix works:
- Diff confined to `portfolio-communicate/**`; no added file
- `--numstat` exactly `1	1`; file still 253 lines; single hunk; line 43 still the `**Downstream pipeline:**` sentence
- `/copywrite` and `/narrative` each keep their slash, exactly once
- `arc_id` + frontmatter + no-intermediate-`/narrative`-pass claim intact
- Lines 24, 96, 217 byte-identical to base

Quoting a bare "24/24" would overstate this: only 4 items actually prove the fix.

**Tests:** `cogni-portfolio` — 7 discovered, **7 passed**, 0 failed, 0 skipped (discovery floor 1, so not a zero-of-zero green).

## Note for the reviewer — two things I did not treat as clean

1. **`check-breadcrumbs` is red on this plugin (14 offenders), and I did not fix them.** All 14 are pre-existing version tags in `skills/portfolio-dashboard/SKILL.md` and `skills/portfolio-scan/SKILL.md` — the count is **identical at `origin/main`**, and the intersection with this PR's touched set is **empty**. Reporting it rather than letting a red guard read as green.
2. **`Closes` vs `Refs` was a judgment call — flagging it explicitly.** The mechanical rule passes `--partial` (→ `Refs`) whenever `deferred[]` is non-empty, on the stated ground that "a non-empty `deferred[]` *is* deferred scope". Here it is not: #1633 is scoped to **line 43 only** — its body says so and its contract *fences* lines 24/96/217 byte-identical — so the wider class was never in scope and is an **adjacent discovery**, not withheld work. #1633's own scope is 100% delivered, so this PR uses `Closes`. Linking it with `Refs` would strand #1633 open behind a merged PR, a known recurring failure on this board. **If you disagree, the remedy is to swap the keyword, not to reopen scope.**

## Follow-up issues

- **#1657** — repo: every `/story-to-*` slash token is unresolvable — 63 occurrences, no command file exists

Measured at `origin/main`: **63** tokens across `.md` files (cogni-workspace 25, cogni-portfolio 19, docs 15, cogni-website 4). This PR removes 2, leaving 61. #1657 must choose between unslashing the prose and adding `commands/story-to-{web,slides,storyboard}.md` forwarders **before** editing — the forwarder route would make all 63 correct as written, touching no prose.

## Not touched

`cogni-portfolio/.claude-plugin/plugin.json` `version` — the patch bump is applied post-merge.