### PR TITLE
Unslash the 36 command-position /story-to-* tokens

### DIFF
--- a/cogni-portfolio/skills/portfolio-communicate/SKILL.md
+++ b/cogni-portfolio/skills/portfolio-communicate/SKILL.md
@@ -72,7 +72,7 @@ If the request is ambiguous, present options:
 
 > "What do you want to use the portfolio content for?"
 > - **Pitch narrative** — arc-structured presentation narrative, ready for story-to-slides (company presents to audience)
-> - **Customer narratives (portfolio-driven website)** — Home, About, Capability, Persona, How-We-Work pages, each arc-structured and ready for `/story-to-web` (company speaks to buyer via web)
+> - **Customer narratives (portfolio-driven website)** — Home, About, Capability, Persona, How-We-Work pages, each arc-structured and ready for `story-to-web` (company speaks to buyer via web)
 > - **Proposals** — per-proposition sales proposals for specific Feature × Market pairs
 > - **Marketing briefs** — market content packages with sizing, buyer profile, messaging themes
 > - **Portfolio workbook** — XLSX spreadsheet with all portfolio data for analysis
@@ -362,8 +362,8 @@ For **customer-narrative**:
 - **Score quality**: "Run `/narrative-review` on any generated file to score against its arc's quality gates (each file already carries `arc_id` in frontmatter)"
 - **Polish prose**: "Run `/copywrite` on any generated file to polish for executive readability while preserving arc structure"
 - **Visual formats** (direct — no intermediate `/narrative` step needed, because each file already carries `arc_id`):
-  - `/story-to-web` → scrollable web page (one per file, or an indexed multi-page site)
-  - `/story-to-slides` → PowerPoint version of any page
+  - `story-to-web` → scrollable web page (one per file, or an indexed multi-page site)
+  - `story-to-slides` → PowerPoint version of any page
   - `/enrich-report` → themed HTML with concept diagrams (value flows, relationship maps) and interactive charts
 - **Marketing content** (if cogni-marketing installed): "These customer narratives are automatically discovered by `/marketing-setup` and used as voice/messaging enrichment when generating marketing content — ensuring consistency between how the website speaks to buyers and how your marketing speaks to the same audience"
 
@@ -371,9 +371,9 @@ For **pitch**:
 - **Score quality**: "Run `/narrative-review` to score against the arc's quality gates"
 - **Polish prose**: "Run `/copywrite` to polish for executive readability while preserving arc structure"
 - **Visual formats** (direct — no intermediate step needed):
-  - `/story-to-slides` → PowerPoint presentation
-  - `/story-to-web` → scrollable landing page
-  - `/story-to-storyboard` → multi-poster print storyboard
+  - `story-to-slides` → PowerPoint presentation
+  - `story-to-web` → scrollable landing page
+  - `story-to-storyboard` → multi-poster print storyboard
   - `/enrich-report` → themed HTML with concept diagrams and data charts
 - **Deepen**: "Run `/why-change` to add web research, customer-specific context, and TIPS enrichment for a deal-ready version"
 

--- a/cogni-portfolio/skills/portfolio-communicate/references/templates-customer-narrative.md
+++ b/cogni-portfolio/skills/portfolio-communicate/references/templates-customer-narrative.md
@@ -1,6 +1,6 @@
 # Templates: Customer Narrative
 
-Output templates for the `customer-narrative` use case. These templates produce the **main components of a portfolio-driven website** from the buyer's perspective — each file is arc-structured and carries an `arc_id` in its YAML frontmatter so that `/story-to-web` (and `/story-to-slides`) can render it directly, with no intermediate `/narrative` pass needed.
+Output templates for the `customer-narrative` use case. These templates produce the **main components of a portfolio-driven website** from the buyer's perspective — each file is arc-structured and carries an `arc_id` in its YAML frontmatter so that `story-to-web` (and `story-to-slides`) can render it directly, with no intermediate `/narrative` pass needed.
 
 **Use case**: `customer-narrative`
 **Audience**: Buyers, executives, decision-makers navigating a portfolio-driven website
@@ -51,7 +51,7 @@ Apply these rules wherever a product or feature is rendered:
 
 ## YAML Frontmatter (all scopes)
 
