### PR TITLE
external-dispatch guard: per-plugin unresolved-target resolution

### DIFF
--- a/scripts/check-external-dispatch.py
+++ b/scripts/check-external-dispatch.py
@@ -47,15 +47,16 @@ live-plugin dangling slug, and vice versa.
 
   1. **retired-prefix** — the registry-driven arm above. Unchanged.
   2. **unresolved-target** — reports a `<live-plugin>:<slug>` token whose slug
-     names no `*/skills/<slug>/SKILL.md` and no `*/agents/<slug>.md` anywhere in
-     the tree under test. The live-plugin set is derived at run time from that
-     tree's `.claude-plugin/marketplace.json` `plugins[]`, never hardcoded, so
-     adding a plugin needs no edit here. Resolution is deliberately GLOBAL rather
-     than per-plugin: a slug that resolves under any listed plugin resolves for
-     every prefix. Tightening that to a per-plugin pair is a real strengthening
-     and a separate decision. The `commands/` namespace is deliberately NOT part
-     of the predicate — a command is a user-facing entry point, not a dispatch
-     target — so a token resolving only to `*/commands/<slug>.md` is reported.
+     names no `skills/<slug>/SKILL.md` and no `agents/<slug>.md` under the
+     plugin its own prefix names. The live-plugin set is derived at run time from
+     that tree's `.claude-plugin/marketplace.json` `plugins[]`, never hardcoded,
+     so adding a plugin needs no edit here. Resolution binds the PAIR, not the
+     slug alone: a slug that resolves under one listed plugin does NOT thereby
+     resolve for every prefix, so a token naming a real slug owned by a DIFFERENT
+     listed plugin is reported as a cross-plugin miswire. The `commands/`
+     namespace is deliberately NOT part of the predicate — a command is a
+     user-facing entry point, not a dispatch target — so a token resolving only
+     to `*/commands/<slug>.md` is reported.
 
      Absent manifest DEGRADES (the arm does not run, and the JSON says so via
      `data.scanned`); a manifest that is present but unreadable or malformed is a
@@ -252,15 +253,20 @@ def load_live_plugins(root):
     return entries, ""
 
 
