### PR TITLE
cogni-consult: widen retired-name scan to agents/ and output-styles/

### DIFF
--- a/cogni-consult/tests/test_route_example_hygiene.sh
+++ b/cogni-consult/tests/test_route_example_hygiene.sh
@@ -12,7 +12,7 @@
 #
 # Which mutation reddens which case. Two recipes are recorded in the pull
 # request — one drives the second case, one drives the fifth against the
-# plugin-root README.md; the retired names they substitute are deliberately not
+# output-styles body; the retired names they substitute are deliberately not
 # spelled here, so this file introduces no new mention of a retired plugin.
 #   route-examples-found         deleting both `Route:` example lines
 #   route-example-slug-resolves  rewriting the route token to any prefix listed
@@ -20,7 +20,7 @@
 #   route-example-non-default    rewriting the route token to consult-design-thinking
 #   route-example-parity         changing the route token at one site only
 #   no-retired-plugin-name       planting any retired prefix in any scanned body
-#                                (the recorded README recipe)
+#                                (the recorded output-styles recipe)
 #
 # RELATIONSHIP TO scripts/check-external-dispatch.py. That repo-level guard reads
 # the SAME registry and already scans this subject file, so this suite is not a
@@ -74,7 +74,8 @@
 # file, so they key on that file. Case 5's predicate is plugin-wide — a retired
 # name is wrong in any authored prose the plugin ships — so it scans an
 # ENUMERATED subject: every `skills/**/SKILL.md`, the plugin-root `README.md`
-# and `CLAUDE.md`, and every `references/**/*.md`.
+# and `CLAUDE.md`, every `references/**/*.md`, every `agents/**/*.md`, and every
+# `output-styles/**/*.md`.
 #
 # What that subject leaves out, and why it is enumerated rather than globbed.
 # `scripts/` and `tests/` are excluded because no lexical carve-out clears them
@@ -86,7 +87,8 @@
 # sits adjacent in the source at all; and 1 bare mention in a comment. Including
 # those trees would make the case permanently red against a correct tree, which
 # is the failure this enumeration exists to avoid. `agents/` and
-# `output-styles/` are authored prose too and are simply not covered yet.
+# `output-styles/` are authored prose too, and are covered: both were added to
+# the subject once they were measured clean under the same bare-name predicate.
 # A whole-tree glob over `$PLUGIN_DIR` is also deliberately avoided: engagement
 # directories live under `$PLUGIN_DIR/{slug}/`, so a glob would scan a user's
 # own engagement content as if it were plugin source.
@@ -199,9 +201,9 @@ fi
 
 # --- case 5: no-retired-plugin-name ------------------------------------------
 # No retired plugin prefix may appear in any scanned body in this plugin — skill
-# bodies, the plugin-root README.md and CLAUDE.md, and references/**/*.md — in a
-# Route: note or in prose. An unreadable, empty, or malformed registry fails
-# rather than passing silently.
+# bodies, the plugin-root README.md and CLAUDE.md, references/**/*.md,
+# agents/**/*.md and output-styles/**/*.md — in a Route: note or in prose. An
+# unreadable, empty, or malformed registry fails rather than passing silently.
 retired_prefixes="$(python3 -c '
 import json, sys
 with open(sys.argv[1], encoding="utf-8") as fh:
@@ -228,10 +230,12 @@ for prefix in prefixes:
 # The suite runs under `set -u` only — there is no `set -e` and no pipefail — so
 # a find over a missing directory is inert here; do not add `set -e` without
 # revisiting this.
-scan_desc='skills/**/SKILL.md, README.md, CLAUDE.md, references/**/*.md'
+scan_desc='skills/**/SKILL.md, README.md, CLAUDE.md, references/**/*.md, agents/**/*.md, output-styles/**/*.md'
 scan_bodies="$({
   find "$PLUGIN_DIR/skills" -name SKILL.md -type f
   find "$PLUGIN_DIR/references" -name '*.md' -type f
+  find "$PLUGIN_DIR/agents" -name '*.md' -type f
+  find "$PLUGIN_DIR/output-styles" -name '*.md' -type f
   [ -f "$PLUGIN_DIR/README.md" ] && printf '%s\n' "$PLUGIN_DIR/README.md"
   [ -f "$PLUGIN_DIR/CLAUDE.md" ] && printf '%s\n' "$PLUGIN_DIR/CLAUDE.md"
 } 2>/dev/null | sort)"
@@ -245,15 +249,16 @@ scan_bodies="$({
 # Before the widening, an absent skills/ tree was caught by a dedicated
 # `-z "$skill_bodies"` test; once the subject grew, a bare emptiness test on the
 # whole set only fires when EVERY surface is empty, so an absent skills/ tree
-# would be absorbed by the other three and pass silently.
+# would be absorbed by the others and pass silently.
 #
