### PR TITLE
cogni-workspace: trigger-shaped descriptions + explicit agent tools

### DIFF
--- a/cogni-workspace/agents/story-to-slides.md
+++ b/cogni-workspace/agents/story-to-slides.md
@@ -1,6 +1,11 @@
 ---
 name: story-to-slides
-description: Transform any narrative with a story arc into an optimized presentation brief.
+description: >
+  Use this agent when a narrative that already has a story arc must become an optimized
+  presentation brief. Typical triggers include the why-change-work orchestrator invoking
+  it for Phase 5 Step 4 (Synthesis); turning a research report, strategy document, or
+  project update into a slide brief; and smoke-testing the narrative transformation before
+  batch processing. See "When to Use" in the agent body for the full scenario list.
 model: opus
 color: green
 ---

--- a/cogni-workspace/agents/story-to-storyboard.md
+++ b/cogni-workspace/agents/story-to-storyboard.md
@@ -1,8 +1,16 @@
 ---
 name: story-to-storyboard
-description: Transform any narrative with a story arc into a storyboard brief for printed posters.
+description: >
+  Use this agent when a narrative that already has a story arc must become a storyboard
+  brief for a printed poster series. Typical triggers include turning a strategy document,
+  project story, or sales narrative into a print poster walkthrough; preparing physical
+  walkthrough material for an executive presentation; and smoke-testing the narrative
+  transformation before the storyboard agent renders it. See "When to Use" in the agent
+  body for the full scenario list.
 model: opus
 color: green
+tools: Skill, Bash
+
 ---
 
 # Story-to-Storyboard Agent

--- a/cogni-workspace/agents/story-to-web.md
+++ b/cogni-workspace/agents/story-to-web.md
@@ -1,6 +1,12 @@
 ---
 name: story-to-web
-description: Transform any narrative with a story arc into a scrollable web narrative brief.
+description: >
+  Use this agent when a narrative that already has a story arc must become a scrollable
+  web-narrative brief. Typical triggers include turning a strategy document, research
+  report, or sales narrative into a landing-page-style web page; producing single-page
+  visual storytelling in landing-page format; and smoke-testing the narrative
+  transformation before the web agent renders it. See "When to Use" in the agent body for
+  the full scenario list.
 model: opus
 color: blue
 ---

--- a/cogni-workspace/agents/storyboard.md
+++ b/cogni-workspace/agents/storyboard.md
@@ -3,6 +3,8 @@ name: storyboard
 description: Render a storyboard-brief.md into a multi-poster .pen file using Pencil MCP.
 model: opus
 color: blue
+tools: Read, Bash, mcp__pencil__open_document, mcp__pencil__set_variables, mcp__pencil__get_guidelines, mcp__pencil__batch_design, mcp__pencil__get_screenshot, mcp__pencil__snapshot_layout
+
 ---
 
 # Storyboard Renderer Agent

--- a/scripts/check-mcp-tool-grant.py
+++ b/scripts/check-mcp-tool-grant.py
@@ -63,16 +63,16 @@ old heuristic plugin-scoped.
 Three residuals, stated rather than implied away. An agent that names a server
 in prose while naming NONE of its tools in a code span is outside both arms.
 The no-`tools:`-key skip is inherited here, and it is not hypothetical: the
-`storyboard` and `web` agents in cogni-workspace declare no `tools:` key, so
-they never reach this arm and their in-span registry names go unjudged.
+`web` agent in cogni-workspace declares no `tools:` key, so it never reaches
+this arm and its in-span registry names go unjudged.
 Measured when this residual was restated — counting the registry
 `provides_tools[]` bare names that `vocabulary_re` matches inside the body's
 `CODE_SPAN_RE` spans, DISTINCT per agent, the unit
