### PR TITLE
cogni-workspace: four story-to-web documentation-consistency fixes

### DIFF
--- a/cogni-workspace/skills/story-to-web/SKILL.md
+++ b/cogni-workspace/skills/story-to-web/SKILL.md
@@ -46,7 +46,7 @@ The brief describes WHAT each section says and which section type to use. The Pe
 | `customer_name` / `provider_name` | from metadata | Organization names |
 | `output_path` | `{source_dir}/cogni-visual/web-brief.md` | Brief output location. In `mode=storyboard` the default filename is `storyboard-brief.md` instead. |
 | `conversion_goal` | `consultation` | CTA type: consultation, demo, download, trial, contact, calculate |
-| `max_sections` | `10` | Maximum section count (forces consolidation if narrative is long). Governs decomposition in both modes. |
+| `max_sections` | `10` | Maximum section count (forces consolidation if narrative is long). Governs decomposition in both modes; in `mode=storyboard` poster capacity (`poster_count` x 3) can bind tighter — see Step 5b. |
 | `mode` | `web` | Output mode. `web` emits a scrollable `web-brief.md`; `storyboard` paginates the same sections into printed posters and emits a `storyboard-brief.md`. |
 | `poster_size` | `A1` | **`mode=storyboard` only.** DIN A0-A3, portrait. Dimensions and scale factor resolve from `storyboard-layouts.md`. |
 | `max_posters` | `4` | **`mode=storyboard` only.** Poster count cap, range 3-5. |
@@ -285,14 +285,16 @@ For each section:
 
 **Read reference:** `references/print/01-poster-architecture.md`
 
-1. **Poster count from narrative length**, then cap at `max_posters` — take the word-count thresholds and the 3-5 bound from the reference's poster-count decision tree.
+1. **Poster count from narrative length**, then cap at `max_posters` — take the word-count thresholds and the 3-5 bound from the reference's poster-count decision tree. Then resolve section capacity (`poster_count` x 3) per the capacity note below before mapping stations in item 2.
 2. **Map arc stations to posters** using the poster templates in the reference.
 3. **Stack 1-3 sections per poster**, taking the height splits, the split-ratio selection rules and the portrait adaptations from `$CLAUDE_PLUGIN_ROOT/libraries/storyboard-layouts.md` — the same library item 4 reads for geometry, and the authoritative home for all three. `references/print/01-poster-architecture.md` restates them for readers arriving from the poster templates.
 4. **Resolve poster geometry from `poster_size`.** Read the scale-factor table in `$CLAUDE_PLUGIN_ROOT/libraries/storyboard-layouts.md` (A0-A3, portrait only): that row gives `print_width`, `print_height` and `scale_factor`. `base_width` / `base_height` are the fixed design resolution 1440 x 2036, and `poster_gap` defaults to that library's base gap of 200px. With `poster_size` and the `poster_count` from item 1, these are exactly the eight frontmatter fields Step 10 writes.
 
+**Section capacity — `poster_count` x 3 — is the binding cap here, not `max_sections`.** Resolve it before item 2's station mapping: Step 5 caps the raw section count at `max_sections`, which can exceed capacity whenever the resolved poster count sits at the low end of the 3-5 bound. When `section_count` exceeds `poster_count` x 3, re-run the too-many-sections reduction in `references/02-section-architecture.md` (§ Step 4: Enforce Section Count -> Too Many Sections (> 10)) with `poster_count` x 3 as the target in place of `max_sections`, including in that block's own validation checkpoint. Adding posters is not an alternative — item 1's count is final.
+
 The reference's poster-count constraints and prohibited patterns bind here rather than advise: a title-only or summary-only poster spends a whole station on nothing the reader can act on, so the first poster opens on `hero`, the last closes on `cta`, and related stations merge instead of the count ever exceeding 5.
 
-**Content checkpoint:** State poster count, the station-to-poster mapping, the height split per poster, and the resolved poster geometry.
+**Content checkpoint:** State poster count, the station-to-poster mapping, the height split per poster, and the resolved poster geometry, and confirm `section_count` is at most `poster_count` x 3.
 
 ---
 
@@ -450,8 +452,10 @@ Generate the final brief with YAML frontmatter and section specifications follow
 
 **`mode=storyboard` only:** follow `$CLAUDE_PLUGIN_ROOT/libraries/EXAMPLE_STORYBOARD_BRIEF.md` instead — its frontmatter and body schema are the contract the `storyboard` agent parses, so reproduce both exactly rather than adapting the web shape. Frontmatter carries the eight poster-geometry fields resolved in Step 5b alongside the shared theme/arc fields — carry them through unchanged rather than recomputing them here; the body is one `## Poster N` block per poster, each holding its 1-3 stacked section YAML blocks with `section_theme` and `height_percent`.
 
+**`industry` provenance.** `industry` is not a caller parameter — it is inferred from the narrative's own content (sector language, customer and process vocabulary), the inference `references/04-image-prompts.md` § Prompt Consistency Rules item 3 already requires of every image prompt. Record the inferred value in the storyboard brief's `industry` frontmatter field so the `storyboard` agent and the print image prompts read one consistent value; in `mode=web` the inference stays implicit in the image prompts and `EXAMPLE_WEB_BRIEF.md` writes no such frontmatter field.
+
 **Final checks:**
