### PR TITLE
Flag live-plugin dispatch tokens that resolve to no skill or agent

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,7 +24,7 @@ jobs:
           python3 scripts/check-breadcrumbs.py
 
   external-dispatch-guard:
-    name: External-dispatch guard (zero retired-engine dispatches)
+    name: External-dispatch guard (retired-prefix and unresolved-target arms)
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -35,7 +35,7 @@ jobs:
       # Keep this name free of ": " — an unquoted YAML plain scalar containing a
       # colon-space makes the whole workflow unparseable, which silently takes
       # every job in this file offline rather than failing one step.
-      - name: Assert zero retired-plugin dispatches in live surfaces (registry scripts/retired-plugins.json)
+      - name: Assert zero retired-plugin dispatches and zero unresolved dispatch targets in live surfaces (registry scripts/retired-plugins.json)
         run: |
           set -euo pipefail
           python3 scripts/check-external-dispatch.py

--- a/cogni-portfolio/skills/portfolio-scan/SKILL.md
+++ b/cogni-portfolio/skills/portfolio-scan/SKILL.md
@@ -35,7 +35,7 @@ setup → ingest (docs) → features (refine) → products (organize) → propos
 
 ## Prerequisites
 
-A cogni-portfolio project must exist for this company. If `cogni-portfolio/{slug}/portfolio.json` does not exist, instruct the user to run `cogni-portfolio:setup` first.
+A cogni-portfolio project must exist for this company. If `cogni-portfolio/{slug}/portfolio.json` does not exist, instruct the user to run `cogni-portfolio:portfolio-setup` first.
 
 **Setup integration:** This skill is typically invoked from `portfolio-setup` Step 5.5 when a company URL and taxonomy template are available. It also works standalone after setup. When invoked from setup, Phase 0 prerequisites are already satisfied.
 
