### PR TITLE
Unnest the 4 remaining nested-backtick narrative-skill spans

### DIFF
--- a/cogni-consult/references/publish-routing.md
+++ b/cogni-consult/references/publish-routing.md
@@ -48,7 +48,7 @@ Consult deliverables are **framework-shaped** (Pyramid / SCQA / MECE), not
 `story-to-web`) auto-detect a narrative arc and build best when the source is a
 story; a WBS-addressed analytical deliverable is not a story, so dispatching them
 directly yields a weak brief. For the same reason this path does **not**
-re-narrate the deliverable through `the `narrative` skill` — arc-ifying a
+re-narrate the deliverable through the `narrative` skill — arc-ifying a
 framework-shaped deliverable softens the executive/Pyramid register it is written
 in.
 

--- a/cogni-consult/skills/consult-publish/SKILL.md
+++ b/cogni-consult/skills/consult-publish/SKILL.md
@@ -126,7 +126,7 @@ execution summary, so read the reference for each route before dispatching:
 one route the skill builds itself rather than dispatching. Consult deliverables
 are framework-shaped (Pyramid / SCQA / MECE), not arc-shaped, so this path does
 **not** dispatch `cogni-workspace:story-to-slides` / `story-to-web` and does **not**
-re-narrate through `the `narrative` skill` — arc-ifying a framework-shaped deliverable
+re-narrate through the `narrative` skill — arc-ifying a framework-shaped deliverable
 weakens its executive register. Derive the outline directly from the
 deliverable's own structure: an ordered list of `{section_title, section_body}`
 entries with citations preserved — Pyramid answer / governing thought → the

--- a/cogni-portfolio/skills/portfolio-communicate/references/templates-customer-narrative.md
+++ b/cogni-portfolio/skills/portfolio-communicate/references/templates-customer-narrative.md
@@ -8,7 +8,7 @@ Output templates for the `customer-narrative` use case. These templates produce 
 
 ## The website component model
 
-A portfolio-driven website — from the buyer's perspective — has these main components. Each corresponds to a scope in this use case and is driven by a specific story arc from `the `narrative` skill`:
+A portfolio-driven website — from the buyer's perspective — has these main components. Each corresponds to a scope in this use case and is driven by a specific story arc from the `narrative` skill:
 
 | Scope | Output file | Component | Arc | Why this arc |
 |---|---|---|---|---|

--- a/cogni-trends/skills/trend-synthesis/SKILL.md
+++ b/cogni-trends/skills/trend-synthesis/SKILL.md
@@ -537,7 +537,7 @@ catalog, dashboard).
 
 **Pipeline:** `trend-scout → value-modeler → trend-research → trend-synthesis → verify-trend-report`
 
-**Optional cross-plugin:** `the `narrative` skill` smarter-service arc — theme-case writer + dimension composer guidance (graceful fallback if absent). The Storytelling Spine in this SKILL.md is self-contained; the `narrative` skill arc-definition is supplementary, not required.
+**Optional cross-plugin:** the `narrative` skill smarter-service arc — theme-case writer + dimension composer guidance (graceful fallback if absent). The Storytelling Spine in this SKILL.md is self-contained; the `narrative` skill arc-definition is supplementary, not required.
 
 **Downstream (via `/verify-trend-report`):** claim verification (`cogni-workspace:claims`), cross-theme structural review, post-verification revision, executive polish (`cogni-workspace:copywriter`), themed HTML (`cogni-workspace:enrich-report`)
 


### PR DESCRIPTION
## Summary

Removes the un-renderable outer backtick pair from the four remaining nested narrative-skill code spans across `cogni-consult`, `cogni-portfolio` and `cogni-trends`, matching the house style #1657 set for `use-case-registry.md:24`.

Markdown has no nesting for single-backtick spans, so the defective 4-backtick form parses as two broken spans instead of the intended prose. Each fix deletes the outer pair and leaves the inner pair byte-identical — one line per file, four lines total. (The defective literal is deliberately not reproduced in this prose; it is held in the `LIT` shell variable in the test plan below.)

- `cogni-consult/references/publish-routing.md:51`
- `cogni-consult/skills/consult-publish/SKILL.md:129`
- `cogni-portfolio/skills/portfolio-communicate/references/templates-customer-narrative.md:11`
- `cogni-trends/skills/trend-synthesis/SKILL.md:540`

## Scope decisions