-Every generated file includes frontmatter that `/story-to-web`, `/narrative-review`, `/copywrite` and friends all understand:
+Every generated file includes frontmatter that `story-to-web`, `/narrative-review`, `/copywrite` and friends all understand:
 
 ```yaml
 ---

--- a/cogni-portfolio/skills/portfolio-communicate/references/templates-pitch.md
+++ b/cogni-portfolio/skills/portfolio-communicate/references/templates-pitch.md
@@ -406,7 +406,7 @@ After generating a pitch narrative, suggest:
 1. **Score quality**: `/narrative-review` — scores against the arc's quality gates (structural compliance, evidence density, technique application)
 2. **Polish prose**: `/copywrite` — applies executive readability standards while preserving arc structure
 3. **Visualize**:
-   - `/story-to-slides` → PowerPoint presentation via PPTX skill
-   - `/story-to-web` → scrollable landing page via Pencil MCP
-   - `/story-to-storyboard` → multi-poster print storyboard via Pencil MCP
+   - `story-to-slides` → PowerPoint presentation via PPTX skill
+   - `story-to-web` → scrollable landing page via Pencil MCP
+   - `story-to-storyboard` → multi-poster print storyboard via Pencil MCP
 4. **Deepen** (if needed): `/why-change` — adds web research, customer-specific context, and TIPS enrichment for a deal-ready version

--- a/cogni-portfolio/skills/portfolio-communicate/references/use-case-registry.md
+++ b/cogni-portfolio/skills/portfolio-communicate/references/use-case-registry.md
@@ -21,7 +21,7 @@ Available communication use cases for portfolio content. Each use case defines a
 
 **Scopes:**
 
-Each scope produces a main component of a portfolio-driven website, driven by a specific story arc from `the `narrative` skill`. Each output file includes `arc_id` in frontmatter so it is directly consumable by `/story-to-web` without an intermediate `/narrative` pass.
+Each scope produces a main component of a portfolio-driven website, driven by a specific story arc from the `narrative` skill. Each output file includes `arc_id` in frontmatter so it is directly consumable by `story-to-web` without an intermediate `/narrative` pass.
 
 | Scope | Output file | Component | Arc |
 |-------|------------|-----------|-----|
@@ -93,7 +93,7 @@ Each scope produces a main component of a portfolio-driven website, driven by a 
 
 **Key differentiator**: Pitch output includes `arc_id` in frontmatter — this makes it directly consumable by story-to-slides, story-to-web, and story-to-storyboard without an intermediate `/narrative` step. Default arc: `jtbd-portfolio`.
 
-**Downstream pipeline:** `/narrative-review` → `/copywrite` → `/story-to-slides`, `/story-to-web`, `/story-to-storyboard`
+**Downstream pipeline:** `/narrative-review` → `/copywrite` → `story-to-slides`, `story-to-web`, `story-to-storyboard`
 
 ---
 
@@ -214,7 +214,7 @@ Users can define reusable custom use cases by saving them to `communicate-use-ca
         ]
       },
       "output_path": "output/communicate/investor/",
-      "downstream": "Polish with /copywrite, then /story-to-slides for pitch deck"
+      "downstream": "Polish with /copywrite, then story-to-slides for pitch deck"
     }
   ]
 }

--- a/cogni-workspace/skills/copywriter/SKILL.md
+++ b/cogni-workspace/skills/copywriter/SKILL.md
@@ -414,7 +414,7 @@ All references are organized in progressive disclosure tiers. Start with `refere
 When polishing a research report (detected by project directory containing `project-config.json` or `00-sub-questions/`), include this guidance after the quality metrics:
 
 > **Next: Visual pipeline**
-> 1. `/story-to-infographic` + `/render-infographic` — Infographic header (Pencil, 10-step validated)
+> 1. `story-to-infographic` + `/render-infographic` — Infographic header (Pencil, 10-step validated)
 > 2. `/enrich-report` — Themed HTML with charts (reuses infographic from step 1)
 >
 > Running story-to-infographic first gives enrich-report a validated, Pencil-rendered header instead of its simplified inline fallback.

--- a/cogni-workspace/skills/story-to-slides/README.md
+++ b/cogni-workspace/skills/story-to-slides/README.md
@@ -31,25 +31,15 @@ Transform any narrative with a story arc into an optimized YAML-based presentati
 
 ### Basic Usage
 
-```bash
-# Single narrative file with default theme (smarter-service)
-/story-to-slides source_path=/path/to/narrative.md language=en
+Dispatch `story-to-slides` with `source_path` (and optionally `theme`, `language`, `arc_type`):
 
