### PR TITLE
cogni-workspace: agent trigger descriptions + explicit tools grants

### DIFF
--- a/cogni-workspace/agents/brief-review-assessor.md
+++ b/cogni-workspace/agents/brief-review-assessor.md
@@ -1,7 +1,14 @@
 ---
 name: brief-review-assessor
-description: Assess visual brief quality from three stakeholder perspectives adapted to the brief type.
-
+description: >
+  Use this agent when a drafted visual brief needs a quality score from three stakeholder
+  perspectives before it is rendered. Typical triggers include story-to-slides, story-to-web or
+  story-to-infographic dispatching a stakeholder review right after drafting their brief; a user
+  asking to "review brief", "review my presentation brief" or "is this brief ready" via the
+  review-brief command; and re-scoring a revised brief in a second round. The brief_type input —
+  slides, web, storyboard or infographic — selects which three perspectives apply. Not for scoring
+  a narrative against story-arc gates; that is narrative-reviewer. See "When to Use" in the agent
+  body for the full scenario list.
 model: haiku
 color: yellow
 tools: ["Read", "Glob"]
@@ -24,6 +31,16 @@ Read the brief file and its source narrative (when available). Load the perspect
 the given brief_type from `libraries/brief-review-perspectives.md`. Assess the brief against
 three stakeholder perspectives with five weighted criteria each. Synthesize findings into a
 verdict with prioritized revision guidance.
+
+## When to Use
+
+- story-to-slides has drafted a `presentation-brief.md` and `stakeholder_review` is true
+- story-to-web has drafted a `web-brief.md` or a `storyboard-brief.md`
+- story-to-infographic has drafted an `infographic-brief.md`
+- User asks to "review brief", "review my presentation brief" or "is this brief ready" via the review-brief command
+- A revised brief needs re-scoring in a second review round
+
+**Not for:** Scoring a narrative against story-arc gates (use narrative-reviewer)
 
 ## Input
 

--- a/cogni-workspace/agents/copywriter.md
+++ b/cogni-workspace/agents/copywriter.md
@@ -2,7 +2,14 @@
 name: copywriter
 model: opus
 color: blue
-description: Polish markdown documents for executive readability using McKinsey Pyramid Principle and messaging frameworks.
+description: >
+  Use this agent when an existing markdown document must be polished for executive readability
+  rather than written from scratch. Typical triggers include the /copywrite command dispatching a
+  file for a full pass or a scoped one (structure-only, tone-only, formatting-only or compress); a
+  sales-mode rewrite that adds Power Positions; and a translate-then-polish pass when TARGET_LANG
+  is set. Not for persona Q&A critique — use reader — and not for generating new narrative prose —
+  use narrative-writer. See "When to Use" in the agent body for the full scenario list.
+tools: Skill, Glob
 ---
 
 # Copywriter Agent (Orchestrator)
@@ -25,6 +32,15 @@ Invoke the copywriter skill to polish a markdown document and return ONLY JSON t
 - `QUALITY_TARGETS`: Custom targets (optional)
 
 **Output:** JSON only (no prose)
+
+## When to Use
+
+- The `/copywrite` command dispatches a markdown file for polishing
+- A scoped pass is wanted — `SCOPE` of `structure-only`, `tone-only`, `formatting-only` or `compress`
+- A sales-mode rewrite is wanted — `MODE=sales`, which enables Power Positions (IS-DOES-MEANS)
+- `TARGET_LANG` is set, so the document is translated and then polished in two passes
+
+**Not for:** Persona Q&A critique (use reader) or generating new narrative prose (use narrative-writer)
 
 ## Constraints
 

--- a/cogni-workspace/agents/html-slides.md
+++ b/cogni-workspace/agents/html-slides.md
@@ -7,6 +7,7 @@ description: >
   HTML slides, browser-based presentations, or an alternative to PowerPoint output.
 model: sonnet
 color: cyan
+tools: Skill, Glob
 ---
 
 # HTML Slides Agent (Orchestrator)

--- a/cogni-workspace/agents/pptx.md
+++ b/cogni-workspace/agents/pptx.md
@@ -1,8 +1,16 @@
 ---
 name: pptx