@@ -117,7 +117,7 @@ The `company.products` array in `portfolio.json` (if present) provides initial o
    mkdir -p "${PROJECT_PATH}/research/.metadata"
    ```
 
-**If no portfolio project exists:** Stop and tell the user: "No portfolio project found for {company}. Run `cogni-portfolio:setup` first to create the project structure."
+**If no portfolio project exists:** Stop and tell the user: "No portfolio project found for {company}. Run `cogni-portfolio:portfolio-setup` first to create the project structure."
 
 ---
 
@@ -347,7 +347,7 @@ Write portfolio metadata to `research/.metadata/scan-output.json`:
   "company_name": "{COMPANY_NAME}",
   "company_slug": "{COMPANY_SLUG}",
   "created": "{ISO_TIMESTAMP}",
-  "skill": "cogni-portfolio:scan",
+  "skill": "cogni-portfolio:portfolio-scan",
   "template_type": "{TEMPLATE_TYPE}",
   "consolidation_mode": "{CONSOLIDATION_MODE}",
   "output_file": "research/{COMPANY_SLUG}-portfolio.md",

--- a/cogni-trends/skills/trends-resume/SKILL.md
+++ b/cogni-trends/skills/trends-resume/SKILL.md
@@ -208,7 +208,7 @@ When `phase` is `complete`, the `next_actions` array from `project-status.sh` co
 
 **Verify & Polish**
 - `cogni-trends:verify-trend-report` — Extended pipeline: claim verification, cross-theme structural review, revisor loop, and a downstream menu for polish + visualization
-- `cogni-workspace:copywrite` — Direct polish-only pass (skip if already invoked through the verify-trend-report Phase 5 menu)
+- `cogni-workspace:copywriter` — Direct polish-only pass (skip if already invoked through the verify-trend-report Phase 5 menu)
 
 **Companion Catalog**
 - `cogni-trends:trend-booklet` — Comprehensive catalog of all ~60 candidates organized by dimension → subcategory → horizon (companion to the curated investment-themes report)

--- a/scripts/check-external-dispatch.py
+++ b/scripts/check-external-dispatch.py
@@ -38,8 +38,30 @@ Two scoping choices, stated because the sibling guard next door made the opposit
     the colon. A retired *skill* on a live plugin (`cogni-x:some-skill`) therefore
     cannot be expressed, and the loader rejects the colon-bearing entry a maintainer
     would reach for rather than silently compiling `cogni-x::`, which would match
-    nothing. Widening to full dispatch tokens is a ~10-line change to `load_registry`
-    (validate the shape instead of manufacturing it) if that case ever arrives.
+    nothing. That case is now covered by the SECOND arm below rather than by
+    widening this registry.
+
+TWO ARMS. Every violation carries an `arm` key naming which one produced it, and
+each arm prints its own remediation — the retired arm's advice is nonsense for a
+live-plugin dangling slug, and vice versa.
+
+  1. **retired-prefix** — the registry-driven arm above. Unchanged.
+  2. **unresolved-target** — reports a `<live-plugin>:<slug>` token whose slug
+     names no `*/skills/<slug>/SKILL.md` and no `*/agents/<slug>.md` anywhere in
+     the tree under test. The live-plugin set is derived at run time from that
+     tree's `.claude-plugin/marketplace.json` `plugins[]`, never hardcoded, so
+     adding a plugin needs no edit here. Resolution is deliberately GLOBAL rather
+     than per-plugin: a slug that resolves under any listed plugin resolves for
+     every prefix. Tightening that to a per-plugin pair is a real strengthening
+     and a separate decision. The `commands/` namespace is deliberately NOT part
+     of the predicate — a command is a user-facing entry point, not a dispatch
+     target — so a token resolving only to `*/commands/<slug>.md` is reported.
+
+     Absent manifest DEGRADES (the arm does not run, and the JSON says so via
+     `data.scanned`); a manifest that is present but unreadable or malformed is a
+     hard exit 2. Absence is a tree that never had the arm's input; corruption is
+     a broken input, and quietly treating the two alike is how a guard reports a
+     clean zero over nothing.
 
 Scope — the surfaces a running session actually dispatches FROM:
 
@@ -84,7 +106,7 @@ semantically to drop the `plugin:skill` token (drop the colon) — exactly the
 discipline the Maintainer-breadcrumb guard uses.
 
 stdlib only; runs under any python3. Exit 0 = clean (zero dispatches),
-1 = dispatch(es) found, 2 = script error.
+1 = dispatch(es) found in either arm, 2 = script error.
 """
 
 import argparse
@@ -115,8 +137,19 @@ EXCLUDE_TOPLEVEL = ("wiki/", "docs/")
 # scanning a foreign tree still reads our own retired set). Override: --registry.
 REGISTRY_BASENAME = "retired-plugins.json"
 
-# Per-line escape hatch for a genuine non-dispatch prose mention.
+# Per-line escape hatch for a genuine non-dispatch prose mention. It suppresses
+# the whole line, and therefore BOTH arms.
 ALLOW_MARKER = "external-dispatch-guard:allow"
+
+# Marketplace manifest, resolved UNDER --root — unlike REGISTRY_BASENAME above,
+# which is anchored on this script. The retired arm asks "what have WE retired";
+# the unresolved-target arm asks "what does THIS tree ship", so it must read the
+# tree under test.
+MARKETPLACE_REL = os.path.join(".claude-plugin", "marketplace.json")
+
+# Arm labels, carried on every violation so a finding is attributable.
+ARM_RETIRED = "retired-prefix"
+ARM_UNRESOLVED = "unresolved-target"
 
 
 def load_registry(path):
@@ -172,6 +205,91 @@ def compile_dispatch_re(prefixes):
         r"\b(?:" + "|".join(re.escape(p) for p in prefixes) + r"):")
 
 
+def load_live_plugins(root):
+    """Return (entries, degraded_reason) for the marketplace under `root`.
+
+    `entries` is a list of (name, dir_rel). An ABSENT manifest degrades — the
+    caller reports the degrade in `data.scanned` and skips the arm — because a
+    tree with no marketplace (every synthetic fixture, any foreign checkout) is
+    not a tree with a broken marketplace. A manifest that IS present but cannot
+    be read or is the wrong shape raises RuntimeError, i.e. exit 2, mirroring the
+    anti-vacuity stance `load_registry` takes: a corrupt input must never read as
+    a clean pass.
+    """
+    path = os.path.join(root, MARKETPLACE_REL)
+    if not os.path.isfile(path):
+        return [], "no-marketplace-manifest"
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+    except (OSError, ValueError) as exc:
+        raise RuntimeError("marketplace manifest {} is unreadable or not valid "
+                           "JSON: {}".format(path, exc))
+    if not isinstance(data, dict):
+        raise RuntimeError(
+            "marketplace manifest {} must be a JSON object".format(path))
+    plugins = data.get("plugins")
+    if not isinstance(plugins, list):
+        raise RuntimeError("marketplace manifest {} must carry a 'plugins' "
+                           "list".format(path))
+    entries = []
+    for item in plugins:
+        if not isinstance(item, dict):
+            continue
+        name = item.get("name")
+        if not isinstance(name, str) or not name.strip():
+            continue
+        source = item.get("source")
+        if isinstance(source, str) and source.strip():
+            rel = source.strip()
+            if rel.startswith("./"):
+                rel = rel[2:]
+        else:
+            rel = name
+        entries.append((name, rel))
+    if not entries:
+        return [], "no-named-plugins-in-manifest"
+    return entries, ""
+
+
+def build_target_index(root, plugin_dirs):
+    """Return the set of slugs that resolve to a skill or an agent.
+
+    Deliberately plain filesystem calls rather than `git ls-files`: the synthetic
+    fixture trees are not git repos, and a git-backed index would come back empty
+    there and make every assertion over them vacuously green.
+    """
+    slugs = set()
+    for rel in plugin_dirs:
+        skills_dir = os.path.join(root, rel, "skills")
+        if os.path.isdir(skills_dir):
+            for entry in os.listdir(skills_dir):
+                if os.path.isfile(os.path.join(skills_dir, entry, "SKILL.md")):
+                    slugs.add(entry)
+        agents_dir = os.path.join(root, rel, "agents")
+        if os.path.isdir(agents_dir):
+            for entry in os.listdir(agents_dir):
+                if entry.endswith(".md") and os.path.isfile(
+                        os.path.join(agents_dir, entry)):
+                    slugs.add(entry[:-3])
+    return slugs
+
+
+def compile_target_re(live_names):
+    r"""Compile `(?:name|…):(slug)` over the live plugin names, or None.
+
+    Names are alternated LONGEST-FIRST so a listed name that is a prefix of
+    another cannot shadow it. At least one slug character is required, so a bare
+    `plugin:` in prose is not a target hit — that shape belongs to the retired
+    arm, which matches the colon alone.
+    """
+    if not live_names:
+        return None
+    ordered = sorted(live_names, key=lambda n: (-len(n), n))
+    return re.compile(
+        r"\b(?:" + "|".join(re.escape(n) for n in ordered) + r"):([a-z][a-z0-9-]*)")
+
+
 def discover_files(root):
     """Tracked live-dispatch surfaces, relative to root, via git ls-files."""
     try:
@@ -195,28 +313,58 @@ def discover_files(root):
     return files
 
 
-def scan_file(abs_path, rel_path, dispatch_re):
-    """Yield violation dicts for one file."""
+def scan_file(abs_path, rel_path, dispatch_re, target_re, resolvable):
+    """Return (violations, tokens_examined) for one file.
+
+    Returns a list rather than yielding: the caller has to sum `tokens_examined`
+    across files, and a generator makes that count meaningless until drained.
+    """
     try:
         with open(abs_path, "r", encoding="utf-8") as fh:
             lines = fh.readlines()
     except (OSError, UnicodeDecodeError) as exc:
         raise RuntimeError("cannot read {}: {}".format(rel_path, exc))
+    found = []
+    tokens_examined = 0
     for lineno, raw in enumerate(lines, start=1):
         line = raw.rstrip("\n")
         if ALLOW_MARKER in line:
             continue
         for m in dispatch_re.finditer(line):
-            yield {
+            found.append({
                 "file": rel_path,
                 "line": lineno,
                 "match": m.group(0),
+                "arm": ARM_RETIRED,
                 "context": line.strip()[:140],
-            }
+            })
+        if target_re is None:
+            continue
+        for m in target_re.finditer(line):
+            tokens_examined += 1
+            slug = m.group(1)
+            # Mutation-recipe invariant: keep the next line exactly as written, on
+            # ONE physical line, and do not repeat its text anywhere else in this
+            # file — the recorded recipe rewrites the FIRST match only (perl -0pi,
+            # no /g), so a second occurrence would mutate the wrong site and report
+            # this arm as decorative.
+            if slug in resolvable:
+                continue
+            found.append({
+                "file": rel_path,
+                "line": lineno,
+                "match": m.group(0),
+                "target": slug,
+                "arm": ARM_UNRESOLVED,
+                "context": line.strip()[:140],
+            })
+    return found, tokens_examined
 
 
-def collect(root, explicit_files, dispatch_re):
+def collect(root, explicit_files, dispatch_re, target_re, resolvable):
     occ = []
+    files_scanned = 0
+    tokens_examined = 0
     if explicit_files:
         pairs = []
         for f in explicit_files:
@@ -229,8 +377,11 @@ def collect(root, explicit_files, dispatch_re):
     else:
         pairs = [(os.path.join(root, rel), rel) for rel in discover_files(root)]
     for abs_path, rel in pairs:
-        occ.extend(scan_file(abs_path, rel, dispatch_re))
-    return occ
+        found, seen = scan_file(abs_path, rel, dispatch_re, target_re, resolvable)
+        occ.extend(found)
+        files_scanned += 1
+        tokens_examined += seen
+    return occ, files_scanned, tokens_examined
 
 
 def main(argv):
@@ -254,7 +405,16 @@ def main(argv):
 
     try:
         retired = load_registry(registry_path)
-        violations = collect(root, args.files, compile_dispatch_re(retired))
+        live_entries, degraded_reason = load_live_plugins(root)
+        # Subtract the retired set from the live set so the two arms partition the
+        # token space: a name that is somehow both listed and retired is judged by
+        # the retired arm alone and can never be reported twice.
+        retired_set = set(retired)
+        live_entries = [(n, d) for (n, d) in live_entries if n not in retired_set]
+        resolvable = build_target_index(root, [d for (_, d) in live_entries])
+        target_re = compile_target_re([n for (n, _) in live_entries])
+        violations, files_scanned, tokens_examined = collect(
+            root, args.files, compile_dispatch_re(retired), target_re, resolvable)
     except RuntimeError as exc:
         print(json.dumps({"success": False, "data": {}, "error": str(exc)}))
         return 2
@@ -273,17 +433,37 @@ def main(argv):
                 "by_plugin": by_plugin,
                 "files_affected": len(sorted({o["file"] for o in violations})),
             },
+            "scanned": {
+                "files": files_scanned,
+                "tokens": tokens_examined,
+                "live_plugins": len(live_entries),
+                "resolvable_targets": len(resolvable),
+                "unresolved_target_arm": target_re is not None,
+                "degraded_reason": degraded_reason,
+            },
         },
         "error": "",
     }
     print(json.dumps(result, indent=2, ensure_ascii=False))
 
-    if violations:
+    if degraded_reason:
+        print("\nNOTE: unresolved-target arm did not run ({}) — resolved 0 live "
+              "plugins from {}".format(
+                  degraded_reason, os.path.join(root, MARKETPLACE_REL)),
+              file=sys.stderr)
+
+    retired_hits = [o for o in violations if o["arm"] == ARM_RETIRED]
+    unresolved_hits = [o for o in violations if o["arm"] == ARM_UNRESOLVED]
+
+    # Each arm prints its own block. Sharing one would hand an operator the other
+    # arm's remedy — "cut over to the vendored cogni-knowledge surface" says
+    # nothing useful about a live plugin naming a skill that does not exist.
+    if retired_hits:
         print("\nFAIL: {} live {} dispatch(es) found "
               "in live-dispatch surfaces:".format(
-                  len(violations), "/".join(p + ":" for p in retired)),
+                  len(retired_hits), "/".join(p + ":" for p in retired)),
               file=sys.stderr)
-        for o in violations:
+        for o in retired_hits:
             print("  {}:{}: {}  ->  {}".format(
                 o["file"], o["line"], o["match"], o["context"]), file=sys.stderr)
         print("\nFix: cut the caller over to the vendored cogni-knowledge "
@@ -291,6 +471,23 @@ def main(argv):
               "it to drop the `plugin:skill` token (drop the colon), or mark the "
               "line with `# external-dispatch-guard:allow` and a rationale.",
               file=sys.stderr)