-# BOTH directory-glob arms — skills/ and references/ — are tested against the
-# ASSEMBLED SUBJECT ($scan_bodies), never with a second find and never with a
-# bare `-d`. A `-d` test asks whether the directory exists, which is a strictly
-# weaker question than whether the scan actually reaches anything inside it: a
-# directory left in place but emptied of its .md files passes `-d` while
-# contributing nothing to the subject, so the surface silently narrows and the
-# case still prints PASS. Testing the subject cannot drift from what is scanned.
+# EVERY directory-glob arm — skills/, references/, agents/, output-styles/ — is
+# tested against the ASSEMBLED SUBJECT ($scan_bodies), never with a second find
+# and never with a bare `-d`. A `-d` test asks whether the directory exists,
+# which is a strictly weaker question than whether the scan actually reaches
+# anything inside it: a directory left in place but emptied of its .md files
+# passes `-d` while contributing nothing to the subject, so the surface silently
+# narrows and the case still prints PASS. Testing the subject cannot drift from
+# what is scanned.
 #
 # The README.md and CLAUDE.md arms are deliberately NOT of that shape and need
 # no conversion: each is a single file gated on `-f`, the identical test the
@@ -266,6 +271,10 @@ printf '%s\n' "$scan_bodies" | grep -q '/skills/.*/SKILL\.md$' \
 [ -f "$PLUGIN_DIR/CLAUDE.md" ] || missing_surface="$missing_surface CLAUDE.md"
 printf '%s\n' "$scan_bodies" | grep -q '/references/.*\.md$' \
   || missing_surface="$missing_surface references/**/*.md"
+printf '%s\n' "$scan_bodies" | grep -q '/agents/.*\.md$' \
+  || missing_surface="$missing_surface agents/**/*.md"
+printf '%s\n' "$scan_bodies" | grep -q '/output-styles/.*\.md$' \
+  || missing_surface="$missing_surface output-styles/**/*.md"
 
 if [ -z "$retired_prefixes" ]; then
   fail "no-retired-plugin-name" "no usable retired_prefixes[] readable from $RETIRED (vacuous scan)"


### PR DESCRIPTION
Closes #1636.

## Summary

Case 5 (`no-retired-plugin-name`) in `cogni-consult/tests/test_route_example_hygiene.sh` now scans `agents/**/*.md` and `output-styles/**/*.md` in addition to the four surfaces #1630 established — so every authored prose surface the plugin ships is covered by the same bare-name-plus-carve-out predicate.

The file's own header (lines 224-227) names **three** registration sites that must move together, and warns that adding a surface to the first two but not the third "is what lets it silently vanish while the case still prints PASS". All three moved:

| Site | Change |
|---|---|
| `$scan_desc` | Names all six surfaces, so the failure message matches what was actually scanned |
| `scan_bodies` assembly | Two `find` calls added **inside** the existing `{ ... } 2>/dev/null \| sort` brace group |
| `$missing_surface` vacuity chain | Two arms added, grepping the **assembled subject** — never `[ -d ]` |

Both new `find` calls derive from `$PLUGIN_DIR`, so `--root` still redirects them, and the group-level `2>/dev/null` keeps a find over a missing directory inert under the suite's `set -u`-only regime (no `set -e`, no pipefail).

**No new `pass` / `fail` call site.** The two arms feed the already-present surface-absent `fail`.

## Why the new vacuity arms grep `$scan_bodies` and not `[ -d ]`

The file records the reason at lines 250-256: `-d` asks whether the directory *exists*, which is strictly weaker than whether the scan *reaches anything inside it*. A directory left in place but emptied of its `.md` files passes `-d` while contributing nothing — the subject narrows silently and the case still prints `PASS`.

This bar is deliberately **above** AC3's literal falsifier, which names only "removing either directory". The emptied-but-present shape is the one that actually slips through, so both shapes are proved red below.

`README.md` / `CLAUDE.md` keep their `-f` arms and correctly so: for a single file, presence and inclusion-in-subject are the same fact, so no emptied-but-present shape exists.

## Evidence

### Suite green, and the widening is real

```
$ bash cogni-consult/tests/test_route_example_hygiene.sh
PASS: route-examples-found
PASS: route-example-slug-resolves
PASS: route-example-non-default
PASS: route-example-parity
PASS: no-retired-plugin-name
```

All 7 prefixes in `scripts/retired-plugins.json`, under the case's own bare-name + `([^/]|$)` carve-out, produce **zero** hits across the 5 newly covered files. The subject gained exactly those 5 paths (4 `agents/`, 1 `output-styles/`).

### Mutation recipe — `guard_verified`

Run from the **repository root**:

```
bash "${CLAUDE_PLUGIN_ROOT}/scripts/mutation-check.sh" \
  --root . \
  --file cogni-consult/output-styles/strategy-advisor.md \
  --expr 's/senior strategy consultant/senior cogni-wiki consultant/' \
  --test 'bash cogni-consult/tests/test_route_example_hygiene.sh' \
  --case no-retired-plugin-name
```

Observed at head: `verdict=guard_verified`, `mutated_result=red`, `restored_result=green` — neither `vacuous_guard` nor `expr_no_op` nor `case_not_found`.

The literal RED line from the mutated run is the **prefix-present** arm — not either vacuous-scan arm, which is what makes it evidence the widened scan actually reached the file:

