### PR TITLE
cogni-workspace: re-ground retired ask references on bundled wiki

### DIFF
--- a/cogni-workspace/references/wiki-tree-reconciliation.md
+++ b/cogni-workspace/references/wiki-tree-reconciliation.md
@@ -296,10 +296,10 @@ sweep touches the bundled copies only, so it decides nothing about promotion.
 | `workflow-research-to-report` | 7/7 resolve | current | promote |
 | `ecosystem-command-reference` | 18 resolve, previously 1 mislabelled + 2 stale, now settled | current | promote |
 
-**Why the ruling is reserved.** Accepting a page into the root tree is what makes
-`cogni-workspace:ask` serve it as a grounded answer. Promoting a stale page therefore does not
-degrade gracefully — it makes the assistant answer confidently and wrongly, which is worse than
-the dangling reference it would have fixed.
+**Why the ruling is reserved.** Accepting a page into the root tree is what puts it in the grounded
+answer set — the pages `wiki/index.md` catalogues and Claude reads directly when answering.
+Promoting a stale page therefore does not degrade gracefully — it makes the assistant answer
+confidently and wrongly, which is worse than the dangling reference it would have fixed.
 
 **The page that was stale, and how it was settled.** `ecosystem-command-reference` stated that
 cogni-workspace ships no commands directory, listed 9 of its then-11 skills, and counted

--- a/cogni-workspace/tests/test-wiki-namespace-sync.sh
+++ b/cogni-workspace/tests/test-wiki-namespace-sync.sh
@@ -2,12 +2,13 @@
 # Wiki namespace-sync guard: no bundled wiki page may name a plugin that no
 # longer exists.
 #
-# Why this exists. `cogni-workspace:ask` answers only from the bundled wiki and
+# Why this exists. The bundled wiki is read directly — a reader points Claude
+# at its `wiki/index.md`, and the answer draws only on the pages it lists and
 # cites every claim with a [[wikilink]]. That contract is only as good as the
 # wiki's freshness, and nothing else enforces it — scripts/check-external-dispatch.py
 # deliberately excludes both wiki trees (EXCLUDE_SEGMENTS / EXCLUDE_TOPLEVEL),
 # because a wiki mirror may legitimately quote a retired dispatch as page content.
-# So a plugin can be absorbed or archived, its pages linger, and `ask` keeps
+# So a plugin can be absorbed or archived, its pages linger, and answers keep
 # citing them confidently. This suite is the wiki-side check that closes that gap.
 #
 # Contract under test:
@@ -31,7 +32,7 @@
 # either tree, so requiring the reverse direction would be red on arrival, and the
 # only ways to green it are authoring the missing pages or keeping an exemption
 # list — the very hand-maintained list this design rejects. A stale page makes
-# `ask` answer wrongly; a missing page only makes it answer less. Guarding the
+# the assistant answer wrongly; a missing page only makes it answer less. Guarding the
 # wrong-answer direction first is the intended sequencing.
 #
 # Namespace matching is boundary-aware, and that is load-bearing. A page stem


### PR DESCRIPTION
Closes #1688.

## Summary

