### PR TITLE
cogni-knowledge: fix false --resweep abort (probe_plugin unreachable in its fenced block)

### DIFF
--- a/cogni-knowledge/skills/knowledge-refresh/SKILL.md
+++ b/cogni-knowledge/skills/knowledge-refresh/SKILL.md
@@ -51,18 +51,7 @@ If `--mode` is missing and `--resweep` was not passed, default to push-mode — 
 - **Push-mode will run** when `--resweep` was **not** passed (push is the default), or when `--mode push` was given explicitly (the `--mode push --resweep` compose case). It runs the **vendored** `wiki-lint` script in-tree + this plugin's own phase skills → resolve the vendored `wiki-lint` scripts.
 - **Resweep will run** whenever `--resweep` was passed. It runs the **vendored** `wiki-claims-resweep` scripts in-tree and dispatches `cogni-workspace:claims` → probe the vendored scripts + `cogni-workspace`.
 
-So a `--resweep`-only invocation (no `--mode`) probes **only** the vendored scripts + `cogni-workspace`, never `cogni-wiki`. Abort cleanly rather than letting a downstream `Skill` dispatch fail with an opaque error. The `probe_plugin` helper handles both the dev-repo sibling layout (`../<plugin>/skills/...`) and the marketplace cache layout (`../../<plugin>/<version>/skills/...`):
-
-```
-probe_plugin() {
-  local plugin="$1" skill="$2"
-  test -f "${CLAUDE_PLUGIN_ROOT}/../${plugin}/skills/${skill}/SKILL.md" && return 0
-  for d in "${CLAUDE_PLUGIN_ROOT}/../../${plugin}/"*/skills/"${skill}"/SKILL.md; do
-    [ -f "$d" ] && return 0
-  done
-  return 1
-}
-```
+So a `--resweep`-only invocation (no `--mode`) probes **only** the vendored scripts + `cogni-workspace`, never `cogni-wiki`. Abort cleanly rather than letting a downstream `Skill` dispatch fail with an opaque error.
 
 **When push-mode will run** (per the decision above), resolve the vendored `wiki-lint` script — push-mode runs `lint_wiki.py` in-tree and dispatches **no** `cogni-wiki:` skill. Resolve it **vendored-first via the same `resolve_wiki_scripts` mechanism** §1 + §2 use, so the pre-flight guard and the §1 invocation share one resolution order + entry-point check:
 