-description: Create, edit, and analyze PowerPoint presentations. Delegates to document-skills:pptx skill for html2pptx conversion, template-based creation, XML editing, and content extraction.
+description: >
+  Use this agent when a finished presentation-brief.md must be rendered into a .pptx deliverable
+  inside Claude Code. Typical triggers include story-to-slides having just produced a brief plus a
+  theme.md with PowerPoint output wanted; converting an existing brief and theme pair into a deck
+  at a given OUTPUT_PATH; and rendering locally rather than through the claude.ai fallback path.
+  Delegates to the document-skills:pptx skill for html2pptx conversion, template-based creation,
+  XML editing and content extraction. Not for HTML slide output — use html-slides. See "When to
+  Use" in the agent body for the full scenario list.
 model: sonnet
 color: cyan
+tools: Skill, Glob
 ---
 
 # PPTX Agent (Orchestrator)
@@ -20,6 +28,14 @@ Invoke the pptx skill to create a presentation from a brief and return ONLY JSON
 - `OUTPUT_PATH`: Full file path where the final `.pptx` must be delivered (required)
 
 **Output:** JSON only (no prose)
+
+## When to Use
+
+- story-to-slides has produced a `presentation-brief.md` plus a `theme.md` and PowerPoint output is wanted
+- An existing brief and theme pair must become a `.pptx` at a given `OUTPUT_PATH`
+- Rendering happens inside Claude Code rather than through the claude.ai fallback path
+
+**Not for:** HTML slide output (use html-slides)
 
 ## Constraints
 

--- a/cogni-workspace/agents/slides-enrichment-artist.md
+++ b/cogni-workspace/agents/slides-enrichment-artist.md
@@ -1,8 +1,16 @@
 ---
 name: slides-enrichment-artist
-description: Generate prep slides and speaker notes, then write the complete presentation-brief.md.
+description: >
+  Use this agent when story-to-slides Step 8.2 must enrich a completed deck and write the final
+  presentation-brief.md. Typical triggers include the orchestrator handing over SLIDE_SPECS,
+  AUDIENCE_MODEL and ARC_ANALYSIS once Steps 8 and 8.1 are done; generating the Methodology prep
+  slide, plus the Buying Center slide in Rich mode; and adding two-section speaker notes across
+  every slide before assembly. It is orchestrator-internal and is never dispatched directly by a
+  user. Not for rendering the deck — use pptx or html-slides. See "When to Use" in the agent body
+  for the full scenario list.
 model: sonnet
 color: green
+tools: Read, Write, Bash
 ---
 
 # Slides Enrichment Artist Agent (Step 8.2 Worker)
