### PR TITLE
cogni-workspace: test coverage for the null suggested_hex branch

### DIFF
--- a/cogni-workspace/tests/test-check-contrast.sh
+++ b/cogni-workspace/tests/test-check-contrast.sh
@@ -54,6 +54,25 @@
 # exactly the refactor the emission property is meant to survive. cc22-cc25 all
 # stay GREEN under it, because every one of them runs the default route where
 # requested is empty -- which is why the narrow path needed a case of its own.
+#
+# Fourth recipe, for the unreachable-threshold arm (the discriminator is
+# cc31-null-suggestion-is-present-and-null):
+#
+#   bash "$HOME/.claude/plugins/marketplaces/managed-service/cogni-service/scripts/mutation-check.sh" \
+#     --root . \
+#     --file cogni-workspace/scripts/check-contrast.py \
+#     --expr 's{^    return None$}{    return "#000000"}m' \
+#     --test 'bash cogni-workspace/tests/test-check-contrast.sh' \
+#     --case cc31-null-suggestion-is-present-and-null
+#
+# The mutant turns the no-direction-clears branch into a constant return, so the
+# discriminator reads (True, '#000000', 1) instead of (True, None, 1). The anchor
+# is single-occurrence: check-contrast.py carries three `return None`, and only
+# suggest_hex's is four-space indented -- parse_hex's two are eight-space, which
+# the `^    ` anchor excludes. cc13/cc14 stay GREEN under the mutant because the
+# BELOW_45 fixture's walk returns early and never reaches the mutated line, and
+# cc15 stays GREEN because a passing pair never calls suggest_hex at all -- which
+# is why this arm needed a case of its own.
 
 set -u
 
@@ -241,6 +260,30 @@ fi
 
 assert_eq "cc15-passing-pair-has-no-suggestion" "None" \
   "$(field "$ABOVE_45" "data['pairs'][0].get('suggested_hex')" --pair fg:bg)"
+
+# When neither lightness direction clears the threshold from the foreground's
+# hue, suggest_hex returns None and the failing pair carries suggested_hex: null.
+NULL_SUGGESTION="$(palette nullsuggestion '{"fg":"#333333","bg":"#757575"}')"
+
+assert_ratio "cc31-null-suggestion-ratio" "2.7422" \
+  "$(field "$NULL_SUGGESTION" "data['pairs'][0]['ratio']" --pair fg:bg)"
+
+# Present-and-null, NOT the absent key cc15 pins: evaluate_pair sets
+# suggested_hex only when the pair fails, so a bare .get() renders both states
+# as None and would grade vacuously -- the membership test is the discriminator.
+# data['evaluated'] is co-asserted as in cc28.
+assert_eq "cc31-null-suggestion-is-present-and-null" "(True, None, 1)" \
+  "$(field "$NULL_SUGGESTION" "('suggested_hex' in data['pairs'][0], data['pairs'][0]['suggested_hex'], data['evaluated'])" --pair fg:bg)"
+
+# A null suggestion is data, not an error. This deliberately bypasses field(),
+# which reads payload.get('data') and DISCARDS payload['success'] -- same
+# inline-python idiom as cc17, keeping --pair fg:bg so all three assertions
+# grade the same invocation.
+assert_eq "cc31-null-suggestion-envelope-succeeds" "(True, True)" \
+  "$(python3 "$SCRIPT" "$NULL_SUGGESTION" --pair fg:bg 2>/dev/null | python3 -c "
+import json, sys
+payload = json.load(sys.stdin)
+print((payload['success'], 'fg on bg' in payload['data']['failures']))" 2>/dev/null)"
 
 echo "=== G. palette handling ==="
 

--- a/cogni-workspace/tests/test-check-contrast.sh
+++ b/cogni-workspace/tests/test-check-contrast.sh
@@ -55,7 +55,7 @@
 # stay GREEN under it, because every one of them runs the default route where
 # requested is empty -- which is why the narrow path needed a case of its own.
 #
-# Fourth recipe, for the unreachable-threshold arm (the discriminator is
+# Fourth recipe, for the null-suggestion arm (the discriminator is
 # cc31-null-suggestion-is-present-and-null):
 #
 #   bash "$HOME/.claude/plugins/marketplaces/managed-service/cogni-service/scripts/mutation-check.sh" \
@@ -65,7 +65,7 @@
 #     --test 'bash cogni-workspace/tests/test-check-contrast.sh' \
 #     --case cc31-null-suggestion-is-present-and-null
 #