-# Project directory (reads all .md files)
-/story-to-slides source_path=/path/to/proposal/ theme=smarter-service language=en
+- Single narrative file, default theme (smarter-service): `source_path=/path/to/narrative.md language=en`
+- Project directory (reads all `.md` files): `source_path=/path/to/proposal/ theme=smarter-service language=en`
+- With a specific theme (created via `pick-theme`): `source_path=/path/to/proposal/ theme=cogni-work language=en`
+- Custom client theme: `source_path=/path/to/proposal/ theme=acme-corp language=de`
+- Why Change project (auto-detected or explicit): `source_path=/path/to/proposals/customer-slug/ arc_type=why-change`
 
-# With a specific theme (created via /grab-theme)
-/story-to-slides source_path=/path/to/proposal/ theme=cogni-work language=en
-
-# Custom client theme
-/story-to-slides source_path=/path/to/proposal/ theme=acme-corp language=de
-
-# Why Change project (auto-detected or explicit)
-/story-to-slides source_path=/path/to/proposals/customer-slug/ arc_type=why-change
-
-# From why-change-work Phase 5 synthesis (automatic invocation)
-/why-change-work  # Automatically invokes story-to-slides in Phase 5
-```
+`why-change-work` Phase 5 synthesis invokes `story-to-slides` automatically.
 
 ### Parameters
 

--- a/cogni-workspace/skills/story-to-slides/README.md
+++ b/cogni-workspace/skills/story-to-slides/README.md
@@ -35,7 +35,7 @@ Dispatch `story-to-slides` with `source_path` (and optionally `theme`, `language
 
 - Single narrative file, default theme (smarter-service): `source_path=/path/to/narrative.md language=en`
 - Project directory (reads all `.md` files): `source_path=/path/to/proposal/ theme=smarter-service language=en`
-- With a specific theme (created via `pick-theme`): `source_path=/path/to/proposal/ theme=cogni-work language=en`
+- With a specific theme (created via `grab-theme`): `source_path=/path/to/proposal/ theme=cogni-work language=en`
 - Custom client theme: `source_path=/path/to/proposal/ theme=acme-corp language=de`
 - Why Change project (auto-detected or explicit): `source_path=/path/to/proposals/customer-slug/ arc_type=why-change`
 

--- a/docs/plugin-guide/cogni-trends.md
+++ b/docs/plugin-guide/cogni-trends.md
@@ -289,7 +289,7 @@ Use this when you have a completed trend report and need to transform it into vi
 
 1. `/trend-synthesis` — compose the trend report from research evidence and claims
 2. the `narrative` skill `/narrative` — transform the report into an arc-driven narrative
-3. cogni-workspace `/story-to-slides` — create a slide deck from the narrative
+3. cogni-workspace `story-to-slides` — create a slide deck from the narrative
 4. cogni-workspace `/claims` — verify the claims registry
 
 ---

--- a/docs/workflows/install-to-infographic.md
+++ b/docs/workflows/install-to-infographic.md
@@ -105,16 +105,16 @@ Set up a visual theme so every visual output — infographics, slides, websites 
 
 ## Step 4: Render Your First Infographic
 
-Turn a short narrative into a one-page infographic via `/story-to-infographic`. This skill produces an infographic-brief.md first, then renders it in one of two style families: hand-drawn (via Excalidraw MCP) or editorial (via Pencil MCP). Running one of each doubles as a live check that both MCPs are wired up.
+Turn a short narrative into a one-page infographic via `story-to-infographic`. This skill produces an infographic-brief.md first, then renders it in one of two style families: hand-drawn (via Excalidraw MCP) or editorial (via Pencil MCP). Running one of each doubles as a live check that both MCPs are wired up.
 
 Start with the sample narrative below — it's a self-contained paragraph you can paste into the chat exactly as-is:
 
 > In 2025, our services team delivered 47 projects across 12 industries. Roughly half touched AI transformation — a three-fold jump from 2024. Client NPS climbed to 68, and 84% of engagements led to follow-on work. The shift: clients now ask us to redesign workflows, not just ship software.
 
-With that narrative in the chat, run the hand-drawn preset first:
+With that narrative in the chat, ask for the hand-drawn preset first:
 
 ```
-/story-to-infographic --style=sketchnote
+Render this narrative as a hand-drawn sketchnote infographic
 ```
 
 This produces an infographic-brief, then renders it via **Excalidraw MCP** into an `.excalidraw` file you can open in the Excalidraw editor. You should see a one-page visual summary of the narrative with hand-drawn styling.
