### PR TITLE
cogni-workspace: floor PAGE_PARITY against silent shrinkage (L10)

### DIFF
--- a/cogni-workspace/tests/test-layering-claim-reconciled.sh
+++ b/cogni-workspace/tests/test-layering-claim-reconciled.sh
@@ -23,6 +23,7 @@
 #   - a literal under an excluded path is NOT flagged
 #   - each page on the PAGE_PARITY allowlist is byte-identical across the two
 #     wiki trees
+#   - the PAGE_PARITY allowlist has not shrunk below its recorded size
 #   - a scan pointed at a missing or empty tree fails rather than reporting clean
 #
 # Literals, not a regex over "foundation". `foundation` alone has many legitimate
@@ -72,6 +73,14 @@
 # would move with the deletion it is meant to catch and could never fire.
 # Do not read L2 as a regression guard against editing a literal's wording; for
 # a mutation that a change can actually flip, target the parity checker (see L4).
+#
+# The parity allowlist has the same floor, for the same reason. PAGE_PARITY is
+# guarded by a hardcoded count in L10, because the per-page byte-identity arms
+# cannot supply one: L4 and L5 build their fixtures by walking PAGE_PARITY
+# itself, L7 runs against the real repo, and check_parity's only cardinality
+# assertion fires at zero rather than at a floor — so all three stay green when
+# an entry is dropped. Adding a page means raising that numeral in the same
+# commit; the note on the constant itself says so at the point of use.
 #
 # Phrase-level survivors. These lines keep foundation vocabulary on purpose and
 # must NOT be caught. Each says something about the workspace *state* other
@@ -245,6 +254,11 @@ cogni-workspace/libraries/svg-patterns.md
 # different one. Both pairs are byte-identical as they are added, so a green run
 # is not evidence they are guarded — mutating one copy is what shows the entry
 # has teeth.
+#
+# Raise the floor in lockstep. L10 pins this list's size to a hardcoded numeral.
+# Adding a page here without raising that numeral leaves the new entry — and
+# every entry added after it — unprotected against silent removal, which is the
+# class L10 exists to close.
 PAGE_PARITY='plugin-cogni-workspace.md
 workflow-install-to-infographic.md
 arch-er-diagram.md
@@ -592,6 +606,39 @@ if [ "$l9_ok" -eq 1 ]; then
   pass "L9 no manifest is exempt — every .claude-plugin manifest is scanned"
 else
   fail "L9 no manifest is exempt — every .claude-plugin manifest is scanned"
+fi
+
+# ---------------------------------------------------------------------------
+# L10 — the PAGE_PARITY allowlist has not shrunk. The parity arms above prove
+# each page ON the list is byte-identical across the trees; the count floor
+# below is what stops an entry being dropped unnoticed. See the header on why
+# that floor is a hardcoded numeral, and the note on the constant for what it
+# obliges of whoever adds a page.
+#
+# Why a standalone case rather than a floor inside check_parity. Were the floor
+# sited there, a dropped entry would make the checker return 1 to every caller —
+# so L5 and L7, which both expect rc 0, would go red reporting a cardinality
+# loss as parity drift, while L4, which already expects rc 1, would stay green.
+# The loss would surface on two cases it has nothing to do with and stay
+# invisible in the one case whose label says "differs". A standalone case reds
+# only itself.
+# ---------------------------------------------------------------------------
+l10_ok=1
+l10_n=0
+while IFS= read -r page; do
+  [ -n "$page" ] || continue
+  l10_n=$((l10_n + 1))
+done <<EOF
+$PAGE_PARITY
+EOF
+if [ "$l10_n" -lt 12 ]; then
+  echo "  expected at least 12 pinned pages, found $l10_n"
+  l10_ok=0
+fi
+if [ "$l10_ok" -eq 1 ]; then
+  pass "L10 the PAGE_PARITY allowlist has not shrunk"
+else
+  fail "L10 the PAGE_PARITY allowlist has not shrunk"
 fi
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #1697.

## Summary

- Add case **L10** to `cogni-workspace/tests/test-layering-claim-reconciled.sh`: a hardcoded shrinkage floor over `PAGE_PARITY`, mirroring the `l2_n -lt 18` floor that already protects `FORBIDDEN_ALL`.
- The counted value is produced by **walking `PAGE_PARITY` at run time**, using the same `while IFS= read -r ... <<EOF` idiom `check_parity` itself uses (and the same `[ -n "$page" ] || continue` blank skip), so the count is provably the number of entries the checker iterates. The floor's right-hand side is the bare integer literal `12`.
- On failure L10 prints an expected-vs-found line — `  expected at least 12 pinned pages, found <n>` — and reports through the existing `pass` / `fail` helpers.
- Header prose records the floor's existence and **why the 12 is hardcoded** (a floor derived from `PAGE_PARITY` moves with the deletion it is meant to catch and could never fire); the note on the constant itself carries the **raise-in-lockstep obligation**, sited where an editor adding a 13th page is already reading.