@@ -72,19 +61,27 @@ WIKI_LINT_SCRIPTS=$(resolve_wiki_scripts wiki-lint lint_wiki.py) \
   && WIKI_LINT_SCRIPTS_OK=yes || WIKI_LINT_SCRIPTS_OK=no
 ```
 
-Capture `WIKI_LINT_SCRIPTS` for reuse in §1 step 1 (it resolves the same directory there, so resolving once here keeps the pre-flight guard and the §1 invocation in lockstep — exactly as the resweep block below shares `RESWEEP_SCRIPTS` with §2). Note `lint_wiki.py` imports the vendored `_wikilib.py` from its sibling `wiki-ingest/scripts/` dir, so the entry-point check assumes the full vendored tree (both `wiki-lint/` and `wiki-ingest/scripts/_wikilib.py`) is present — the same sibling-import posture `knowledge-finalize` Step 10.5 already relies on.
+Capture `WIKI_LINT_SCRIPTS` for reuse in §1 step 1 (it resolves the same directory there, so resolving once here keeps the pre-flight guard and the §1 invocation in lockstep). Note `lint_wiki.py` imports the vendored `_wikilib.py` from its sibling `wiki-ingest/scripts/` dir, so the entry-point check assumes the full vendored tree (both `wiki-lint/` and `wiki-ingest/scripts/_wikilib.py`) is present — the same sibling-import posture `knowledge-finalize` Step 10.5 already relies on.
 
 If `WIKI_LINT_SCRIPTS_OK` is `no`, abort with the missing-vendored-scripts message:
 
 > Push-mode requires the vendored `wiki-lint` script (`lint_wiki.py`), which is missing from this install.
 > Reinstall/upgrade cogni-knowledge via the marketplace, then retry.
 
-**When `--resweep` was passed**, the live-source re-check runs the **vendored** `wiki-claims-resweep` scripts in-tree (no `cogni-wiki` dispatch) and dispatches `cogni-workspace:claims`. Resolve the vendored scripts **vendored-first via the same `resolve_wiki_scripts` mechanism §2 uses** — one resolution order + one entry-point existence check shared between the pre-flight guard and the §2 invocation (do not duplicate it as a bare `test -d`, which would not check the entry-point or honour the fallback layout) — and probe `cogni-workspace:claims`:
+**When `--resweep` was passed**, the live-source re-check runs the **vendored** `wiki-claims-resweep` scripts in-tree (no `cogni-wiki` dispatch) and dispatches `cogni-workspace:claims`. Resolve the vendored scripts **vendored-first via the same `resolve_wiki_scripts` mechanism §2 uses** — one resolution order + one entry-point existence check shared between the pre-flight guard and the §2 invocation (do not duplicate it as a bare `test -d`, which would not check the entry-point or honour the fallback layout) — and probe `cogni-workspace:claims`. The `probe_plugin` helper handles both the dev-repo sibling layout (`../<plugin>/skills/...`) and the marketplace cache layout (`../../<plugin>/<version>/skills/...`), and is defined here, immediately before its sole invocation:
 
 ```
 source "${CLAUDE_PLUGIN_ROOT}/scripts/resolve-wiki-scripts.sh"
 RESWEEP_SCRIPTS=$(resolve_wiki_scripts wiki-claims-resweep extract_page_claims.py) \
   && RESWEEP_SCRIPTS_OK=yes || RESWEEP_SCRIPTS_OK=no