@@ -122,7 +122,7 @@ This produces an infographic-brief, then renders it via **Excalidraw MCP** into 
 Now try the editorial preset:
 
 ```
-/story-to-infographic --style=economist
+Render this narrative as an editorial-style infographic
 ```
 
 Same narrative, but this time rendered via **Pencil MCP** into a `.pen` file — a clean editorial data page in the style of The Economist. Open it in the Pencil editor to compare.

--- a/docs/workflows/portfolio-to-pitch.md
+++ b/docs/workflows/portfolio-to-pitch.md
@@ -2,7 +2,7 @@
 
 **Pipeline**: cogni-portfolio (end-to-end) — setup → foundation → commercial layer → messaging → pitch
 **Duration**: 2–5 hours for a first pitch; longer if the foundation work is new
-**End deliverable**: `output/communicate/pitch/{market-slug}.md` — an arc-structured presentation narrative produced by `/portfolio-communicate`, ready to render with `/story-to-slides` or `/story-to-web`
+**End deliverable**: `output/communicate/pitch/{market-slug}.md` — an arc-structured presentation narrative produced by `/portfolio-communicate`, ready to render with `story-to-slides` or `story-to-web`
 
 ```mermaid
 graph LR
@@ -26,7 +26,7 @@ Along the way you produce:
 - **Foundation** — products, features, (optionally) a lean-canvas import, (optionally) a discovered inventory from `/portfolio-ingest` and `/portfolio-scan`
 - **Commercial layer** — markets with TAM/SAM/SOM, ICPs and buyer personas per market
 - **Messaging** — IS/DOES/MEANS propositions per Feature × Market, sharpened with competitor battle cards and (optionally) solution blueprints with pricing tiers
-- **Pitch** — `output/communicate/pitch/{market-slug}.md` (arc-structured, `arc_id` in frontmatter). Optionally render visually with `/story-to-slides`, `/story-to-web`, or `/story-to-storyboard`
+- **Pitch** — `output/communicate/pitch/{market-slug}.md` (arc-structured, `arc_id` in frontmatter). Optionally render visually with `story-to-slides`, `story-to-web`, or `story-to-storyboard`
 - **Optional visuals** — `/portfolio-dashboard` (interactive HTML) and `/portfolio-architecture` (Excalidraw product-feature map)
 
 ## Prerequisites
@@ -209,7 +209,7 @@ Render the mid-market SaaS pitch as a slide deck
 Create a scrollable web version of the DACH manufacturing pitch
 ```
 
-These dispatch to `/story-to-slides` or `/story-to-web` inside cogni-workspace, inheriting your workspace theme.
+These dispatch to `story-to-slides` or `story-to-web` inside cogni-workspace, inheriting your workspace theme.
 
 ### Optional — stakeholder visuals (shared)
 

