### PR TITLE
repo: drop the retired `ask` skill from the root marketplace entry

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -56,14 +56,13 @@
       "source": "./cogni-workspace",
       "version": "0.6.116",
       "maturity": "preview",
-      "description": "The horizontal layer of the insight-wave marketplace — it owns the shared workspace state the vertical business plugins consume. Manages shared infrastructure (env vars, settings), MCP server installation and Desktop config patching, theme management, theme picker, plugin discovery, workspace health, an interactive workspace-configuration dashboard, Obsidian vault integration, a bundled vendor-curated insight-wave reference wiki queryable via the ask skill, and cross-plugin claim verification — submitting sourced assertions, verifying them against their cited URLs, and guiding deviation resolution.",
+      "description": "The horizontal layer of the insight-wave marketplace — it owns the shared workspace state the vertical business plugins consume. Manages shared infrastructure (env vars, settings), MCP server installation and Desktop config patching, theme management, theme picker, plugin discovery, workspace health, an interactive workspace-configuration dashboard, Obsidian vault integration, a bundled vendor-curated insight-wave reference wiki read directly from its bundled wiki/index.md, and cross-plugin claim verification — submitting sourced assertions, verifying them against their cited URLs, and guiding deviation resolution.",
       "keywords": [
         "workspace",
         "themes",
         "orchestrator",
         "insight-wave",
-        "wiki",
-        "ask"
+        "wiki"
       ]
     },
     {


### PR DESCRIPTION
Closes #1668.

## Summary
- `.claude-plugin/marketplace.json` line 59: replace the description clause `a bundled vendor-curated insight-wave reference wiki queryable via the ask skill` with `a bundled vendor-curated insight-wave reference wiki read directly from its bundled wiki/index.md`, matching the wording already landed at `cogni-workspace/.claude-plugin/plugin.json:4`.
- `.claude-plugin/marketplace.json` lines 65-66: remove the `"ask"` keywords element and the now-trailing comma after `"wiki"`, as one atomic edit — deleting the element without the comma leaves the manifest unparseable.
- No other file is touched. No `version` field anywhere in the diff — the patch bump is applied post-merge.

Diff is 1 file, +2/-3.

## Scope decisions

**Included:** exactly the two surfaces the issue names, in one file. Commit `8ec875ad` (PR #1670, closed #1641) retired `cogni-workspace/skills/ask/` and rewrote the plugin's own `plugin.json` description, but never touched the root manifest, which carries an independent hand-duplicated copy.

**Deliberately excluded — the graft is clause-scoped.** The upstream `plugin.json` description has since gained trailing story-arc-narrative and executive-copywriting clauses the marketplace entry never had. Importing them would be separate drift riding in on an unrelated fix, so only the `ask` → wiki clause is grafted and the marketplace sentence keeps its own `, and cross-plugin claim verification` ending.

**Deliberately excluded — the fence.** This issue was split out of #1641 because that issue's acceptance criteria fence every changed path to `cogni-workspace/`, `wiki/`, `docs/`, or the root `README.md`. Widening *this* PR past the one file it was split out for would repeat the mistake in the other direction. Historical/audit records are **not** swept: `cogni-workspace/references/absorption-roadmap.md` lines 73 and 361 sit inside tables that document designates as preserved historical inventory, and `cogni-workspace/skills/copywriter/references/10-stakeholder-review/executive-review.md:55` uses "ask" as a sales term, not the skill.

## Verification run on this branch

| Check | Result |
|---|---|
| `python3 -c "import json;json.load(open('.claude-plugin/marketplace.json'))"` | exits 0 |
| `cogni-workspace` entry `keywords` | `["workspace","themes","orchestrator","insight-wave","wiki"]` — 5 elements, order preserved, `wiki` survives |
| standalone `ask` token in that entry's `description` (case-insensitive) | 0 hits |
| `foundation` in that entry | 0 hits (`test-layering-claim-reconciled.sh` case L9 scans this file) |
| `git diff -U0 origin/main -- . \| grep '^[+-].*"version"'` | no output — no version line moved |
| `git diff --name-only origin/main` | `.claude-plugin/marketplace.json` only |
| `python3 scripts/check-version-bump.py --mode pr` | exits 0, `status: "ok"` (not `degraded`) — the mirror invariant was asserted, not skipped |
| `bash cogni-workspace/tests/test-layering-claim-reconciled.sh` | exits 0, L1-L9 all pass |
| `python3 scripts/run-plugin-tests.py` | exits 0 — **136/136 suites passed**, 0 failed, 0 timed out |

## Observations recorded for the reviewer, deliberately not acted on

**1. The `wiki/index.md` path is bundle-root-relative.** The settled upstream wording says `read directly from its bundled wiki/index.md`. There is no `cogni-workspace/wiki/index.md`; the real index is `cogni-workspace/wiki/wiki/index.md` — i.e. `wiki/index.md` relative to the bundled wiki root, which is how the phrase reads. This is a pre-existing property of already-merged `plugin.json` wording. The issue explicitly asks these two copies to match, so this PR matches them rather than unilaterally diverging; any rewording belongs upstream.

**2. A `/simplify` finding was raised and rejected.** The pre-commit quality pass proposed deleting the mechanism clause entirely (`...reference wiki, and cross-plugin claim verification...`) rather than replacing it, arguing the description should name the capability and not its access mechanism. That was **not** applied: it would falsify the issue's own Desired behavior ("matching the wording already landed in `cogni-workspace/.claude-plugin/plugin.json`") and the issue-time acceptance contract's item 4, which requires the surviving clause to assert the read-directly claim. Recorded here so the reviewer sees the alternative was considered rather than missed.

**3. Routing note.** The plan routed this file to `plugin-dev:plugin-settings`, which covers `.claude/*.local.md` per-project settings — a different concern from a marketplace manifest. It was loaded as reference material per protocol and contributed nothing; the edit follows the plan's own precise, 4d-validated instruction. Flagging it as a small routing-table mis-target, not a defect in this diff.

## Follow-up issues

- **#1688** — two stale present-tense `cogni-workspace:ask` references outside this issue's one-file fence (`cogni-workspace/references/wiki-tree-reconciliation.md:300`, and header rationale comments at `cogni-workspace/tests/test-wiki-namespace-sync.sh` lines 5, 10, 34). Filed with an explicit out-of-scope list so the historical-inventory tables are not swept.
- **#1689** — **the recurrence guard.** Nothing asserts the root `marketplace.json` ↔ `plugin.json` `description` mirror, which is *why* this issue exists. `scripts/check-version-bump.py` already enumerates plugins from `plugins[].source` and loads both manifests in one pass to assert a `version` mirror, and is CI-wired. Measured before filing: `description` is byte-identical for 7/8 plugins (cogni-workspace the sole divergence), and `keywords` is a **subset** for 8/8 but **equal for only 5/8** — so the guard is specified as description-strict-equality plus keywords-**subset**, never keywords-equality, which would land red on three correctly-behaving plugins.

`cogni-knowledge/references/absorption-roadmap.md:235` was deliberately **not** filed — already tracked by #1669. Both follow-ups passed the pre-file duplicate gate.

## Plan record
https://github.com/cogni-work/insight-wave/issues/1668#issuecomment-5459318458