### PR TITLE
cogni-trends: regression guard for complete-phase next_actions dispatch tokens

### DIFF
--- a/cogni-trends/tests/test-project-status.sh
+++ b/cogni-trends/tests/test-project-status.sh
@@ -8,6 +8,21 @@
 # v0.4.22), but this fixture pins the script's own contract so any future
 # schema-drift or silent-exception regression in the read path surfaces fast.
 #
+# Also a regression guard for issue #1717 — the `complete)` arm of the script's
+# next_actions block was reachable by no suite, so its dispatch tokens (notably
+# cogni-workspace:copywriter) had no coverage. The second fixture below drives the
+# script to PHASE=complete and pins that token set by exact whole-token equality.
+#
+# Mutation recipe proving that guard has teeth (cogni-service instrument):
+#   bash <cogni-service>/scripts/mutation-check.sh --root <repo-root> \
+#     --file cogni-trends/scripts/project-status.sh \
+#     --expr 's/cogni-workspace:copywriter/cogni-workspace:copywrite/g' \
+#     --test 'bash cogni-trends/tests/test-project-status.sh' \
+#     --case 'project-status-03-next-actions-copywriter'
+# Verdict must be guard_verified: cases -03 and -04 go RED under the mutation and
+# GREEN on restore. The token has exactly one occurrence in the script, so the
+# expression cannot silently no-op.
+#
 # Usage: bash cogni-trends/tests/test-project-status.sh
 # Exits non-zero on any assertion failure.
 
@@ -114,4 +129,118 @@ if failures:
 print("\nAll assertions passed.")
 PYEOF
 
+# ---------------------------------------------------------------------------
+# Second fixture — complete phase (issue #1717).
+# ---------------------------------------------------------------------------
+PROJECT_DIR_COMPLETE="$TMPROOT/complete-project"
+mkdir -p "$PROJECT_DIR_COMPLETE/.metadata"
+
+cat > "$PROJECT_DIR_COMPLETE/tips-project.json" <<EOF
+{
+  "project_id": "fixture-complete-phase",
+  "project_slug": "fixture-complete-phase",
+  "project_language": "en",
+  "industry": "test",
+  "subsector": "test",
+  "research_topic": "test"
+}
+EOF
+
+# workflow_state "report-complete" is the unconditional route to PHASE=complete
+# (project-status.sh:509-510) — it depends on no artifact file. There is no
+# metadata.copywriter_applied key, so HAS_COPYWRITER stays at its default of
+# false (:162, flip site :303-315) and the guard at :862 is entered. No booklet,
+# enriched-report, dashboard or portfolio-context artifacts are written either,
+# which is what makes the token set asserted below an exact seven.
+cat > "$PROJECT_DIR_COMPLETE/.metadata/trend-scout-output.json" <<EOF
+{
+  "execution": {
+    "workflow_state": "report-complete"
+  }
+}
+EOF
+
+# --health-check is DELIBERATELY omitted here, and the omission is load-bearing:
+# project-status.sh:1041-1107 injects additional next_actions entries under
+# `if $HEALTH_CHECK`, and `complete` is in the gated case list at :1054. Passing
+# the flag would put the exact-set pin below at the mercy of the staleness
+# detector. Do not copy the --health-check from the invocation above.
+OUTPUT_COMPLETE="$(bash "$SCRIPT" "$PROJECT_DIR_COMPLETE" 2>/dev/null)"
+RC_RUN_COMPLETE=$?
+if [ $RC_RUN_COMPLETE -ne 0 ]; then
+  echo "FAIL: project-status.sh exited $RC_RUN_COMPLETE on the complete-phase fixture" >&2
+  echo "$OUTPUT_COMPLETE" >&2
+  exit 1
+fi
+
+ASSERT_COMPLETE="$TMPROOT/assert-complete.py"
+cat > "$ASSERT_COMPLETE" <<'PYEOF'
+import json, sys
+
+doc = json.load(sys.stdin)
+artifacts = doc.get("artifacts", {})
+skills = [a.get("skill") for a in doc.get("next_actions", [])]
+
+failures = []
+
+def check(label, actual, expected):
+    if actual == expected:
+        print(f"PASS: {label} - {actual}")
+    else:
+        print(f"FAIL: {label} - got {actual!r}, expected {expected!r}")
+        failures.append(label)
+
+# Anti-vacuity. Without this, a fixture that silently stops reaching `complete`
+# would leave the token cases below asserting over some other phase's
+# next_actions instead of failing loudly.
+check("project-status-01-complete-phase", doc.get("phase"), "complete")
+
+# project-status.sh:1152 emits `"copywriter_applied": $HAS_COPYWRITER` unquoted,
+# so this is a real JSON boolean. False proves the :862 guard was entered rather
+# than skipped, which is the precondition for the copywriter token being emitted.
+check("project-status-02-copywriter-applied-false", artifacts.get("copywriter_applied"), False)
+
+# Exact whole-token membership, never a substring or prefix test:
+# "cogni-workspace:copywrite" is a strict PREFIX of the correct token, so any
+# containment check would match both spellings and prove nothing.
+check("project-status-03-next-actions-copywriter", "cogni-workspace:copywriter" in skills, True)
+
+# The full set the `complete)` arm emits under this minimal fixture
+# (project-status.sh:858-877). Every optional-artifact branch fires because every
+# HAS_* flag sits at its false default; the trends-bridge arm at :874 does not,
+# because it also requires a portfolio context below v3.1.
+check(
+    "project-status-04-next-actions-token-set",
+    sorted(skills),
+    [
+        "cogni-trends:trend-booklet",
+        "cogni-trends:trends-catalog",
+        "cogni-trends:trends-dashboard",
+        "cogni-workspace:copywriter",
+        "cogni-workspace:enrich-report",
+        "cogni-workspace:story-to-slides",
+        "cogni-workspace:story-to-web",
+    ],
+)
+
+if failures:
+    print(f"\n{len(failures)} assertion(s) failed", file=sys.stderr)
+    sys.exit(1)
+print("\nAll complete-phase assertions passed.")
+PYEOF
+
+# Exit-code aggregation. This file runs under `set -u` with no `set -e` and no
+# `pipefail`, so the exit status of the LAST statement is the script's own. With
+# two assertion blocks, capturing each rc and exiting explicitly is what stops a
+# green second block from swallowing a red first one — scripts/run-plugin-tests.py
+# classifies purely on exit code and would report a false green otherwise.
+# Nothing may sit between a pipeline and its `$?` capture.
 printf '%s' "$OUTPUT" | python3 "$ASSERT_SCRIPT"