-- YAML frontmatter complete (type, version, theme, theme_path, conversion_goal, arc_id if available, confidence_score as average of per-section scores)
+- YAML frontmatter complete (type, version, theme, theme_path, conversion_goal, arc_id if available, confidence_score as average of per-section scores; plus `industry` in `mode=storyboard`)
 - Header and footer sections present (`mode=web` only)
 - All sections specified with type, section_theme, arc_role, headline, confidence
 - First section is hero (dark), last content section is CTA (accent)
@@ -522,7 +526,6 @@ Replace `{absolute_path_to_storyboard_brief}` with the `output_path` resolved in
 | **print/02-poster-copywriting.md** | 6, 8 | *(`mode=storyboard`)* Print-vs-web copy overrides, poster governing-headline rules |
 | **print/03-image-prompts.md** | 6 | *(`mode=storyboard`)* Print-resolution prompt suffix, max-2-images rule, poster image sizing |
 | **print/04-validation.md** | 9 | *(`mode=storyboard`)* Replaces 05-validation.md — all four layers against the storyboard schema, plus print-specific checks and poster font-size minimums |
-| **cta-taxonomy.md** (library) | 6b | CTA types, urgency levels, arc-to-CTA heuristics |
 
 ### Libraries (loaded as needed)
 

--- a/cogni-workspace/skills/story-to-web/references/print/01-poster-architecture.md
+++ b/cogni-workspace/skills/story-to-web/references/print/01-poster-architecture.md
@@ -172,6 +172,8 @@ PROHIBITED PATTERNS:
     that is not a content poster with 1-3 stacked web sections
 ```
 
+**Reachability of the 5-poster branch.** At the default `max_posters` of 4 the `> 1500` word-count branch never fires — the `Never exceed max_posters parameter` constraint above clamps the result to 4 posters. It is reachable only when the caller explicitly passes `max_posters=5`. Treat 5 posters as opt-in, never the automatic outcome of a long narrative.
+
 ---
 
 ## Arc Label Assignment


### PR DESCRIPTION
Closes #1680.

## Summary

Four documentation-consistency nits deferred from the `story-to-storyboard` -> `story-to-web` fold. All four were verified to reproduce against the merged base before any edit; none changes behaviour.

- **Drop the duplicate `cta-taxonomy.md` registration.** `## Bundled Resources` registered it twice — once in the References table (self-labelled `(library)`) and once in the Libraries table, both at step 6b with near-identical Purpose text. The file exists only at `libraries/cta-taxonomy.md`, so the References row was a mis-registration and is the one removed; the Libraries row is retained byte-identical. Sibling skills (`story-to-slides`, `story-to-infographic`) register it once each, so this restores the family shape. The two load sites are untouched.
- **Record the 5-poster branch as opt-in.** In `references/print/01-poster-architecture.md` § Poster Count Decision, the `> 1500` word-count branch sat directly above its own `Never exceed max_posters parameter (default 4)` constraint, making it unreachable at default configuration. The branch is annotated, not deleted — it stays live for callers who pass `max_posters=5`.
- **Name the binding section cap in `mode=storyboard`.** Step 5 caps the raw section count at `max_sections` (default 10) while Step 5b stacks at most 3 sections across at most `max_posters` posters. At the reference's 3-poster minimum, capacity is 9 — below `max_sections` — so poster capacity, not `max_sections`, binds, and the overflow case had no instruction. Step 5b now states the cap and resolves overflow by re-running the existing reduction procedure in `references/02-section-architecture.md` with `poster_count` x 3 as the target, rather than inventing a second merge rule.
- **Document the origin of `industry`.** It had zero occurrences in `SKILL.md` — no Parameters row, no Step 10 clause — while three surfaces still consume it (`references/print/03-image-prompts.md`, `agents/storyboard.md`, `libraries/EXAMPLE_STORYBOARD_BRIEF.md`). Step 10 now documents it as inferred from the narrative.

## Scope decisions