+
+    if unresolved_hits:
+        print("\nFAIL: {} unresolved-target dispatch(es) found — a live plugin "
+              "prefix naming a skill or agent that does not exist:".format(
+                  len(unresolved_hits)), file=sys.stderr)
+        for o in unresolved_hits:
+            print("  {}:{}: {}  ->  {}".format(
+                o["file"], o["line"], o["match"], o["context"]), file=sys.stderr)
+        print("\nFix: repoint the token at a target that exists — the directory "
+              "name under */skills/ or the file basename under */agents/ — since "
+              "the prefix is live and only the slug is dead. If the line is prose "
+              "about a target that is genuinely gone, drop the colon so it stops "
+              "being dispatch-shaped, or mark the line with "
+              "`# external-dispatch-guard:allow` and a rationale.",
+              file=sys.stderr)
+
+    if violations:
         return 1
     return 0
 

--- a/tests/test_check_external_dispatch.sh
+++ b/tests/test_check_external_dispatch.sh
@@ -339,6 +339,254 @@ assert d['success'] is True, d
 assert d['data']['summary']['total']==0, d['data']['summary']
 "
 
+# ===========================================================================
+# Unresolved-target arm (ed20-ed33). The retired-prefix arm above is driven by
+# scripts/retired-plugins.json; this second arm is driven by the marketplace
+# manifest of the tree under --root, and reports a <live-plugin>:<slug> token
+# whose slug names no */skills/<slug>/SKILL.md and no */agents/<slug>.md.
+# ===========================================================================
+
+# --- livetree: two listed plugins, one resolvable skill, one resolvable agent,
+# --- and a caller naming one target that does not exist.
+LT="$WORK/livetree"
+mkdir -p "$LT/.claude-plugin" "$LT/cogni-alpha/skills/alpha-run" \
+         "$LT/cogni-alpha/agents" "$LT/cogni-beta/agents"
+printf '%s' '{"plugins":[{"name":"cogni-alpha","source":"./cogni-alpha"},{"name":"cogni-beta","source":"./cogni-beta"}]}' \
+  > "$LT/.claude-plugin/marketplace.json"
+printf -- '---\nname: alpha-run\n---\nA resolvable skill target.\n' \
+  > "$LT/cogni-alpha/skills/alpha-run/SKILL.md"
+printf -- '---\nname: beta-helper\n---\nA resolvable agent target.\n' \
+  > "$LT/cogni-beta/agents/beta-helper.md"
+printf -- '---\nname: caller\n---\nDispatches cogni-beta:no-such-thing for the missing step.\nThen cogni-alpha:alpha-run and cogni-beta:beta-helper, both of which resolve.\n' \
+  > "$LT/cogni-alpha/agents/caller.md"
+printf -- '---\nname: marked\n---\nHistorical: cogni-beta:also-missing was the old entry point.  <!-- external-dispatch-guard:allow -->\n' \
+  > "$LT/cogni-alpha/agents/marked.md"
+printf -- '---\nname: retired\n---\nDispatches cogni-wiki:wiki-query for the base.\n' \
+  > "$LT/cogni-alpha/agents/retired.md"
+
+set +e
+OUT=$(python3 "$GUARD" --root "$LT" "cogni-alpha/agents/caller.md" 2>/dev/null)
+CODE=$?
+set -e
+check "ed20 unresolvable live-plugin dispatch exits 1" \
+  "$([ "$CODE" -eq 1 ] && echo 0 || echo 1)"
+
+assert_json "ed21 unresolved-target violation names file line match and target" "$OUT" "
+import json,sys
+d=json.load(sys.stdin)
+v=d['data']['violations']
+assert d['success'] is False, d
+assert d['data']['summary']['total']==1, d['data']['summary']
+o=v[0]
+assert o['file']=='cogni-alpha/agents/caller.md', o
+assert o['line']==4, o
+assert o['match']=='cogni-beta:no-such-thing', o
+assert o['target']=='no-such-thing', o
+"
+
+# ed22 is the recorded mutation-recipe case. It asserts the arm PRODUCED a
+# finding, so neutering the resolvability test (every slug looks resolvable,
+# the arm empties) turns this line red. A case asserting a clean zero would
+# stay green under that mutation and prove nothing.
+assert_json "ed22 the finding is attributed to the unresolved-target arm" "$OUT" "
+import json,sys
+d=json.load(sys.stdin)
+arms=[o['arm'] for o in d['data']['violations']]
+assert 'unresolved-target' in arms, arms
+"
+
+assert_json "ed23 a dispatch resolving to a skill directory is not reported" "$OUT" "
+import json,sys
+d=json.load(sys.stdin)
+m=[o['match'] for o in d['data']['violations']]
+assert 'cogni-alpha:alpha-run' not in m, m
+"
+
+assert_json "ed24 a dispatch resolving to an agent file is not reported" "$OUT" "
+import json,sys
+d=json.load(sys.stdin)
+m=[o['match'] for o in d['data']['violations']]
+assert 'cogni-beta:beta-helper' not in m, m
+"
+
+# --- livetree2: identical shape, every dispatch resolvable (negative control).
+LT2="$WORK/livetree2"
+mkdir -p "$LT2/.claude-plugin" "$LT2/cogni-alpha/skills/alpha-run" \
+         "$LT2/cogni-alpha/agents" "$LT2/cogni-beta/agents"
+cp "$LT/.claude-plugin/marketplace.json" "$LT2/.claude-plugin/marketplace.json"
+cp "$LT/cogni-alpha/skills/alpha-run/SKILL.md" "$LT2/cogni-alpha/skills/alpha-run/SKILL.md"
+cp "$LT/cogni-beta/agents/beta-helper.md" "$LT2/cogni-beta/agents/beta-helper.md"
+printf -- '---\nname: caller\n---\nDispatches cogni-alpha:alpha-run and cogni-beta:beta-helper only.\n' \
+  > "$LT2/cogni-alpha/agents/caller.md"
+
+set +e
+OUT=$(python3 "$GUARD" --root "$LT2" "cogni-alpha/agents/caller.md" 2>/dev/null)
+CODE=$?
+printf '%s' "$OUT" | python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+assert d['success'] is True, d
+assert d['data']['summary']['total']==0, d['data']['summary']
+"
+JCODE=$?
+set -e
+check "ed25 an all-resolvable tree exits 0 with zero violations" \
+  "$([ "$CODE" -eq 0 ] && [ "$JCODE" -eq 0 ] && echo 0 || echo 1)"
+
+set +e
+OUT=$(python3 "$GUARD" --root "$LT" "cogni-alpha/agents/retired.md" 2>/dev/null)
+CODE=$?
+set -e
+assert_json "ed26 a retired-prefix dispatch is still reported by its own arm" "$OUT" "
+import json,sys
+d=json.load(sys.stdin)
+v=d['data']['violations']
+assert d['data']['summary']['total']==1, d['data']['summary']
+assert v[0]['arm']=='retired-prefix', v[0]
+assert v[0]['match']=='cogni-wiki:', v[0]
+"
+
+# --- ed27: the two arms partition the token space. A name that is BOTH
+# --- marketplace-listed and registry-retired is adjudicated by the retired arm
+# --- alone, never counted twice. The real tree cannot exercise this: its
+# --- retired set and its marketplace names are already disjoint.
+printf '%s' '{"retired_prefixes": ["cogni-wiki", "cogni-alpha"]}' > "$WORK/overlap.json"
+set +e
+OUT=$(python3 "$GUARD" --root "$LT" --registry "$WORK/overlap.json" \
+      "cogni-alpha/agents/caller.md" 2>/dev/null)
+CODE=$?
+set -e
+assert_json "ed27 an overlapping name is judged by the retired arm alone" "$OUT" "
+import json,sys
+d=json.load(sys.stdin)
+v=d['data']['violations']
+alpha=[o for o in v if o['match'].startswith('cogni-alpha')]
+assert len(alpha)==1, alpha
+assert alpha[0]['arm']=='retired-prefix', alpha[0]
+assert not [o for o in v if o['arm']=='unresolved-target' and o['match'].startswith('cogni-alpha')], v
+"
+
+# --- ed28: an ABSENT manifest degrades explicitly. It must never read as a
+# --- clean pass that silently examined nothing.
+set +e
+OUT=$(python3 "$GUARD" --root "$WORK/clean" "cogni-demo/skills/demo/SKILL.md" 2>/dev/null)
+CODE=$?
+printf '%s' "$OUT" | python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+s=d['data']['scanned']
+assert s['degraded_reason']=='no-marketplace-manifest', s
+assert s['unresolved_target_arm'] is False, s
+assert s['live_plugins']==0, s
+"
+JCODE=$?
+set -e
+check "ed28 an absent marketplace manifest degrades and says so" \
+  "$([ "$CODE" -eq 0 ] && [ "$JCODE" -eq 0 ] && echo 0 || echo 1)"
+
+# --- ed29: a manifest that is PRESENT but malformed is a hard error, not a
+# --- degrade. Absence is a tree without the input; corruption is a broken one.
+BMF="$WORK/badmanifest"
+mkdir -p "$BMF/.claude-plugin" "$BMF/cogni-alpha/agents"
+printf '%s' '{"plugins": [' > "$BMF/.claude-plugin/marketplace.json"
+printf -- '---\nname: c\n---\nDispatches cogni-alpha:whatever here.\n' \
+  > "$BMF/cogni-alpha/agents/c.md"
+set +e
+OUT=$(python3 "$GUARD" --root "$BMF" "cogni-alpha/agents/c.md" 2>/dev/null)
+CODE=$?
+printf '%s' "$OUT" | python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+assert d['success'] is False, d
+assert d['error'], d
+assert 'marketplace' in d['error'], d['error']
+"
+JCODE=$?
+set -e
+check "ed29 a malformed marketplace manifest exits 2 and never 0" \
+  "$([ "$CODE" -eq 2 ] && [ "$JCODE" -eq 0 ] && echo 0 || echo 1)"
+
+set +e
+OUT=$(python3 "$GUARD" --root "$LT" "cogni-alpha/agents/caller.md" 2>/dev/null)
+CODE=$?
+set -e
+assert_json "ed30 the scanned block reports a non-zero examined count" "$OUT" "
+import json,sys
+d=json.load(sys.stdin)
+s=d['data']['scanned']
+for k in ('files','tokens','live_plugins','resolvable_targets'):
+    assert isinstance(s[k], int), (k, s)
+assert isinstance(s['unresolved_target_arm'], bool), s
+assert isinstance(s['degraded_reason'], str), s
+assert s['files']>0 and s['tokens']>0, s
+# 5 = alpha-run (skill) + beta-helper, caller, marked, retired (agents).
+# The caller files are themselves agents, so they resolve too — that is the
+# index doing exactly what it claims, not an over-count.
+assert s['live_plugins']==2 and s['resolvable_targets']==5, s
+"
+
+# --- ed31: the discover-mode exclusions cover the new arm too. This fixture
+# --- puts the unresolvable token under */wiki/ on a path that the
+# --- */skills/*/SKILL.md pathspec DOES match (a git glob's * crosses /), so the
+# --- file is genuinely discovered and then suppressed by the segment rule.
+LXC="$WORK/livexc"
+mkdir -p "$LXC/.claude-plugin"
+git -C "$LXC" init -q 2>/dev/null || { mkdir -p "$LXC"; git -C "$LXC" init -q; }
+git -C "$LXC" config user.email t@t.test
+git -C "$LXC" config user.name test
+mkdir -p "$LXC/cogni-knowledge/skills/k" "$LXC/cogni-foo/wiki/skills/w" "$LXC/cogni-foo/skills/s"
+printf '%s' '{"plugins":[{"name":"cogni-knowledge","source":"./cogni-knowledge"},{"name":"cogni-foo","source":"./cogni-foo"}]}' \
+  > "$LXC/.claude-plugin/marketplace.json"
+printf -- '---\nname: k\n---\nHistory: this named cogni-foo:no-such-thing once.\n' \
+  > "$LXC/cogni-knowledge/skills/k/SKILL.md"
+printf -- '---\nname: w\n---\nMirror page quoting cogni-foo:no-such-thing verbatim.\n' \
+  > "$LXC/cogni-foo/wiki/skills/w/SKILL.md"
+printf -- '---\nname: s\n---\nDispatches cogni-foo:s only, which resolves.\n' \
+  > "$LXC/cogni-foo/skills/s/SKILL.md"
+git -C "$LXC" add -A >/dev/null 2>&1
+git -C "$LXC" commit -qm init >/dev/null 2>&1
+
+set +e
+OUT=$(python3 "$GUARD" --root "$LXC" 2>/dev/null)
+CODE=$?
+printf '%s' "$OUT" | python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+assert d['data']['summary']['total']==0, d['data']['violations']
+assert d['data']['scanned']['files']>0, d['data']['scanned']
+"
+JCODE=$?
+set -e
+check "ed31 discover-mode exclusions cover the unresolved-target arm" \
+  "$([ "$CODE" -eq 0 ] && [ "$JCODE" -eq 0 ] && echo 0 || echo 1)"
+
+set +e
+OUT=$(python3 "$GUARD" --root "$LT" "cogni-alpha/agents/caller.md" 2>/dev/null)
+CODE=$?
+set -e
+assert_json "ed32 the summary block keeps exactly its original keys" "$OUT" "
+import json,sys
+d=json.load(sys.stdin)
+assert set(d['data']['summary'])=={'total','by_plugin','files_affected'}, sorted(d['data']['summary'])
+assert 'scanned' in d['data'], sorted(d['data'])
+"
+
+# --- ed33: the per-line escape hatch suppresses the new arm as well. It is
+# --- read before either arm runs, so a marked line is invisible to both.
+set +e
+OUT=$(python3 "$GUARD" --root "$LT" "cogni-alpha/agents/marked.md" 2>/dev/null)
+CODE=$?
+printf '%s' "$OUT" | python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+assert d['success'] is True, d
+assert d['data']['summary']['total']==0, d['data']['summary']
+"
+JCODE=$?
+set -e
+check "ed33 the allow marker suppresses an unresolved-target finding" \
+  "$([ "$CODE" -eq 0 ] && [ "$JCODE" -eq 0 ] && echo 0 || echo 1)"
+
 echo ""
 if [ "$FAILED" -eq 0 ]; then
   green "All external-dispatch-guard tests passed."