+RC_ASSERT_MAIN=$?
+printf '%s' "$OUTPUT_COMPLETE" | python3 "$ASSERT_COMPLETE"
+RC_ASSERT_COMPLETE=$?
+
+if [ "$RC_ASSERT_MAIN" -ne 0 ] || [ "$RC_ASSERT_COMPLETE" -ne 0 ]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
Closes #1717.

## Summary

`cogni-trends/scripts/project-status.sh` emits its `complete`-phase `next_actions`
dispatch tokens from the `complete)` arm of the `case "$PHASE"` block — including the
`cogni-workspace:copywriter` token guarded by `HAS_COPYWRITER=false`. No suite under
`cogni-trends/tests/` reached that arm, so a token typo of #1696's class shipped with
no regression coverage and #1696's own "suite stays green" criterion was vacuously
satisfiable in both directions.

This adds a second fixture to `cogni-trends/tests/test-project-status.sh` that drives
the script to `PHASE=complete` and pins the emitted token set by **exact whole-token
equality**, plus the exit-code aggregation that makes the new block's verdict actually
reach the harness.

- **Fixture.** A second minimal project under the suite's existing `mktemp -d` (already
  covered by its `EXIT` trap) writing only `tips-project.json` and
  `.metadata/trend-scout-output.json` with `execution.workflow_state = "report-complete"`
  — the unconditional route to `PHASE=complete`, which depends on no artifact file. No
  `metadata.copywriter_applied` key, so `HAS_COPYWRITER` stays at its `false` default and
  the copywriter guard is entered. No booklet / enriched-report / dashboard /
  portfolio-context artifacts, which is what makes the pinned token set an exact seven.
- **`--health-check` is deliberately omitted**, and the omission is load-bearing: the
  script injects extra `next_actions` entries under `if $HEALTH_CHECK` and `complete` is
  in that gated case list, so passing the flag would put the exact-set pin at the mercy
  of the staleness detector. This differs from the pre-existing invocation above it,
  which does pass the flag; an inline comment says so.
- **Four assertions**, in a second heredoc, reusing the file's `check()` shape verbatim:
  - `project-status-01-complete-phase` — `phase == "complete"`. Anti-vacuity: without it,
    a fixture that silently stopped reaching `complete` would leave the token cases
    grading some other phase's `next_actions`.
  - `project-status-02-copywriter-applied-false` — `artifacts.copywriter_applied is False`.
    The script emits that key unquoted, so it is a real JSON boolean; `False` proves the
    copywriter guard was entered rather than skipped.
  - `project-status-03-next-actions-copywriter` — exact whole-token membership of
    `cogni-workspace:copywriter` in `next_actions[].skill`.
  - `project-status-04-next-actions-token-set` — sorted equality against all seven tokens
    the arm emits under this fixture.