- Prose only. No `plugin.json` `version` is touched — the patch bump is applied post-merge, per plugin actually touched.
- The correctly-formed phrase is deliberate house style and is left alone. Measured at base: **87 occurrences across 84 distinct lines** (3 lines carry two — `trend-synthesis/SKILL.md:540`, `copywriter/references/09-preservation-modes/arc-preservation.md:66`, `docs/plugin-guide/cogni-sales.md:46`).
- No `/story-to-*` or other command token is altered; that class is #1657's.
- Both `SKILL.md` edits are body prose, below the frontmatter (which ends at line 14 in `consult-publish/SKILL.md` and line 20 in `trend-synthesis/SKILL.md`), so no frontmatter surface is touched.
- `trend-synthesis/SKILL.md:540` carries two occurrences of the phrase; only the first (nested) one is edited — the second is already correct and stays byte-identical.
- `use-case-registry.md:24` is already clean at base (#1657 has merged), so this PR sweeps 4 sites, not the 5 the issue enumerates.
- No guidance-skill routing is attached. A docs-generator pass rewrites whole regions, not single lines, so routing these four one-line prose fixes through one would put the untouched lines this PR explicitly fences at risk.

## Test plan

All base values below were measured at `origin/main` @ `96bcd3c6`.

```sh
# The defective nested literal and the correct house form, held in shell vars so
# this PR body does not reproduce the bug it fixes.
LIT='`the `narrative` skill`'   # 4 backticks - the defect
PHR='the `narrative` skill'     # the correct form (a SUBSTRING of LIT)

# 1. Nested form gone repo-wide.
#    NOTE: `git grep -c` prints PER-FILE counts (at base it prints four
#    "<path>:1" lines) and prints nothing at all when clean, exiting 1 - so it
#    never literally "returns 0". Count occurrences for a clean numeric zero.
git grep -o -F -- "$LIT" -- '*.md' | wc -l                                   # expect 0   (base: 4)

# 2. AC3 diff shape: no hunk touches a line that did not carry the nested form.
#    This REPLACES the old "correctly-formed phrase count unchanged (expect 87)"
#    check, which was vacuous by construction: PHR is a substring of LIT, so the
#    4 defective sites are counted inside the total too, and the fix deletes only
#    the outer backticks - the total is identical whether the fix is right,
#    wrong, or absent. (It also mis-stated its own base: `| wc -l` counts LINES,
#    so it printed 84, not the 87 occurrences it asserted.)
git diff origin/main -U0 | grep -E '^-'  | grep -v '^---' | wc -l                # expect 4
git diff origin/main -U0 | grep -E '^-'  | grep -v '^---' | grep -c -F -- "$LIT" # expect 4
git diff origin/main -U0 | grep -E '^\+' | grep -v '^+++' | wc -l                # expect 4
git diff origin/main -U0 | grep -E '^\+' | grep -v '^+++' | grep -c -F -- "$LIT" # expect 0
#    The (removed-lines, removed-lines-carrying-LIT) = (4, 4) pair is the teeth:
#    if the edit touched any line that did NOT carry the nested form, the first
#    number exceeds the second and AC3 is falsified. The final 0 confirms no
#    added line reintroduces the defect.

# 3. Diff shape.
git diff --stat origin/main    # expect: 4 files changed, 4 insertions(+), 4 deletions(-)

# 4. No command token altered - inspect ADDED/REMOVED lines only.
#    The old form grepped the RAW diff, which carries 3 lines of context by
#    default. `story-to-` sits at publish-routing.md:48 (exactly the L-3 context
#    boundary) and at consult-publish/SKILL.md:128, so the raw-diff form returns
#    2 against an expectation of 0 - a FALSE FAILURE reporting an altered token
#    when nothing was altered. Restricting to +/- lines returns 0.
git diff origin/main -U0 | grep -E '^[+-]' | grep -Ev '^(\+\+\+|---)' \
  | grep -c 'story-to-'          # expect 0

# 5. No version bump.
git diff origin/main --name-only -- '*/.claude-plugin/plugin.json'   # expect empty
```

## Follow-up issues

- **#1666** — 5 nested-backtick artifacts of the identical defect class with `copywriter` as the inner word, across `cogni-consult/skills/consult-publish/SKILL.md` (3 sites) and `cogni-trends/skills/verify-trend-report/` (2 sites).

Found by the Step 6.5 `skill-quality-reviewer` whole-file pass during this resolve run, not by the issue text. Deliberately **not** fixed here: this issue's acceptance criteria fence the diff to lines carrying the *narrative* nested form, so sweeping them in would violate the bar this PR is graded against, and would pull `verify-trend-report/` into a PR with no other reason to touch it. Same reason #1663 was itself split out of #1657.

`Closes #1663` is still correct rather than `Refs`: #1663's own falsifier is narrative-specific and now returns 0. #1666 is newly-discovered scope, not deferred scope of this issue.

## Review notes

Annotations from the Step 6.5 skill-quality gate. **Every entry is `introduced_by_change: false`** — pre-existing whole-skill conditions this 8-byte diff did not cause — so per the gate's own rule they are annotated here rather than re-planned, and none blocks.

- `cogni-trends/skills/trend-synthesis/SKILL.md` is **over its length cap** (34294 chars vs a 31500 cap at complexity 17). Strictly pre-existing: base was 34296, so this change made it 2 chars *smaller*. The net-growth rule resolves a pre-existing over-cap this diff did not grow to annotate-only — no coupled rewrite, no filed follow-up. The reviewer also noted the overage reads as largely legitimate: the skill already ships a populated `references/` tree with a phase-gated index, and the remaining body is workflow spine rather than offloadable detail.
- `cogni-consult/skills/consult-publish/SKILL.md` carries two clauses framing current behaviour against a prior state ("now", "no longer"). Pre-existing prose; rewriting it would breach this issue's line fence.
- `cogni-consult/skills/consult-publish/SKILL.md` also carries 3 of the 5 `copywriter`-inner artifacts now tracked in #1666.

**One condition a reviewer should know about, unrelated to this diff:** `check-breadcrumbs.sh` fails on `cogni-portfolio` with 14 offenders (version tokens in `portfolio-dashboard/SKILL.md` and `portfolio-scan/SKILL.md`). Verified **identical at base** — same 14 offenders, same lines, base `rc=1`. This diff introduces none, and the touched `cogni-portfolio` file is not among them. It is flagged because that guard is absolute rather than touched-set-scoped, so it fires for any change that brings `cogni-portfolio` into the touched set.