### PR DESCRIPTION
Closes #1671.

## Summary

Adds a second, **independent** arm to `scripts/check-external-dispatch.py`. The existing arm compiles its alternation from `scripts/retired-plugins.json`, so it can only match a token whose **prefix** names a retired plugin — a live plugin naming a skill that no longer exists is structurally invisible to it, because the prefix stays live and only the slug dies. The script's own docstring already conceded this gap.

The new `unresolved-target` arm reports a `<live-plugin>:<slug>` token whose slug names no `*/skills/<slug>/SKILL.md` **and** no `*/agents/<slug>.md` in the tree under test. The live-plugin set is derived at run time from that tree's `.claude-plugin/marketplace.json` `plugins[]` — nothing is hardcoded, so adding a plugin needs no edit here.

## What changed

- **Two arms, separately attributed.** Every violation carries an `arm` key (`retired-prefix` / `unresolved-target`), and each arm prints its own stderr block with its own remediation. The retired arm's advice — "cut the caller over to the vendored cogni-knowledge surface" — is nonsense for a live-plugin dangling slug, so sharing one block would hand an operator the wrong remedy. The retired block's text and summary line are byte-identical to base.
- **`data.scanned`** is a new third key under `data`: `files`, `tokens`, `live_plugins`, `resolvable_targets`, `unresolved_target_arm`, `degraded_reason`. This is what makes a clean run provably non-vacuous — `data.summary.files_affected` counts only *violating* files and is `0` on a green run. `data.summary` keeps exactly its original keys, and the exit-2 envelope is untouched.
- **Absence degrades, corruption does not.** No `.claude-plugin/marketplace.json` under `--root` → the arm does not run, `scanned.degraded_reason` names the missing input, and a `NOTE:` goes to stderr. A manifest that is *present but malformed* is a hard exit 2. Quietly treating those alike is how a guard reports a clean zero over nothing. This matters because every pre-existing fixture tree is manifest-less — they all take the degrade path, which is why `ed01`-`ed19` are unaffected.
- **The arms partition the token space.** Registered retired prefixes are subtracted from the live set before the target regex is compiled, so a name that is somehow both listed and retired is judged by the retired arm alone and can never be double-reported.