@@ -17,6 +25,16 @@ Take a complete slide deck (title slide + content slides + closing slide + refer
 3. **Assemble and write the complete presentation-brief.md** — frontmatter, slides with prep slides inserted and renumbered, speaker notes integrated, CTA summary, generation metadata
 
 This is additive work — you enrich existing slides and assemble the final file, you don't reshape the deck's message architecture.
+
+## When to Use
+
+- story-to-slides Step 8.2 hands over `SLIDE_SPECS`, `AUDIENCE_MODEL` and `ARC_ANALYSIS` once Steps 8 and 8.1 are done
+- The Methodology prep slide is needed, plus the Buying Center slide in Rich mode
+- Two-section speaker notes must be added across every slide before assembly
+
+This agent is orchestrator-internal: story-to-slides is its only caller and it is never dispatched directly by a user.
+
+**Not for:** Rendering the deck (use pptx or html-slides)
 
 ## RESPONSE FORMAT (MANDATORY)
 

--- a/cogni-workspace/agents/story-to-slides.md
+++ b/cogni-workspace/agents/story-to-slides.md
@@ -8,6 +8,7 @@ description: >
   batch processing. See "When to Use" in the agent body for the full scenario list.
 model: opus
 color: green
+tools: Skill, Bash
 ---
 
 # Story-to-Slides Agent

--- a/cogni-workspace/agents/story-to-web.md
+++ b/cogni-workspace/agents/story-to-web.md
@@ -9,6 +9,7 @@ description: >
   the full scenario list.
 model: opus
 color: blue
+tools: Skill, Bash
 ---
 
 # Story-to-Web Agent

--- a/cogni-workspace/agents/storyboard.md
+++ b/cogni-workspace/agents/storyboard.md
@@ -1,6 +1,12 @@
 ---
 name: storyboard
-description: Render a storyboard-brief.md into a multi-poster .pen file using Pencil MCP.
+description: >
+  Use this agent when a completed storyboard-brief.md must be rendered into a multi-poster .pen
+  file for print via Pencil MCP. Typical triggers include story-to-web running in storyboard mode
+  having just produced a brief; a user asking to "render the storyboard", "create the poster .pen
+  file" or "design the storyboard posters"; and re-rendering the poster series after a brief
+  revision. Not for creating a brief from a narrative — use story-to-web in storyboard mode for
+  that. See "When to Use" in the agent body for the full scenario list.
 model: opus
 color: blue
 tools: Read, Bash, mcp__pencil__open_document, mcp__pencil__set_variables, mcp__pencil__get_guidelines, mcp__pencil__batch_design, mcp__pencil__get_screenshot, mcp__pencil__snapshot_layout

--- a/cogni-workspace/agents/web.md
+++ b/cogni-workspace/agents/web.md
@@ -1,8 +1,16 @@
 ---
 name: web
-description: Render a web-brief.md into a .pen file and self-contained HTML page using Pencil MCP.
+description: >
+  Use this agent when a completed web-brief.md must be rendered into a scrollable landing-page
+  .pen file and exported as a self-contained HTML page via Pencil MCP. Typical triggers include
+  the story-to-web skill having just produced a brief; a user asking to "render the web
+  narrative", "create the .pen file" or "design the landing page"; and a downstream consumer
+  needing the exported HTML for embedding, such as an export-html-report landing page. Not for
+  creating a brief from a narrative — use the story-to-web skill for that. See "When to Use" in
+  the agent body for the full scenario list.
 model: opus
 color: cyan
+tools: Read, Write, Bash, mcp__pencil__open_document, mcp__pencil__set_variables, mcp__pencil__get_variables, mcp__pencil__get_guidelines, mcp__pencil__batch_design, mcp__pencil__batch_get, mcp__pencil__get_screenshot, mcp__pencil__snapshot_layout
 ---
 
 # Web Renderer Agent


### PR DESCRIPTION
Closes #1683.

## Summary

- Rewrites **6** `cogni-workspace/agents/*.md` `description:` fields into the `plugin-dev:agent-development` trigger shape — a `Use this agent when …` opening, 2–4 concrete scenarios, a not-for discriminator, and a pointer to a heading that actually exists in that file.
- Adds an explicit least-privilege `tools:` key to the **7** agents that had none. Repo-wide `summary.skipped_no_tools` goes **7 → 0**.
- Adds a `## When to Use` body section to the 4 agents that lacked one, so no new pointer dangles. `storyboard` and `web` already had one, so those two are frontmatter-only.
- No rename, no delete, no `name:` / `model:` / `color:` change, no `plugin.json` version move (the bump is post-merge).

## The issue's population counts are stale — re-measured at base

The issue measured "against the tree at the #1677 merge". **PR #1713 (issue #1681) landed after that** and had already closed part of the cohort. Re-enumerated from the source at `03b006be`:

| Population | Issue claims | Actual at base | Already fixed by #1713 |
|---|---|---|---|
| (a) no trigger language | 10 | **6** | `narrative-reviewer`, `story-to-slides`, `story-to-storyboard`, `story-to-web` |
| (b) no `tools:` key | 9 | **7** | `story-to-storyboard`, `storyboard` |

Union is **9** files. The four descriptions #1713 already fixed are deliberately **not** re-churned — they are the reference style this PR imitates, not work items. `storyboard` is population (a) only (its existing `tools:` line is untouched); `html-slides` is population (b) only (its description already carries trigger language).

## Tool grants, each derived from a confirmed body call site

| File | Grant | Why |
|---|---|---|
| `web.md` | `Read, Write, Bash` + 8 `mcp__pencil__*` | Read `:52`/`:71` · Bash `:46`/`:419` · Write `:474`/`:547` · the pencil tools its body names |
| `copywriter.md`, `pptx.md`, `html-slides.md` | `Skill, Glob` | `Skill` for the mandatory delegation; `Glob` for the documented path-existence check |
| `story-to-slides.md`, `story-to-web.md` | `Skill, Bash` | Skill delegation + the genuine Phase-3 `grep`/`awk` metric extraction |
| `slides-enrichment-artist.md` | `Read, Write, Bash` | Read `:60-62` · Write `:135`/`:155` · Bash `:118` |

**Why `Glob` rather than `Read` or `Bash`** for the three delegation orchestrators: each documents a "check the path is provided and exists" step without naming a tool. Dropping it would drop a capability the workflow uses; `Read` would hand a delegation-only agent the document *contents* its own Constraints block forbids it to touch; `Bash` would hand it arbitrary shell for what is a `test -f`. `Glob` answers exactly the documented question and nothing more, and it is already house vocabulary — `brief-review-assessor.md:7` carries `tools: ["Read", "Glob"]`.

## The guard interaction is `web.md`, not `storyboard.md`

The issue's Constraint section attributes the pencil-bare-name risk to `storyboard.md`. **That is false at base**: `storyboard.md:6` already grants six `mcp__pencil__*` tools, is already in the enforced population, and is already green.

The live instance is **`web.md`** — no `tools:` key, while its body names six registry `provides_tools[]` bare names inside backtick code spans (`open_document`, `set_variables`, `get_guidelines`, `batch_design`, `get_screenshot`, `batch_get`). Adding the key flips it from `skipped_no_tools` into *judged*. The grant covers all six, so the `provides_tools_body_name_ungranted` arm stays green, and `pencil.required_by` already lists `cogni-workspace`, so the `required_by` arm stays green too. The six backticked names are left **in place and still backticked** — the guard is satisfied by granting the capability, not by hiding the call sites.

**Observation delta is zero.** `get_variables` and `snapshot_layout` are real Pencil tools absent from the registry vocabulary, so granting them yields `granted_outside_vocabulary` *observations* (report-only, never a violation). Both were **already** present at base from sibling grants, so the observation set at head is byte-identical to base — 10 entries, unchanged.

## Verification — measured at base and at head

| Check | Base `03b006be` | Head |
|---|---|---|
| `python3 scripts/check-mcp-tool-grant.py` | exit 0, `violations: 0`, `skipped_no_tools: 7` | exit 0, `violations: 0`, **`skipped_no_tools: 0`** |
| `python3 scripts/run-plugin-tests.py --filter cogni-workspace` | exit 0, 20/20 | exit 0, **20/20**, 0 failed |
| `bash tests/test_check_mcp_tool_grant.sh` (repo root) | — | exit 0, **60 PASS / 0 failed** |
| `bash cogni-workspace/tests/test-relocated-skill-hygiene.sh` | — | exit 0, P1/P2/P3 pass |
| cogni-service `check-frontmatter.sh cogni-workspace` | exit 0, `clean: true` | exit 0, **`clean: true`** |
| cogni-service `check-breadcrumbs.sh cogni-workspace` | — | exit 0, `clean: true` |

`tests/test_check_mcp_tool_grant.sh` was run **explicitly**: it is underscore-named and sits at the repo root, so `--filter cogni-workspace` does not discover it — yet its live-tree arms A1/A2 (`total == 0`) and liveness floors L1–L4 are the only thing that grades `web.md`'s new grant end-to-end. A green filtered run alone would have said nothing about it.

Description lengths after the rewrite (cap 1024, rubric's best band 200–1000): `brief-review-assessor` 688 · `copywriter` 565 · `pptx` 623 · `slides-enrichment-artist` 593 · `storyboard` 541 · `web` 594.

## Review notes

`web.md`'s system prompt sits at **95.7%** of its 28,000-char soft cap (26,784). That is **pre-existing and unchanged by this PR** — the edit is frontmatter-only, so the body is byte-identical to base. Per the net-growth rule a pre-existing near-cap unit this diff did not grow is annotated, not rewritten, and no follow-up is filed for it.

## Open questions

Both are recorded as `kind: avoidable` escalations — neither holds this PR, and neither has been silently restated as something it isn't.

1. **AC4 asks that `skipped_no_tools` "drops by 9". That is falsified by construction.** The measured baseline at `03b006be` is **7**, and a column-0 `tools:` scan over all 26 files in `cogni-workspace/agents/` finds exactly those same 7 lacking the key — so the maximum achievable drop is **7 → 0**, which this PR delivers. Same root cause as the stale title counts: the issue predates PR #1713. Reading AC4 literally would require re-editing files #1713 already corrected. **Please confirm AC4 should read "reaches 0".**

2. **AC5 names `bash cogni-workspace/scripts/check-frontmatter.sh`, a path that does not exist anywhere in this repo.** The real instrument is cogni-service's `scripts/check-frontmatter.sh`, and it takes the plugin root **positionally**, not behind a `--root` flag. The verification table above runs the real one. **Please confirm AC5 should be restated against it.**

A third item, recorded but not built: `check-mcp-tool-grant.py` early-returns `skipped_no_tools` when no `tools:` key is present, so this drift class is invisible to CI *by construction*, and `test-skill-trigger-phrases.sh` globs `skills/**/SKILL.md` only — there is no agent-side trigger-language guard at all. Nothing prevents the next new agent shipping trigger-less and grant-less. An alternative plan proposed shipping a `cogni-workspace/tests/` re-drift guard alongside this fix; it was not picked because the 4c rubric selects the smallest blast radius. The insight is recorded on the issue's plan record rather than lost.