### PR TITLE
cogni-workspace: narrative-review drops the uncomputed 0-100 score

### DIFF
--- a/cogni-workspace/CLAUDE.md
+++ b/cogni-workspace/CLAUDE.md
@@ -150,7 +150,7 @@ The two recognized-but-never-emitted values exist because this engine is a web-s
 
 Absorbed from cogni-narrative and cogni-copywriting when both were retired. These are now the only copies. Both were stateless file-in/file-out transformers with no project lifecycle of their own, which is what put them on the infrastructure side of the cut-line rule at the top of this file.
 
-- `narrative` transforms structured input into an executive narrative using one of 11 story arcs and, with `--format`, condenses an existing narrative into executive briefs, talking points or one-pagers; `narrative-review` scores the result against quality gates (0–100, A–F). Agents: `narrative-writer`, `narrative-reviewer`, `narrative-adapter`
+- `narrative` transforms structured input into an executive narrative using one of 11 story arcs and, with `--format`, condenses an existing narrative into executive briefs, talking points or one-pagers; `narrative-review` scores the result against quality gates, returning a pass/warn/fail verdict per gate. Agents: `narrative-writer`, `narrative-reviewer`, `narrative-adapter`
 - `copywriter` polishes documents with 7 messaging frameworks (BLUF, Pyramid, SCQA, STAR, PSB, FAB, Inverted Pyramid), arc-aware preservation, and EN/DE-pivot translation across seven languages; `copy-reader` runs parallel stakeholder personas; `copy-json` polishes text fields inside JSON. Agents: `copywriter`, `reader`
 - `commands/{narrative,narrative-review,narrative-adapt,copywrite,review-doc}.md` register the five slash commands
 

--- a/cogni-workspace/README.md
+++ b/cogni-workspace/README.md
@@ -36,7 +36,7 @@ cogni-workspace is the ecosystem's infrastructure-as-plugin layer: a dedicated p
 9. **File and track issues** — `cogni-issues` uses the authenticated GitHub CLI to consult, deduplicate, create, list, and inspect plugin issues with atomic labels
 10. **Troubleshoot plugin failures** — `workspace-status`'s plugin-level tier diagnoses plugin integrity, cross-plugin dependencies, stale state, and common setup errors; reachable through `/troubleshoot`
 11. **Verify claims against their cited sources** — `claims` runs the six-mode claim-verification lifecycle (submit, verify, dashboard, inspect, resolve, cobrowse) that cogni-trends, cogni-portfolio, cogni-consult and cogni-knowledge submit sourced assertions to; `claim-entity` is the cross-plugin data contract those plugins write against
-12. **Shape content into an executive narrative** — `narrative` transforms structured input using one of 11 story arc frameworks and, with `--format`, condenses an existing narrative into executive briefs, talking points or one-pagers, and `narrative-review` scores the result against quality gates (0–100, A–F)
+12. **Shape content into an executive narrative** — `narrative` transforms structured input using one of 11 story arc frameworks and, with `--format`, condenses an existing narrative into executive briefs, talking points or one-pagers, and `narrative-review` scores the result against quality gates, returning a pass/warn/fail verdict per gate
 13. **Polish documents for executive readability** — `copywriter` applies seven messaging frameworks (BLUF, Pyramid, SCQA, STAR, PSB, FAB, Inverted Pyramid) with arc-aware preservation and EN/DE-pivot translation across seven languages; `copy-reader` runs parallel stakeholder personas over a document; `copy-json` polishes text fields inside JSON
 
 ## What it means for you
