### PR TITLE
Unnest the 5 nested-backtick `copywriter` code spans repo-wide

### DIFF
--- a/cogni-consult/skills/consult-publish/SKILL.md
+++ b/cogni-consult/skills/consult-publish/SKILL.md
@@ -93,7 +93,7 @@ lineage entry (step 5), so a second format never overwrites the first.
 ### 3. Optional voice polish
 
 The brief text may be polished with `cogni-workspace:copywriter` before
-handoff. This is optional and graceful-degrading — **if `the `copywriter` skill` is
+handoff. This is optional and graceful-degrading — **if the `copywriter` skill is
 not installed, skip it with a one-line note**; the route still produces a valid
 brief.
 
@@ -156,7 +156,7 @@ render, so the run never requires a renderer at all. `cogni-workspace:enrich-rep
 `story-to-infographic` remain available only as an explicit opt-in local-render
 fallback (they render locally and apply a cogni-workspace theme, which the
 brief-only contract otherwise avoids) — they are no longer the standard path.
-When `the `copywriter` skill` is absent, the optional polish step is skipped. Either
+When the `copywriter` skill is absent, the optional polish step is skipped. Either
 way the run still produces a valid brief.
 
 ### 4.5 Resolve assumption placeholders (mandatory)
@@ -236,7 +236,7 @@ If multiple formats were produced in this session, list each brief path.
 - **No render dependency.** Every format builds a consult-native brief, so the
   standard path never renders and never dispatches a renderer —
   `cogni-workspace:enrich-report` / `story-to-infographic` remain an opt-in
-  local-render fallback only. When `the `copywriter` skill` is absent the optional
+  local-render fallback only. When the `copywriter` skill is absent the optional
   polish step is skipped. Either way the run still produces a valid brief — a
   missing downstream plugin degrades the output, it never fails the run.
 - **Assumption resolution is fail-loud, not graceful-degrading.** The step-4.5

--- a/cogni-trends/skills/verify-trend-report/SKILL.md
+++ b/cogni-trends/skills/verify-trend-report/SKILL.md
@@ -385,7 +385,7 @@ The user can re-enter this skill later to pick a different path; downstream skil
 | Verification returns FAIL | Present failed claims interactively in Phase 3. Do not auto-correct. |
 | Reviewer returns `revise` but no priorities | Treat as `accept` (defensive — cogni-trends reviewer rarely emits this state) |
 | Revisor validation fails | Surface specific failure to the user; do not auto-rerun. Backup at `.tips-trend-report-pre-revision-v{N}.md` is canonical. |
-| `the `copywriter` skill` not installed | Phase 5 menu skips the polish option silently |
+| the `copywriter` skill not installed | Phase 5 menu skips the polish option silently |
 | `cogni-workspace:enrich-report` not available | Phase 5 menu skips the visualize option silently |
 
 ## Integration

--- a/cogni-trends/skills/verify-trend-report/references/downstream-options.md
+++ b/cogni-trends/skills/verify-trend-report/references/downstream-options.md
@@ -19,7 +19,7 @@ AskUserQuestion:
       description: "See the full option set (slides, web, storyboard, catalog, dashboard)"
 ```
 
-If `the `copywriter` skill` is not installed, omit the polish option silently. If `cogni-workspace:enrich-report` is not available, omit the visualize option. If both are missing, skip the menu entirely and direct the user to `/trends-resume`.
+If the `copywriter` skill is not installed, omit the polish option silently. If `cogni-workspace:enrich-report` is not available, omit the visualize option. If both are missing, skip the menu entirely and direct the user to `/trends-resume`.
 
 ## Option 1 — Polish
 


### PR DESCRIPTION
Closes #1666.

## Summary
Deletes the outer backtick pair on five sites where a prose phrase was wrapped in single backticks while already containing an inner backtick pair around `copywriter`. Single-backtick spans do not nest in Markdown, so each site currently parses as two broken code spans instead of one prose sentence containing one code span.

The defective literal, kept fenced so this PR body does not reproduce the defect it fixes:

```
`the `copywriter` skill`
```

Sites fixed, all verified byte-exact at `origin/main` (0256a769) before editing:

| Site | Structure it sits in |
|---|---|
| `cogni-consult/skills/consult-publish/SKILL.md:96` | inside a bold run that opens at :96 and closes at :97 |
| `cogni-consult/skills/consult-publish/SKILL.md:159` | plain paragraph-opening sentence |
| `cogni-consult/skills/consult-publish/SKILL.md:239` | 2-space-indented continuation of the bullet opened at :236 |
| `cogni-trends/skills/verify-trend-report/SKILL.md:388` | left cell of the fallback-behavior table row |
| `cogni-trends/skills/verify-trend-report/references/downstream-options.md:22` | the one line also carrying `cogni-workspace:enrich-report` and `/trends-resume` |