--- a/docs/workflows/research-to-report.md
+++ b/docs/workflows/research-to-report.md
@@ -168,12 +168,12 @@ This runs 5 parallel stakeholder personas (executive, technical, legal, marketin
 
 Distill the polished report into a single-page visual summary using cogni-workspace's story-to-infographic skill. This extracts the 3–5 most impactful data points and produces an infographic brief that auto-renders into a visual.
 
-**Command**: `/story-to-infographic` or describe what you want
+**Command**: `story-to-infographic` or describe what you want
 
 **Example prompts:**
 
 ```
-/story-to-infographic
+Create an infographic from my research report
 ```
 
 ```


### PR DESCRIPTION
Closes #1657.

> **Link is `Refs`, not `Closes`, and that is a mechanical consequence — not a claim that #1657 is unfinished.** `service-resolve` requires `--partial` whenever `deferred[]` is non-empty, and this run filed one follow-up (#1663). **Every acceptance criterion of #1657 is satisfied by this PR** (AC1 recorded, AC2 argued below, AC3 vacuous, AC4/AC6 preserved, AC5 fixed), so **#1657 should be closed when this merges.** Flagging explicitly because a `Refs`-only link makes the issue invisible to the reap sweep, which is how issues end up open forever behind a merged PR that finished them. **Maintainer override, 2026-08-27:** the link is now `Closes` — `closingIssuesReferences` was empty, so #1657 would not have auto-closed on merge. The `Refs` form was the skill's mechanical rule firing on a non-empty `deferred[]`, not a judgment that the issue is unfinished; every AC of #1657 is in scope of this PR.

## Summary

`story-to-{web,slides,storyboard,infographic}` ship as **skills**, not slash commands — `git ls-files '*/commands/story-to-*'` is empty while all four `cogni-workspace/skills/story-to-*/SKILL.md` exist. Every `/story-to-*` token written in command position is therefore an instruction a reader cannot run as written.

This PR unslashes the **36 command-position** tokens across 10 markdown files and leaves the **25 filesystem path segments** byte-identical. It also fixes the AC5 nested-backtick artifact at `use-case-registry.md:24`.

## Scope decisions

**Remedy (a) — unslash the prose — is binding; AC1 is satisfied.** The choice, and the rejection of remedy (b) (adding `commands/story-to-*.md` forwarders), were recorded on the issue **before any edit**, at [comment 5440823028](https://github.com/cogni-work/insight-wave/issues/1657#issuecomment-5440823028). (b) was rejected on three grounds: it collides with open #1643, which folds `story-to-storyboard` into `story-to-web`, and with epic #1648's surface-reduction thesis; its AC names only 3 of the 4 live slugs, so it would have reported green while 17 `/story-to-infographic` tokens stayed broken; and (a) continues the precedent #1633 set. **No `commands/` file is created by this PR.**

**AC3 is VACUOUS, not satisfied.** Its antecedent ("If (b)") is unmet. `cogni-workspace/commands/story-to-{web,slides,storyboard}.md` are deliberately absent — do not read AC3 as passing, it was never in play.

**AC4 preserved.** `use-case-registry.md:43` is byte-identical and still on line 43; the file is 253 lines at both base and head. Line 24 was the only edit above line 43, so the guard reduced to "line 24 stays exactly one line" — it does.

**AC5 fixed.** `use-case-registry.md:24` no longer carries the nested span `` `the `narrative` skill` ``.

**AC6 preserved.** No `plugin.json` is touched — the patch bump is post-merge. The diff also touches no `*.sh`, no `*.yml`, and nothing under `.github/`.

### AC2 — the deviation, argued rather than asserted compliant

**This PR does not satisfy AC2 as written, and does not claim to.** AC2's literal command is unsatisfiable without damage.

| Matcher | base | head | AC2 target |
|---|---|---|---|
| broad — `git grep -o -E '/story-to-[a-z]+' -- '*.md' \| wc -l` | 61 | **25** | 0 (not reached, deliberately) |
| command-position — ``git grep -o -E '(^\|[[:space:]`(])/story-to-[a-z]+' -- '*.md' \| wc -l`` | 36 | **0** | — |

The two matchers **partition the 61 exhaustively** (36 + 25 = 61); no token falls in a third class, and zero command-position tokens exist outside `*.md`. The 25 residual occurrences are real filesystem path segments — `${CLAUDE_PLUGIN_ROOT}/skills/story-to-web/references/02-section-architecture.md`, `${CLAUDE_PLUGIN_ROOT}/agents/story-to-infographic.md` and friends. Driving the broad grep to `0` would rewrite live reference paths and turn `cogni-website/tests/test-cross-plugin-path-hygiene.sh` red — the very guard that protects them.

The issue's own **Desired behavior** says every occurrence must "resolve, **or is not written as a command**". A path segment is not written as a command, so it is already compliant; AC2's grep is simply broader than the property AC2 exists to enforce. AC2's *second* clause — every resulting bare slug has a matching `cogni-workspace/skills/<slug>/SKILL.md` — **is** satisfied, for all four slugs.

The 10 edited files and the 10 files holding the 25 preserved path segments are **disjoint sets**, so byte-identity of the 25 is structural rather than a matter of careful editing.

### Incidental fix riding along — disclosed, not silent