## Predicate: skills + agents, deliberately not commands

The issue's literal wording — "resolves to no `*/skills/<slug>/SKILL.md`" — is **too narrow and is not built as worded**. Measured over the real tree: 208 in-scope files, 233 tokens, of which **24 resolve only in the agents namespace** (`cogni-trends:trend-generator`, `cogni-workspace:claim-verifier`, and 22 more). A skills-only predicate would report all 24 working dispatches as findings and could never be green.

`commands/` is deliberately excluded: a command is a user-facing entry point, not a dispatch target. Exactly one in-scope token resolves only there (`cogni-workspace:copywrite`), and it is repointed below rather than being made to resolve.

## Repoints, not suppressions

The new arm finds exactly four sites at base. All four are repointed at targets that exist — no `external-dispatch-guard:allow` markers were used:

| Site | Was | Now |
|---|---|---|
| `cogni-portfolio/skills/portfolio-scan/SKILL.md:38` | `cogni-portfolio:setup` | `cogni-portfolio:portfolio-setup` |
| `cogni-portfolio/skills/portfolio-scan/SKILL.md:120` | `cogni-portfolio:setup` | `cogni-portfolio:portfolio-setup` |
| `cogni-portfolio/skills/portfolio-scan/SKILL.md:350` | `cogni-portfolio:scan` | `cogni-portfolio:portfolio-scan` |
| `cogni-trends/skills/trends-resume/SKILL.md:211` | `cogni-workspace:copywrite` | `cogni-workspace:copywriter` |

