### PR TITLE
cogni-workspace: CI teeth for the retired theme-extraction class

### DIFF
--- a/cogni-workspace/tests/test-layering-claim-reconciled.sh
+++ b/cogni-workspace/tests/test-layering-claim-reconciled.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
-# Layering-claim guard: no surface may reassert that cogni-workspace is the
-# foundation layer every other plugin depends on.
+# Retired-claim guard. Two subjects, one scanner: no surface may reassert that
+# cogni-workspace is the foundation layer every other plugin depends on, and no
+# surface may reassert the retired live-website / PowerPoint theme-extraction
+# paths that Operation 10 replaced.
 #
 # Why this exists. references/absorption-roadmap.md Decision 1 replaced the
 # LAYERING claim (cogni-workspace is the layer everything depends on) with a
@@ -15,11 +17,12 @@
 # reintroduce the claim silently.
 #
 # Contract under test:
-#   - none of the FORBIDDEN literals appears anywhere outside the excluded paths
+#   - none of the FORBIDDEN_ALL literals appears anywhere outside the excluded
+#     paths — that is the layering-claim set and the retired theme-extraction set
 #   - every one of those literals is actually caught when present (no dead config)
 #   - a literal under an excluded path is NOT flagged
-#   - the eight pages this reconciliation touched are byte-identical across the
-#     two wiki trees
+#   - each page on the PAGE_PARITY allowlist is byte-identical across the two
+#     wiki trees
 #   - a scan pointed at a missing or empty tree fails rather than reporting clean
 #
 # Literals, not a regex over "foundation". `foundation` alone has many legitimate
@@ -34,14 +37,41 @@
 # vacuous. They are retained here anyway, and case L2 plants each one in a
 # fixture, so the scanner is proven to catch each phrase.
 #
-# What L2 does and does not prove. L2 reads the literals from FORBIDDEN, plants
-# each in a fixture, and scans with FORBIDDEN — so it proves the SCANNER catches
-# a planted phrase, but it cannot detect a literal being *reworded*: a
-# substitution changes the planted text and the needle together, leaving L2
-# green. The count floor below is what protects the set — dropping an entry takes
-# l2_n under the floor and turns L2 red. Do not read L2 as a regression guard
-# against editing a literal's wording; for a mutation that a change can actually
-# flip, target the parity checker (see L4).
+# The retired theme-extraction subject. references/absorption-roadmap.md retired
+# the live-website and PPTX theme-extraction operations in favour of Operation 10
+# (the Claude Design bundle importer), and a later sweep removed every surviving
+# claim from both wiki trees, cogni-workspace/README.md and the theme-system RFC.
+# Nothing stopped the class returning, so FORBIDDEN_EXTRACTION carries it here
+# under the same scanner. Each of its four literals was measured ZERO-hit
+# repo-wide over tracked files on the post-sweep tree, outside the excluded paths
+# below — so each is a claim about this repo's current state, matching the
+# measurement convention the layering literals follow.
+#
+# REJECTED / NOT SCANNED — two candidates were measured and deliberately left
+# out, because each still hits live, correct prose in
+# cogni-workspace/skills/manage-themes/SKILL.md. They are recorded here so a
+# later editor does not re-propose them, and they are cited by quoted text
+# rather than line number, the same way the phrase-level survivors further down
+# are cited. "PowerPoint template"
+# survives in the live Operation-10 discovery question, "Do you have a website,
+# PowerPoint template, or brand guidelines (colors/fonts) I can use as a starting
+# point?". "PPTX extraction" survives in TWO places, not one: the sentence
+# documenting the retirement itself, "The live-website and PPTX extraction paths
+# that once held 3 and 4 were retired in favour of Operation 10", and the
+# rationale heading "Why this replaced the live website and PPTX extraction
+# paths". Scanning either would turn L1 red on correct prose.
+#
+# What L2 does and does not prove. L2 reads the literals from FORBIDDEN_ALL,
+# plants each in a fixture, and scans with FORBIDDEN_ALL — so it proves the
+# SCANNER catches a planted phrase, but it cannot detect a literal being
+# *reworded*: a substitution changes the planted text and the needle together,
+# leaving L2 green. The count floor below is what protects BOTH sets — it is
+# sized to the union (14 layering + 4 extraction = 18), so dropping an entry from
+# either constant takes l2_n under the floor and turns L2 red. The floor is a
+# hardcoded numeral on purpose: a count derived from the constants it guards
+# would move with the deletion it is meant to catch and could never fire.
+# Do not read L2 as a regression guard against editing a literal's wording; for
+# a mutation that a change can actually flip, target the parity checker (see L4).
 #
 # Phrase-level survivors. These lines keep foundation vocabulary on purpose and
 # must NOT be caught. Each says something about the workspace *state* other
