### PR TITLE
cogni-knowledge: knowledge-curate pre-flight gates on wiki existence

### DIFF
--- a/cogni-knowledge/skills/knowledge-curate/SKILL.md
+++ b/cogni-knowledge/skills/knowledge-curate/SKILL.md
@@ -19,6 +19,7 @@ Read `${CLAUDE_PLUGIN_ROOT}/references/inverted-pipeline.md` §"Phase 2 — `kno
 
 - No `plan.json` exists at `<project_path>/.metadata/` — offer `knowledge-plan` first.
 - No `binding.json` exists at the resolved knowledge root — offer `knowledge-setup` first.
+- `binding.wiki_path` does not resolve to a directory containing `.cogni-wiki/config.json` — the binding is stale.
 
 ## Parameters
 
@@ -35,7 +36,7 @@ Read `${CLAUDE_PLUGIN_ROOT}/references/inverted-pipeline.md` §"Phase 2 — `kno
 
 ### 0. Pre-flight
 
-**No wiki engine required.** cogni-knowledge bundles its wiki engine under `scripts/vendor/cogni-wiki/`, resolved vendored-first by every wiki-touching step, and this skill resolves none of it directly — Step 0.5's coverage check runs cogni-knowledge's own `scripts/wiki-coverage.py`. There is no `cogni-wiki` plugin install to probe and no hard dependency to abort on (clean-break — no cogni-research dispatch either). The binding read below is the gate: it aborts on `success: false` and yields `wiki_path` as `WIKI_ROOT`.
+**No wiki engine required.** cogni-knowledge bundles its wiki engine under `scripts/vendor/cogni-wiki/`, resolved vendored-first by every wiki-touching step, and this skill resolves none of it directly — Step 0.5's coverage check runs cogni-knowledge's own `scripts/wiki-coverage.py`. There is no `cogni-wiki` plugin install to probe and no hard dependency to abort on (clean-break — no cogni-research dispatch either). The binding read below is the gate, together with the `.cogni-wiki/config.json` and `wiki/` existence checks that follow it: it aborts on `success: false` and yields `wiki_path` as `WIKI_ROOT`.
 
 **Binding + plan.** Resolve `knowledge_root` (same logic as `knowledge-plan`). Read the binding:
 
@@ -45,6 +46,8 @@ python3 ${CLAUDE_PLUGIN_ROOT}/scripts/knowledge-binding.py read \
 ```
 
 On `success: false` → abort, offer `knowledge-setup`. On success, capture `data.binding.wiki_path` (the bound wiki root) and `data.binding.curator_defaults` — `wiki_path` is threaded as `WIKI_ROOT` (Steps 0.5 + 3); `curator_defaults` is read in Step 1.
+
+Confirm `<WIKI_ROOT>/.cogni-wiki/config.json` exists; abort otherwise. Confirm `<WIKI_ROOT>/wiki/` exists. On either miss the binding is stale — abort and offer `knowledge-setup`, the same remedy as the `success: false` abort above.
 
 Read `<project_path>/.metadata/plan.json`. Parse `topic`, `market`, `output_language`, `sub_questions[]`. If `--sub-question-ids` was passed, filter to that subset (reject ids not present).
 

--- a/cogni-knowledge/skills/knowledge-curate/SKILL.md
+++ b/cogni-knowledge/skills/knowledge-curate/SKILL.md
@@ -36,7 +36,7 @@ Read `${CLAUDE_PLUGIN_ROOT}/references/inverted-pipeline.md` §"Phase 2 — `kno
 
 ### 0. Pre-flight
 