```
FAIL: no-retired-plugin-name - retired plugin prefix(es) present in a <root>/cogni-consult scanned body (skills/**/SKILL.md, README.md, CLAUDE.md, references/**/*.md, agents/**/*.md, output-styles/**/*.md): cogni-wiki
```

**The recipe falsifies *this* change, not a pre-existing guard.** Proved directly: with the same prefix planted in the same file, the **base** suite still prints `PASS: no-retired-plugin-name`, while the changed suite goes red. `output-styles/` is a surface #1630 did not cover, which is exactly what AC6 requires.

Two notes on replaying it:

- `--root` **must be the repo root**, not the plugin directory. The suite reads `$REPO_ROOT/scripts/retired-plugins.json` and `$REPO_ROOT/.claude-plugin/marketplace.json`, so a plugin-only root reds the case on the *registry* arm and proves nothing about the widening.
- `check-preflight.sh`'s mutation-recipe gate globs `*/tests/test-*.sh` (hyphen) while this suite is `test_route_example_hygiene.sh` (underscore), so that gate records `not_applicable`. **This recipe is ungated** — it was replayed by hand, with RED and restored-GREEN both observed. Do not read the preflight's silence as green.

### Vacuity guard — both shapes red

Run against a scratch tree replicating the repo shape (`scripts/` + `.claude-plugin/` + `cogni-consult/`), since a plugin-only root would red on the registry arm instead.

**Shape A — directory removed** (`agents/`):

```
FAIL: no-retired-plugin-name - scanned surface(s) absent under <root>/cogni-consult: agents/**/*.md (vacuous scan — the subject would silently narrow)
```

**Shape B — directory present but emptied** (`output-styles/`, 0 entries, directory never leaves the tree):

```
FAIL: no-retired-plugin-name - scanned surface(s) absent under <root>/cogni-consult: output-styles/**/*.md (vacuous scan — the subject would silently narrow)
```

Control and post-restore runs both print `PASS`. Shape B is the one a `[ -d ]` test would have missed.

## Two base facts the acceptance criteria state incorrectly

Recorded so the review grades against reality rather than the AC's text:

1. **AC4's falsifier is false at base.** It names "a second `pass`/`fail` call site" as the falsifier, but case 5 already has **three** reachable `fail` call sites at `origin/main` (registry unusable; a scanned surface absent; a retired prefix present) and **one** `pass`, in a single mutually-exclusive `if`/`elif`/`else` chain. The real invariant — preserved here — is **one result line per run, with no NEW call site added**. Call-site count is unchanged at 3 `fail` + 1 `pass`.

2. **The `mutation-check.sh` the AC names is cogni-service's**, at `${CLAUDE_PLUGIN_ROOT}/scripts/mutation-check.sh` (flags `--root`/`--file`/`--expr`/`--test`/`--case`) — *not* `cogni-consult/scripts/mutation-check.sh`, which is a different, flagless, hardcoded two-tuple harness that merely shares the basename. The recipe above targets the former.

## Scope

- **In:** one file, `cogni-consult/tests/test_route_example_hygiene.sh`.
- **Out:** the 5 newly covered subject files (`cogni-consult/agents/*.md`, `cogni-consult/output-styles/strategy-advisor.md`). They are read-only inputs to the guard and are untouched.
- The match stays **bare-name** with the `([^/]|$)` carve-out — a colon anchor would be permanently green against the defect class the case exists to catch.
- The subject stays **enumerated**, never a whole-tree glob: engagement directories live at `cogni-consult/{slug}/`.
- The suite file still spells **zero** retired plugin prefixes — the recipe's substituted name lives in this PR body, not in the guard.
- No `plugin.json` / `marketplace.json` version touch — the bump is post-merge.

## Prose updated in step

`SCOPE OF EACH CASE` · the now-false "simply not covered yet" sentence · the case-5 inline enumeration · "absorbed by the other three" (a stale surface count) · "BOTH directory-glob arms" → every glob arm · the two recipe-provenance lines, repointed from the README body to the `output-styles` body.

Left alone as still-accurate: the `scripts/`/`tests/` exclusion rationale, the whole-tree-glob avoidance paragraph, the defect-class provenance lines, and the `-f`-arms-need-no-conversion note.

Two of those rewrites made the surface count explicit (`ALL FOUR`, `the other five`); the pre-commit quality pass replaced both with count-free wording, so a future surface addition does not have to edit them again.

## Test plan

- [x] `bash cogni-consult/tests/test_route_example_hygiene.sh` — 5/5 `PASS`, exit 0
- [x] Sibling cases 1-4 unchanged in behavior and still passing
- [x] Mutation recipe replayed by hand — `guard_verified` (red → green)
- [x] Recipe proved green-at-base with the same prefix planted (so it falsifies this change)
- [x] Vacuity shape A (directory removed) reds, naming `agents/**/*.md`
- [x] Vacuity shape B (directory emptied, present) reds, naming `output-styles/**/*.md`
- [x] Call-site count unchanged: 3 `fail` + 1 `pass` for the case id
- [x] Guard spells no retired prefix
- [x] `bash -n` clean; all added comment lines ≤ 80 chars
