### PR TITLE
cogni-workspace: orphaned-trigger-phrase arm (C10) + retirement record

### DIFF
--- a/cogni-workspace/references/retired-trigger-phrases.tsv
+++ b/cogni-workspace/references/retired-trigger-phrases.tsv
@@ -1,0 +1,51 @@
+# Retired trigger phrases — an append-only record of phrases that a deleted skill once advertised.
+#
+# Why this file exists. The collision guard next to it (tests/test-skill-trigger-phrases.sh) folds
+# the live claim surface with `sort | uniq -d`, so it sees a phrase claimed by TWO skills and is
+# structurally blind to one claimed by NONE. When a skill is deleted, its phrases leave no trace in
+# the tree at all — so "which phrases ought to be claimed" is not derivable from the tree, and only
+# an enumerated record can express it. Case C10 reads this file and cross-checks it against the live
+# extractor in both directions.
+#
+# Why this is not the roster that suite rejects. The suite rejects a per-skill EXEMPTION list: one
+# that must track the extractor's own name key, enumerates live skills, and makes findings
+# disappear. This is the opposite object. It is scoped to retirement events rather than to skills,
+# its population is closed by history, it names no live skill except as an owner attribution that
+# C10 verifies, and every row only ever ADDS a way for the suite to go red. The in-repo precedent is
+# references/wiki-tree-reconciliation.md and its enforcement arm tests/test-wiki-tree-parity.sh,
+# where a one-sided page with no recorded decision turns the suite red and the documented fix is to
+# record the decision rather than route around the guard.
+#
+# Schema — four tab-separated fields, no trailing spaces:
+#   phrase_key  status            owner              reason
+#   phrase_key  the extractor's normal form: trimmed, internal whitespace collapsed to single
+#               spaces, lowercased. C10 re-derives this and rejects a row whose key is not already
+#               normalized, so the comm-join against the live set cannot silently miss.
+#   status      claimed | retired
+#   owner       the live skill that claims it (status=claimed), or - (status=retired)
+#   reason      non-empty, author-written. C10 reddens on an empty reason, so a row cannot be added
+#               without saying why.
+#
+# Provenance: the story-to-storyboard to story-to-web fold. That skill advertised eleven phrases.
+# The fold absorbed two, a later revision re-claimed three more, and the remaining six were left
+# claimed by nobody. All eleven are recorded below.
+#
+# Budget snapshot, measured once rather than restated per row. At the time these six were retired,
+# story-to-web's resolved description was 1006 of the 1024-char platform cap — 18 characters of
+# headroom, not enough for one phrase plus its quoting and comma. Measured with check-frontmatter's
+# own resolve_description (the value the gate tests), not a YAML parser, which counts one more.
+# Nothing re-measures this line, so treat it as a dated observation: re-measure before relying on
+# it. The per-row reasons below deliberately carry only durable rationale.
+#
+# phrase_key	status	owner	reason
+storyboard	claimed	story-to-web	Absorbed by the fold; story-to-web serves print output in storyboard mode.
+druckposter	claimed	story-to-web	Absorbed by the fold; the German entry point to the same storyboard mode.
+poster series	claimed	story-to-web	Re-claimed after the fold, using headroom reclaimed by compressing the description.
+print posters from narrative	claimed	story-to-web	Re-claimed after the fold, in the same compression pass.
+poster erstellen	claimed	story-to-web	Re-claimed after the fold, in the same compression pass.
+storyboard aus bericht	retired	-	Retired, not re-claimed: no headroom in the absorbing description (see the budget snapshot above), and the German claim "Druckposter" already routes report-to-poster intent.
+posterpraesentation	retired	-	Retired, not re-claimed: no headroom in the absorbing description, and the surviving "Druckposter" plus "Poster erstellen" carry the German poster intent.
+poster fuer workshop	retired	-	Retired, not re-claimed: a usage-context variant rather than a distinct capability; "Poster erstellen" already routes it.
+poster walkthrough	retired	-	Retired, not re-claimed: survives as body prose in story-to-web and as unquoted prose in the story-to-storyboard agent, neither of which the extractor reads as a claim; "poster series" carries the intent.
+create poster storyboard	retired	-	Retired, not re-claimed: a compound of two phrases story-to-web already claims separately, "storyboard" and "poster series".
+physical walkthrough posters	retired	-	Retired, not re-claimed: the physical-output nuance is carried by "print posters from narrative".