-# The mutant turns the no-direction-clears branch into a constant return, so the
+# The mutant turns the null-suggestion branch into a constant return, so the
 # discriminator reads (True, '#000000', 1) instead of (True, None, 1). The anchor
 # is single-occurrence: check-contrast.py carries three `return None`, and only
 # suggest_hex's is four-space indented -- parse_hex's two are eight-space, which
@@ -261,8 +261,17 @@ fi
 assert_eq "cc15-passing-pair-has-no-suggestion" "None" \
   "$(field "$ABOVE_45" "data['pairs'][0].get('suggested_hex')" --pair fg:bg)"
 
-# When neither lightness direction clears the threshold from the foreground's
-# hue, suggest_hex returns None and the failing pair carries suggested_hex: null.
+# suggest_hex returns None here, but NOT because the hue is unreachable. The -1
+# walk genuinely never clears -- best 4.4883 at #030303. The +1 walk DOES clear
+# unsnapped at lightness 0.99 (ratio 4.5084) and is rejected only by the module's
+# own snapped re-verification: #FCFCFC re-scores 4.4910, below 4.5. Both true
+# endpoints would clear (#000000 = 4.5578, #FFFFFF = 4.6075) and are never
+# evaluated, because the accumulating `candidate_lightness += direction * step`
+# terminates at -3.1e-17 and 1.0000000000000007, so the range guard breaks one
+# step short of pure black and pure white. The None is the conjunction of those
+# two facts, so a walk refactor that lands exactly on 0.0/1.0 will legitimately
+# turn this case red -- review that as an intentional behaviour change, not a
+# broken fixture. The endpoint miss itself is tracked separately as issue 1684.
 NULL_SUGGESTION="$(palette nullsuggestion '{"fg":"#333333","bg":"#757575"}')"
 
 assert_ratio "cc31-null-suggestion-ratio" "2.7422" \


### PR DESCRIPTION
Closes #1659.

## Summary

- Adds `cc31-*` to `cogni-workspace/tests/test-check-contrast.sh` — the suite's first coverage of `suggest_hex()`'s `return None` arm (`check-contrast.py:175`).
- Fixture `{"fg":"#333333","bg":"#757575"}` on `--pair fg:bg`: ratio 2.7422, fails 4.5:1, and `suggest_hex` returns `None`, so the pair carries `suggested_hex: null`. The `-1` walk genuinely never clears (best 4.4883 at `#030303`); the `+1` walk **does** clear unsnapped at lightness 0.99 (4.5084, `#FCFCFC`) and is rejected only by the module's own snapped re-verification (`#FCFCFC` re-scores 4.4910); and both true endpoints would clear (`#000000` = 4.5578, `#FFFFFF` = 4.6075) but are never evaluated, because the accumulating lightness step terminates just outside `[0, 1]`. The `null` is the conjunction of those two facts, not an unreachable hue.
- Three assertions — the ratio pin, the present-and-null discriminator, and the envelope read.
- Records a fourth mutation recipe in the suite header, matching the three already there.

`cogni-workspace/scripts/check-contrast.py` is unchanged.

## Why each assertion is shaped the way it is

Each one is aimed at a specific way this case could have graded vacuously.

| Assertion | Guards against |
|---|---|
| `cc31-null-suggestion-ratio` | A constant-return mutant satisfying a verdict by accident — the suite header's standing rule that every fixture pins its ratio. |
| `cc31-null-suggestion-is-present-and-null` | `.get('suggested_hex')` renders **present-and-null** and **absent-key** identically as `None`. `evaluate_pair` sets the key only when the pair fails, so `cc15` (a passing pair) pins the absent state and this pins the present-and-null one. Asserted as the tuple `('suggested_hex' in pair, pair['suggested_hex'], data['evaluated'])`; the co-asserted `evaluated` count means a run that formed no pair cannot read as a pass. |
| `cc31-null-suggestion-envelope-succeeds` | `field()` reads `payload.get('data')` and **discards `payload['success']`**, so an envelope assertion routed through it would grade nothing. This one bypasses `field()` using the inline-python idiom `cc17` already establishes, and keeps `--pair fg:bg` so all three assertions grade the same invocation. |

## Verification