-**No wiki engine required.** cogni-knowledge bundles its wiki engine under `scripts/vendor/cogni-wiki/`, resolved vendored-first by every wiki-touching step, and this skill resolves none of it directly — Step 0.5's coverage check runs cogni-knowledge's own `scripts/wiki-coverage.py`. There is no `cogni-wiki` plugin install to probe and no hard dependency to abort on (clean-break — no cogni-research dispatch either). The binding read below is the gate, together with the `.cogni-wiki/config.json` and `wiki/` existence checks that follow it: it aborts on `success: false` and yields `wiki_path` as `WIKI_ROOT`.
+**No wiki engine required.** cogni-knowledge bundles its wiki engine under `scripts/vendor/cogni-wiki/`, resolved vendored-first by every wiki-touching step, and this skill resolves none of it directly — Step 0.5's coverage check runs cogni-knowledge's own `scripts/wiki-coverage.py`. There is no `cogni-wiki` plugin install to probe and no hard dependency to abort on (clean-break — no cogni-research dispatch either). The binding read below is the gate, together with the `.cogni-wiki/config.json` and `wiki/` existence checks that follow it.
 
 **Binding + plan.** Resolve `knowledge_root` (same logic as `knowledge-plan`). Read the binding:
 

--- a/cogni-knowledge/tests/test_skill_contracts.sh
+++ b/cogni-knowledge/tests/test_skill_contracts.sh
@@ -122,6 +122,8 @@ assert_grep 'wiki-coverage.json' "$CURATE" "skill-contracts-38-writes-coverage-m
 assert_grep 'WIKI_COVERAGE_PATH=' "$CURATE" "skill-contracts-39-forwards-wiki-coverage-path knowledge-curate: forwards WIKI_COVERAGE_PATH to source-curator (#309)"
 assert_grep 'WIKI_ROOT=' "$CURATE" "skill-contracts-40-forwards-wiki-root-source knowledge-curate: forwards WIKI_ROOT to source-curator (#309)"
 assert_grep 'fail-soft' "$CURATE" "skill-contracts-41-coverage-pre-check-fail knowledge-curate: coverage pre-check is fail-soft, not a hard abort (#309)"
+# Sibling parity: curate threads WIKI_ROOT but did not confirm the bound wiki exists (#1707).
+assert_grep_f 'Confirm `<WIKI_ROOT>/.cogni-wiki/config.json` exists; abort otherwise. Confirm `<WIKI_ROOT>/wiki/` exists.' "$CURATE" "skill-contracts-113-curate-preflight-confirms-wiki-exists knowledge-curate: pre-flight confirms the bound wiki exists before Step 0.5 (#1707)"
 
 # --- knowledge-fetch SKILL.md --------------------------------------------
 FETCH="$PLUGIN_ROOT/skills/knowledge-fetch/SKILL.md"


### PR DESCRIPTION
Closes #1707.

## Summary

- `knowledge-curate`'s Step 0 pre-flight now confirms `<WIKI_ROOT>/.cogni-wiki/config.json` and `<WIKI_ROOT>/wiki/` exist immediately after the binding read, aborting cleanly with the `knowledge-setup` remedy — the same sentence `knowledge-compose` and `knowledge-verify` already carry.
- Corrected the pre-flight lead sentence, which claimed the binding read alone was the gate. It now matches compose's wording: the gate is the binding read *together with* the two existence checks that follow it.
- Added the stale-binding `## Never run when` bullet the five wiki-touching siblings carry, copied verbatim.
- New fixed-string contract assertion `skill-contracts-113` pins the check sentence in `test_skill_contracts.sh`.

## Scope decisions