+probe_plugin() {
+  local plugin="$1" skill="$2"
+  test -f "${CLAUDE_PLUGIN_ROOT}/../${plugin}/skills/${skill}/SKILL.md" && return 0
+  for d in "${CLAUDE_PLUGIN_ROOT}/../../${plugin}/"*/skills/"${skill}"/SKILL.md; do
+    [ -f "$d" ] && return 0
+  done
+  return 1
+}
 probe_plugin cogni-workspace claims && CLAIMS_OK=yes || CLAIMS_OK=no
 ```
 
@@ -125,7 +122,7 @@ Then continue with the binding-resolution checks:
    ```
    python3 "$WIKI_LINT_SCRIPTS/lint_wiki.py" --wiki-root <wiki_path>
    ```
-   Capture stdout as `LINT_JSON`. This is a read-only pass — it writes **no** `wiki/audits/lint-*.md` file and **no** `wiki/log.md` line; the stale findings come back in-process on stdout. (Re-homed off the `cogni-wiki:wiki-lint` skill dispatch so push-mode needs no `cogni-wiki` install — the staleness check is a sibling-plugin script, not a skill dispatch.)
+   Capture stdout as `LINT_JSON`. This is a read-only pass — it writes **no** `wiki/audits/lint-*.md` file and **no** `wiki/log.md` line; the stale findings come back in-process on stdout. (Re-homed off the `cogni-wiki:wiki-lint` skill dispatch so push-mode needs no `cogni-wiki` install.)
 
 2. **Parse stale findings + evidence-aware refresh candidates.** Two inputs feed the refresh menu:
    - **Time-based (stale).** From `LINT_JSON`, keep the `data.warnings[]` entries whose `class` is `stale_page` or `stale_draft`; each carries a `page` field (the slug) + a `message`. Collect the slug for each. For the step-3 selection label, read each stale page's title from its resolved wiki page's `title:` frontmatter (the warning dict carries the slug, not the title).
@@ -192,7 +189,7 @@ The per-topic loop fails soft: a topic that dies mid-chain leaves valid manifest
 
 ### 2. Resweep — native inline orchestration (opt-in)
 
-Runs **only when `--resweep` is passed** — after push completes (if `--mode push` was given), or **alone** when `--resweep` carries no `--mode`. It re-verifies the bound wiki's cited claims against **live** source URLs, the one thing the zero-network per-run pipeline structurally never does. Never auto-dispatched — the operator must pass the flag, so every finalize/verify/dashboard run stays zero-network and fast.
+Runs **only when `--resweep` is passed** — after push completes (if `--mode push` was given), or **alone** when `--resweep` carries no `--mode`. It re-verifies the bound wiki's cited claims against **live** source URLs, the one thing the zero-network per-run pipeline structurally never does. Never auto-dispatched, so every finalize/verify/dashboard run stays zero-network and fast.
 
 This is an **inline orchestration over the vendored `wiki-claims-resweep` scripts plus the claims engine** — there is **no** `cogni-wiki:` dispatch. The two vendored scripts are deterministic plumbing (claim extraction + plan-materialize/aggregate); the live-source re-verification (WebFetch + LLM-compare against the live page) is the job of `cogni-workspace:claims`. The vendored script directory was already resolved **vendored-first** in the Step 0 pre-flight (`RESWEEP_SCRIPTS`, via `resolve_wiki_scripts wiki-claims-resweep extract_page_claims.py`, exactly as `knowledge-dashboard`/`knowledge-resume` do); reuse that value here. If you are entering §2 without the pre-flight value in hand (e.g. a manual re-entry), re-resolve it identically — `resolve_wiki_scripts` is idempotent:
 

--- a/cogni-knowledge/tests/test_refresh_resweep_contract.sh
+++ b/cogni-knowledge/tests/test_refresh_resweep_contract.sh
@@ -16,7 +16,7 @@
 # public --resweep* flags unchanged. The vendored scripts are resolved
 # vendored-first via resolve_wiki_scripts(), mirroring knowledge-dashboard.
 #
-# bash 3.2 + grep only.
+# bash 3.2 + grep + awk.
 
 set -eu
 
@@ -84,6 +84,38 @@ assert_not_grep 'Skill("cogni-wiki:wiki-lint"' "$REFRESH" "refresh-resweep-24-pu
 assert_grep 'lint_wiki.py' "$REFRESH" "refresh-resweep-25-push-mode-lints-vendored knowledge-refresh: push-mode still lints (vendored lint_wiki.py in-tree)"
 assert_not_grep 'Skill("cogni-wiki:wiki-refresh"' "$REFRESH" "refresh-resweep-26-pull-mode-wiki-refresh knowledge-refresh: pull-mode wiki-refresh dispatch removed"
 assert_not_grep 'from-research' "$REFRESH" "refresh-resweep-27-research-flag-removed-pull knowledge-refresh: --from-research flag removed with pull-mode"
+
+# --- 9) probe_plugin definition and call share one fenced block -------------
+# A flat assert_grep on the invocation literal is not enough: it stays green when
+# `probe_plugin()` is defined in a DIFFERENT fenced block than the one calling it,
+# which is the standalone-exit-127 defect this guards. The predicate is
+# BIDIRECTIONAL, so it also rejects the duplicate-definition shortcut: a block
+# that calls without defining is FAIL-NODEF, one that defines without calling is
+# FAIL-ORPHANDEF.
+fence_scope_result=$(awk '
+  /^```/ {
+    if (inf) {
+      if (hascall) { sawcall = 1; if (!hasdef) nodef = 1 }
+      else if (hasdef) orphan = 1
+    }
+    inf = !inf; hasdef = 0; hascall = 0; next
+  }
+  inf && /probe_plugin\(\)[ \t]*\{/ { hasdef = 1 }
+  inf && /probe_plugin[ \t]+[A-Za-z]/ { hascall = 1 }
+  END {
+    if (!sawcall)    print "FAIL-NOBLOCK"
+    else if (nodef)  print "FAIL-NODEF"
+    else if (orphan) print "FAIL-ORPHANDEF"
+    else             print "PASS"
+  }
+' "$REFRESH") || true
+
+if [ "$fence_scope_result" = "PASS" ]; then
+  green "PASS: refresh-resweep-28-probe-plugin-fence-scoped knowledge-refresh: probe_plugin is defined in the same fenced block that calls it"
+else
+  red "FAIL: refresh-resweep-28-probe-plugin-fence-scoped knowledge-refresh: probe_plugin definition/call are not fence-co-located ($fence_scope_result)"
+  errors=$((errors + 1))
+fi
 
 if [ $errors -eq 0 ]; then
   green ""


### PR DESCRIPTION
Closes #1708.

## Summary

`knowledge-refresh --resweep` aborted on **every** invocation, including installs where `cogni-workspace` was present.

`probe_plugin()` was defined in a standalone fenced block, but its sole invocation — `probe_plugin cogni-workspace claims && CLAIMS_OK=yes || CLAIMS_OK=no` — sat in a *different* fenced block. That second block re-sources its other dependency (`resolve-wiki-scripts.sh`) but never re-defined the helper, so run standalone the call is `command not found` (exit 127), the `||` arm sets `CLAIMS_OK=no` unconditionally, and the missing-`cogni-workspace` abort fired every time. A false abort, not an unreachable one: the gate was stuck closed.

This takes the **merge** arm, never a duplicate definition:

- The standalone definition fence is **deleted** and `probe_plugin()` relocated into the `--resweep` fence, after the `resolve_wiki_scripts` lines and immediately before its invocation. Definition and call now share one shell scope.
- The invocation is retained **byte-for-byte**, and stays inside the `--resweep`-gated block — so the invariant that a push-only run never probes `cogni-workspace` is preserved.
- The sentence that introduced the old fence moves onto the paragraph that introduces the surviving one, with its trailing colon handled so no sentence runs into a doubled colon.
- The `cogni-workspace` abort message is unchanged in substance.

### Regression guard

`tests/test_refresh_resweep_contract.sh` gains case `refresh-resweep-28-probe-plugin-fence-scoped`. A flat `assert_grep` on the invocation literal would **stay green on the broken file**, so the new case parses fenced blocks and is deliberately **bidirectional**:

| tree state | verdict |
|---|---|
| definition and call in one fence (fixed) | `PASS` |
| call without definition (the shipped bug) | `FAIL-NODEF` |
| definition left orphaned in its own fence (the duplicate shortcut) | `FAIL-ORPHANDEF` |
| no calling fence at all | `FAIL-NOBLOCK` |

The `FAIL-ORPHANDEF` arm is what makes the guard enforce "don't just paste a second copy" — a one-directional predicate would have passed that. Existing ids `00`–`27` are unrenumbered; both arms carry the same id; the case gates on its own variable, not the shared `errors` accumulator. The `|| true` on the command substitution is load-bearing under the file's `set -eu`.

The suite header's `# bash 3.2 + grep only.` is updated to name `awk`, so it stops asserting something false.

## Scope decisions

**Considered and rejected: hoisting `probe_plugin` into `scripts/resolve-wiki-scripts.sh`** (which the calling fence already sources). It looks like the deeper fix; it is not, on re-enumerated evidence:

1. **Population.** 15 live `knowledge-*` skills define `probe_plugin()` inline (17 files, 2 under `_archive/`). Removing only this one leaves 14 inline definitions *plus* one sourced definition — two shapes where there is currently one. Consistency gets worse until a 15-file sweep lands.
2. **Cohesion.** `resolve-wiki-scripts.sh` scopes itself to locating a cogni-wiki *engine skill's* `scripts/` dir; `probe_plugin` probes an arbitrary *plugin* for an arbitrary *skill*. Hoisting would make the filename inaccurate and force a header-contract rewrite.
3. **Silent shadowing.** Most of those skills already source that file near their inline copy, with no shadow coverage in its suite.

The bug-producing property is **fence separation**, not duplication — and all 14 siblings were independently checked and are already fence-co-located, so the defect class had exactly one member. This PR removes it and guards against its return. The consolidation is filed as #1720 (a DRY item, explicitly **not** a latent-bug sweep — claiming "14 more instances of this bug" would be false).

## Test plan

All run from the repo root and were executed on this branch:

- [x] `bash cogni-knowledge/tests/test_refresh_resweep_contract.sh` → `ALL PASS`, exit 0 (cases 00–27 plus the new 28)
- [x] `bash cogni-knowledge/tests/test_skill_contracts.sh` → exit 0
- [x] `bash cogni-knowledge/tests/test_refresh_push_chain.sh` → exit 0
- [x] `python3 scripts/run-plugin-tests.py --filter cogni-knowledge/tests` → 78/78 suites pass, exit 0 (this is what CI's `plugin-test-suites` job runs)
- [x] `python3 scripts/check-case-id-pairing.py` → exit 0
- [x] `python3 scripts/check-result-line-plainness.py` → exit 0
- [x] `python3 scripts/check-breadcrumbs.py` → exit 0
- [x] `grep -cF 'probe_plugin() {' cogni-knowledge/skills/knowledge-refresh/SKILL.md` → `1` (not duplicated)
- [x] `grep -cF 'probe_plugin cogni-wiki' …` and `grep -cF 'probe_plugin cogni-research' …` → `0` and `0`
- [x] Diff confined to `cogni-knowledge/`; no `version` field in the diff

## Mutation recipe

`cogni-knowledge` ships no `mutation-check.sh`, so the guard's teeth are shown by hand. Run from the repo root **on this branch** (so `git checkout --` restores the fixed file). Executed end-to-end; the quoted output is observed, not predicted:

```bash
# 1. Baseline — the guard is green on the fixed tree.
bash cogni-knowledge/tests/test_refresh_resweep_contract.sh; echo "rc=$?"
#   PASS: refresh-resweep-28-probe-plugin-fence-scoped ...
#   ALL PASS      rc=0

# 2. Mutate — rename the definition so the fence still CALLS probe_plugin
#    but no longer DEFINES it. This is exactly the shipped bug.
sed -i.mut 's/^probe_plugin() {$/probe_plugin_MUTANT() {/' \
  cogni-knowledge/skills/knowledge-refresh/SKILL.md

bash cogni-knowledge/tests/test_refresh_resweep_contract.sh; echo "rc=$?"
#   FAIL: refresh-resweep-28-probe-plugin-fence-scoped knowledge-refresh: probe_plugin
#         definition/call are not fence-co-located (FAIL-NODEF)
#   1 test(s) failed      rc=1

# 3. Restore.
git checkout -- cogni-knowledge/skills/knowledge-refresh/SKILL.md
rm -f cogni-knowledge/skills/knowledge-refresh/SKILL.md.mut
bash cogni-knowledge/tests/test_refresh_resweep_contract.sh; echo "rc=$?"   # ALL PASS, rc=0
```

The `FAIL-ORPHANDEF` and `FAIL-NOBLOCK` arms were exercised the same way (re-introducing the standalone definition fence, and removing the call) and each emitted its own distinct verdict. A guard that stayed green through these would be vacuous.

## Review notes

- **`--resweep` is not yet usable end-to-end, and this PR does not claim otherwise.** The pre-commit skill-quality gate found the *same defect class one fence away*: §2's fence calls `resolve_wiki_scripts` without sourcing `resolve-wiki-scripts.sh`, so once the pre-flight clears, that block false-aborts on its own. Across the file, three fences call `resolve_wiki_scripts`; two source it, one does not. That is a **different helper in a different section**, outside #1708's acceptance criteria and outside its contract, so it is filed as **#1721 (S2-major)** rather than folded in here. #1708's own acceptance bar — the pre-flight probe — is fully met by this PR.
- **`knowledge-refresh/SKILL.md` is pre-existing over its advisory length cap** (`chars_body` 34,504 vs a 24,000 cap). Not chased here: coupling a whole-file rewrite to a focused bug fix is the wrong trade. The prose pass shed 175 chars of restated caveats, leaving the file **123 chars smaller than it entered** — net-negative against base.

## Follow-up issues

- **#1720** — consolidate the 15 duplicated inline `probe_plugin()` definitions (DRY/maintenance, not a bug sweep).
- **#1721** — §2 calls `resolve_wiki_scripts` without sourcing it; the same false abort, one fence away (S2-major).