@@ -145,7 +145,7 @@ State lives in two layers that other plugins consume. Configuration (env vars, t
 | `claim-verifier` | agent | Fetches one source URL and verifies every claim against it, returning deviation analysis as strict JSON |
 | `source-inspector` | agent | Opens a source URL via claude-in-chrome and walks the user to the relevant passage (cobrowse / inspect) |
 | `narrative` | skill | Transform structured input into an executive narrative using one of 11 story arc frameworks; with `--format`, condense one into an executive brief, talking points or a one-pager |
-| `narrative-review` | skill | Score a narrative against story-arc quality gates — 0–100 composite with an A–F grade and the top 3 fixes |
+| `narrative-review` | skill | Score a narrative against story-arc quality gates — a pass/warn/fail verdict per gate and the top 3 fixes |
 | `copywriter` | skill | Polish, rewrite or create business documents with 7 messaging frameworks, arc-aware preservation, and EN/DE-pivot translation |
 | `copy-reader` | skill | Review a document through parallel stakeholder persona Q&A, then synthesize the feedback |
 | `copy-json` | skill | Adapter that polishes text fields inside JSON — extracts, polishes via `copywriter`, writes back |

--- a/cogni-workspace/agents/narrative-reviewer.md
+++ b/cogni-workspace/agents/narrative-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: narrative-reviewer
 description: |
-  Review and score narrative files against story arc quality gates. Produces a structured scorecard with pass/warn/fail per gate, overall score, and improvement suggestions.
+  Review and score narrative files against story arc quality gates. Produces a structured scorecard with a pass/warn/fail verdict per gate and improvement suggestions.
 
   Use this agent proactively after narrative generation to review quality, or when a user asks to review, score, or audit an existing narrative — including re-scoring one after edits to compare it against an earlier run.
 
@@ -45,14 +45,14 @@ You will receive:
 ## Constraints
 
 - **DO NOT** modify the narrative file -- review is read-only
-- **DO NOT** fabricate quality scores -- the skill measures objectively
+- **DO NOT** fabricate quality verdicts -- the skill measures objectively
 - **DO NOT** apply your own quality criteria -- use only the skill's gates and rubric
 - **DO NOT** write the scorecard yourself -- the skill handles output writing
 - Your only responsibility is parameter relay and skill invocation
 
 ## Output
 
-Return the JSON summary produced by the narrative-review skill. Do not modify or augment it.
+Return whichever JSON summary the narrative-review skill produces -- success or failure -- unmodified and unaugmented; never fabricate one.
 
 On success, the skill returns:
 
@@ -61,8 +61,6 @@ On success, the skill returns:
   "success": true,
   "source_path": "insight-summary.md",
   "arc_id": "corporate-visions",
-  "overall_score": 82,
-  "grade": "B",
   "gates": {
     "structural": "pass",
     "critical": "pass",
@@ -86,5 +84,3 @@ On failure, the skill returns:
   "error": "Description of what went wrong"
 }
 ```
-
-Return whichever JSON the skill produces. Do not fabricate success/failure responses.

--- a/cogni-workspace/commands/narrative-review.md
+++ b/cogni-workspace/commands/narrative-review.md
@@ -14,7 +14,7 @@ allowed-tools:
 
 # /narrative-review Command
 
-Score an existing narrative markdown file against the narrative skill's quality gates. Produces a scorecard with pass/warn/fail per gate, overall score (0-100), and top 3 improvement suggestions.
+Score an existing narrative markdown file against the narrative skill's quality gates. Produces a scorecard with pass/warn/fail per gate and top 3 improvement suggestions.
 
 ## Argument Parsing
 

--- a/cogni-workspace/skills/narrative-review/SKILL.md
+++ b/cogni-workspace/skills/narrative-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: narrative-review
-description: "Score and review existing narrative files against story arc quality gates. This skill should be used when the user asks to \"review a narrative\", \"score a narrative\", \"check narrative quality\", \"validate narrative\", \"audit narrative\", \"grade a narrative\", \"evaluate narrative quality\", \"narrative scorecard\", \"rate my narrative\", \"run quality gates on a narrative\", or when the narrative-reviewer agent evaluates a generated narrative."
+description: "Review existing narrative files against story arc quality gates, returning a pass/warn/fail verdict per gate. This skill should be used when the user asks to \"review a narrative\", \"score a narrative\", \"check narrative quality\", \"validate narrative\", \"audit narrative\", \"grade a narrative\", \"evaluate narrative quality\", \"narrative scorecard\", \"rate my narrative\", \"run quality gates on a narrative\", or when the narrative-reviewer agent evaluates a generated narrative."
 allowed-tools: Read, Write, Edit, Glob, Grep
 ---
 
@@ -8,14 +8,14 @@ allowed-tools: Read, Write, Edit, Glob, Grep
 
 ## Purpose
 
-Evaluate an existing narrative markdown file against the `narrative` skill quality gates. Produce a structured scorecard with pass/warn/fail per gate, an overall score (0-100), and the top 3 actionable improvement suggestions.
+Evaluate an existing narrative markdown file against the `narrative` skill quality gates. Produce a structured review report with a `pass`/`warn`/`fail` verdict per gate, the criterion-level verdicts behind each one, and the top 3 actionable improvement suggestions.
 
 ## When to Use
 
 - Review a narrative after generation to assess quality
 - Audit an existing insight summary for arc compliance
 - Compare narrative quality before and after edits
-- Score narratives for quality tracking across projects
+- Track per-gate verdicts for quality tracking across projects
 
 **Not for:**
 - Generating new narratives (use `cogni-workspace:narrative` skill instead)
@@ -48,8 +48,6 @@ Two outputs:
   "success": true,
   "source_path": "insight-summary.md",
   "arc_id": "corporate-visions",
-  "overall_score": 82,
-  "grade": "B",
   "gates": {
     "structural": "pass",
     "critical": "pass",
@@ -65,15 +63,20 @@ Two outputs:
 }
 ```
 
-### Grading Scale
+### Verdict Vocabulary
 
-| Score | Grade | Meaning |
-|-------|-------|---------|
-| 90-100 | A | Publication-ready, all gates pass |
-| 80-89 | B | Strong, minor improvements possible |
-| 70-79 | C | Acceptable, several improvements needed |
-| 60-69 | D | Below standard, significant rework needed |
-| 0-59 | F | Fails critical gates, major rework required |
+Every criterion resolves to one of three verdicts, and every gate derives its status from
+the criteria it contains. There is no composite figure and no letter grade -- the workflow
+computes neither, so it reports neither.
+
+| Level | Verdict | Meaning |
+|-------|---------|---------|
+| Criterion | `met` | The criterion's target condition holds |
+| Criterion | `partial` | An intermediate band defined by the rubric holds |
+| Criterion | `unmet` | The criterion's failing band holds |
+
+Gate status is derived from those criterion verdicts by the rule in
+[references/scoring-rubric.md](references/scoring-rubric.md) §Evaluation Principles.
 
 ---
 
@@ -103,16 +106,16 @@ Evaluate the narrative against each gate category. Use the scoring rubric in [re
 
 **Gate evaluation order (matches narrative skill Phase 5):**
 
-1. **Structural Gate** (30 points max)
-2. **Critical Gate** (25 points max)
-3. **Evidence Gate** (25 points max)
-4. **Structure Gate** (10 points max)
-5. **Language Gate** (10 points max)
+1. **Structural Gate**
+2. **Critical Gate**
+3. **Evidence Gate**
+4. **Structure Gate**
+5. **Language Gate**
 
 For each gate:
-- Count specific pass/fail criteria
-- Assign points based on rubric
-- Determine gate status: `pass` / `warn` / `fail`
+- Assign each criterion `met` / `partial` / `unmet` per the rubric
+- Derive gate status from those criterion verdicts using the rubric's gate-status rule
+- Record the gate status: `pass` / `warn` / `fail`
 
 ### Step 4: Generate Scorecard
 
@@ -123,27 +126,24 @@ Write `narrative-review.md` to the same directory as the source file:
 type: narrative-review
 source: "{source filename}"
 arc_id: "{arc_id}"
-overall_score: {0-100}
-grade: "{A-F}"
 date_reviewed: "{ISO 8601}"
 ---
 
 # Narrative Review: {source filename}
 
-**Arc:** {arc_display_name} | **Score:** {score}/100 ({grade}) | **Language:** {language}
+**Arc:** {arc_display_name} | **Language:** {language}
 
 ---
 
 ## Gate Results
 
-| Gate | Status | Score | Details |
-|------|--------|-------|---------|
-| Structural | {pass/warn/fail} | {x}/30 | {summary} |
-| Critical | {pass/warn/fail} | {x}/25 | {summary} |
-| Evidence | {pass/warn/fail} | {x}/25 | {summary} |
-| Structure | {pass/warn/fail} | {x}/10 | {summary} |
-| Language | {pass/warn/fail} | {x}/10 | {summary} |
-| **Total** | | **{total}/100** | |
+| Gate | Status | Criteria | Details |
+|------|--------|----------|---------|
+| Structural | {pass/warn/fail} | {n met, n partial, n unmet} | {summary} |
+| Critical | {pass/warn/fail} | {n met, n partial, n unmet} | {summary} |
+| Evidence | {pass/warn/fail} | {n met, n partial, n unmet} | {summary} |
+| Structure | {pass/warn/fail} | {n met, n partial, n unmet} | {summary} |
+| Language | {pass/warn/fail} | {n met, n partial, n unmet} | {summary} |
 
 ---
 
@@ -157,23 +157,23 @@ date_reviewed: "{ISO 8601}"
 
 ## Detailed Analysis
 
-### Structural Gate ({x}/30)
+### Structural Gate ({pass/warn/fail})
 
 {Detailed findings for each structural criterion}
 
-### Critical Gate ({x}/25)
+### Critical Gate ({pass/warn/fail})
 
 {Detailed findings for each critical criterion}
 
-### Evidence Gate ({x}/25)
+### Evidence Gate ({pass/warn/fail})
 
 {Detailed findings for each evidence criterion}
 
-### Structure Gate ({x}/10)
+### Structure Gate ({pass/warn/fail})
 
 {Detailed findings for each structure criterion}
 
-### Language Gate ({x}/10)
+### Language Gate ({pass/warn/fail})
 
 {Detailed findings for each language criterion}
 ```
@@ -186,9 +186,9 @@ Return the JSON summary (see Output section above).
 
 ## Gate Evaluation Details
 
-For detailed scoring criteria per gate -- including partial credit rules, counting methods, and edge cases -- load [references/scoring-rubric.md](references/scoring-rubric.md).
+For the per-criterion verdict bands per gate -- including counting methods and edge cases -- load [references/scoring-rubric.md](references/scoring-rubric.md).
 
-**Gate summary:** Structural (30 pts) | Critical (25 pts) | Evidence (25 pts) | Structure (10 pts) | Language (10 pts)
+**Gate summary:** each of Structural, Critical, Evidence, Structure and Language returns `pass`, `warn` or `fail`, derived from its own criterion verdicts by the one rule the rubric states.
 
 ---
 
@@ -196,7 +196,8 @@ For detailed scoring criteria per gate -- including partial credit rules, counti
 
 - DO NOT modify the narrative file -- this is a read-only review
 - DO NOT fabricate or assume quality issues -- only report what is measurably found
-- ALWAYS compute expected word ranges from arc proportions x target length for scoring
+- DO NOT emit a composite score, a letter grade or a per-gate point total -- the workflow computes none of them
+- ALWAYS compute expected word ranges from arc proportions x target length for the word-count criteria
 - ALWAYS check against the language-specific header names
 
 ---
@@ -205,7 +206,7 @@ For detailed scoring criteria per gate -- including partial credit rules, counti
 
 | File | Purpose | Load When |
 |------|---------|-----------|
-| `references/scoring-rubric.md` | Detailed scoring weights and edge cases | Step 3 |
+| `references/scoring-rubric.md` | Criterion verdict bands and edge cases | Step 3 |
 
 **Cross-skill dependencies** (files owned by the `narrative` skill):
 

--- a/cogni-workspace/skills/narrative-review/references/scoring-rubric.md
+++ b/cogni-workspace/skills/narrative-review/references/scoring-rubric.md
@@ -1,34 +1,36 @@
 # Scoring Rubric
 
-Detailed scoring rules and edge cases for narrative review quality gates.
+Detailed evaluation rules and edge cases for narrative review quality gates.
 
-## Scoring Principles
+## Evaluation Principles
 
-1. **Binary where possible** -- Most criteria are pass/fail for their allocated points
-2. **Partial credit** -- Some criteria allow partial points (documented below)
-3. **Gate status** -- Derived from percentage of points earned:
-   - `pass`: >= 80% of gate points
-   - `warn`: 50-79% of gate points
-   - `fail`: < 50% of gate points
+1. **Binary where possible** -- Most criteria resolve to `met` or `unmet`, with no middle band
+2. **Partial** -- Some criteria define an intermediate band; those resolve to `partial` (documented below)
+3. **Gate status** -- Derived from the verdicts of that gate's criteria:
+   - `pass`: every criterion is `met`
+   - `warn`: no criterion is `unmet`, and at least one is `partial`
+   - `fail`: any criterion is `unmet`
+
+The same rule applies identically to all five gates. There is no composite figure and no
+letter grade: the workflow computes neither, so it reports neither.
 
 ---
 
-## Structural Gate (30 points)
+## Structural Gate
 
-### Exactly 4 `##` headers (10 points)
+### Exactly 4 `##` headers
 
-- **10 points:** Exactly 4 `##` lines in narrative body
-- **5 points:** 3 or 5 `##` lines (close but wrong)
-- **0 points:** Fewer than 3 or more than 5
+- **met:** Exactly 4 `##` lines in narrative body
+- **partial:** 3 or 5 `##` lines (close but wrong)
+- **unmet:** Fewer than 3 or more than 5
 
 **How to count:** Only count lines starting with `## ` (hash-hash-space) below the YAML frontmatter closing `---`. Do not count `#` (h1) or `###` (h3) lines.
 
-### Headers match arc element names (10 points)
+### Headers match arc element names
 
-- **10 points:** All 4 headers match expected names exactly
-- **7 points:** 3 of 4 match
-- **5 points:** 2 of 4 match
-- **0 points:** Fewer than 2 match
+- **met:** All 4 headers match expected names exactly
+- **partial:** 2 or 3 of 4 match
+- **unmet:** Fewer than 2 match
 
 **Matching rules:**
 - Compare against `language-templates.md` for the detected `arc_id` and `language`
@@ -36,78 +38,74 @@ Detailed scoring rules and edge cases for narrative review quality gates.
 - Trailing/leading whitespace is trimmed before comparison
 - Subtitles after `:` are part of the expected name (e.g., "Why Change: Unconsidered Needs")
 
-### Headers in correct sequence (5 points)
+### Headers in correct sequence
 
-- **5 points:** All headers in correct arc order
-- **0 points:** Any header out of order
+- **met:** All headers in correct arc order
+- **unmet:** Any header out of order
 
 Only evaluated if at least 3 headers match expected names.
 
-### No extra `##` headers (5 points)
+### No extra `##` headers
 
-- **5 points:** No extra `##` headers beyond the 4 arc elements
-- **2 points:** 1 extra `##` header
-- **0 points:** 2+ extra `##` headers
+- **met:** No extra `##` headers beyond the 4 arc elements
+- **partial:** 1 extra `##` header
+- **unmet:** 2+ extra `##` headers
 
 ---
 
-## Critical Gate (25 points)
+## Critical Gate
 
-### Total word count (10 points)
+### Total word count
 
 Compute the expected range from the narrative's `target_length` frontmatter field (default 1675 if absent): `total_lower = target_length * 0.85`, `total_upper = target_length * 1.15`.
 
-- **10 points:** Within target range (`total_lower` to `total_upper`)
-- **7 points:** Within 10% beyond target bounds (i.e., `total_lower * 0.90` to `total_upper * 1.10`)
-- **3 points:** Within 25% beyond target bounds (i.e., `total_lower * 0.75` to `total_upper * 1.25`)
-- **0 points:** Beyond 25% of target bounds
+- **met:** Within target range (`total_lower` to `total_upper`)
+- **partial:** Beyond the target range but within 25% of its bounds (i.e., `total_lower * 0.75` to `total_upper * 1.25`)
+- **unmet:** Beyond 25% of target bounds
 
 **Word count method:** Count all words in the markdown body below frontmatter. Exclude YAML frontmatter, citation markup (`<sup>`, `</sup>`), and markdown formatting characters.
 
-### Arc-specific title (5 points)
+### Arc-specific title
 
-- **5 points:** Title is specific, compelling, and reflects the arc's rhetorical frame
-- **2 points:** Title exists but is generic or does not reflect the arc
-- **0 points:** Title missing or is literally "Insight Summary"
+- **met:** Title is specific, compelling, and reflects the arc's rhetorical frame
+- **partial:** Title exists but is generic or does not reflect the arc
+- **unmet:** Title missing or is literally "Insight Summary"
 
 **Generic title indicators:** "Summary", "Report", "Analysis", "Overview", "Insight Summary", "Research Results" used alone without arc-specific framing.
 
-### Hook present (5 points)
+### Hook present
 
 Compute expected hook range from the arc's hook proportion x target range.
 
-- **5 points:** Hook paragraph exists within the computed hook range between `#` title and first `##`
-- **3 points:** Hook exists but outside computed range by up to 25%
-- **0 points:** No hook paragraph or word count below 50% of expected hook range
+- **met:** Hook paragraph exists within the computed hook range between `#` title and first `##`
+- **partial:** Hook exists but outside computed range by up to 25%
+- **unmet:** No hook paragraph or word count below 50% of expected hook range
 
-### Frontmatter complete (5 points)
+### Frontmatter complete
 
 Required fields: `title`, `arc_id`, `word_count`, `language`, `date_created`
 
-- **5 points:** All required fields present
-- **3 points:** 3-4 fields present
-- **0 points:** Fewer than 3 fields present
+- **met:** All required fields present
+- **partial:** 3-4 fields present
+- **unmet:** Fewer than 3 fields present
 
 ---
 
-## Evidence Gate (25 points)
+## Evidence Gate
 
-### Minimum 15 citations (10 points)
+### Minimum 15 citations
 
-- **10 points:** 15+ unique citations
-- **7 points:** 12-14 citations
-- **5 points:** 8-11 citations
-- **2 points:** 4-7 citations
-- **0 points:** Fewer than 4 citations
+- **met:** 15+ unique citations
+- **partial:** 4-14 citations
+- **unmet:** Fewer than 4 citations
 
 **Counting method:** Count unique `<sup>[N]` patterns where N is a citation number. Each unique N counts once regardless of how many times it appears.
 
-### All quantitative claims cited (10 points)
+### All quantitative claims cited
 
-- **10 points:** Every number, percentage, or quantitative claim has an adjacent citation
-- **7 points:** 1-2 uncited quantitative claims
-- **3 points:** 3-5 uncited quantitative claims
-- **0 points:** 6+ uncited quantitative claims
+- **met:** Every number, percentage, or quantitative claim has an adjacent citation
+- **partial:** 1-5 uncited quantitative claims
+- **unmet:** 6+ uncited quantitative claims
 
 **Quantitative claim detection:** Look for patterns like:
 - Percentages: `X%`, `X percent`
@@ -117,58 +115,56 @@ Required fields: `title`, `arc_id`, `word_count`, `language`, `date_created`
 
 **Exclusions:** Page numbers, citation numbers, list ordinals, dates, and version numbers are NOT quantitative claims.
 
-### No broken citation refs (5 points)
+### No broken citation refs
 
-- **5 points:** All citations use valid `<sup>[N](file.md)</sup>` format
-- **3 points:** 1-2 citations with format issues
-- **0 points:** 3+ citations with format issues
+- **met:** All citations use valid `<sup>[N](file.md)</sup>` format
+- **partial:** 1-2 citations with format issues
+- **unmet:** 3+ citations with format issues
 
 **Format issues:** Missing closing `</sup>`, missing `(file.md)` link, non-sequential numbering, duplicate numbers.
 
 ---
 
-## Structure Gate (10 points)
+## Structure Gate
 
-### Element word counts within targets (5 points)
+### Element word counts within targets
 
 Compute each element's expected range: `[proportion * total_lower, proportion * total_upper]` using proportions from the arc definition.
 
-- **5 points:** All 4 elements within computed proportional range (+/-10% tolerance)
-- **3 points:** 3 of 4 elements within range
-- **1 point:** 2 of 4 elements within range
-- **0 points:** Fewer than 2 elements within range
+- **met:** All 4 elements within computed proportional range (+/-10% tolerance)
+- **partial:** 2 or 3 of 4 elements within range
+- **unmet:** Fewer than 2 elements within range
 
-### Transitions between elements (5 points)
+### Transitions between elements
 
 Check for transition text: the last paragraph of each section (except the last) should connect to the next section's theme.
 
-- **5 points:** Clear transitions between all 3 section boundaries
-- **3 points:** Transitions at 2 of 3 boundaries
-- **1 point:** Transition at 1 boundary
-- **0 points:** No transition text detected
+- **met:** Clear transitions between all 3 section boundaries
+- **partial:** Transitions at 1 or 2 of 3 boundaries
+- **unmet:** No transition text detected
 
 **Transition indicators:** Phrases like "Building on...", "This urgency...", "Against this backdrop...", "With these capabilities...", opening sentences that reference the prior section's conclusion.
 
 ---
 
-## Language Gate (10 points)
+## Language Gate
 
-### Proper umlauts (5 points) -- only if `language: de`
+### Proper umlauts -- only if `language: de`
 
-- **5 points:** Zero ASCII fallbacks found
-- **3 points:** 1-3 ASCII fallbacks
-- **0 points:** 4+ ASCII fallbacks
+- **met:** Zero ASCII fallbacks found
+- **partial:** 1-3 ASCII fallbacks
+- **unmet:** 4+ ASCII fallbacks
 
 **ASCII fallback patterns to search for:** `ue` (should be `ü`), `ae` (should be `ä`), `oe` (should be `ö`), `ss` where `ß` is correct. Common false positives: compound words where "ue", "ae", "oe" are natural letter combinations at morpheme boundaries (e.g., "aeroplane") -- use German language knowledge to distinguish.
 
-If `language: en`, award full 5 points automatically.
+If `language: en`, record `met` automatically.
 
-### Consistent language (5 points)
+### Consistent language
 
-- **5 points:** Body text is consistently in the declared language
-- **3 points:** Minor language mixing (1-2 foreign sentences)
-- **0 points:** Significant language mixing
+- **met:** Body text is consistently in the declared language
+- **partial:** Minor language mixing (1-2 foreign sentences)
+- **unmet:** Significant language mixing
 
 **Exceptions:** Framework names (TIPS, MECE, SWOT), brand names, and technical terms may remain in English regardless of language setting.
 
-If `language: en`, award full 5 points automatically (English is the default).
+If `language: en`, record `met` automatically (English is the default).

--- a/docs/plugin-guide/cogni-workspace.md
+++ b/docs/plugin-guide/cogni-workspace.md
@@ -297,7 +297,7 @@ Eleven arc frameworks are available, each a fixed sequence of four named element
 
 The skill analyses the input's structure and proposes a best-fit arc; `--arc {arc-id}` overrides it. Target length defaults to ~1,675 words, with section proportions preserved rather than sections cut.
 
-`narrative-review` scores an existing narrative against the arc's quality gates across four dimensions — structural compliance, critical accuracy, evidence density, language — producing a 0–100 composite, an A–F grade, and the top three actionable fixes. With `--format`, `narrative` also condenses an existing narrative into an executive brief, talking points, or a one-pager, condensing proportionally so the arc survives the reduction.
+`narrative-review` scores an existing narrative against the arc's quality gates across five dimensions — structural compliance, critical accuracy, evidence density, structure, language — producing a pass/warn/fail verdict per gate and the top three actionable fixes. With `--format`, `narrative` also condenses an existing narrative into an executive brief, talking points, or a one-pager, condensing proportionally so the arc survives the reduction.
 
 Commands: `/narrative`, `/narrative-review`, `/narrative-adapt`.
 


### PR DESCRIPTION
Closes #1646.

## Summary

`narrative-review` advertised an `overall_score` (0-100) and an A-F letter grade that **nothing in the workflow computed**. The skill grants no `Bash` in `allowed-tools` and ships no script, so both figures were a model's impression rendered in the typography of a measurement — and the grade boundaries sat exactly where that impression is least stable.

Both are removed, along with every per-gate point total. All fifteen sub-criteria across all five gates now resolve to one uniform verdict vocabulary — `met` / `partial` / `unmet` — and each gate derives `pass` / `warn` / `fail` from its own criterion verdicts by a single rule stated once, in the rubric.

## What changed

| File | Change |
|---|---|
| `skills/narrative-review/references/scoring-rubric.md` | All three Evaluation Principles restated off points; the gate-status rule (was `pass: >= 80% of gate points`) re-specified in criterion terms; point parentheticals dropped from the five gate headings; all fifteen sub-criteria converted to verdict bands under one uniform collapse (top band → `met`, 0-band → `unmet`, every intermediate → `partial`) |
| `skills/narrative-review/SKILL.md` | Purpose, JSON contract keys, the whole Grading Scale table (replaced by a Verdict Vocabulary table), gate point maxima, the assign-points steps, the scorecard frontmatter, the `**Score:**` header segment, the Gate Results `Score` column and `**Total**` row, the five `({x}/30)`-style subheadings, the gate-summary line, plus the two points-derived phrasings at the rubric cross-reference ("partial credit rules") and the Bundled Resources row ("scoring weights") |
| `agents/narrative-reviewer.md` | Description, the `overall_score`/`grade` keys in the success-JSON example (now key-for-key identical to the skill contract), and the fabricate-scores constraint |
| `commands/narrative-review.md` | Command description |
| `cogni-workspace/README.md` | `:39` capability line and the `narrative-review` component row |
| `cogni-workspace/CLAUDE.md` | `:153` narrative-review clause |
| `docs/plugin-guide/cogni-workspace.md` | `:300` — and its "four dimensions" undercount corrected to **five**, since the per-gate rewrite makes that cardinality load-bearing |

**Every counting method, detection pattern, exclusion list and computed-range formula in the rubric is preserved verbatim** — those are what make the surviving numbers (word-count bands, the 15-citation floor, per-element proportions) observations rather than scores.

## Scope decisions

**The no-script arm was taken, and AC5 sanctions it explicitly.** Exploration found only **9 of the 15 sub-criteria are mechanically decidable** by a stdlib script; the other 6 (arc-title quality, hook identification, quantitative-claims-cited, transitions, German umlaut morphology, language consistency) need a reader — and the Language gate has *no* mechanically-decidable criterion at all. A partial script therefore produces exactly the split AC2's falsifier forbids: one gate reading a script while another estimates in prose. Removing the numeric surface entirely is what keeps one treatment across all five gates.

A second reason: the precedent the issue cites, `skills/copywriter/scripts/calculate_readability.py`, prints a bare result dict and a bare `{"error": ...}` — it does **not** emit the repo-standard `{success, data, error}` envelope AC4 would have required, so the script arm would have had to improve on its own cited precedent.

**Left deliberately unchanged.** `cogni-workspace/README.md:153` (agent row, "Quality-gate scoring and scorecard generation") names no figure, and the bare activity verb is the repo's own convention for figure-free rows. The 10 quoted trigger phrases in `SKILL.md`'s `description:` are router vocabulary, not output claims, and they carry this skill's contribution to `test-skill-trigger-phrases.sh` case C9's coverage floor — only the description's unquoted lead clause was retuned. `allowed-tools:` keeps its no-`Bash` posture. No `version` field in any manifest is touched.

## Corrections to the issue's own anchors

- `cogni-workspace/README.md:151` → the real row is **`:148`** (`:151` is the unrelated `copy-json` row).
- `cogni-workspace/CLAUDE.md:154` → the real line is **`:153`** (`:154` is the unrelated `copywriter` bullet).
- AC8's `tests/test-relocated-skill-hygiene.sh` actually lives at **`cogni-workspace/tests/`**. Its `TREE_SPECS` narrative arms are untouched and green.
- `docs/plugin-guide/cogni-workspace.md:300` carries the identical claim, is **in-fence** under `docs/`, and the issue body never named it. It is fixed here.

## Test plan

All run against this branch:

- [x] `python3 scripts/run-plugin-tests.py --filter cogni-workspace` — exit 0, `data.total: 20`, `failed: 0` (AC7)
- [x] `bash cogni-workspace/tests/test-arc-reference-sync.sh` — exit 0, 8 PASS (AC7)
- [x] `bash cogni-workspace/tests/test-relocated-skill-hygiene.sh` — exit 0, 3 PASS, cogni-narrative arms intact (AC8)
- [x] `bash cogni-workspace/tests/test-skill-trigger-phrases.sh` — exit 0, 9 PASS; C9 coverage floor and C1 no-collision both hold after the description edit
- [x] `python3 scripts/check-breadcrumbs.py` — 0 violations (AC9)
- [x] `check-frontmatter.sh cogni-workspace` — 0 violations
- [x] `git diff origin/main -- '*plugin.json' '*marketplace.json'` — empty, no `version` field changed (AC9)
- [x] Grep of `SKILL.md` + `scoring-rubric.md` for `overall_score`, `{A-F}`, `{0-100}`, `/100`, `/30`, `/25`, `points`, `pts` — no match (AC1). The only surviving occurrences of the word "composite" are the two *prohibition* sentences this PR adds.
- [x] Agent success-JSON keys vs skill contract keys — both `['arc_id','gates','source_path','success','top_improvements']`, identical
- [x] `git diff --name-only origin/main` — all 7 paths under `cogni-workspace/` or `docs/` (AC10)

## Mutation recipe

**Not applicable, deliberately.** This PR adds no script, no test suite and no guard, so there is no new executable check whose teeth a mutation could demonstrate. Per AC5's second arm, the criterion is satisfied by this statement: **the numeric surface was removed entirely rather than backed by computation.** No composite score, letter grade or per-gate point total survives anywhere in `SKILL.md`, `references/scoring-rubric.md`, `agents/narrative-reviewer.md` or `commands/narrative-review.md`, so no uncomputed figure is left for a script to have to compute. The four existing suites listed above are unmodified and are the regression fence.

## Review notes

The Step 6.5 skill-quality gate returned `needs_revision` with three `preference`-category findings and **no structural issues**. Two were auto-fixed in this branch: the output-honesty prose (the description's unquoted lead clause, the Purpose sentence, and a "When to Use" bullet that still asserted the skill emits a score), and an avoid-duplication fix collapsing the gate-status rule to one authoritative statement in the rubric with a pointer from `SKILL.md`.

The third finding is **not** fixed here and is recorded rather than silently dropped: the `## Constraints` block is a CAPS command stack whose four legacy lines assert rules without reasoning. It is marked `introduced_by_change: false` — pre-existing drift unrelated to this issue — and de-CAPSing it would widen the diff past what #1646 asks for.

## Follow-up issues

- **#1715** — repo + cogni-trends: two out-of-fence surfaces still advertise narrative-review's removed 0-100 composite and A-F grade

## Open questions

Both entries below are classified `avoidable` — they record decisions made rather than blocking questions, and neither holds this PR.

1. *(avoidable)* **AC10's fence vs. cross-surface consistency.** AC10 fences every changed path to `cogni-workspace/**` or `docs/**`, yet repo-root `README.md:26` and `cogni-trends/skills/trend-synthesis/references/story-arc-loop.md` carry the same 0-100/A-F claim. AC6's falsifier names only the cogni-workspace README and CLAUDE.md, so the two criteria do not strictly contradict — but merging this leaves those two surfaces temporarily advertising a contract the skill no longer honours. Answered by deferral to #1715 rather than by widening the fence. A reviewer who would rather hold until #1715 lands can say so.

2. *(avoidable)* **A dangling termination predicate in another plugin.** `story-arc-loop.md:24` terminates an authoring-time re-scoring loop on `overall_score >= 75`. After this PR no such figure is emitted, so that predicate is unsatisfiable until #1715 repoints it. Verified nothing breaks mechanically: no `.py`, `.sh` or `.json` in the repo reads `overall_score` from this skill, and `test-arc-reference-sync.sh` never references narrative-review. Recorded because it is a real cross-plugin consequence, not merely prose drift. #1715 also carries an explicit criterion that the file's historical iteration log at `:27-120` be left byte-identical — it records runs that really did emit those values.