- **In:** `skills/knowledge-curate/SKILL.md` (three prose edits) and `tests/test_skill_contracts.sh` (one assertion). Two files, both under `cogni-knowledge/`. No `plugin.json` `version` touched — the bump is post-merge.
- **Placement:** the new paragraph sits after the binding read and before Step 0.5's `wiki-coverage.py` call, since it depends on `WIKI_ROOT`. It is a hard abort and is deliberately kept clear of Step 0.5's fail-soft block, which is unaltered — `skill-contracts-41` still asserts `fail-soft` on this file and still passes.
- **Not gated on `--dry-run`:** the binding read it follows runs unconditionally, and none of the four sibling pre-flights branch this check on a flag.
- **`assert_grep_f`, not `assert_grep`:** the pattern carries regex metacharacters (`.` in `config.json`, plus `<` / `>`), and `tests/README.md` requires the fixed-string form for exactly this case. A BRE `.` would match any character and pass green against a near-miss.
- **Case id 113** is the next unused number, confirmed by enumerating every id present in the suite (00–112 plus the `90b` variant), not by trusting a claimed maximum. Nothing was renumbered, per `tests/README.md` rule 3.

### The lead sentence is deliberately *not* byte-identical to compose:76

It adopts compose's `together with the ... existence checks that follow it` clause while **retaining curate's own trailing clause** (`it aborts on success: false and yields wiki_path as WIKI_ROOT`). Truncating it to match compose exactly would drop information this skill states and compose does not.

### Out of scope, deliberately

- `references/inverted-pipeline.md` §"Phase 2" describes curate's pre-flight but never claims a wiki-existence gate, so it does **not** go false from this change — no doc edit is owed.
- `knowledge-plan` and `knowledge-fetch` never thread `WIKI_ROOT` (grep-confirmed: neither references `wiki_path` or `.cogni-wiki/config.json`) and correctly do not carry this check. They were not swept in.
- The four sibling pre-flights are unchanged. `knowledge-ingest`'s stronger `and is writeable` variant was **not** copied: curate writes into `.metadata/`, not the wiki, so the compose/verify form is the right sibling.

## Test plan — executed, not proposed

- `bash cogni-knowledge/tests/test_skill_contracts.sh` → `ALL PASS`, exit 0, including the new `skill-contracts-113` case. `skill-contracts-41` still passes, so Step 0.5's fail-soft posture survived.
- `python3 scripts/run-plugin-tests.py --filter cogni-knowledge` → **79/79 suites pass, 0 failed.**
- `git diff --name-only origin/main...HEAD` → only `cogni-knowledge/skills/knowledge-curate/SKILL.md` and `cogni-knowledge/tests/test_skill_contracts.sh`.
- No `version` key appears in the diff.
- The new check sits after the binding capture and before both the `plan.json` read and Step 0.5's `wiki-coverage.py` call.

## Mutation recipe

Replayed before this PR was opened — **verdict: `guard_verified`** (mutated → `red`, restored → `green`). `mutation-check.sh` ships with cogni-service and lives outside this repo, so substitute your own checkout for `<managed-service>`. Run from the repository root; `--file` is `--root`-relative.

```
bash <managed-service>/cogni-service/scripts/mutation-check.sh \
  --root . \
  --file cogni-knowledge/skills/knowledge-curate/SKILL.md \
  --expr 's|<WIKI_ROOT>/\.cogni-wiki/config\.json|MUTANT|' \
  --test 'bash cogni-knowledge/tests/test_skill_contracts.sh' \
  --case skill-contracts-113-curate-preflight-confirms-wiki-exists
```

The suite is invoked **directly**, not through a discovery runner: this plugin's suites are underscore-named (`test_*.sh`), and a runner globbing `test-*.sh` would discover zero of them and return a vacuous green.

`mutation-check.sh` applies `--expr` with `perl -0pi` and no `/g`, so it substitutes the **first** match in the file. That match is the new Step 0 paragraph, and only because the other two mentions of `.cogni-wiki/config.json` (the `## Never run when` bullet and the lead sentence) deliberately use the **bare, un-prefixed** form. Preserve that if you edit them.

## Note on the issue's cited line numbers

Issue #1707 cites `knowledge-compose/SKILL.md:101` and `knowledge-verify/SKILL.md:89`. At `origin/main` those checks are at **`:87` and `:75`** — the line numbers are stale, the quoted wording is accurate. This change anchored on the quoted text throughout. The acceptance criteria stand as written.