- **Exit-code aggregation.** The suite runs `set -u` with no `set -e` and no `pipefail`,
  and its terminal `printf | python3` supplied the whole script's exit status. Appending a
  second block would have made *its* rc the file's rc and silently swallowed a red first
  block — a false green under `scripts/run-plugin-tests.py`, which classifies purely on
  exit code. Each block's rc is now captured immediately after its pipeline (nothing in
  between) and an explicit aggregated `exit` follows. No `set -e`/`pipefail` is
  introduced; the suite's `set -u`-only posture is preserved.

Plan record: https://github.com/cogni-work/insight-wave/issues/1717#issuecomment-5492989098

## Scope decisions

- **In:** `cogni-trends/tests/test-project-status.sh` only — `git status` shows exactly
  one changed path.
- **Out — `cogni-trends/scripts/project-status.sh` is byte-unmodified.** It already emits
  the correct token, and the r-less spelling `cogni-workspace:copywrite` is absent
  tree-wide at base. This is a pure regression guard, not a bug fix; letting the fix and
  its guard land in one hand is exactly what this issue exists to prevent.
- **No new test file.** `scripts/run-plugin-tests.py` discovers suites through two
  non-recursive globs (`tests/*.sh`, `*/tests/*.sh`), and this suite already matches — so
  AC3's discovery half needs no new path. Confirmed:
  `python3 scripts/run-plugin-tests.py --list --filter trends` lists
  `cogni-trends/tests/test-project-status.sh`.
- **Out — #1718** (`scripts/check-external-dispatch.py`'s `DEFAULT_GLOBS` missing
  `*/scripts/*`) is a separate, already-tracked issue and is untouched.
- **Pre-existing assertions are unchanged and still pass** — the six `counts.*` checks and
  `stages-4`..`stages-8` are byte-identical, and no existing case id was renamed or
  renumbered.
- **Not inherited as a template:** `test-stale-detection.sh`'s fixture comment claims it
  reaches the `complete` phase, but the fixture writes `workflow_state`
  `"candidates_agreed"`, which matches no arm and resolves to `PHASE="scouting"`. Filed
  as #1738 rather than fixed here.

## Test plan — all executed on this branch

| Check | Result |
|---|---|
| `bash cogni-trends/tests/test-project-status.sh` | **rc=0**, 15 `PASS:` lines, 0 `FAIL:` |
| `python3 scripts/run-plugin-tests.py --filter cogni-trends` | **rc=0** — 4/4 suites passed |
| `python3 scripts/run-plugin-tests.py --list --filter trends` | lists this suite (AC3 discovery) |
| `python3 scripts/check-case-id-pairing.py` | **rc=0**, 0 violations |
| `python3 scripts/check-result-line-plainness.py` | **rc=0**, 0 violations |
| Case-id uniqueness census (run, then `awk … \| sort \| uniq -d`) | empty — no duplicate ids |
| `git diff --stat -- cogni-trends/scripts/project-status.sh` | empty — script byte-unmodified |

**Exit-code aggregation, proved by falsification.** Mutating one *pre-existing*
expectation (`counts.investment_themes` 5 → 999) so the **first** block goes red while
the second stays green: the suite exits **1**, and the transcript shows
`FAIL: counts.investment_themes` alongside `PASS: project-status-04-next-actions-token-set`.
Reverted, the suite is rc=0 again. Without the aggregation this case exits 0.

## Mutation recipe

Run from a checkout of this branch; `--root` is never inferred.

```bash
bash <cogni-service>/scripts/mutation-check.sh \
  --root <repo-root> \
  --file cogni-trends/scripts/project-status.sh \
  --expr 's/cogni-workspace:copywriter/cogni-workspace:copywrite/g' \
  --test 'bash cogni-trends/tests/test-project-status.sh' \
  --case 'project-status-03-next-actions-copywriter'
```

The expression has exactly one match site in the script, so it cannot silently no-op.

**Executed, both cases:**

| `--case` | `mutated_result` | `restored_result` | `verdict` |
|---|---|---|---|
| `project-status-03-next-actions-copywriter` | `red` | `green` | **`guard_verified`** |
| `project-status-04-next-actions-token-set` | `red` | `green` | **`guard_verified`** |

That is AC3's "red at the pre-fix token, green after", demonstrated rather than asserted.
`git diff --stat` on the script is empty afterwards — the harness restored it byte-for-byte
and it ships unmodified. The recipe is also recorded in the suite's own header comment.

## Follow-up issues

- #1738 — `cogni-trends/tests/test-stale-detection.sh`'s shared-fixture comment claims the
  fixture "has reached 'complete' phase", but `build_project()` writes `workflow_state`
  `"candidates_agreed"`, which matches no arm of the phase chain and resolves to
  `PHASE="scouting"`. Verified at `origin/main` by executing the script against a
  byte-for-byte replica of the fixture. A separate file and a separate defect; nothing in
  this PR depends on it.