The transform is the same fixed-string substitution that landed for the `narrative` counterpart in #1663: drop the outer pair, keep the inner pair, let the surrounding words fall back to plain prose. Every one of the five is a pure two-character deletion — added-line length equals removed-line length minus 2 at all five sites, and no line is re-wrapped to absorb the freed characters.

## Evidence

The acceptance bar's own warning is that the corrected phrase is a *substring* of the nested literal, so counting the plain phrase before and after is invariant and grades nothing. Only the nested-literal count grades:

- **Non-vacuous at base** — this returns **5**, across exactly the five lines above (3 + 1 + 1):

  ```
  git grep -c -F '`the `copywriter` skill`' origin/main -- '*.md'
  ```

- **Zero at head** — the same fixed-string grep over `*.md` returns **0** repo-wide (exit 1, no hits):

  ```
  git grep -c -F '`the `copywriter` skill`' -- '*.md'
  ```

- **No collateral hunks:** the diff is 5 removed / 5 added lines across 3 files. Every removed line carried the nested literal at base — 0 removed lines fall outside the fence.
- **Neighbour tokens intact,** checked on added/removed lines only (a raw `git diff | grep` counts unified-context lines and false-fails on tokens nothing touched): the token multiset on the removed side equals the added side exactly — `cogni-workspace:enrich-report` x1, `/trends-resume` x1.
- **Table shape preserved:** row :388 still carries 3 pipes / 2 cells, matching its eight sibling rows at :381-:389.
- **No version touched:** `git diff --name-only` lists only the three markdown files; 0 `"version"` lines appear on any added or removed line.

### What the test run does and does not prove

136/136 repo suites pass (`scripts/run-plugin-tests.py`, 0 failed). That is evidence this change **broke nothing** — it is **not** evidence the change is correct. No suite in this repo inspects markdown code-span well-formedness: there is no markdownlint or remark config, and none of `lint.yml`'s eight `check-*.py` gates covers this pattern. The fixed-string grep above is the only real proof, and a PR body leaning on the green CI run would be leaning on nothing.

No `## Mutation recipe` section is included: the diff touches no `*/tests/test-*.sh` and no `*/scripts/check-*.sh`, so there is no guard here for a mutation to falsify.

## Scope decisions

- **Included:** exactly the five `*.md` lines named in the issue, one edit per occurrence.
- **There is no sixth occurrence.** An early exploration pass in this session reported `cogni-trends/scripts/project-status.sh:750` as a non-`*.md` instance of the class. Verified at `origin/main`, that line carries a **well-formed** single span around the bare word, not the nested outer-pair form. A repo-wide fixed-string sweep over every tracked file (not just `*.md`) returns exactly the five markdown sites, so the filed set is complete and closed. The correction is recorded here because it changed an acceptance criterion on the follow-up below.
- **Neighbour tokens deliberately not touched:** `consult-publish/SKILL.md:95` already carries a correctly-formed `cogni-workspace:copywriter` span one line above site 1, and is **not** consistency-renamed. In these sentences `the` and `skill` are ordinary English words, not part of an invocation token.
- **The class-retiring guard is out of scope** by the issue's explicit instruction, and is filed separately (below).

## Deviation — argued, not asserted away

The resolve pipeline's pre-commit prose pass normally dispatches an Edit-capable simplifier at any touched `SKILL.md`. **It was deliberately not dispatched here.** Turning a prose editor loose on these two files would rewrite lines that did not carry the nested literal at base, breaching this issue's do-not-sweep acceptance criterion — the bar this PR is graded against. Both units are also far below the net-growth approach zone (`consult-publish` 12963 / 22500 = 58%, `verify-trend-report` 17930 / 28500 = 63%) and both **shrink** under this diff, so no growth budget is engaged and there is nothing for the pass to claw back. Sub-zone prose accretion is `service-simplify`'s standing corpus-wide sweep, not this fenced five-line diff's job.

The read-only skill-quality gate **did** run on both files and returned `pass`, with zero auto-fixable and zero structural findings.

## Follow-up issues

- #1686 — repo: add a repo-wide guard for the nested-single-backtick code-span class.

This is the third point fix for one defect class (#1657, then #1663, then this one). No deterministic guard covers the shape, so each occurrence is found only because someone happens to read the file. #1686 carries that class-level decision on its own bar — including an explicit adjudication of whether the checker's glob should extend past `*.md`, argued on its own merits rather than on the `project-status.sh` line corrected above.