Two `cogni-workspace` surfaces still described the retired `cogni-workspace:ask` skill (retired by PR #1670, closing #1641) as a live answering path, in the present tense. Both predate the retirement and were unreachable from the two follow-ups that swept alongside it — #1668 fenced to the root `marketplace.json`, #1669 fenced to `cogni-knowledge/`. This re-grounds both on the bundled-wiki read path that replaced the skill, preserving each surface's argument intact.

- **`cogni-workspace/references/wiki-tree-reconciliation.md`** — the "Why the ruling is reserved" paragraph no longer says `cogni-workspace:ask` serves an accepted page as a grounded answer. It now attributes the same effect to the bundled-wiki read path, reusing the file's own "grounded answer set" vocabulary from the "Reversing it" line just below it — so that line needs no edit and cannot end up contradicting the rewrite. Net line delta 0, so nothing below the paragraph drifts.
- **`cogni-workspace/tests/test-wiki-namespace-sync.sh`** — three header rationale comments (lines 5, 10, 34) no longer name `ask` as a live consumer. **Comment lines only**: every added and removed line in this file matches `^[+-][[:space:]]*#`. No assertion, helper, matcher or fixture is touched.

The read-path wording is not invented — it matches what is already on `main`: `cogni-workspace/README.md:98` says "Read the bundled wiki index at `wiki/index.md`", `cogni-workspace/README.md:35` says "read it directly, starting from its `wiki/index.md`", and `README.md:228` says "point Claude at that index and it reads the pages it needs, citing each one."

The replacements deliberately keep a *person or an answer* as the grammatical agent. "The wiki keeps citing them confidently" and "a stale page makes the wiki answer wrongly" would both be category errors — a wiki is read, it does not cite or answer. The surviving subjects are "answers" and "the assistant".

## Scope decisions

- **The complete in-scope set was enumerated, not sampled.** `git grep -n 'cogni-workspace:ask' origin/main -- cogni-workspace/` and ``git grep -n '`ask`' origin/main -- cogni-workspace/`` return exactly four lines across two files, and nothing else.
- **Grading-grep tension checked and resolved, not escalated.** The out-of-scope `references/absorption-roadmap.md:73` reads ``folded into `ask`'s bundled wiki`` — the **bare** `` `ask` `` form, never the qualified `cogni-workspace:ask` form. So `grep -rn 'cogni-workspace:ask' cogni-workspace/` reaches zero hits with the issue's out-of-scope fence fully intact, and there is nothing to arbitrate.
- **The `skill-cogni-workspace-ask.md` fixture is left alone.** It is a synthetic page filename written under `$TMPROOT` by `mk_page`, exercising the false-positive arm of the boundary matcher in case C5 — not a claim about a live skill. Rewriting it would change what the suite tests. (It shifts from line 298 to 299, since the line-5 edit adds one header line above it.)
- **The Decision-4 table rows are byte-identical.** `tests/test-wiki-tree-parity.sh` `check_recorded()` reads this record as one whole string and asserts each one-sided page stem is a literal substring of it (`if stem not in text`), so reflowing or trimming those seven rows would redden that suite. The edited paragraph contains none of the stems.
- **No denylist added.** The suite derives its allowed namespace set at runtime from `plugins[].name`. An `ask`-name assertion would be exactly the hand-maintained list the suite's own header argues against, so no new suite, guard script, denylist or registry entry is introduced.
- **No version bump.** `plugin.json` / `marketplace.json` versions are untouched — the post-merge workflow applies the patch bump per plugin actually touched.
- **Out-of-scope surfaces confirmed untouched**, per the issue: `references/absorption-roadmap.md`, `skills/copywriter/`, and all of `cogni-knowledge/` (tracked by #1669). `git diff --name-only` lists exactly the two files above.

## Mutation recipe

This diff is comments-only and adds no assertion of its own, so the recipe proves the suite it edits is a real guard rather than decoration: it reverts the boundary-aware namespace matcher to a plain startswith matcher, which lets the retired `cogni-consulting` pages pass under the live `cogni-consult` roster entry, and expects case C4 to go RED.

The matcher is `"$p"|"$p"-*)` at `cogni-workspace/tests/test-wiki-namespace-sync.sh:133` on this branch (132 on `main` — this diff adds one header line above it). The `--expr` is content-anchored, so the shift does not affect it, and it matches exactly once in the file.

Run from the repo root of this branch's checkout:

```
bash ~/.claude/plugins/marketplaces/managed-service/cogni-service/scripts/mutation-check.sh \
  --root . \
  --file cogni-workspace/tests/test-wiki-namespace-sync.sh \
  --expr 's/"\$p"\|"\$p"-\*\)/"\$p"*)/' \
  --test 'bash cogni-workspace/tests/test-wiki-namespace-sync.sh' \
  --case C4
```

Mutated, the line becomes `"$p"*) matched=1; break ;;`. With C4's fixture roster ` cogni-consult cogni-workspace `, the glob `cogni-consult*` then matches the stem `cogni-consulting`, no offenders are reported, and C4's `assert_rc 1` and `assert_out_has "plugin-cogni-consulting.md"` both fail. The suite emits `PASS: <label>` / `FAIL: <label>`, which is the label vocabulary `mutation-check.sh` classifies on, and the case label's first token is `C4`. The `--expr` is single-quoted at the call site and evaluated by `perl -0pi`; `\$` keeps perl from interpolating the shell variable `$p` the guard is written against.

## Verification

Run against this branch's head:

- `bash cogni-workspace/tests/test-wiki-namespace-sync.sh` — exits 0, 8/8 cases PASS (including C4 and C5)
- `bash cogni-workspace/tests/test-wiki-tree-parity.sh` — exits 0, 12/12 cases PASS (the `check_recorded` literal-substring guard over the edited record)
- `python3 scripts/run-plugin-tests.py` — exits 0
- `grep -rn 'cogni-workspace:ask' cogni-workspace/` — 0 hits (was 2)
- `grep -c 'ask' cogni-workspace/tests/test-wiki-namespace-sync.sh` — 1 (was 4); the survivor is the C5 fixture filename
- `grep -c 'cogni-workspace:ask' cogni-workspace/references/wiki-tree-reconciliation.md` — 0 (was 1)
- every added/removed line in the `.sh` diff matches `^[+-][[:space:]]*#`
- `git diff --name-only` lists exactly the two files named above; no `plugin.json` / `marketplace.json`

## Plan record

The full resolution plan, the 4d validation results and the refine-pass summary are recorded on the issue: https://github.com/cogni-work/insight-wave/issues/1688#issuecomment-5483094133