## Verification

| Check | Result |
|---|---|
| `bash tests/test_check_external_dispatch.sh` | **33 PASS / 0 FAIL**, exit 0 — `ed01`-`ed19` unchanged, `ed20`-`ed33` new |
| `python3 scripts/check-external-dispatch.py` (repo root, no args) | exit 0, `summary.total == 0` |
| same run, non-vacuity | `scanned.files=208 tokens=233 live_plugins=8 resolvable_targets=184 arm=active` |
| `scripts/check-result-line-plainness.py` | exit 0 |
| `scripts/check-case-id-pairing.py` | exit 0 |
| `scripts/check-version-bump.py` | `status: ok`, mode `pr`, 0 touched, **not** degraded |
| `scripts/check-breadcrumbs.py` | exit 0 |
| `scripts/run-plugin-tests.py` | exit 0 — no sibling suite reddened by the repoints |
| mutation check | `verdict: guard_verified` (mutated **red**, restored **green**) |

Before the repoints the arm reported those four sites and nothing else; after them the tree is green. No test suite anywhere greps the three repointed literals.

## New test cases

`ed20` unresolvable token exits 1 · `ed21` violation names file/line/match/target · **`ed22` arm attribution — the mutation-recipe case** · `ed23` skill-resolving token not reported · `ed24` agent-resolving token not reported · `ed25` all-resolvable tree exits 0 clean · `ed26` retired arm still fires on its own arm · `ed27` an overlapping name is judged by the retired arm alone · `ed28` absent manifest degrades and says so · `ed29` malformed manifest exits 2, never 0 · `ed30` `scanned` block types + non-zero counts · `ed31` discover-mode exclusions cover the new arm · `ed32` `summary` keeps exactly its original keys · `ed33` the allow marker suppresses a new-arm finding.