## Scope decisions

- **Placement: a new L-prefixed case, not a floor inside `check_parity`.** Reachability decides it, and it was measured rather than assumed. A `compared -lt 12` check inside the checker returns 1 to *every* caller, so under a one-entry deletion **L5** and **L7** — both of which assert rc 0 — go red reporting a cardinality loss as parity drift, while **L4** already expects rc 1 and stays **green**. The shrinkage signal would land on two innocent cases and stay invisible in the one case whose label says "differs". A standalone case reds only itself; the manual mutation below confirms L1–L9 all stay green.
- **`PAGE_PARITY` membership is unchanged.** All 12 entries stay exactly as they are — this issue adds protection, never membership.
- **Diff confined to one file** under `cogni-workspace/tests/`. A repo-wide grep confirms this suite is the only reader of `PAGE_PARITY`.
- **`check_parity`'s existing liveness floor stays as-is.** It fires only on total emptiness (`compared -eq 0 && mismatches -eq 0`); L10 is the cardinality assertion it never was.
- **Next free case id is L10** — L1 through L9 are used with no gaps.
- Nothing deferred; no follow-up issues filed.

A **binding arm was planned and then dropped** during the refine pass, and the reason is worth recording: it would have built a fixture from `PAGE_PARITY`, run `check_parity`, and asserted rc 0 with no `MISSING`/`DRIFT` line, claiming to prove `compared == l10_n`. That proof is unobservable — `check_parity` never prints `compared` — and because the fixture is built by walking the very constant the checker walks, `MISSING` is structurally unreachable, so the arm would have been **green at any list size, including a shrunk one**. It would also have re-run a fixture loop L4 and L5 already run.

## Test plan

- [x] `bash cogni-workspace/tests/test-layering-claim-reconciled.sh` exits 0 and prints `PASS: L10 ...` (10/10 cases green).
- [x] Sibling wiki suites green: `test-wiki-bare-name-roster.sh` (28), `test-wiki-namespace-sync.sh` (8), `test-wiki-tree-parity.sh` (12), `tests/test_release_bundle_wiki.sh` (36, at the repo root), plus `test-mcp-declaration-hygiene.sh` (15).
- [x] One `PAGE_PARITY` entry deleted by hand: **only L10 went red** (`expected at least 12 pinned pages, found 11`); L1–L9 all stayed green. Restored, suite back to rc 0.
- [x] The mutation recipe below runs to `guard_verified`.

## Mutation recipe

The expression deletes exactly one `PAGE_PARITY` entry: `workflow-trends-to-solutions.md`, chosen because it is inert with respect to every existing assertion. (`arch-er-diagram.md` would be the wrong pick — it is hardcoded into L4's fixture and asserted **by name**, so mutating it would red L4 through L4's own assertion rather than through the new floor, a false attribution.) The pattern matches once; a zero-occurrence match is a hard `expr_no_op` error, never a silent pass.

`--root` is the repo root you are running against — substitute your own checkout:

```bash
bash "${CLAUDE_PLUGIN_ROOT}/scripts/mutation-check.sh" \
  --root <your-insight-wave-checkout> \
  --file cogni-workspace/tests/test-layering-claim-reconciled.sh \
  --expr 's/^workflow-trends-to-solutions\.md\n//m' \
  --test 'bash cogni-workspace/tests/test-layering-claim-reconciled.sh' \
  --case L10
```

Observed — recorded from the actual run against this branch, not asserted:

- `mutated_result`: **red**
- `restored_result`: **green**
- `verdict`: **guard_verified**
- exit code: **0**; the file was byte-identical to its pre-run state afterwards.

## Review notes

- The `/simplify` pass collapsed a genuine three-site restatement of the "hardcoded on purpose / raise in lockstep" rationale down to two, so the L10 case comment now defers to the header — matching the convention L2's own case comment already follows (*"See the header on what this case cannot prove"*). Three of four cleanup angles flagged this independently.
- Three `/simplify` findings were **skipped**, deliberately: extracting a shared `assert_min_entries` helper (L2's `l2_n` is its plant-loop's fixture-path index, not a comparable counter, so the helper would have exactly one call site — and routing L2 through it would edit a case this issue's scope fence excludes); replacing the count loop with `printf | grep -c` (two angles rejected it on consistency and on spawning a subprocess to replace an in-shell loop, and it neighbours the derived-count shape AC2 forbids); and dropping the `l10_ok` flag (L3 already uses that shape for a single-assertion case, so it is house style).

## Plan record

The full resolution plan, including the rejected alternative and the refine pass, is recorded on the issue: https://github.com/cogni-work/insight-wave/issues/1697#issuecomment-5495926199