- `bash cogni-workspace/tests/test-check-contrast.sh` → all cases pass, exit 0. The three new labels print `PASS`.
- Guard has teeth — `mutation-check.sh` reports **`guard_verified`** (mutated red, restored green).
- **Attribution proven**, not assumed: under the mutant, `cc13`, `cc14` and `cc15` all stay `PASS` and the only failure is `cc31-null-suggestion-is-present-and-null`. `cc13`/`cc14` run a fixture whose walk returns early and never reaches the mutated line; `cc15`'s passing pair never calls `suggest_hex` at all.
- The mutation anchor `^    return None$` is single-occurrence: `check-contrast.py` carries three `return None`, and only `suggest_hex`'s is four-space indented — `parse_hex`'s two are eight-space.
- `git diff origin/main -- cogni-workspace/scripts/check-contrast.py` is empty; no `plugin.json` version touched.

## Mutation recipe

```
bash "$HOME/.claude/plugins/marketplaces/managed-service/cogni-service/scripts/mutation-check.sh" \
  --root . \
  --file cogni-workspace/scripts/check-contrast.py \
  --expr 's{^    return None$}{    return "#000000"}m' \
  --test 'bash cogni-workspace/tests/test-check-contrast.sh' \
  --case cc31-null-suggestion-is-present-and-null
```

## Scope decisions

- Fenced to `cogni-workspace/tests/**`, per the acceptance contract derived at triage.
- New ids are `cc31-*`, appended after `cc15` in section F, beside the `suggested_hex` contract they pin. **No existing id renumbered** — the suite header records the ids as a machine contract for the pairing guard and `mutation-check.sh --case`, says "Do not renumber", and sanctions numeric-vs-file-order divergence for exactly this reason.
- The threshold matters: a sweep over 46,656 colour pairs finds 21 null-returning cases at the 4.5 normal-text threshold and **zero** at 3.0, so a `--large-pair` fixture could never reach this arm.

## Correction to the issue body

The issue cites `check-contrast.py:114` for the `return None`. That anchor is **stale** — `:114` is blank space in the output-envelope region. The real `return None` is `:175`. The test comments deliberately name symbols rather than line numbers, so they cannot rot the same way.

## Follow-up issues

- **#1684** — `suggest_hex`'s lightness walk stops one step short of the `L=0.0` / `L=1.0` endpoints.

  The walk accumulates `candidate_lightness += direction * 0.01` and breaks when the accumulator leaves `[0, 1]`, so float drift means it never evaluates the endpoints exactly. Across every fixture probed, the best effective ratio the walk reaches is ~4.491 against a 4.5 threshold. For this PR's own fixture, pure black scores **4.558** and *would* clear — so the tool reports "no suggestion" where a valid one exists.

  Not fixed here: it would require changing `check-contrast.py` (fenced out) and would invalidate the very fixture this issue asks for. It also raises a real question for #1684 to settle — whether the `return None` arm is reachable *only* as an artifact of the truncated walk, in which case fixing the walk may make it dead code and this case should be retired with it.

## Open questions

None blocking.

## Operational disclosure

The revision push cleared `check-token-scope.sh --strict` via the **`--allow-overscoped` flag**
(scoped to that single invocation; the env-var form is deliberately not used, because it leaks into
the nested `run-tests` and false-blocks `check-preflight`).

The runner token is a `gh auth login` OAuth (`gho_`) token whose scope set is fixed by the GitHub
CLI OAuth app and cannot be narrowed: `forbidden_scopes: ["workflow"]`, `extra_scopes: ["gist",
"read:org", "workflow"]`. This machine is a personal, dedicated runner operating against the
operator's own repository, which is the condition `cogni-service/CLAUDE.md` § Operational hardening
states for the opt-out. The gate itself is unchanged and still exits 1 by default.

## Revision history

`d0bf2087` → `4597b879` — comment-only correction of the false mechanism claim raised as the gating
`major` in the automated verdict. No fixture, assertion or expected value changed; all 20
`cogni-workspace/tests/` suites stay green.

## Review notes

Two quality findings were raised and deliberately **not** applied, because both would edit pre-existing cases outside this diff:

- A `payload()` sibling to `field()` would collapse the three hand-rolled raw-envelope `python3 -c` blocks (`cc02`, `cc17`, and this PR's third assertion) and restore the `PARSE_ERROR` guard those hand-rolled blocks drop. Worth doing as its own change.
- The "Do not renumber" convention is written as a local note beside the `cc28`-`cc30` cluster. With a second id-vs-file-order exception now, it reads as a file-level invariant that belongs in the header.
