### PR TITLE
cogni-trends: emit copywriter skill token from project-status.sh

### DIFF
--- a/cogni-trends/scripts/project-status.sh
+++ b/cogni-trends/scripts/project-status.sh
@@ -860,7 +860,7 @@ case "$PHASE" in
       add_action "cogni-trends:trend-booklet" "Build the comprehensive TIPS catalog of all candidates as a companion to the report"
     fi
     if [ "$HAS_COPYWRITER" = "false" ]; then
-      add_action "cogni-workspace:copywrite" "Polish report prose for executive readability"
+      add_action "cogni-workspace:copywriter" "Polish report prose for executive readability"
     fi
     if [ "$HAS_ENRICHED_REPORT" = "false" ]; then
       add_action "cogni-workspace:enrich-report" "Generate themed HTML with charts and diagrams"


### PR DESCRIPTION
Closes #1696.

## Summary
- `cogni-trends/scripts/project-status.sh:863` now emits `cogni-workspace:copywriter` instead of `cogni-workspace:copywrite`, so the `complete`-phase `next_actions` entry names the **skill** every consumer surface names.
- Restores agreement across the producer/consumer seam: `cogni-trends/skills/trends-resume/SKILL.md:211` (documented bullet, repointed by #1695) and :228 ("Only show actions that appear in `next_actions`" — a literal string-equality membership match that the old spelling failed).
- Target verified at `origin/main`: `cogni-workspace/skills/copywriter/SKILL.md` exists, so the new token resolves to a real skill. `cogni-workspace/commands/copywrite.md` (`name: copywrite`) is the slash command and is deliberately *not* the dispatch target.
- One-character edit, one line, one file. No behavioural change beyond the emitted token: `add_action` (`:803-806`) serializes its first argument verbatim, and the sibling entries in the same `case` arm already use this exact fully-qualified shape.

## Scope decisions
**Included** — only the emitter at `:863`. The surrounding `copywriter` identifiers are deliberately untouched, enumerated against `origin/main`: `HAS_COPYWRITER` (7 lines — `:162`, `:310`, `:527`, `:749`, `:750`, `:862`, `:1152`), `COPYWRITER_SCOPE` (`:163`, `:311`, `:1153`), the emitted JSON keys `copywriter_applied` / `copywriter_scope` (`:1152-1153`), the stage-detail string at `:750`, and the metadata read at `:302-311`. A blanket `s/copywrite/copywriter/g` would corrupt all of them; the diff is a single targeted line, applied line-scoped *and* literal-scoped.

**Not touched** — every other `copywrite` occurrence repo-wide is a legitimate `/copywrite` slash-command mention, `cogni-workspace/commands/copywrite.md`'s own self-reference (`name: copywrite`), or `copy-json`'s `.{basename}.copywrite-tmp.md` temp-file name — never a dispatch token. The two other `next_actions` consumers in cogni-trends were checked and need no change: `skills/trends-dashboard/scripts/generate-dashboard.py:889` reads the array generically and `tests/test-stale-detection.sh:162` only extracts it — neither matches on token literals. AC3 is a verification step, covered in the test plan below rather than by an edit.

**Deferred to follow-ups** (filed as `svc:deferred` issues, see below):
1. *A `complete`-phase regression assertion.* All four suites under `cogni-trends/tests/` contain zero `copywrit` hits and none drives the phase past `modeling`, so AC2 ("suite stays green") is trivially satisfiable and proves nothing about this fix. A durable guard is separable work with its own fixture cost.
2. *Teaching the external-dispatch guard to see shell-emitted tokens.* `scripts/check-external-dispatch.py`'s `DEFAULT_GLOBS` (`:120-126`) covers `*/skills/*/SKILL.md`, `*/agents/*.md`, `*/commands/*.md`, `*/hooks/*`, `*/hooks/*/*` — `*/scripts/*` is absent, which is exactly why this token was invisible before and after the fix. That is a repo-root CI-guard change with a different blast radius and reviewer, not a cogni-trends change.

## Test plan
All five checks below were **executed against the pushed head** (`origin/fix/issue-1696-copywriter-dispatch-token`), not merely proposed:

- [x] `grep -n 'cogni-workspace:copywrite\([^r]\|$\)' cogni-trends/scripts/project-status.sh` returns **no** matches (AC1 falsifier). Verified against a 44,825-byte read of the file at head — a non-zero byte count was asserted first, so the "no matches" result is evidence rather than a vacuous read.
- [x] `grep -n 'cogni-workspace:copywriter' cogni-trends/scripts/project-status.sh` returns exactly one hit, at line 863, inside the `complete)` arm.
- [x] Collateral-rename check: `grep -c 'HAS_COPYWRITER'` is **7** and `grep -c 'COPYWRITER_SCOPE'` is **3** at head, both unchanged from base; `copywriter_applied` / `copywriter_scope` still resolve. `git diff main...HEAD --stat` is one file, one insertion, one deletion.
- [x] `bash cogni-trends/tests/test-project-status.sh`, `test-stale-detection.sh`, `test-agent-frontmatter-names.sh` and `test-research-manifest-sections.sh` each exit 0 (AC2). **Note this is a weak signal, stated plainly:** none of the four reaches the `complete)` arm, so they were green before the change too. Follow-up #1717 exists precisely because AC2 is vacuous as written.
- [x] `git grep 'cogni-workspace:copywrite\([^r]\|$\)'` at head returns zero repo-wide occurrences in a dispatch position (AC3); `cogni-workspace/commands/copywrite.md` still opens with `name: copywrite`, so the slash-command surface is untouched.

## Mutation recipe
Not applicable. The diff touches neither a `*/tests/test-*.sh` nor a `*/scripts/check-*.sh` — it changes one string literal in a status-reporting script — so there is no guard in this PR whose teeth a mutation could verify. The regression guard that *would* be mutable is deferred to #1717.

## Follow-up issues
- #1717 — cogni-trends: no suite reaches the complete phase, so the next_actions dispatch tokens have no regression guard
- #1718 — repo: the external-dispatch guard cannot see shell-emitted dispatch tokens (`*/scripts/*` absent from DEFAULT_GLOBS)