Replacing the ```bash fence in `cogni-workspace/skills/story-to-slides/README.md` necessarily un-slashes two tokens that are **not** `/story-to-*`: `/grab-theme` and `/why-change-work`. Both are themselves unresolvable (no `grab-theme` skill or command exists anywhere; no `why-change-work` skill exists in cogni-workspace). They go bare as a byproduct of removing the block that contained them, not as a scope expansion. Every other co-located unresolvable token — `/pick-theme`, `/install-mcp`, `/manage-themes` — is deliberately left untouched, as are `/narrative`, `/narrative-review`, `/copywrite`, `/render-infographic` (which does resolve).

## Verification

- command-position `36 → 0`; broad `61 → 25`; every surviving hit is preceded by `skills` or `agents`
- `use-case-registry.md`: line 43 byte-identical, 253 lines at base and head, additions == deletions
- `cogni-website/` contributes a **zero-line diff**
- guards green: `test-relocated-skill-hygiene.sh` (3 cases), `test-de-ascii-orthography.sh` (13 cases incl. a mutation check), `cogni-website/tests/test-cross-plugin-path-hygiene.sh` (8 cases), `verify-theme-backcompat.sh`
- `check-frontmatter.sh` clean on both touched plugins (41 + 52 units)
- **`check-breadcrumbs.sh` is RED on cogni-portfolio — 14 offenders, all PRE-EXISTING and none in a file this diff touches.** Base count is also 14. They live in `skills/portfolio-dashboard/SKILL.md` and `skills/portfolio-scan/SKILL.md`; this diff touches neither. Named here rather than silently rewritten.

**No `scripts/mutation-check.sh --expr` recipe applies to this PR.** The change adds no guard and modifies no test or check script — `check-preflight.sh` independently reaches the same conclusion, skipping its `mutation-recipe` instrument as `not_applicable` ("no touched path matching `*/tests/test-*.sh` or `*/scripts/check-*.sh`"). Handoff preflight overall: **clean, rc=0 — 5 passed, 0 failed, 2 skipped**; the other skip is `agent-length` (`not_applicable`, no touched `agents/*.md`). `skill-length` passes advisory-only: both touched `SKILL.md` are pre-existing over-cap, and this diff **shrinks** both, so the net-growth budget holds with no coupled rewrite.

### Author self-grade against the issue-time contract

Graded against the 19-item contract derived at triage time (before any branch existed): **17 satisfied, 1 residual, 1 fixed in a follow-up commit.** Contract item 12 was reported violated by the grader and is a **false positive** — `use-case-registry.md:96` *is* correctly backticked (`` `story-to-slides` ``, `` `story-to-web` ``, `` `story-to-storyboard` ``); verified byte-wise rather than accepted.

**Residual — contract item 17 vs item 13, a genuine conflict between two items of the same contract.** Item 13 requires the `bash` fence in `story-to-slides/README.md` be dissolved (a fenced `/story-to-slides` cannot be fixed by adding backticks, which render literally inside a fence). Item 17 requires non-`story-to` token counts stay at their base values. The fence contained `/grab-theme` and `/why-change-work`, so dissolving it necessarily drops their leading slashes: `/grab-theme` 3 → 2, `/why-change-work` 1 → 0. The two items cannot both hold. Item 13 wins because it is the one the issue's Desired behavior actually mandates; item 17's purpose — no scope creep — is otherwise honoured. Both tokens are themselves unresolvable, so nothing that resolved stopped resolving.

A follow-up commit narrowed this as far as it goes: the first pass had also silently **renamed** `grab-theme` to `pick-theme`, a semantic change genuinely outside scope. That rename is reverted — the token keeps its own name and only loses the slash the deleted fence carried.

### Gates deliberately not run — named, not silently skipped

- **Step 6.4 `/simplify` (code pass)** — inert: the diff is prose-only markdown, no code.
- **Step 6.4b prose-simplify agents** and **Step 6.5 skill-quality-reviewer** — not dispatched. Both touched `SKILL.md` files change by a **single character** each (`` `/story-to-X` `` → `` `story-to-X` ``), and both files **shrink** (−6 B and −1 B), so the net-growth budget is satisfied with no coupled rewrite. Dispatching a prose editor here would rewrite files this PR barely touches. Recording the skip rather than reporting a green gate that examined nothing.

## Open questions

1. **(genuine)** AC2 as written cannot be satisfied without damage — see above. Please write the ruling **into the issue's AC2 text**, not only as a PR comment: an AC body edit bumps the issue's `lastEditedAt` past the already-derived review contract and forces a re-derive, whereas a comment-only ruling leaves the superseded literal bar re-demandable at the next grading. Suggested wording: *"command-position count 36 → 0, and the broad matcher returns exactly 25, proving the path segments were preserved."*
2. **(avoidable — recorded, not blocking)** Replacement wording for the two unlabeled "type this" fences in `docs/workflows/install-to-infographic.md`. Chosen by matching the verified sibling precedent at `docs/workflows/research-to-report.md:180`. Reword freely if the onboarding voice should differ. Worth a human read: that file's "Step 4: Render Your First Infographic" is an onboarding walkthrough, and no gate can decide whether the rewritten step is still followable.

## Follow-up issues

- #1663 — the 4 remaining nested-backtick `` `the `narrative` skill` `` artifacts outside this issue's AC5 scope (two live in sibling plugins `cogni-consult` / `cogni-trends`).