--- a/cogni-workspace/tests/test-skill-trigger-phrases.sh
+++ b/cogni-workspace/tests/test-skill-trigger-phrases.sh
@@ -41,6 +41,9 @@
 #     prose, or in single quotes inside a double-quoted scalar, is invisible
 #     to this guard and fails the coverage floor
 #   - an empty or missing skills directory fails rather than reporting clean
+#   - a phrase the retirement record marks as claimed, that no live skill
+#     yields, fails as an orphan; and a phrase it marks as retired, that a live
+#     skill DOES yield, fails as a stale record
 #
 # Scoped to one plugin on purpose. The obvious generalization — scan every
 # plugin at once — is wrong here: `cogni-portfolio:markets` and
@@ -49,6 +52,28 @@
 # disambiguates by plugin. Only phrases competing INSIDE one plugin's skill set
 # are unambiguously a defect. A cross-plugin version of this check would need a
 # hand-maintained exemption list, which is the thing this design rejects.
+#
+# That rejection stands, and C10's retirement record is not an instance of it.
+# The discriminator is the direction of effect, not the fact of being a file.
+# An exemption list makes the guard QUIETER: every row removes a finding, and a
+# guard that is quiet because it stopped looking is worse than no guard. C10's
+# record makes it LOUDER: every row adds a way to go red, and the record itself
+# is checked in both directions against the live extractor, so a row that stops
+# being true reddens rather than silently persisting. It is also scoped to
+# retirement EVENTS rather than to skills — its population is closed by history
+# and it enumerates no live skill except as an owner attribution C10 verifies —
+# so it needs no syncing with the extractor's name key as skills come and go.
+# The in-repo precedent is references/wiki-tree-reconciliation.md and its
+# enforcement arm tests/test-wiki-tree-parity.sh: a one-sided page with no
+# recorded decision turns that suite red, and the documented fix is to record
+# the decision rather than route around the guard.
+#
+# The record is needed at all because absence is not derivable from this tree.
+# Collision detection folds the live surface with `sort | uniq -d`, which can
+# only see a phrase claimed by two skills; a phrase claimed by NONE leaves no
+# trace here to fold. When a skill is deleted its phrases vanish from the tree
+# entirely, so nothing the extractor can read remembers that they were ever
+# routed. Only an enumerated record can carry that.
 #
 # The extractor takes the description block as everything from `description:` up
 # to the next top-level frontmatter key. Both YAML block styles in the tree
@@ -365,6 +390,11 @@ fi
 # per-skill exemption list — the thing this suite's design rejects. Pointing
 # this case at a broken extractor turns it red, exactly as C1-C8 do.
 #
+# That claim is about C9 specifically, and stays true of it: C9 enumerates
+# nothing, because it derives its population from the live tree on every run.
+# C10 below deliberately does carry a record; the header states why, and why it
+# is not the roster this design rejects.
+#
 # Single-quoted spans are deliberately NOT harvested, and the fix for a
 # single-quoted description is to migrate it rather than to widen the regex.
 # A boundary-aware widening is possible and mints no garbage, so that is not
@@ -398,6 +428,140 @@ if [ "$c9_scanned" -gt 0 ] && [ -z "$c9_missing" ]; then
 else
   echo "     skills contributing zero phrases:$c9_missing (scanned $c9_scanned)"
   fail "C9 every real cogni-workspace skill contributes at least one trigger phrase"