@@ -112,11 +142,11 @@
 # one does not), and scripts/release-bundle-wiki.sh states that drift between
 # releases is acceptable. A tree-wide diff would be red on arrival and would
 # pressure someone into running that rsync --delete sync, which sweeps unrelated
-# drift. Naming the eight pages this change touched keeps the assertion true and
-# useful at the same time. Four are the layering-claim pages; the other four are
-# the group-B workflow pages back-ported bundle -> root, pinned here so the
-# sections that once existed only in the bundle cannot drift back out of the
-# root tree unnoticed.
+# drift. Naming an explicit allowlist of pages keeps the assertion true and
+# useful at the same time. One group is the layering-claim pages; another is the
+# group-B workflow pages back-ported bundle -> root, pinned here so the sections
+# that once existed only in the bundle cannot drift back out of the root tree
+# unnoticed; later entries each carry their own reason below.
 #
 # Case-label shape matches test-wiki-namespace-sync.sh on purpose: "PASS: <case>"
 # / "FAIL: <case>", because the cogni-service mutation harness classifies a case
@@ -155,6 +185,23 @@ cogni-workspace is the shared foundation
 foundation: cogni-workspace
 span four tiers'
 
+# Phrases that assert the retired live-website / PowerPoint theme-extraction
+# paths. Same matching rules as FORBIDDEN: one per line, case-insensitive fixed
+# strings, never regexes. Kept a separate constant from the layering set above
+# because it is a different subject with its own measurement record.
+FORBIDDEN_EXTRACTION='extract mode
+theme extraction
+from live websites
+extracted from live'
+
+# The union both literal readers consume, and the only value the scanner reads.
+# The newline below is a real one, as in the constants above: "\n" inside double
+# quotes is not a newline to bash, and that spelling fuses the last layering
+# literal to the first extraction literal into one entry matching nothing —
+# silently dropping a live literal and taking l2_n to 17.
+FORBIDDEN_ALL="$FORBIDDEN
+$FORBIDDEN_EXTRACTION"
+
 # Repo-relative path fragments exempt from the scan. See the header for why each
 # one is here.
 #
@@ -189,6 +236,15 @@ cogni-workspace/libraries/svg-patterns.md
 # here pins the two copies to each other. The roster-derived scan does not reach it
 # either: that bullet named a MANIFEST, not a plugin, so a roster of plugin names
 # never sees it.
+#
+# concept-theme-inheritance.md and skill-cogni-workspace-manage-themes.md join
+# with the theme-extraction sweep. Both were edited in both trees by that sweep,
+# both are the most prose-heavy of the pages it touched, and until now neither
+# had a byte-identity arm anywhere: no other file under cogni-workspace/tests/
+# names either page, and the one sibling that does pin a wiki page pins a
+# different one. Both pairs are byte-identical as they are added, so a green run
+# is not evidence they are guarded — mutating one copy is what shows the entry
+# has teeth.
 PAGE_PARITY='plugin-cogni-workspace.md
 workflow-install-to-infographic.md
 arch-er-diagram.md
@@ -198,7 +254,9 @@ workflow-content-pipeline.md
 workflow-portfolio-to-pitch.md
 workflow-trends-to-solutions.md
 plugin-cogni-portfolio.md
-concept-slug-based-lookups.md'
+concept-slug-based-lookups.md
+concept-theme-inheritance.md
+skill-cogni-workspace-manage-themes.md'
 
 # ---------------------------------------------------------------------------
 # The checkers. Fixture cases and the real-repo cases drive these same two