- **The `industry` arm was chosen on evidence, not preference.** The issue offers two arms: a Parameters-table row, or a Step 10 narrative-inference clause. The narrative arm was taken because `references/04-image-prompts.md` (loaded at Step 6 in *both* modes, with `print/03-image-prompts.md` layered as overrides) already directs every image prompt to match the narrative's industry context, and `EXAMPLE_WEB_BRIEF.md` carries no such frontmatter field. A Parameters row scoped `mode=storyboard only` would therefore have asserted something false while closing the filed nit.
- **No behaviour change.** `max_sections` stays `10`, `max_posters` stays `4`, the `Never exceed max_posters parameter (default 4)` constraint and the `More than 5 posters under any circumstances` prohibition are both intact. Raising `max_posters` to make the 5-poster branch reachable would have been a behaviour change and was not done. The overflow rule stays inside the 3-5 poster bound and never authorises adding posters.
- **Step 5b regains no relocated content.** The word-count thresholds and the 3-5 bound stay in the reference where the fold put them; Step 5b still defers to the decision tree and gained no inline numeric threshold.
- **Untouched on purpose:** `agents/storyboard.md` and `libraries/EXAMPLE_STORYBOARD_BRIEF.md` (both consume `industry` and keep working — the deliverable is documenting the origin, never removing consumers), the `SKILL.md` frontmatter `description:` block (its ASCII German spellings are deliberate triggering coverage), and `.claude-plugin/plugin.json` (the post-merge workflow owns the version bump).
- **One item in the issue is not acted on, deliberately.** The issue's `## Not in scope` section states the `storyboard-layouts.md` Libraries-row anchor moved to `5b`. The shipped row actually reads `4, 5b`, which is correct — Step 4 reads that library for geometry as well as Step 5b. "Correcting" it on the issue's say-so would have introduced a defect, so the row is untouched. Flagging it because the issue's own inventory is wrong here, not the code.
- **Title says five nits; four are delivered.** That is the issue's own accounting — its `## Not in scope` section records the fifth as already fixed inside the parent PR. Four acceptance criteria, four hunks.
- **No new guard.** No existing suite asserts on resource-table shape, poster-count branch reachability, Step 5b prose, or the `industry` surface, and adding one for an S4 prose nit is disproportionate. The four deliverables are prose mechanisms, so the achievable evidence is grep-anchored plus the existing suite staying green.

## Test plan

- [x] `cogni-workspace/tests/` — 20 discovered, 20 passed, 0 failed, 0 skipped. Includes the three suites that bind this territory: `test-de-ascii-orthography.sh`, `test-skill-trigger-phrases.sh`, `test-relocated-skill-hygiene.sh`.
- [x] `check-breadcrumbs.sh cogni-workspace` — clean, 49 files scanned, 0 offenders.
- [x] `check-frontmatter.sh cogni-workspace` — clean, 0 violations.
- [x] Frontmatter `description:` block byte-identical to base (no hunk inside it).
- [x] `cta-taxonomy.md` retains exactly one registration row in `## Bundled Resources`, under `### Libraries`.
- [x] The `> 1500` branch and the `Never exceed max_posters parameter (default 4)` constraint both still present in the poster reference.
- [x] No word-count threshold (`800`/`1500`) anywhere in the SKILL.md Step 5b block.
- [x] No breadcrumb token (`#1677`/`#1680`/`#1643`/`PR #`/`issue #`/version) in either changed file.
- [x] `git diff --stat origin/main` lists exactly the two files under `cogni-workspace/skills/story-to-web/`.
- [x] Skill length signal: `chars_body` 34421 -> 35627 against a 49500 cap (69.5% -> 72%), `over_cap: false` at both ends — below the 0.9 approach zone, so no net-growth budget binds.

## Review notes

The Step 6.5 skill-quality gate returned `needs_revision` with three auto-fixable `preference` nits, all applied in this branch:

1. The `max_sections` Parameters row still read "Governs decomposition in both modes" with no hint that storyboard mode binds tighter — now cross-references Step 5b.
2. Step 10's frontmatter-completeness checklist omitted `industry`, so a storyboard brief could pass Step 10's own gate while missing a field `agents/storyboard.md` parses — now enumerated.
3. The new capacity paragraph says "resolve it before item 2" but sits after item 4 — item 1 now carries a forward pointer.

It also raised one **pre-existing structural observation, `introduced_by_change: false`**, annotated here rather than re-planned: the skill threads roughly ten inline `mode=storyboard only` branches through the shared workflow body, so each run loads variant rules it will not use. The scaffolding for a fuller fold already exists (`references/print/01-04`). Body size is not the trigger — the unit is at 72% of its cap — the cost is per-run irrelevant context. Out of scope for an S4 documentation fix.

The Step 6.4 `/simplify` pass proposed two further changes that were **declined** because they would have violated this issue's own acceptance criteria: relocating the section-capacity paragraph out of Step 5b into the poster reference (AC3 fences it to Step 5b), and relocating the `industry` provenance clause out of `SKILL.md` into `references/print/03-image-prompts.md` (AC4 fences it to the Parameters table or Step 10). The second also rested on a false premise — that storyboard mode loads `print/03` *instead of* `04-image-prompts.md`, when in fact `print/03` is layered as an override on top of it.

## Operational disclosure

Step 7.5's token-scope preflight was cleared with the `--allow-overscoped` flag (per-invocation, never the environment variable). The runner token reports `status: over_scoped`, `extra_scopes: [gist, read:org, workflow]`, `forbidden_scopes: [workflow]` — the fixed scope set of a `gh auth login` OAuth token, which cannot be narrowed. This machine is a personal, dedicated runner against the operator's own repository, which is the condition `cogni-service/CLAUDE.md` § Operational hardening states for the opt-out, and the operator authorised this posture standing on 2026-08-20 on the condition that every drain disclose it. Re-scoping to a fine-grained PAT remains the better end state and would remove the exception entirely.

## Plan record

The resolution plan, validation results and refine-pass summary are recorded on the issue: https://github.com/cogni-work/insight-wave/issues/1680#issuecomment-5466805935