-`summary.provides_tools_code_span_names` itself uses — `storyboard` carries 5
-and `web` carries 6. Unlike the block-form snapshot below, no `summary.*`
-counter re-derives these two: the skip returns before the arm that would have
-counted them, so the figure is hand-taken and goes stale silently. The
-residual stays real while either agent keeps a `tools:`-free frontmatter,
+`summary.provides_tools_code_span_names` itself uses — `web` carries 6.
+Unlike the block-form snapshot below, no `summary.*`
+counter re-derives it: the skip returns before the arm that would have
+counted it, so the figure is hand-taken and goes stale silently. The
+residual stays real while `web` keeps a `tools:`-free frontmatter,
 whatever the count. And a code span inside a DISCLAIMING sentence would read
 as affirmative — that has no instance today, and the span requirement is what
 keeps the edge narrow, but it is real. Finally, the vocabulary is only as
@@ -84,8 +84,8 @@ its own server's `provides_tools[]`, and a name absent from it is surfaced as
 a `granted_outside_vocabulary` observation. Today that reports 9 gaps. Each is
 one record naming the gap once and carrying its granting agents as evidence,
 because the fix is one edit to the registry however many agents grant the name
-— emitting per agent would have restated one fact 17 times and pointed each
-copy at a file that is by construction not where the fix goes.
+— emitting per agent would have restated one fact once per granting agent and
+pointed each copy at a file that is by construction not where the fix goes.
 
 It reports rather than fails, and that is the whole of the decision. A grant
 outside the vocabulary is a registry-accuracy fact, not an agent defect: the
@@ -109,8 +109,9 @@ Two residuals follow from those choices rather than being overlooked. The
 channel is non-failing by design, so a stale registry still waits on a human;
 what changed is that it can no longer wait unseen. And a grant of an
 UNREGISTERED namespace has no vocabulary to resolve against and is skipped by
-construction — 18 of the 73 grant tokens are in that class today, the same
-population the `required_by` arm already skips for the same reason.
+construction — 18 grant tokens are in that class today, against the
+`summary.grant_tokens` total the guard re-derives every run, and they are the
+same population the `required_by` arm already skips for the same reason.
 
 The namespace token class admits HYPHENS. Real namespaces here are spelled
 `claude-in-chrome`, and an `[A-Za-z0-9_]`-only class matches nothing at all in


### PR DESCRIPTION
Closes #1681

## Summary

- Reframes the `description:` of `agents/story-to-storyboard.md`, `agents/story-to-web.md` and `agents/story-to-slides.md` into the `plugin-dev:agent-development` "Use this agent when… Typical triggers include…" shape — three trigger scenarios each, drawn from each agent's own `## When to Use` section so frontmatter and body cannot disagree. Uses the repo's house folded form `description: >` (matching the direct sibling `agents/story-to-infographic.md:5`).
- Adds `tools: Skill, Bash` to `agents/story-to-storyboard.md` — exactly what its body exercises (the mandatory Skill delegation at `:68-85`, the grep/awk `bash` block at `:91-97`). The omitted key previously meant unrestricted tool inheritance.
- Adds an explicit grant to `agents/storyboard.md`: `Read`, `Bash`, and the **six** Pencil MCP ops its body actually names. Inline-comma form, matching `agents/render-infographic-pencil.md:19`, the other Pencil renderer in this plugin.
- Narrows three now-stale present-tense literals in `scripts/check-mcp-tool-grant.py`'s docstring that this change falsifies.

## Why the guard docstring is in this diff

`scripts/check-mcp-tool-grant.py` skips any agent with no `tools:` key (`skipped_no_tools`, `:403-407`). Its docstring recorded `storyboard` and `web` as the two live instances of that residual. Granting `storyboard.md` a `tools:` key makes that claim half-false — and **the docstring itself states that no `summary.*` counter re-derives the figure**, so nothing in CI would have caught the drift. Three literals moved:

| Anchor | Was | Now |
|---|---|---|
| `:66` | "the `storyboard` and `web` agents … declare no `tools:` key" | narrowed to `web` alone, singular agreement; keeps its 6 |
| `:87` | "restated one fact **17** times" | de-numeralised to "once per granting agent" so it cannot rot again |
| `:112` | "18 of the **73** grant tokens" | 18 kept; the moving denominator defers to the `summary.grant_tokens` counter the guard re-derives every run |