@@ -269,14 +327,14 @@ scan_literals() {
 $(grep_hits "$root" "$lit")
 EOF
   done <<EOF
-$FORBIDDEN
+$FORBIDDEN_ALL
 EOF
 
   # Liveness floor: a scan that examined no literals is not evidence of a clean
   # tree, it is evidence of a broken constant. Same half-dead-arm failure
   # test-wiki-namespace-sync.sh guards with its own empty-tree case.
   if [ "$scanned" -eq 0 ]; then
-    echo "ERROR [$label] no literals scanned — FORBIDDEN is empty"
+    echo "ERROR [$label] no literals scanned — FORBIDDEN_ALL is empty"
     return 1
   fi
   [ "$offenders" -eq 0 ]
@@ -351,10 +409,10 @@ while IFS= read -r lit; do
   run_scan "$TMPROOT/l2/$l2_n" "planted"
   assert_rc 1 && assert_out_has "docs/page.md" || l2_ok=0
 done <<EOF
-$FORBIDDEN
+$FORBIDDEN_ALL
 EOF
-if [ "$l2_n" -lt 14 ]; then
-  echo "  expected at least 14 literals, found $l2_n"
+if [ "$l2_n" -lt 18 ]; then
+  echo "  expected at least 18 literals, found $l2_n"
   l2_ok=0
 fi
 if [ "$l2_ok" -eq 1 ]; then

--- a/cogni-workspace/tests/test-mcp-declaration-hygiene.sh
+++ b/cogni-workspace/tests/test-mcp-declaration-hygiene.sh
@@ -426,8 +426,8 @@ fi
 
 # --- D1: the two wiki copies stay byte-identical --------------------------
 # No other suite covers this page: test-wiki-tree-parity.sh deliberately does
-# not assert tree equality, and test-layering-claim-reconciled.sh pins a
-# four-page allowlist this page is not on.
+# not assert tree equality, and test-layering-claim-reconciled.sh pins a named
+# allowlist this page is not on.
 
 if [ -f "$REPO_ROOT/$WIKI_PAGE_REL" ] && [ -f "$REPO_ROOT/$BUNDLED_PAGE_REL" ]; then
   if cmp -s "$REPO_ROOT/$WIKI_PAGE_REL" "$REPO_ROOT/$BUNDLED_PAGE_REL"; then

--- a/cogni-workspace/tests/test-wiki-tree-parity.sh
+++ b/cogni-workspace/tests/test-wiki-tree-parity.sh
@@ -9,8 +9,9 @@
 # one-sided page nobody decided on. Nothing enforced either before this suite:
 #   - test-wiki-namespace-sync.sh compares filename stems against the marketplace
 #     roster, so it never looks inside a page or at either config
-#   - test-layering-claim-reconciled.sh pins eight named pages to byte-identity
-#     and scans for retired wording, so it is silent on every other page
+#   - test-layering-claim-reconciled.sh pins a named allowlist of pages to
+#     byte-identity and scans for retired wording, so it is silent on every
+#     other page
 # Both would stay green while a config overstated its tree by nine pages and a
 # page linked to something that had been deleted out from under it. That is the
 # gap this closes.


### PR DESCRIPTION
Closes #1673.

Plan record: https://github.com/cogni-work/insight-wave/issues/1673#issuecomment-5465890957

## Summary

- Adds `FORBIDDEN_EXTRACTION`, a structurally separate and individually enumerable constant holding four literals — `extract mode`, `theme extraction`, `from live websites`, `extracted from live` — beside the 14 layering literals, which are left byte-untouched (a different subject).
- Unions both sets into `FORBIDDEN_ALL` and points **both** literal-reading sites at it: `scan_literals`' heredoc and L2's own planting-loop heredoc. Missing either would scan without planting, or plant without scanning.
- Raises the L2 count floor from `14` to `18` (14 layering + 4 extraction). It stays a hardcoded numeral — a floor derived from the constant it guards moves with the deletion it is meant to catch and can never fire.
- Adds `concept-theme-inheritance.md` and `skill-cogni-workspace-manage-themes.md` to `PAGE_PARITY` (10 → 12).
- Header: the contract block now names both subjects; a new block records each literal as measured zero-hit and records the two rejected candidates under an explicit **REJECTED / NOT SCANNED** label; the new parity pages get their rationale in the same inline per-entry block their siblings use.
- De-numbers three page-count self-claims that were **already false at base** and that this change widens further: this file (said eight, real value ten), `test-wiki-tree-parity.sh` (said eight), `test-mcp-declaration-hygiene.sh` (said four).

## Scope decisions

**Union into L2, not a separate `L2b` with a private floor.** Exploration recommended the latter. Rejected: the acceptance criteria require the existing floor to rise to the new grand total, and a union that leaves it at 14 leaves every new literal silently removable with L2 still green — the defect the criterion names. Arm 4's control below measures exactly that.

**`EXCLUDED` gains nothing.** `is_excluded` matches by **substring**, so any widening would blind the 14 layering literals too — the revert class L9 exists to catch. The four new literals need no exclusion: each is zero-hit repo-wide, and the guard file itself is already excluded.

**Literal choice.** `PowerPoint template` is excluded — it hits the live Operation-10 discovery question in `cogni-workspace/skills/manage-themes/SKILL.md`. `PPTX extraction` is excluded, and it survives in **two** live places, not the one the issue cites: the sentence documenting the retirement itself, and the "Why this replaced the live website and PPTX extraction paths" rationale. Both are recorded in the header under an explicit REJECTED / NOT SCANNED label, cited by quoted text per this file's own convention — so a reviewer grepping the diff for those strings reads a rejection record, not an added literal.

**Sibling-suite comments included, not deferred.** Both live under `cogni-workspace/tests/`, both are comment-only one-liners, and both misstate the cardinality of the very list this PR extends. Their replacement wording deliberately contains none of the 18 scanned literals — those files are not on `EXCLUDED`, so writing the retired vocabulary into them would turn L1 red.

## Test plan

| Check | Result |
|---|---|
| `bash cogni-workspace/tests/test-layering-claim-reconciled.sh` | exit 0, L1–L9 all PASS |
| `test-mcp-declaration-hygiene.sh` | exit 0, 15 passed |
| `test-wiki-bare-name-roster.sh` | exit 0 |
| `test-wiki-namespace-sync.sh` | exit 0 |
| `test-wiki-tree-parity.sh` | exit 0, 12 cases |
| L2 actually scans 18 literals | floor temporarily raised to 99 → suite reported `expected at least 99 literals, found 18` |
| Each new literal is zero-hit repo-wide | `git grep -IliF` returns only the guard file (which is on `EXCLUDED`) for all four |
| Both new parity pages byte-identical at base | `cmp` clean before the change — which is why the mutation recipe, not the green run, is the evidence |

## Mutation recipe

Run from the branch checkout root. `--file` is resolved relative to `--root`. Every triple below is **observed**, not asserted; the runs used `cogni-service` v0.0.469's `scripts/mutation-check.sh`.

**Arm 1 — the `concept-theme-inheritance.md` parity entry has teeth**
```bash
bash "${CLAUDE_PLUGIN_ROOT}/scripts/mutation-check.sh" --root . \
  --file cogni-workspace/wiki/wiki/pages/concept-theme-inheritance.md \
  --expr 's/\A/DRIFT-PROBE\n/' \
  --test 'bash cogni-workspace/tests/test-layering-claim-reconciled.sh' --case L7
```
→ `mutated_result: red` · `restored_result: green` · **`verdict: guard_verified`**

*Attribution control:* delete the `concept-theme-inheritance.md` line from `PAGE_PARITY`, re-run the identical command, restore.
→ `mutated_result: green` · `restored_result: green` · **`verdict: vacuous_guard`** — the same page mutation is invisible without the new entry, so arm 1's redness is attributable to the new entry rather than to a pre-existing one.

**Arm 2 — the `skill-cogni-workspace-manage-themes.md` parity entry has teeth**
```bash
bash "${CLAUDE_PLUGIN_ROOT}/scripts/mutation-check.sh" --root . \
  --file cogni-workspace/wiki/wiki/pages/skill-cogni-workspace-manage-themes.md \
  --expr 's/\A/DRIFT-PROBE\n/' \
  --test 'bash cogni-workspace/tests/test-layering-claim-reconciled.sh' --case L7
```
→ `mutated_result: red` · `restored_result: green` · **`verdict: guard_verified`**

*Attribution control — note the quote hazard.* This entry is the **last** in `PAGE_PARITY`, so it carries the closing `'`. A line-anchored delete of the bare filename matches nothing and the control silently returns `guard_verified`, which would read as attribution proven when nothing was removed. The control must move the quote:
```bash
perl -0pi -e "s/^concept-theme-inheritance\.md\nskill-cogni-workspace-manage-themes\.md'/concept-theme-inheritance.md'/m" \
  cogni-workspace/tests/test-layering-claim-reconciled.sh
```
→ with the entry genuinely removed: `mutated_result: green` · **`verdict: vacuous_guard`**. (The naive form was run first and returned `guard_verified`; it was identified as vacuous and re-run correctly.)

**Arm 3 — the new literal set is actually scanned**
```bash
bash "${CLAUDE_PLUGIN_ROOT}/scripts/mutation-check.sh" --root . \
  --file cogni-workspace/README.md \
  --expr 's/\A/theme extraction\n/' \
  --test 'bash cogni-workspace/tests/test-layering-claim-reconciled.sh' --case L1
```
→ `mutated_result: red` · `restored_result: green` · **`verdict: guard_verified`**

*Attribution:* by construction — no layering literal contains the substring `theme` (measured: 0 of 14), so only a newly added literal can catch the planted phrase. The redness cannot come from a pre-existing arm.

**Arm 4 — the raised floor is what fires when a new literal is dropped**
```bash
bash "${CLAUDE_PLUGIN_ROOT}/scripts/mutation-check.sh" --root . \
  --file cogni-workspace/tests/test-layering-claim-reconciled.sh \
  --expr 's/^theme extraction\n//m' \
  --test 'bash cogni-workspace/tests/test-layering-claim-reconciled.sh' --case L2
```
→ `mutated_result: red` · `restored_result: green` · **`verdict: guard_verified`** (verified the expression matches exactly one site).

*Attribution control:* run the identical deletion with the floor reverted to `14`.
→ `mutated_result: green` · **`verdict: vacuous_guard`** — at the old floor the same deletion is invisible. This is the direct measurement that the floor rise, not the pre-existing floor, is load-bearing.

## Quality pass — findings deliberately not applied

The pre-commit `/simplify` pass raised four findings that were skipped rather than applied. Recording them so the decision is reviewable rather than silent:

1. **Hoist the git-work-tree mode probe out of `grep_hits`.** Measured real: growing the set 14 → 18 costs +1.6 s (+44%, 3.6 s → 5.2 s), and hoisting the per-literal `git rev-parse` probe would cut the suite to ~2.7 s — below the base. Skipped because `grep_hits` is untouched by this diff, and refactoring the scanner's core helper inside a guard-hardening PR is exactly the change that would muddy the attribution this PR's mutation recipe exists to establish. Worth doing on its own.
2. **Rename `FORBIDDEN` → `FORBIDDEN_LAYERING` for naming symmetry.** Skipped: it churns the constant the acceptance criteria ask to leave byte-untouched, making it harder for a reviewer to confirm the 14 literals are unchanged.
3. **Split the single `-lt 18` floor into two per-set floors (14 and 4).** A fair point — a rebalance across the two constants keeps `l2_n` at 18 while a whole subject disappears. Skipped as a design strengthening beyond this issue's bar, which settled explicitly on the single raised floor.
4. **Drop the second `PPTX extraction` citation.** Skipped deliberately: the second site is the correction that the issue's own inventory was wrong (it names only one), so removing it would undo the finding.

## Follow-up issues

- #1697 — `PAGE_PARITY` has no shrinkage floor, so a pinned page can be silently unpinned. The same class the L2 floor closes for literals, left open for parity pages; no acceptance criterion here reaches it.