+fi
+
+# ---------------------------------------------------------------------------
+# C10 — the orphan direction. C1/C2 detect a phrase claimed by TWO skills;
+# nothing detected one claimed by NONE, because `sort | uniq -d` over the live
+# surface cannot see what is not there. A retirement can therefore delete
+# routing coverage with every case green — which is what happened to six
+# phrases of the folded story-to-storyboard skill, caught only by a human
+# reviewer.
+#
+# The record at references/retired-trigger-phrases.tsv supplies the population
+# the tree cannot. This case cross-checks it against the live extractor in both
+# directions, so the record cannot quietly go stale in either:
+#
+#   claimed, not yielded  -> ORPHAN        (the routing loss this case exists for)
+#   claimed, wrong owner  -> MISATTRIBUTED (the record names a skill that does not claim it)
+#   retired, yielded      -> STALE RECORD  (a retired phrase came back)
+#
+# The live side comes from emit_phrases itself — never a second parser — so
+# pointing this case at a broken extractor turns it red exactly as C1-C9 do.
+# Row hygiene is enforced here too: four fields, a known status, a NON-EMPTY
+# reason, and a key already in the extractor's normal form. The reason check is
+# what stops the record degrading into a bare list nobody has to justify.
+#
+# bash-3.2 portable: flat temp files plus sort/comm/awk, no associative arrays.
+# ---------------------------------------------------------------------------
+c10_ok=1
+C10_LEDGER="$WS_ROOT/references/retired-trigger-phrases.tsv"
+mkdir -p "$TMPROOT/c10"
+
+if [ ! -f "$C10_LEDGER" ] || [ ! -r "$C10_LEDGER" ]; then
+  echo "     retirement record missing or unreadable: $C10_LEDGER"
+  c10_ok=0
+else
+  # Strip comments and blank lines. Everything below reads this.
+  grep -v '^[[:space:]]*#' "$C10_LEDGER" | grep -v '^[[:space:]]*$' > "$TMPROOT/c10/rows" || true
+
+  # One pass for all three counts. `rows` is carried for the diagnostic only —
+  # rows == 0 implies both status counts are 0, so it is never the deciding arm.
+  read -r c10_rows c10_claimed_n c10_retired_n <<EOF
+$(awk -F'\t' '{n++} $2 == "claimed" {c++} $2 == "retired" {r++} END {print n+0, c+0, r+0}' "$TMPROOT/c10/rows")
+EOF
+
+  # Anti-vacuity floor, mirroring C8/C9: an empty or single-status record must
+  # fail rather than pass on an empty loop. Without this, truncating the file
+  # would make every direction below iterate over nothing and report clean.
+  if [ "$c10_claimed_n" -eq 0 ] || [ "$c10_retired_n" -eq 0 ]; then
+    echo "     record is vacuous: rows=$c10_rows claimed=$c10_claimed_n retired=$c10_retired_n (each must be > 0)"
+    c10_ok=0
+  fi
+
+  # Row hygiene. A malformed row is reported, never skipped — skipping one
+  # would let a typo silently drop a phrase out of both directions.
+  # The key check is ASCII-gated on purpose. awk's tolower is byte-wise, while
+  # the extractor normalizes in python, whose lower() folds non-ASCII too — so
+  # on a non-ASCII key the two disagree, this check would call it already-normal,
+  # and the row would then never join the live set. That loses a direction
+  # SILENTLY, which is the failure class C10 exists to close. Rejecting the
+  # non-ASCII key outright keeps one normal form without a second parser.
+  c10_bad=$(awk -F'\t' '
+    NF != 4                                  { print "  field-count " NF " (want 4): " $0; next }
+    $2 != "claimed" && $2 != "retired"        { print "  unknown status \"" $2 "\": " $0; next }
+    $2 == "retired" && $3 != "-"              { print "  retired row must have owner \"-\", got \"" $3 "\": " $0; next }
+    { r = $4; gsub(/^[ \t]+|[ \t]+$/, "", r) }
+    r == ""                                   { print "  empty reason: " $0; next }
+    $1 ~ /[^\x20-\x7e]/                       { print "  key has a non-ASCII byte, so awk and the extractor would normalize it differently: " $0; next }
+    {
+      k = tolower($1)
+      gsub(/^[ \t]+|[ \t]+$/, "", k)
+      gsub(/[ \t]+/, " ", k)
+      if (k != $1) print "  key not in normal form (want \"" k "\"): " $0
+    }
+  ' "$TMPROOT/c10/rows")
+  if [ -n "$c10_bad" ]; then
+    echo "     malformed record rows:"
+    echo "$c10_bad"
+    c10_ok=0
+  fi
+
+  # The live side, from the suite's own extractor. A non-zero rc is red: an
+  # extractor that could not read the tree is not evidence the tree agrees.
+  if emit_phrases "$WS_ROOT/skills" > "$TMPROOT/c10/raw" 2>"$TMPROOT/c10/raw.err"; then
+    cut -f1 "$TMPROOT/c10/raw" | sort -u > "$TMPROOT/c10/live"
+
+    awk -F'\t' '$2 == "claimed" { print $1 }' "$TMPROOT/c10/rows" | sort -u > "$TMPROOT/c10/claimed"
+    awk -F'\t' '$2 == "retired" { print $1 }' "$TMPROOT/c10/rows" | sort -u > "$TMPROOT/c10/retired"
+
+    # Direction A — recorded claimed, yielded by nobody. The orphan.
+    c10_orphans=$(comm -23 "$TMPROOT/c10/claimed" "$TMPROOT/c10/live")
+    if [ -n "$c10_orphans" ]; then
+      echo "$c10_orphans" | while IFS= read -r phrase; do
+        [ -z "$phrase" ] && continue
+        owner=$(awk -F'\t' -v p="$phrase" '$1 == p { print $3 }' "$TMPROOT/c10/rows")
+        echo "     ORPHAN \"$phrase\" recorded as claimed by $owner but yielded by no live skill"
+      done
+      c10_ok=0
+    fi
+
+    # Direction B — recorded retired, yielded after all. A stale record.
+    c10_stale=$(comm -12 "$TMPROOT/c10/retired" "$TMPROOT/c10/live")
+    if [ -n "$c10_stale" ]; then
+      echo "$c10_stale" | while IFS= read -r phrase; do
+        [ -z "$phrase" ] && continue
+        owners=$(awk -F'\t' -v p="$phrase" '$1 == p { print $2 }' "$TMPROOT/c10/raw" | sort -u | tr '\n' ' ')
+        echo "     STALE RECORD \"$phrase\" recorded retired but claimed by: $owners"
+      done
+      c10_ok=0
+    fi
+
+    # Direction C — owner attribution. A claimed row must name the skill the
+    # extractor actually attributes the phrase to. Gated on the phrase being
+    # live at all: without that guard an orphan satisfies this condition too and
+    # reports twice, the second time with a message that is false about the
+    # state ("not yielded under that name" implies it is yielded under another).
+    c10_mis=$(awk -F'\t' '
+      NR == FNR             { live[$1 "\t" $2] = 1; phrase[$1] = 1; next }
+      $2 == "claimed" && ($1 in phrase) {
+        if (!(($1 "\t" $3) in live)) print "     MISATTRIBUTED \"" $1 "\" recorded as claimed by " $3 " but not yielded under that name"
+      }
+    ' "$TMPROOT/c10/raw" "$TMPROOT/c10/rows")
+    if [ -n "$c10_mis" ]; then
+      echo "$c10_mis"
+      c10_ok=0
+    fi
+  else
+    echo "     emit_phrases failed over $WS_ROOT/skills: $(cat "$TMPROOT/c10/raw.err")"
+    c10_ok=0
+  fi
+fi
+
+if [ "$c10_ok" -eq 1 ]; then
+  pass "C10 the retirement record and the live tree agree in both directions"
+else
+  fail "C10 the retirement record and the live tree agree in both directions"
 fi
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #1682.

## Summary

- Adds `cogni-workspace/references/retired-trigger-phrases.tsv` — a tab-separated record of the eleven trigger phrases the deleted `story-to-storyboard` skill advertised. Five rows are `claimed` (owner `story-to-web`), six are `retired`, each with a non-empty author-written reason.
- Adds case **C10** to `cogni-workspace/tests/test-skill-trigger-phrases.sh`. The existing arms are all collision-shaped — `scan_skills` folds the live surface with `sort | uniq -d`, which by construction sees a phrase claimed by **two** skills and is blind to one claimed by **none**. C10 adds the missing direction.

C10 drives the suite's own `emit_phrases` (never a second extractor) and cross-checks the record against the live tree in **both** directions, so neither side can go stale silently:

| Condition | Report |
|---|---|
| recorded `claimed`, yielded by nobody | `ORPHAN` — the routing loss this issue is about |
| recorded `claimed`, yielded under a different skill | `MISATTRIBUTED` |
| recorded `retired`, yielded after all | `STALE RECORD` |

Plus row hygiene (four fields, known status, `retired` rows own `-`, **non-empty reason**, key already in the extractor's normal form and ASCII) and an anti-vacuity liveness floor mirroring C8/C9 — a missing, unreadable, empty, or single-status record fails rather than passing on an empty loop.

Case ids C1–C9 are neither renumbered nor repurposed.

## Scope decisions

**All six phrases are accounted for, all via AC1's "recorded as retired with the reason" arm.** None is re-claimed. `story-to-web`'s resolved description is **1006 of the 1024-char cap** — 18 characters of headroom, not enough for one phrase plus its quoting and comma — and `story-to-infographic` is at 1011. The skills with real headroom (`manage-markets` 540, `narrative-review` 469) are topically unrelated, so parking a poster phrase there would create a routing defect rather than fix one. Each retired row's reason names the surviving claim that already carries the intent.

Those figures are measured with `check-frontmatter.sh`'s own `resolve_description` — **the value the gate tests** — not `yaml.safe_load`, which keeps a trailing newline and reports one more.

**Why a record is admissible in a suite that rejects rosters.** The header and the C9 comment both reject a hand-maintained list, and this diff amends both rather than quietly contradicting them. The discriminator is the direction of effect: an *exemption* list makes the guard quieter — every row removes a finding, and a guard that is quiet because it stopped looking is worse than no guard. This record makes it louder — every row adds a way to go red, and the record is itself falsified in both directions against the live extractor. It is also scoped to retirement *events* rather than to skills, so it needs no syncing with the extractor's name key as skills come and go.

The in-repo precedent is `references/wiki-tree-reconciliation.md` and its enforcement arm `tests/test-wiki-tree-parity.sh`, where per `cogni-workspace/CLAUDE.md` *"a one-sided page with no decision written down turns the suite red: the fix is to record the decision ... not to route around the guard."*

> An earlier draft of this plan cited `absorption-roadmap.md` Decision 9 as the precedent. **That citation was false and was removed before any code was written.** Decision 9 is *"the de-ascii orthography guard stays a sampling guard, and grows by rows"*; its rationale is that no shape-based rule separates three populations sharing one scan root — it does not ratify curated tables on bidirectional-falsifiability grounds. Recorded here because the claim was persuasive enough to survive two independent planning passes.

**File placement.** `.tsv` under `references/`, not `.md`: `test-de-ascii-orthography.sh` scans every `.md` under the plugin root, and three retired phrases are ASCII-folded German (`Posterpraesentation`, `Poster fuer Workshop`, `Storyboard aus Bericht`) — exactly that guard's subject matter. Bare `references/` is also not in `test-relocated-skill-hygiene.sh`'s `TREE_SPECS`, so the new file enters none of P1/P2/P3. Both suites verified green below.

## Test plan — executed, not asserted

`run-tests.sh --dir cogni-workspace/tests` → **20 discovered, 20 passed, 0 failed, 0 skipped.**

Every C10 direction was falsified individually (mutate → red → restore → green):

| Probe | Result |
|---|---|
| remove a **claimed** phrase from a live description | `ORPHAN` red |
| plant a **retired** phrase into a live description | `STALE RECORD` red |
| point a `claimed` row at the wrong owner | `MISATTRIBUTED` red |
| add a `claimed` row for a phrase live nowhere | `ORPHAN` red, and **not** also `MISATTRIBUTED` |
| blank a row's reason | malformed-row red |
| give a `retired` row a non-`-` owner | malformed-row red |
| non-ASCII key | malformed-row red |
| truncate the record to comments | vacuity-floor red |

## Mutation recipe

Run from the repository root. The mutated phrase is **claimed at head**, not one of the six retired ones, so this exercises the orphan direction specifically:

```bash
bash "$HOME/.claude/plugins/marketplaces/managed-service/cogni-service/scripts/mutation-check.sh" \
  --root . \
  --file cogni-workspace/skills/story-to-web/SKILL.md \
  --expr 's/"poster series", //' \
  --test 'bash cogni-workspace/tests/test-skill-trigger-phrases.sh' \
  --case C10
```

Executed result: `"mutated_result": "red", "restored_result": "green", "verdict": "guard_verified"`.

## Review notes

- **A reviewer may reasonably want C10 split in two.** It currently clears one flag for six properties — record existence, the vacuity floor, four hygiene rules, and three cross-check directions — so `--case C10` going red does not locate which one fired. Splitting into a well-formedness case and an agreement case would let `mutation-check --case` select a single property. Left out deliberately: it moves the case-id contract this PR's recipe references, and each direction is individually falsified above. Say the word and it is a small follow-up.
- **The three directions are asserted only against the real (currently green) tree**, not against fixtures the way C2–C7 are. The probes above prove they have teeth today; a fixture arm would protect them from a future refactor.

## Follow-up issues

- #1723 — nothing forces a *future* retirement to write a record row. C10 proves the record and the tree agree with each other, so a retirement that deletes a skill and its rows in one move leaves both sides agreeing and C10 green. Catching that needs a base-vs-head comparison, a different mechanism from this suite's tree-only extractor.