`ed22` asserts the arm **produced** a finding rather than asserting a clean zero. That direction is load-bearing: neutering the resolvability test makes every slug look resolvable and empties the arm, so a clean-zero assertion would stay green under its own mutation and prove nothing.

## Mutation recipe

```bash
bash ~/.claude/plugins/cache/managed-service/cogni-service/0.0.469/scripts/mutation-check.sh --root . --file scripts/check-external-dispatch.py --expr 's/if slug in resolvable:/if True:/' --test 'bash tests/test_check_external_dispatch.sh' --case ed22
```

Run it from a checkout of this branch. If that version directory is gone, use the newest under the same parent — everything after the path is version-independent.

The rewritten line `if slug in resolvable:` occurs **exactly once** in the file and carries an invariant comment at its site, in the same shape as the existing one guarding `load_registry`. `perl -0pi` without `/g` rewrites the first match only, so a second textual copy would mutate the wrong site and report the arm decorative.

## Deliberately out of scope

Three sites carry the same literals and are **not** touched, so a reviewer does not read them as misses:

- `cogni-portfolio-evals/skill-snapshots/portfolio-scan-v0/SKILL.md` — matches no guard glob (`/skill-snapshots/`, not `/skills/`); it is a frozen eval snapshot, and repointing it would falsify the snapshot.
- `cogni-trends/scripts/project-status.sh:863` — emits the same dead `cogni-workspace:copywrite` id, but `scripts/` is not a live-dispatch surface under `DEFAULT_GLOBS`.
- The pre-existing `ed07` wiki fixture lives at `cogni-foo/wiki/concepts/SKILL.md`, which matches no guard glob, so its exclusion assertion is weaker than it looks. The new `ed31` fixture deliberately puts its wiki file at a path the `*/skills/*/SKILL.md` pathspec **does** match (a git glob's `*` crosses `/`), so the exclusion is genuinely load-bearing there. `ed07` is left alone.

Prose passes were scoped out: `portfolio-scan/SKILL.md` is a **pre-existing** over-cap (167.8% of its complexity-scaled budget) that this diff grew by exactly the 30 characters of the mandated repoint. Per the net-growth rule that is annotate-only — a coupled prose rewrite of a 50KB skill inside a guard PR is scope creep. `trends-resume/SKILL.md` sits at 77.5%, under cap.

## Open questions

1. **(genuine — please confirm before merge)** The `portfolio-scan/SKILL.md:350` repoint changes documented **output data**, not prose: it rewrites the `"skill"` value inside the fenced JSON provenance stamp written to `research/.metadata/scan-output.json`, from `cogni-portfolio:scan` to `cogni-portfolio:portfolio-scan`. Any consumer keying on the old literal string — including already-written metadata in existing portfolio project directories — would stop matching. I could not settle this from the repo: the stamp is emitted by prose instruction rather than by a script whose readers are greppable, and no schema pins the value (the stamp carries its own `"version": "1.3.0"`, which this change does not bump). The review contract mandates the repoint, so it is performed; the open question is whether a consumer migration or a stamp version bump should accompany it.

2. **(avoidable — recorded for the metric, not blocking)** The issue's four plan-time acceptance criteria were materially under-specified against the 19 items the triage review contract derived: they said nothing about per-arm attribution, the no-manifest degrade path, exclusion inheritance, the allow-marker hatch, or the retired-arm regression bar. More consequentially, AC1's literal skills-only predicate would have shipped a guard that fires on 24 pieces of working code. Resolved from the code rather than escalated, since the agent namespace is enumerable and the contract rules on it explicitly.

## Follow-up issues

- #1694 — tighten the unresolved-target arm from a global slug set to a per-plugin pair. Today `cogni-trends:portfolio-scan` resolves purely because *some* plugin owns a `portfolio-scan` skill; the cross-plugin miswire class is not yet covered. This is a recorded choice for this increment, stated in the guard's docstring, not an oversight.