### PR TITLE
Repoint story-to-storyboard refs to story-to-web mode=storyboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Each plugin implements an established framework (Corporate Visions, Double Diamo
 
 > "Initialize my insight-wave workspace and check plugin health"
 
-**Rendering.** The `story-to-slides`, `story-to-infographic`, `story-to-storyboard` and `story-to-web` skills transform narratives into visual formats: slide decks (11 layout types), scrollable web narratives, printed poster storyboards, and single-page infographics. Skills generate structured briefs; agents render them into .pptx, .excalidraw, .pen, or .html files. All visuals inherit brand identity from your workspace theme.
+**Rendering.** The `story-to-slides`, `story-to-infographic` and `story-to-web` skills transform narratives into visual formats: slide decks (11 layout types), scrollable web narratives, printed poster storyboards (`story-to-web` in `mode=storyboard`), and single-page infographics. Skills generate structured briefs; agents render them into .pptx, .excalidraw, .pen, or .html files. All visuals inherit brand identity from your workspace theme.
 
 > "Create a slide deck from the sales presentation, then enrich the trend report with charts and diagrams"
 

--- a/cogni-portfolio/README.md
+++ b/cogni-portfolio/README.md
@@ -220,7 +220,7 @@ cogni-portfolio/
 | cogni-marketing | No | Customer narratives from portfolio-communicate are auto-discovered by marketing-setup for voice/messaging enrichment |
 | cogni-trends | No | Bidirectional TIPS integration via trends-bridge |
 | cogni-knowledge | No | Pitch arcs (technology-futures, strategic-foresight, trend-panorama, theme-thesis) in portfolio-communicate draw on cogni-knowledge research syntheses for evidence |
-| cogni-workspace | No | Theme selection for portfolio-dashboard via pick-theme; claim verification for research-backed assertions via portfolio-verify; the `narrative` skill's arc definitions shape the pitch use case, and `copywriter` audience tuning drives acronym-expansion depth; pitch output consumable by `story-to-slides`, `story-to-web`, and `story-to-storyboard` |
+| cogni-workspace | No | Theme selection for portfolio-dashboard via pick-theme; claim verification for research-backed assertions via portfolio-verify; the `narrative` skill's arc definitions shape the pitch use case, and `copywriter` audience tuning drives acronym-expansion depth; pitch output consumable by `story-to-slides` and `story-to-web` (including `mode=storyboard` print storyboards) |
 | cogni-sales | No | Downstream consumer — why-change pitch builds on portfolio features and propositions |
 | document-skills | No | Document ingestion (docx, pptx, xlsx, pdf) via portfolio-ingest; XLSX export via portfolio-communicate |
 

--- a/cogni-portfolio/skills/portfolio-communicate/SKILL.md
+++ b/cogni-portfolio/skills/portfolio-communicate/SKILL.md
@@ -38,7 +38,7 @@ Internal portfolio data (slugs, TAM/SAM/SOM, relevance tiers, quality scores) is
 | `workbook` | Leadership, analysts | Structured spreadsheet with all portfolio data | XLSX |
 | Custom/ad-hoc | Any audience | User-defined voice, sections, review | Markdown |
 
-Each use case defines its own voice, output templates, and review criteria. Both the `pitch` and `customer-narrative` use cases emit output with `arc_id` in frontmatter, making them directly consumable by story-to-slides, story-to-web, and story-to-storyboard — **no intermediate `/narrative` step needed.** `customer-narrative` is unique in that its arc varies per scope — see the mapping table in Step 1b.
+Each use case defines its own voice, output templates, and review criteria. Both the `pitch` and `customer-narrative` use cases emit output with `arc_id` in frontmatter, making them directly consumable by story-to-slides and story-to-web (`mode=storyboard` for print) — **no intermediate `/narrative` step needed.** `customer-narrative` is unique in that its arc varies per scope — see the mapping table in Step 1b.
 
 ## Prerequisites
 
@@ -372,8 +372,7 @@ For **pitch**:
 - **Polish prose**: "Run `/copywrite` to polish for executive readability while preserving arc structure"
 - **Visual formats** (direct — no intermediate step needed):
   - `story-to-slides` → PowerPoint presentation
-  - `story-to-web` → scrollable landing page
-  - `story-to-storyboard` → multi-poster print storyboard
+  - `story-to-web` → scrollable landing page, or multi-poster storyboard (`mode=storyboard`)
   - `/enrich-report` → themed HTML with concept diagrams and data charts
 - **Deepen**: "Run `/why-change` to add web research, customer-specific context, and TIPS enrichment for a deal-ready version"
 

--- a/cogni-portfolio/skills/portfolio-communicate/references/templates-pitch.md
+++ b/cogni-portfolio/skills/portfolio-communicate/references/templates-pitch.md
@@ -1,6 +1,6 @@
 # Templates: Pitch Narrative
 
-Output templates for the `pitch` use case. Transforms portfolio entities into arc-structured presentation narratives that the `narrative` skill downstream tools (story-to-slides, story-to-web, story-to-storyboard) can consume directly.
+Output templates for the `pitch` use case. Transforms portfolio entities into arc-structured presentation narratives that the `narrative` skill downstream tools (story-to-slides, story-to-web — including its `mode=storyboard` print storyboard) can consume directly.
 
 **Use case**: `pitch`
 **Audience**: Executives, decision-makers, conference audiences, board members
@@ -407,6 +407,5 @@ After generating a pitch narrative, suggest:
 2. **Polish prose**: `/copywrite` — applies executive readability standards while preserving arc structure
 3. **Visualize**:
    - `story-to-slides` → PowerPoint presentation via PPTX skill
-   - `story-to-web` → scrollable landing page via Pencil MCP
-   - `story-to-storyboard` → multi-poster print storyboard via Pencil MCP
+   - `story-to-web` → scrollable landing page via Pencil MCP, or multi-poster print storyboard with `mode=storyboard`
 4. **Deepen** (if needed): `/why-change` — adds web research, customer-specific context, and TIPS enrichment for a deal-ready version

--- a/cogni-portfolio/skills/portfolio-communicate/references/use-case-registry.md
+++ b/cogni-portfolio/skills/portfolio-communicate/references/use-case-registry.md
@@ -91,9 +91,9 @@ Each scope produces a main component of a portfolio-driven website, driven by a 
 | `overview` | `pitch/portfolio-overview.md` | Portfolio-wide narrative for investors, board, or keynotes |
 | `all` | All of the above | Overview + one narrative per market (ordered by priority) |
 
-**Key differentiator**: Pitch output includes `arc_id` in frontmatter — this makes it directly consumable by story-to-slides, story-to-web, and story-to-storyboard without an intermediate `/narrative` step. Default arc: `jtbd-portfolio`.
+**Key differentiator**: Pitch output includes `arc_id` in frontmatter — this makes it directly consumable by story-to-slides and story-to-web (including its `mode=storyboard` print storyboards) without an intermediate `/narrative` step. Default arc: `jtbd-portfolio`.
 
-**Downstream pipeline:** `/narrative-review` → `/copywrite` → `story-to-slides`, `story-to-web`, `story-to-storyboard`
+**Downstream pipeline:** `/narrative-review` → `/copywrite` → `story-to-slides`, `story-to-web` (`mode=storyboard` for print storyboards)
 
 ---
 

--- a/cogni-trends/scripts/project-status.sh
+++ b/cogni-trends/scripts/project-status.sh
@@ -866,8 +866,7 @@ case "$PHASE" in
       add_action "cogni-workspace:enrich-report" "Generate themed HTML with charts and diagrams"
     fi
     add_action "cogni-workspace:story-to-slides" "Create a PowerPoint presentation from the report"
-    add_action "cogni-workspace:story-to-web" "Create a scrollable landing page from the report"
-    add_action "cogni-workspace:story-to-storyboard" "Create a multi-poster print storyboard"
+    add_action "cogni-workspace:story-to-web" "Create a scrollable landing page from the report — or a multi-poster print storyboard with mode=storyboard"
     add_action "cogni-trends:trends-catalog" "Import to industry catalog for cross-pursuit reuse"
     if [ "$HAS_DASHBOARD" = "false" ]; then
       add_action "cogni-trends:trends-dashboard" "Generate interactive TIPS project dashboard"

--- a/cogni-trends/skills/trends-resume/SKILL.md
+++ b/cogni-trends/skills/trends-resume/SKILL.md
@@ -217,8 +217,7 @@ When `phase` is `complete`, the `next_actions` array from `project-status.sh` co
 - `cogni-workspace:story-to-infographic` + `/render-infographic` — Create an editorial infographic from the trend report (optional, for premium Pencil-rendered visual header in enriched HTML)
 - `cogni-workspace:enrich-report` — Themed HTML with Chart.js visualizations and concept diagrams (detects and reuses existing infographic if story-to-infographic was run first)
 - `cogni-workspace:story-to-slides` — PowerPoint presentation brief
-- `cogni-workspace:story-to-web` — Scrollable web landing page
-- `cogni-workspace:story-to-storyboard` — Multi-poster print storyboard
+- `cogni-workspace:story-to-web` — Scrollable web landing page, or a multi-poster print storyboard with `mode=storyboard`
 
 **Accumulate**
 - `cogni-trends:trends-catalog` — Import to industry catalog for cross-pursuit reuse

--- a/cogni-trends/skills/verify-trend-report/SKILL.md
+++ b/cogni-trends/skills/verify-trend-report/SKILL.md
@@ -401,7 +401,7 @@ The user can re-enter this skill later to pick a different path; downstream skil
 - `cogni-workspace:copywriter` (optional) — Phase 5 menu option
 - `cogni-workspace:enrich-report` (optional) — Phase 5 menu option
 
-**Downstream (via `/trends-resume`):** `cogni-workspace:story-to-slides`, `cogni-workspace:story-to-web`, `cogni-workspace:story-to-storyboard`, `trends-catalog import`, `trends-dashboard`
+**Downstream (via `/trends-resume`):** `cogni-workspace:story-to-slides`, `cogni-workspace:story-to-web` (incl. `mode=storyboard` print storyboards), `trends-catalog import`, `trends-dashboard`
 
 ## Debugging
 


### PR DESCRIPTION
Closes #1676.

## Summary

#1643 folded the `story-to-storyboard` skill into `story-to-web` as the `mode=storyboard` print pagination mode and deleted `cogni-workspace/skills/story-to-storyboard/`. Its AC11 fenced every changed path to `cogni-workspace/`, `wiki/` or `docs/`, so **11 cross-plugin references survived pointing at a slug that no longer resolves** — three of them live dispatches, not prose.

This repoints all 11 onto `cogni-workspace:story-to-web` with `mode=storyboard`, per maintainer ruling 4. 8 files, +11 −15.

### The three live sites are FOLDED, not repointed in place

`add_action` (`cogni-trends/scripts/project-status.sh:802-806`) is a pure shell string-append into a hand-built `next_actions` JSON array with **no dedup of any kind**. Repointing the storyboard row onto `cogni-workspace:story-to-web` would therefore have emitted *two indistinguishable `story-to-web` rows* to the operator — degrading the very surface this issue exists to repair. Each storyboard row is deleted and its sibling `story-to-web` row enriched with the mode. The two bullet lists whose `story-to-*` rows mirror those `add_action` calls fold in step, preserving `trends-resume`'s "render `next_actions` verbatim" contract.

The multi-poster print storyboard capability stays discoverable at **every one of the 11 sites** as a `story-to-web` mode — it is never silently deleted.

## Scope decisions

**Deliberately untouched — the surviving agent.** #1643 retired the skill *directory*; the **agent** `cogni-workspace/agents/story-to-storyboard.md` survives and correctly delegates to story-to-web in storyboard mode. Three hits name that live agent and are correct as-is: the agent's own `name:`, `cogni-workspace/README.md:189` (a row explicitly typed `agent`), and `cogni-workspace/tests/test-relocated-skill-hygiene.sh:127`. The retired thing is the **skill slug**, not the agent name — a distinction the issue's unqualified "no prose advertises a retired skill" clause does not draw, and the dominant over-sweep hazard here.

**Deliberately untouched — dated snapshots.** `docs/architecture/loop-health-map.md:275` and `docs/audit-report.md:96`, per the issue.

**Not done:** no forwarder `SKILL.md` (ruling 4 rejected it); no new CI guard (that blindness is #1671); no `plugin.json` version touch (post-merge).

**Guidance-skill routing skipped.** All 11 edits are one-line prose/string tweaks, so `skill-routing-map` rule 5 applies. Recorded here rather than silently omitted.

## Correction to the unblocking comment

That comment states `cogni-portfolio/skills/portfolio-communicate/SKILL.md:376` "did not appear in a grep of the merged tree". Against `origin/main` (77fee0e4) it **is** present, at exactly line 376, and is in scope. Re-deriving the site list at pick time — which the same comment asked for — is what surfaced this. Had the note been taken at face value, one of the three live dispatches would have been dropped.

## Verification

| Check | Result |
|---|---|
| `check-external-dispatch.py` | rc=0, 0 violations |
| `check-readme-inventory-sync.py` | rc=0, 0 violations |
| `check-version-bump.py` (pr mode) | rc=0, clean, 0 plugins touched |
| `run-plugin-tests.py --filter cogni-trends` | rc=0, total=4, passed=4 |
| `run-plugin-tests.py --filter cogni-portfolio` | rc=0, total=7, passed=7 |
| `bash -n project-status.sh` | rc=0 |
| `grep -rn 'story-to-storyboard'` | 5 hits, all fenced (3 agent, 2 docs) |
| `grep -rn 'cogni-workspace:story-to-storyboard' --include='*.sh' --include='*.py'` | 0 hits |

**A green `check-external-dispatch.py` is evidence of nothing here** and should not be read as coverage: its unresolved-target arm resolves a `plugin:slug` against `*/skills/<slug>/SKILL.md` **or** `*/agents/<slug>.md`, so the surviving agent absorbed what would otherwise have been a violation. It also never scans `*/references/**`, `*/scripts/*` or top-level READMEs. That is #1671.

## Review notes

The pre-commit skill-quality gate returned `needs_revision` on all three touched `SKILL.md` files. **Every finding is `introduced_by_change: false` or `preference`** — none is damage this diff caused, and none was auto-fixed. Recorded so they are visible rather than swallowed:

1. **`trends-resume/SKILL.md:211` documents `cogni-workspace:copywriter`, but `project-status.sh:863` emits `cogni-workspace:copywrite`.** Verified true. The reviewer proposed changing the skill to match the script — **that fix would be backwards**: open issue **#1696** records the script's `copywrite` as the *stale pre-repoint* token. Left alone; already tracked.
2. **`trends-resume/SKILL.md:217` documents a `story-to-infographic` option `project-status.sh` never emits**, so the `**Visualize**` list is not fully 1:1 with `next_actions` even after this fold. Verified true and pre-existing. Not filed: resolving it is a scope call (drop the bullet, or add the emission) that belongs to a maintainer, not to a storyboard-repoint PR.
3. `portfolio-communicate/SKILL.md` is pre-existing **16% over** its length cap (36,514 / 31,500). Not introduced here, and the reviewer called it explicitly non-blocking. This PR was held to a net-growth budget on that file and lands it at **−4 bytes** vs base.
4. Three `preference` nits in `verify-trend-report/SKILL.md` (roadmap commentary, provenance parentheticals, one unqualified skill name) — all pre-existing, all outside this change's fence.

The `/simplify` quality pass applied nothing. Its one actionable finding — "strip the mode gloss from `use-case-registry.md:96` because sibling `Downstream pipeline:` lines carry no gloss" — was **falsified against the file**: line 43 carries exactly that kind of per-skill gloss, and 69/121/145/183 are prose, so line 96 is consistent with house style rather than deviating from it.