The dated `Measured when adopted:` snapshot at `:43-51` is deliberately **untouched** — it is a frozen historical record, and rewriting it would falsify a dated measurement. This PR does move those live values by one agent; saying so here beats silently editing a record.

## Verification (measured, not asserted)

Guard `rc=0`, `findings: 0` before and after. Counters moved exactly as predicted:

| Counter | Base | Head |
|---|---|---|
| `skipped_no_tools` | 9 | **7** |
| `grant_tokens` | 73 | **79** |
| `provides_tools_code_span_names` | 27 | **32** |
| `provides_tools_grant_names_resolved` | 55 | **61** |
| `tools_form_counts.comma` | 14 | **16** (block unchanged at 10) |
| `by_arm` | `{}` | `{}` |

- `tests/test_check_mcp_tool_grant.sh` — `rc=0`, **0 failed** (V7, L1–L4 floors, R4a fixture all green; the floors are lower bounds and every moved counter rose).
- `cogni-workspace/tests/test-mcp-declaration-hygiene.sh` — `rc=0`, 15 passed.
- `run-tests.sh --dir cogni-workspace/tests` — **20 discovered, 20 passed, 0 failed**.
- `check-frontmatter.sh cogni-workspace` — `rc=0`, 0 violations. *(Note: this gate was already clean at base, so it is a stays-green guard — it can falsify this change but cannot confirm it landed.)*
- `check-breadcrumbs.sh cogni-workspace` — clean, 48 files, 0 offenders.
- Description lengths vs the 1024-char cap: **463 / 442 / 427** (`storyboard` unchanged at 76). All agents well clear of the length approach zone (max 54% of the system-prompt cap).
- `git diff` over `cogni-workspace/agents/` changes **no** `name:`, `model:` or `color:` line.

## Scope decisions

- **Included outside the plugin:** `scripts/check-mcp-tool-grant.py` (repo root), docstring only — no code change. Reason above.
- **Not widened:** `storyboard.md`'s own `description:`, and `tools:` on `story-to-web.md` / `story-to-slides.md` / `web.md`, are outside this issue's acceptance criteria and belong to the plugin-wide superset already tracked in **#1683**. No follow-up issue is filed — it would duplicate an open one. `web.md` in particular **must** stay `tools:`-free: it is now the sole remaining live instance of the residual the narrowed docstring names.
- **No registry edit:** `references/mcp-git-registry.json` already lists `cogni-workspace` in pencil's `required_by`, so the new grant satisfies that arm as-is. `mcp__pencil__snapshot_layout` is outside pencil's `provides_tools[]` vocabulary and therefore surfaces as a **non-failing** `granted_outside_vocabulary` observation — a pre-existing record (`render-infographic-pencil.md` already grants that name), so the record count is unchanged at 9; only its granting-agent evidence gains this agent.
- **Not granted:** `export_nodes`, `batch_get`, `get_editor_state` — verified absent from `storyboard.md`'s body. Copying `render-infographic-pencil.md`'s ten-op grant wholesale would have passed every gate while restating "the operations its body exercises" as "everything Pencil offers".

## Mutation recipe

```bash
scripts/mutation-check.sh --root . \
  --file cogni-workspace/agents/storyboard.md \
  --expr 's/mcp__pencil__/mcp__pencilzz__/g' \
  --test 'bash tests/test_check_mcp_tool_grant.sh' --case V7
```

**Executed, not asserted:** under the mutation the suite returns `rc=1` with `FAIL: V7 the real tree is clean on the provides_tools arm over a live span population` (3 failed); on restore it returns `rc=0`, 0 failed. That proves the new grant is load-bearing for this file — repointing the namespace to an unregistered one leaves `storyboard.md`'s five in-vocabulary Pencil names unresolved at server level.

Note that **deleting** the `tools:` key instead would *not* redden V7 — the guard would simply resume skipping the agent. That asymmetry is exactly why the rename is the mutation with teeth, and it is the same invisible-absence class the script's own preamble was written to describe.

## Open questions

None.