-def build_target_index(root, plugin_dirs):
-    """Return the set of slugs that resolve to a skill or an agent.
+def build_target_index(root, plugin_entries):
+    """Return {plugin name: set of slugs that plugin owns}.
+
+    Keyed on the marketplace `name` and populated from that entry's own `source`
+    dir, so the arm can resolve a token's plugin and slug as a PAIR. Two entries
+    sharing a name union rather than clobber.
 
     Deliberately plain filesystem calls rather than `git ls-files`: the synthetic
     fixture trees are not git repos, and a git-backed index would come back empty
     there and make every assertion over them vacuously green.
     """
-    slugs = set()
-    for rel in plugin_dirs:
+    owned = {}
+    for name, rel in plugin_entries:
+        slugs = owned.setdefault(name, set())
         skills_dir = os.path.join(root, rel, "skills")
         if os.path.isdir(skills_dir):
             for entry in os.listdir(skills_dir):
@@ -272,11 +278,15 @@ def build_target_index(root, plugin_dirs):
                 if entry.endswith(".md") and os.path.isfile(
                         os.path.join(agents_dir, entry)):
                     slugs.add(entry[:-3])
-    return slugs
+    return owned
 
 
 def compile_target_re(live_names):
-    r"""Compile `(?:name|…):(slug)` over the live plugin names, or None.
+    r"""Compile `(name|…):(slug)` over the live plugin names, or None.
+
+    Group 1 is the plugin the token names and group 2 its slug: the arm resolves
+    the two as a pair, so the matched prefix has to survive the match rather than
+    being discarded by a non-capturing group.
 
     Names are alternated LONGEST-FIRST so a listed name that is a prefix of
     another cannot shadow it. At least one slug character is required, so a bare
@@ -287,7 +297,7 @@ def compile_target_re(live_names):
         return None
     ordered = sorted(live_names, key=lambda n: (-len(n), n))
     return re.compile(
-        r"\b(?:" + "|".join(re.escape(n) for n in ordered) + r"):([a-z][a-z0-9-]*)")
+        r"\b(" + "|".join(re.escape(n) for n in ordered) + r"):([a-z][a-z0-9-]*)")
 
 
 def discover_files(root):
@@ -342,13 +352,14 @@ def scan_file(abs_path, rel_path, dispatch_re, target_re, resolvable):
             continue
         for m in target_re.finditer(line):
             tokens_examined += 1
-            slug = m.group(1)
+            plugin = m.group(1)
+            slug = m.group(2)
             # Mutation-recipe invariant: keep the next line exactly as written, on
             # ONE physical line, and do not repeat its text anywhere else in this
             # file — the recorded recipe rewrites the FIRST match only (perl -0pi,
             # no /g), so a second occurrence would mutate the wrong site and report
             # this arm as decorative.
-            if slug in resolvable:
+            if slug in resolvable.get(plugin, ()):
                 continue
             found.append({
                 "file": rel_path,
@@ -411,7 +422,7 @@ def main(argv):
         # the retired arm alone and can never be reported twice.
         retired_set = set(retired)
         live_entries = [(n, d) for (n, d) in live_entries if n not in retired_set]
-        resolvable = build_target_index(root, [d for (_, d) in live_entries])
+        resolvable = build_target_index(root, live_entries)
         target_re = compile_target_re([n for (n, _) in live_entries])
         violations, files_scanned, tokens_examined = collect(
             root, args.files, compile_dispatch_re(retired), target_re, resolvable)
@@ -423,6 +434,10 @@ def main(argv):
     for o in violations:
         plugin = o["file"].split("/", 1)[0]
         by_plugin[plugin] = by_plugin.get(plugin, 0) + 1
+
+    # Distinct slugs across every plugin's set. `resolvable` is keyed by plugin
+    # now, so a bare len() on it would silently degenerate into a plugin count.
+    resolvable_target_count = len({s for slugs in resolvable.values() for s in slugs})
 
     result = {
         "success": not violations,
@@ -437,7 +452,7 @@ def main(argv):
                 "files": files_scanned,
                 "tokens": tokens_examined,
                 "live_plugins": len(live_entries),
-                "resolvable_targets": len(resolvable),
+                "resolvable_targets": resolvable_target_count,
                 "unresolved_target_arm": target_re is not None,
                 "degraded_reason": degraded_reason,
             },
@@ -474,16 +489,22 @@ def main(argv):
 
     if unresolved_hits:
         print("\nFAIL: {} unresolved-target dispatch(es) found — a live plugin "
-              "prefix naming a skill or agent that does not exist:".format(
+              "prefix naming a skill or agent that plugin does not own:".format(
                   len(unresolved_hits)), file=sys.stderr)
         for o in unresolved_hits:
-            print("  {}:{}: {}  ->  {}".format(
-                o["file"], o["line"], o["match"], o["context"]), file=sys.stderr)
-        print("\nFix: repoint the token at a target that exists — the directory "
-              "name under */skills/ or the file basename under */agents/ — since "
-              "the prefix is live and only the slug is dead. If the line is prose "
-              "about a target that is genuinely gone, drop the colon so it stops "
-              "being dispatch-shaped, or mark the line with "
+            owners = sorted(
+                n for n, slugs in resolvable.items() if o["target"] in slugs)
+            note = "  [owned by: {}]".format(", ".join(owners)) if owners else ""
+            print("  {}:{}: {}  ->  {}{}".format(
+                o["file"], o["line"], o["match"], o["context"], note),
+                file=sys.stderr)
+        print("\nFix: where a hit is annotated `[owned by: ...]` the slug is real "
+              "but the PREFIX names the wrong plugin — repoint the prefix at that "
+              "owner. Otherwise the slug names nothing anywhere: repoint it at a "
+              "target this plugin owns — the directory name under its skills/ or "
+              "the file basename under its agents/. If the line is prose about a "
+              "target that is genuinely gone, drop the colon so it stops being "
+              "dispatch-shaped, or mark the line with "
               "`# external-dispatch-guard:allow` and a rationale.",
               file=sys.stderr)
 

--- a/tests/test_check_external_dispatch.sh
+++ b/tests/test_check_external_dispatch.sh
@@ -35,7 +35,9 @@
 # `mutation-check.sh --case <id>` addresses exactly one assertion. Every id in
 # this file is `edNN`: `ed01`-`ed09` for cases 1-5, `ed10`-`ed19` for the
 # registry cases R1-R6 (R1 -> ed10/ed11, R2 -> ed12/ed13, R3 -> ed14,
-# R4 -> ed15, R5 -> ed16/ed17, R6 -> ed18/ed19). `R1`-`R6` remain the names of
+# R4 -> ed15, R5 -> ed16/ed17, R6 -> ed18/ed19), `ed20`-`ed33` for the
+# unresolved-target arm and `ed34`-`ed36` for its per-plugin pair binding.
+# `R1`-`R6` remain the names of
 # the LOGICAL case groups in the header notes and the section dividers below;
 # they are not ids and must never be emitted as one. Never introduce an
 # `R<n><letter>` id here: tests/test_check_mcp_tool_grant.sh already emits
@@ -43,8 +45,23 @@
 # `R`-stemmed id in this file would be ambiguous in any harness run whose
 # `--test` captures both suites. The whole-token matching rule the ids depend
 # on is stated once, with the regex, above the registry cases below. A new
-# assertion takes the next free id — `ed20` onward — never a renumbering and
+# assertion takes the next free id — `ed37` onward — never a renumbering and
 # never an `R`-stemmed id.
+#
+# Mutation recipe (proves the per-plugin pair binding is load-bearing):
+#   scripts/mutation-check.sh --root . \
+#     --file scripts/check-external-dispatch.py \
+#     --expr 's/if slug in resolvable\.get\(plugin, \(\)\):/if any(slug in owned for owned in resolvable.values()):/' \
+#     --test 'bash tests/test_check_external_dispatch.sh' --case ed34
+#
+# The replacement restores GLOBAL resolution — valid Python, and `resolvable` is
+# a scan_file parameter so `.values()` is in scope — so the wrong-owner token in
+# livetree3 resolves again, `summary.total` drops to 0 and ed34 goes red. No /m
+# is needed: the pattern carries no ^ or $ anchor. The substitution is
+# non-global, which is safe only while that gate literal occurs exactly once in
+# the guard — an invariant the guard's own comment above the line states.
+# ed22 CANNOT carry this recipe: its token `cogni-beta:no-such-thing` resolves
+# under no plugin, so it stays green when the binding is loosened back.
 
 set -eu
 
@@ -340,10 +357,12 @@ assert d['data']['summary']['total']==0, d['data']['summary']
 "
 
 # ===========================================================================
-# Unresolved-target arm (ed20-ed33). The retired-prefix arm above is driven by
+# Unresolved-target arm (ed20-ed36). The retired-prefix arm above is driven by
 # scripts/retired-plugins.json; this second arm is driven by the marketplace
 # manifest of the tree under --root, and reports a <live-plugin>:<slug> token
-# whose slug names no */skills/<slug>/SKILL.md and no */agents/<slug>.md.
+# whose slug names no skills/<slug>/SKILL.md and no agents/<slug>.md UNDER THE
+# PLUGIN ITS OWN PREFIX NAMES — the plugin and the slug resolve as a pair, so a
+# real slug owned by a different listed plugin is reported (ed34-ed36).
 # ===========================================================================
 
 # --- livetree: two listed plugins, one resolvable skill, one resolvable agent,
@@ -586,6 +605,56 @@ JCODE=$?
 set -e
 check "ed33 the allow marker suppresses an unresolved-target finding" \
   "$([ "$CODE" -eq 0 ] && [ "$JCODE" -eq 0 ] && echo 0 || echo 1)"
+
+# --- ed34/ed35: the arm resolves the PLUGIN and the SLUG as a pair. A token
+# --- naming a real slug owned by a DIFFERENT listed plugin is a cross-plugin
+# --- miswire and must be reported, even though the slug exists in the tree.
+# --- Deliberately its own tree, never $LT: ed21 hard-asserts summary.total==1
+# --- and ed30 hard-asserts live_plugins==2 / resolvable_targets==5 against $LT,
+# --- so planting a target there would flip two verdicts this change must keep.
+LT3="$WORK/livetree3"
+mkdir -p "$LT3/.claude-plugin" "$LT3/cogni-beta/skills/beta-only" \
+         "$LT3/cogni-alpha/agents"
+printf '%s' '{"plugins":[{"name":"cogni-alpha","source":"./cogni-alpha"},{"name":"cogni-beta","source":"./cogni-beta"}]}' \
+  > "$LT3/.claude-plugin/marketplace.json"
+printf -- '---\nname: beta-only\n---\nA skill owned by cogni-beta and by nobody else.\n' \
+  > "$LT3/cogni-beta/skills/beta-only/SKILL.md"
+printf -- '---\nname: xcaller\n---\nDispatches cogni-alpha:beta-only, whose slug cogni-beta owns.\nThen cogni-beta:beta-only and cogni-alpha:xcaller, both correctly paired.\n' \
+  > "$LT3/cogni-alpha/agents/xcaller.md"
+
+set +e
+OUT=$(python3 "$GUARD" --root "$LT3" "cogni-alpha/agents/xcaller.md" 2>/dev/null)
+CODE=$?
+set -e
+# ed34 is the recorded mutation-recipe case for the pair binding (see the recipe
+# in this file's header). It asserts the arm PRODUCED the cross-plugin finding,
+# so loosening the gate back to a global lookup empties the arm and reds it.
+assert_json "ed34 a slug owned by another listed plugin is reported as unresolved" "$OUT" "
+import json,sys
+d=json.load(sys.stdin)
+assert d['success'] is False, d
+assert d['data']['summary']['total']==1, d['data']['summary']
+o=d['data']['violations'][0]
+assert o['file']=='cogni-alpha/agents/xcaller.md', o
+assert o['line']==4, o
+assert o['match']=='cogni-alpha:beta-only', o
+assert o['target']=='beta-only', o
+assert o['arm']=='unresolved-target', o
+"
+check "ed35 the cross-plugin miswire exits 1" \
+  "$([ "$CODE" -eq 1 ] && echo 0 || echo 1)"
+# Attribution control: the redness above is the mis-pairing, not a broken tree.
+assert_json "ed36 correctly paired tokens in the same tree are examined and cleared" "$OUT" "
+import json,sys
+d=json.load(sys.stdin)
+# All three tokens must be COUNTED — that is what separates 'the paired tokens
+# resolved' from 'the regex stopped matching them', which the absence checks
+# below cannot tell apart on their own.
+assert d['data']['scanned']['tokens']==3, d['data']['scanned']
+matches=[o['match'] for o in d['data']['violations']]
+assert 'cogni-beta:beta-only' not in matches, matches
+assert 'cogni-alpha:xcaller' not in matches, matches
+"
 
 echo ""
 if [ "$FAILED" -eq 0 ]; then


### PR DESCRIPTION
Closes #1694.

## Summary

The `unresolved-target` arm resolved a `<live-plugin>:<slug>` token against a **global** slug index, so a slug owned by any listed plugin resolved for every prefix — `cogni-trends:portfolio-scan` passed purely because `cogni-portfolio` owns a `portfolio-scan` skill. The cross-plugin miswire class was invisible. Resolution now binds the **pair**.

- `build_target_index()` returns `{plugin name: set of slugs that plugin owns}` instead of one flat set, keyed on the marketplace `name` and populated from that entry's own `source` dir. Two entries sharing a name union rather than clobber.
- `compile_target_re()` captures the plugin half — group 1 plugin, group 2 slug — keeping the longest-first alternation and the mandatory `[a-z][a-z0-9-]*` slug class.
- `scan_file()`'s gate becomes `if slug in resolvable.get(plugin, ()):` — still one physical line, still the only occurrence of that literal in the file, per the mutation-recipe invariant comment above it.
- The arm's stderr remediation now splits the two failure shapes: a hit whose slug is real but owned by another live plugin is annotated `[owned by: ...]` and the fix text says *repoint the prefix*; a slug that names nothing anywhere keeps the old *repoint the slug* advice.
- The module docstring's arm-2 paragraph stated the global rule as a deliberate, separate decision. It now states the pair rule.

## Acceptance criteria

- **AC1 — a slug owned by a different plugin is reported.** New case `ed34` over an isolated `livetree3` fixture: `cogni-alpha:beta-only`, where `beta-only` is owned only by `cogni-beta`, is reported with `arm: unresolved-target`. `ed35` asserts the exit code, `ed36` is the attribution control.
- **AC2 — still green at HEAD, nothing repointed, nothing suppressed.** `python3 scripts/check-external-dispatch.py` exits 0 with `summary.total == 0` across 8 live plugins / 207 surfaces / 231 tokens, `unresolved_target_arm: true`. **Zero sites newly flagged**, so no repointing was needed and no `external-dispatch-guard:allow` marker was added to any live-dispatch surface.
- **AC3 — the mutation recipe proves the binding is load-bearing.** Recorded in the suite header and reproduced below; verified returning `guard_verified` (mutated **red**, restored **green**).
- **AC4 — `ed01`-`ed33` keep their verdicts, docstring updated.** Full suite: 36 PASS, 0 FAIL. The new cases live in their own tree precisely so `ed21` (`summary.total==1`) and `ed30` (`live_plugins==2`, `resolvable_targets==5`) are untouched by construction.

## Mutation recipe

```bash
scripts/mutation-check.sh --root . \
  --file scripts/check-external-dispatch.py \
  --expr 's/if slug in resolvable\.get\(plugin, \(\)\):/if any(slug in owned for owned in resolvable.values()):/' \
  --test 'bash tests/test_check_external_dispatch.sh' --case ed34
```

The replacement restores global resolution — valid Python, and `resolvable` is a `scan_file` parameter so `.values()` is in scope — so the wrong-owner token resolves again, `summary.total` drops to 0 and `ed34` goes red. Verified: `verdict: guard_verified`.

**`ed22` deliberately cannot carry this recipe.** Its token `cogni-beta:no-such-thing` resolves under *no* plugin, so it stays green when the pair binding is loosened back to global and would report `vacuous_guard`. `ed34` is the case whose redness is attributable to the pair binding specifically.

## Scope decisions

- `data.scanned.resolvable_targets` keeps its current meaning — the count of **distinct slugs** across live plugins — so `ed30`'s `==5` keeps its verdict. `main()` now computes it explicitly, because a bare `len()` on the newly plugin-keyed map would silently degenerate into a plugin count.
- **The new failure class is not recorded in the JSON.** A cross-plugin miswire and a dangling slug are both `arm: unresolved-target`; the distinction is derived at print time from `resolvable` and appears only in the stderr remediation. Stamping an `owned_by` field on the violation dict would put it on the guard's contract surface and let `ed34` assert the distinguishing datum directly — a real improvement, but it widens `data.violations[]`, which this issue did not ask for. Flagged for a reviewer rather than taken unilaterally.
- No `plugin.json` `version` is touched — the bump is post-merge.

## Incidental

- Line 279 of the guard carried a stray literal backspace byte (`0x08`) inside the `compile_target_re` docstring — invisible in terminal output, pre-existing, and on a line this change rewrites anyway. It is gone; the file now has zero control characters outside `\n`/`\t`. Called out because it is not implied by the issue.
- `ed36` initially asserted only that the two correctly-paired tokens were absent from the reported matches. That was **entailed** by `ed34` (which pins `total==1` and `violations[0]`), so it could never fail independently, and it stayed green under the recipe above. It now also asserts `scanned.tokens == 3`, which separates "the paired tokens were examined and cleared the gate" from "the regex stopped matching them". Verified red under two independent falsifiers (dropping the token counter; truncating the scanned line range) and green on restore.

## Test plan

- [x] `python3 scripts/check-external-dispatch.py` → exit 0, `summary.total == 0`, `resolvable_targets: 183`
- [x] `bash tests/test_check_external_dispatch.sh` → exit 0, 36 PASS, 0 FAIL
- [x] `python3 scripts/check-case-id-pairing.py` → exit 0, 0 violations
- [x] mutation recipe → `guard_verified`

## Operational disclosure

Step 7.5's `check-token-scope.sh --strict` reported `over_scoped` (`extra_scopes: gist, read:org, workflow`; `forbidden_scopes: workflow`) and was cleared with the **`--allow-overscoped` flag**, scoped to that single invocation — not the `COGNI_SERVICE_ALLOW_OVERSCOPED` env var, which leaks into nested test runs. This runner is a personal, dedicated machine operating on the operator's own repo, which is the condition `cogni-service/CLAUDE.md` §Operational hardening states for the opt-out. The gate's status is surfaced, not silenced. Re-scoping the runner token to a fine-grained PAT remains the standing remediation that would make the exception unnecessary.