### PR TITLE
cogni-knowledge: citation-family-aware citation primitives

### DIFF
--- a/cogni-knowledge/scripts/_knowledge_lib.py
+++ b/cogni-knowledge/scripts/_knowledge_lib.py
@@ -590,6 +590,19 @@ def normalize_citation_format(value: str | None) -> str:
     return _normalize_choice(value, VALID_CITATION_FORMATS, "ieee")
 
 
+def citation_family(value: str | None) -> str:
+    """The citation family — `numbered` or `author_date` — a citation format
+    belongs to. Callers dispatch on this rather than re-deriving the mapping.
+
+    Total by construction: `normalize_citation_format` never raises and always
+    returns a member of VALID_CITATION_FORMATS, every one of which is a key of
+    CITATION_FAMILY, so the lookup cannot KeyError. Unknown, empty and None all
+    normalize to `ieee` and therefore resolve to `numbered` — the family the
+    pipeline actually renders — and the deprecated `wikilink` alias follows the
+    same route."""
+    return CITATION_FAMILY[normalize_citation_format(value)]
+
+
 def normalize_target_words(value, default: int = 2000) -> int:
     """Coerce a target-word value to a positive int; non-positive/unparseable →
     `default`. Tolerates a string from a flag or a number from a binding/plan."""
@@ -657,6 +670,80 @@ def extract_inline_citation_urls(text: str) -> list[str]:
     if not text:
         return []
     return [a or b for a, b in _INLINE_CITATION_URL_RE.findall(text)]
+
+
+# --- author-date counterparts -------------------------------------------------
+# The author-date families (apa/mla/harvard) carry no `[N]`, so every numbered
+# primitive above returns nothing useful for them. These are the counterparts,
+# added beside the numbered ones rather than replacing them: the numbered regexes
+# encode edge behaviour `verify-store.py` and `citation-store.py` depend on, and a
+# single widened pattern would put that at risk to save one function.
+#
+# The inline shapes are `([Author, Year](url))` (APA), `([Author](url))` (MLA) and
+# `([Author Year](url))` (Harvard) — one parenthesized markdown link, so all three
+# are the same shape and one pattern covers them. Two properties are load-bearing:
+#
+#   * The destination is SCHEME-ANCHORED (`https?`/`file`), exactly as the numbered
+#     pattern is. Without it, `([Author, Year](url))` is indistinguishable from
+#     ordinary parenthesized prose like `(see [the annex](#section-3))`, which a
+#     scheme-agnostic pattern would strip out of a draft as if it were a citation.
+#   * The label class is `[^\[\]]+`, which excludes `[` and `]`, so the `[[N]]`
+#     wikilink anti-pattern (references/citation-formats.md:45) can never match.
+#
+# The destination alternation mirrors `_INLINE_CITATION_URL_RE` edge-for-edge: the
+# angle-bracketed `(<url>)` branch FIRST so a URL legitimately containing `)` is
+# not truncated at that inner `)`, the unbracketed branch second; `file:` a
+# first-class scheme; and `[^>]`/`[^)]` rather than `\S` so a `file://` path with a
+# literal space is captured whole.
+_AUTHOR_DATE_CITATION_URL_RE = re.compile(
+    r"\(\[[^\[\]]+\]\((?:<((?:https?|file)://[^>]+)>|((?:https?|file)://[^)]+?))\)\)"
+)
+
+# Stripping and extracting share ONE pattern, deliberately. What counts as an
+# author-date marker must be a single definition: a second pattern differing only
+# in its capture groups would have to be kept byte-identical by hand, and a
+# one-sided edge fix would leave strip and extract disagreeing about what a marker
+# is — with each unit case exercising only one of the two, nothing would catch it.
+# `.sub()` with a literal empty replacement never dereferences groups, so the
+# capturing form serves both. The alias is what the strip reads under.
+_AUTHOR_DATE_MARKER_RE = _AUTHOR_DATE_CITATION_URL_RE
+
+
+def strip_author_date_citation_markers(text: str) -> str:
+    """Remove every inline `([Author, Year](url))` marker, leaving the surrounding
+    prose. The author-date counterpart of `strip_inline_citation_markers`; a
+    parenthesized markdown link whose destination is not http(s)/file is ordinary
+    prose and is left alone."""
+    return _AUTHOR_DATE_MARKER_RE.sub("", text)
+
+
+def extract_author_date_citation_urls(text: str) -> list[str]:
+    """Every http(s) or file:// URL inside an `([Author, Year](url))` inline marker
+    in `text`, in appearance order (raw). The author-date counterpart of
+    `extract_inline_citation_urls`, over the edge set the pattern above documents."""
+    if not text:
+        return []
+    return [a or b for a, b in _AUTHOR_DATE_CITATION_URL_RE.findall(text)]
+
+
+def strip_citation_markers(text: str, citation_format: str | None = None) -> str:
+    """Remove inline citation markers of whichever family `citation_format`
+    belongs to, dispatched through `citation_family`.
+
+    The `numbered` branch delegates to `strip_inline_citation_markers` unchanged,
+    so an author-date marker deliberately SURVIVES under a numbered format."""
+    if citation_family(citation_format) == "author_date":
+        return strip_author_date_citation_markers(text)
+    return strip_inline_citation_markers(text)
+
+
+def extract_citation_urls(text: str, citation_format: str | None = None) -> list[str]:
+    """Inline citation URLs of whichever family `citation_format` belongs to,
+    dispatched through `citation_family`. The `numbered` branch delegates to
+    `extract_inline_citation_urls` unchanged."""
+    if citation_family(citation_format) == "author_date":
+        return extract_author_date_citation_urls(text)
+    return extract_inline_citation_urls(text)
 
 
 def first_url(fm_value: str) -> str:
@@ -859,6 +946,59 @@ def renumber_inline_citations(body: str) -> str:
             lambda m: "<sup>[" + str(remap[int(m.group(1))]) + "]", body
         )
     return body
+
+
+def author_surname_sort_key(author: str | None) -> tuple[int, str]:
+    """Sort key for an author-date reference entry: surname, casefolded.
+
+    Surname derivation, first hit wins: the text before the first comma (the
+    `Last, First` form), else the last whitespace-delimited token (`First Last`),
+    else the whole value. A single-token value such as the `publisher:` surrogate
+    `europa.eu` that `resolve_author_year` falls back to has no surname to split
+    out, so it sorts under itself.
+
+    TOTAL and non-raising by construction, which is the point: `resolve_author_year`
+    returns `("", "")` for a page it cannot read rather than signalling, so an
+    empty author reaches this key on the ordinary path. The leading int is a
+    presence flag — 0 for a real surname, 1 for an empty one — so empty authors
+    sort LAST as a block instead of leading the list, and the ordering stays
+    deterministic rather than depending on input order."""
+    surname = str(author or "").strip()
+    if "," in surname:
+        surname = surname.split(",", 1)[0].strip()
+    elif " " in surname:
+        surname = surname.rsplit(None, 1)[-1].strip()
+    return (1, "") if not surname else (0, surname.casefold())
+
+
+def build_author_date_reference_list(entries) -> list[str]:
+    """The author-date reference list: deduped by source, sorted alphabetically by
+    author surname, UN-numbered.
+
+    The author-date counterpart of the numbered family's reference pass — and a
+    genuinely new one: `renumber_inline_citations` only remaps the body's inline
+    markers and builds no list at all. `references/citation-formats.md:39` specifies
+    "an alphabetical, un-numbered reference list" for these families, so entries
+    carry no `**[N]**` prefix.
+
+    Each entry is a mapping carrying `rendered` (the bibliography line) plus the
+    identity to dedup on — `slug`, falling back to `url`. Dedup is by that source
+    identity, never by the rendered string: two renderings of one source must
+    collapse to one entry, and a rendered-string key would silently keep both.
+    First occurrence of a source wins. Ties beyond the surname key fall back to the
+    source key, so the order is total even when two sources share an author."""
+    by_source = {}
+    for entry in entries or []:
+        # setdefault keeps the FIRST occurrence of a source and spells the
+        # identity rule once — the same key the tiebreak below sorts on, so the
+        # two can never drift apart into a dedup partition the ordering disagrees
+        # with. Insertion order is irrelevant: the sort below is total.
+        by_source.setdefault(str(entry.get("slug") or entry.get("url") or ""), entry)
+    ordered = sorted(
+        by_source.items(),
+        key=lambda kv: (author_surname_sort_key(kv[1].get("author")), kv[0]),
+    )
+    return [str(entry.get("rendered") or "") for _, entry in ordered]
 
 
 # --- pre_extracted_claims block-list parser (used by verify-store.py prefilter) -

--- a/cogni-knowledge/tests/test_knowledge_lib.sh
+++ b/cogni-knowledge/tests/test_knowledge_lib.sh
@@ -1337,6 +1337,146 @@ def assert_extract_pdf_text():
         kl.load_pypdf = orig
 
 
+def assert_citation_family_dispatch():
+    # The numbered family.
+    assert kl.citation_family("ieee") == "numbered"
+    assert kl.citation_family("chicago") == "numbered"
+    # The author-date family.
+    assert kl.citation_family("apa") == "author_date"
+    assert kl.citation_family("mla") == "author_date"
+    assert kl.citation_family("harvard") == "author_date"
+    # Normalization is inherited from normalize_citation_format, so case and
+    # surrounding whitespace do not change the family.
+    assert kl.citation_family("APA") == "author_date"
+    assert kl.citation_family("  Harvard  ") == "author_date"
+    # The deprecated `wikilink` alias routes to ieee, hence numbered.
+    assert kl.citation_family("wikilink") == "numbered"
+    # TOTAL: every value the format field can carry degrades to the family the
+    # pipeline actually renders, rather than raising at a call site. A bare
+    # CITATION_FAMILY[fmt] subscript would KeyError on each of these.
+    for degenerate in ("bibtex", "", None):
+        assert kl.citation_family(degenerate) == "numbered", degenerate
+
+
+def assert_strip_author_date_citation_markers():
+    # All three author-date shapes strip with NO residue — asserted by full-string
+    # equality, so a stray paren or a surviving year would fail.
+    apa = "AI is regulated ([Doe, 2024](https://x.eu/c)). Next."
+    assert kl.strip_author_date_citation_markers(apa) == "AI is regulated . Next.", \
+        kl.strip_author_date_citation_markers(apa)
+    mla = "AI is regulated ([Doe](https://x.eu/c))."
+    assert kl.strip_author_date_citation_markers(mla) == "AI is regulated ."
+    harvard = "AI is regulated ([Doe 2024](https://x.eu/c))."
+    assert kl.strip_author_date_citation_markers(harvard) == "AI is regulated ."
+    # Multiple markers in one sentence.
+    two = "A ([Doe, 2024](https://a.org/x)) and B ([Roe, 2023](https://b.org/y))."
+    assert kl.strip_author_date_citation_markers(two) == "A  and B ."
+    # No-op when absent.
+    assert kl.strip_author_date_citation_markers("plain text") == "plain text"
+    assert kl.strip_author_date_citation_markers("") == ""
+    # Scheme-anchored: an ordinary parenthesized markdown link is prose, not a
+    # citation, and must survive untouched.
+    prose = "As noted (see [the annex](#section-3)) the rule applies."
+    assert kl.strip_author_date_citation_markers(prose) == prose, \
+        kl.strip_author_date_citation_markers(prose)
+    # The [[N]] wikilink anti-pattern can never match (label class excludes []).
+    wl = "A ([[2]](https://a.org/x))."
+    assert kl.strip_author_date_citation_markers(wl) == wl, \
+        kl.strip_author_date_citation_markers(wl)
+    # The family-aware dispatcher BRANCHES rather than applying both patterns:
+    # under a numbered format an author-date marker SURVIVES, and the result is
+    # byte-identical to the existing numbered strip.
+    assert kl.strip_citation_markers(apa, "ieee") == kl.strip_inline_citation_markers(apa)
+    assert "([Doe, 2024](https://x.eu/c))" in kl.strip_citation_markers(apa, "ieee")
+    assert kl.strip_citation_markers(apa, "apa") == "AI is regulated . Next."
+    # ... and conversely a numbered marker survives under an author-date format.
+    numbered = "AI is regulated<sup>[3](https://x.eu/c)</sup>."
+    assert kl.strip_citation_markers(numbered, "ieee") == "AI is regulated."
+    assert kl.strip_citation_markers(numbered, "apa") == numbered
+
+
+def assert_extract_author_date_citation_urls():
+    # Appearance order across two http markers.
+    text = "A ([Doe, 2024](https://a.org/x)). B ([Roe, 2023](https://b.org/y))."
+    assert kl.extract_author_date_citation_urls(text) == \
+        ["https://a.org/x", "https://b.org/y"], kl.extract_author_date_citation_urls(text)
+    # file:// is first-class.
+    f = "C ([Doe, 2024](file:///abs/p.pdf))."
+    assert kl.extract_author_date_citation_urls(f) == ["file:///abs/p.pdf"], \
+        kl.extract_author_date_citation_urls(f)
+    # An UNBRACKETED file:// path with a literal space is captured whole, not
+    # truncated at the space ([^)] rather than \S).
+    fs = "D ([Doe, 2024](file:///abs/V8 Data.pdf))."
+    assert kl.extract_author_date_citation_urls(fs) == ["file:///abs/V8 Data.pdf"], \
+        kl.extract_author_date_citation_urls(fs)
+    # The angle-bracketed destination form.
+    fb = "E ([Doe, 2024](<file:///abs/V8 Data.pdf>))."
+    assert kl.extract_author_date_citation_urls(fb) == ["file:///abs/V8 Data.pdf"], \
+        kl.extract_author_date_citation_urls(fb)
+    # Mixed file + http in one sentence yields BOTH, in order.
+    mixed = "F ([Doe, 2024](file:///abs/p.pdf)) and ([Roe, 2023](https://w.org/z))."
+    assert kl.extract_author_date_citation_urls(mixed) == \
+        ["file:///abs/p.pdf", "https://w.org/z"], kl.extract_author_date_citation_urls(mixed)
+    # A marker carrying no URL, and empty text, contribute nothing.
+    assert kl.extract_author_date_citation_urls("G ([Doe, 2024]).") == []
+    assert kl.extract_author_date_citation_urls("") == []
+    # Scheme-anchored: an ordinary parenthesized markdown link yields no URL.
+    assert kl.extract_author_date_citation_urls("(see [the annex](#section-3))") == []
+    # The family-aware dispatcher branches.
+    assert kl.extract_citation_urls(text, "apa") == ["https://a.org/x", "https://b.org/y"]
+    assert kl.extract_citation_urls(text, "ieee") == []
+    numbered = "A<sup>[1](https://a.org/x)</sup>."
+    assert kl.extract_citation_urls(numbered, "ieee") == \
+        kl.extract_inline_citation_urls(numbered) == ["https://a.org/x"]
+    assert kl.extract_citation_urls(numbered, "apa") == []
+
+
+def assert_build_author_date_reference_list():
+    # Insertion order deliberately differs from alphabetical order, and `roe` is
+    # cited twice under two different renderings of the SAME source — so a dedup
+    # keyed on the rendered string (rather than source identity) would keep both.
+    entries = [
+        {"slug": "roe", "author": "Roe, Jane", "rendered": "Roe, Jane (2023). Later."},
+        {"slug": "doe", "author": "J. Doe", "rendered": "Doe, J. (2019). Earlier."},
+        {"slug": "roe", "author": "Roe, Jane", "rendered": "Roe, Jane (2023). DUPLICATE."},
+        {"slug": "acme", "author": "Acme Corp", "rendered": "Acme Corp (2020). Mid."},
+    ]
+    out = kl.build_author_date_reference_list(entries)
+    # Exactly one entry per distinct source, in surname order (Corp < Doe < Roe),
+    # asserted by full-list equality — not membership, not length.
+    assert out == [
+        "Acme Corp (2020). Mid.",
+        "Doe, J. (2019). Earlier.",
+        "Roe, Jane (2023). Later.",
+    ], out
+    # Un-numbered: no **[N]** prefix and no [[N]] wikilink shape.
+    for line in out:
+        assert "**[" not in line and "[[" not in line, line
+
+    # Degenerate authors: the ("", "") resolve_author_year returns for a page it
+    # cannot read, and a surname-less `publisher:` surrogate. Neither may raise,
+    # and empty sorts LAST as a block rather than leading the list.
+    degenerate = [
+        {"slug": "blank", "author": "", "rendered": "BLANK"},
+        {"slug": "surrogate", "author": "europa.eu", "rendered": "SURROGATE"},
+        {"slug": "doe", "author": "J. Doe", "rendered": "DOE"},
+    ]
+    assert kl.build_author_date_reference_list(degenerate) == \
+        ["DOE", "SURROGATE", "BLANK"], kl.build_author_date_reference_list(degenerate)
+    # Deterministic when two sources share one author (slug tiebreak).
+    tied = [
+        {"slug": "z", "author": "Doe, J", "rendered": "Z"},
+        {"slug": "a", "author": "Doe, J", "rendered": "A"},
+    ]
+    assert kl.build_author_date_reference_list(tied) == ["A", "Z"]
+    # Empty input.
+    assert kl.build_author_date_reference_list([]) == []
+    assert kl.build_author_date_reference_list(None) == []
+    # The sort key itself is total and non-raising over every degenerate form.
+    for bad in ("", None, "   ", "europa.eu"):
+        kl.author_surname_sort_key(bad)
+
+
 check("parse_synthesis_sources", assert_parse_synthesis_sources)
 check("frontmatter_scalar", assert_frontmatter_scalar)
 check("tokenization_primitives", assert_tokenization_primitives)
@@ -1381,6 +1521,10 @@ check("resolve_wiki_scripts", assert_resolve_wiki_scripts)
 check("load_pypdf", assert_load_pypdf)
 check("extract_pdf_text", assert_extract_pdf_text)
 check("resolve_author_year", assert_resolve_author_year)
+check("citation_family_dispatch", assert_citation_family_dispatch)
+check("strip_author_date_citation_markers", assert_strip_author_date_citation_markers)
+check("extract_author_date_citation_urls", assert_extract_author_date_citation_urls)
+check("build_author_date_reference_list", assert_build_author_date_reference_list)
 PY
 )
 
@@ -1440,6 +1584,10 @@ grade resolve_wiki_scripts    "klib-40 resolve_wiki_scripts — single Python SS
 grade load_pypdf              "klib-41 load_pypdf (#583) — fail-soft optional import: returns None (absent) or a module with PdfReader (present), never raises, stable verdict across calls"
 grade extract_pdf_text        "klib-42 extract_pdf_text (#583) — reason vocabulary (ok/pypdf_unavailable/no_text_layer/extract_failed) via injected fake pypdf, min_chars gate boundary, per-page exception skip, page count reported"
 grade resolve_author_year     "klib-43 resolve_author_year — explicit author:/published_date: beat the publisher:/fetched_at: surrogates; a legacy page carrying only the surrogates still resolves non-empty on both legs; neither/no-frontmatter/degenerate -> ('',''), never raises"
+grade citation_family_dispatch "klib-44 citation_family (#1748) — the first functional reader of CITATION_FAMILY: ieee/chicago→numbered, apa/mla/harvard→author_date, case/whitespace-insensitive, wikilink alias→numbered, and unknown/''/None→numbered rather than KeyError"
+grade strip_author_date_citation_markers "klib-45 strip_author_date_citation_markers (#1748) — APA/MLA/Harvard markers removed with no residue, multiple per sentence, no-op when absent; scheme-anchored so ordinary parenthesized prose links and the [[N]] anti-pattern survive; strip_citation_markers BRANCHES (author-date marker survives under ieee, numbered marker survives under apa)"
+grade extract_author_date_citation_urls "klib-46 extract_author_date_citation_urls (#1748) — the edge set klib-11 pins, transposed: appearance order, file:// first-class, unbracketed file:// with a literal space captured whole, angle-bracketed form, mixed file+http both in order, URL-less marker and ''→[]; scheme-anchored; extract_citation_urls dispatches per family"
+grade build_author_date_reference_list "klib-47 build_author_date_reference_list (#1748) — dedup by SOURCE identity not rendered string, alphabetical by surname across 'Last, First' and 'First Last', un-numbered (no **[N]**/[[N]]), ('','')+surname-less publisher surrogate sort last without raising, slug tiebreak, empty/None→[]"
 
 if [ $errors -gt 0 ]; then
   red "$errors case(s) failed."


### PR DESCRIPTION
Closes #1748.

Child 2 of 3 under tracker #1744. Pure library code — **no consumer is wired here**; child 3 (#1749) does the end-to-end flip.

## Summary

- **`citation_family(value)`** — the first functional reader of `CITATION_FAMILY`, composed as `CITATION_FAMILY[normalize_citation_format(value)]`. That composition is what makes it **total**: `normalize_citation_format` never raises and always returns a member of `VALID_CITATION_FORMATS`, every one of which is a key of the dict — so unknown / `""` / `None` and the deprecated `wikilink` alias all resolve to `numbered` instead of `KeyError`-ing at a call site.
- **`strip_author_date_citation_markers`** / **`extract_author_date_citation_urls`** — the `([Author, Year](url))` (APA), `([Author](url))` (MLA) and `([Author Year](url))` (Harvard) shapes. Both share **one** scheme-anchored pattern, so strip and extract cannot drift apart on what counts as a marker.
- **`strip_citation_markers`** / **`extract_citation_urls`** — dispatch on `citation_family`. The `numbered` branch delegates to the existing functions unchanged, so an author-date marker deliberately *survives* under a numbered format (and vice versa) — proving the dispatch is a real branch, not both patterns applied unconditionally.
- **`author_surname_sort_key`** + **`build_author_date_reference_list`** — dedup by source identity, alphabetical by surname, un-numbered per `references/citation-formats.md:39`. The sort key is total and non-raising over the `("", "")` that `resolve_author_year` returns for a page it cannot read, and over surname-less `publisher:` surrogates like `europa.eu`; empty authors sort last as a block, with a source-key tiebreak so ordering is deterministic.

## Two details worth a reviewer's eye

**The author-date pattern is scheme-anchored on purpose.** `([Author, Year](url))` is shape-identical to an ordinary parenthesized markdown link, so a scheme-agnostic pattern would strip legitimate prose such as `(see [the annex](#section-3))` out of a draft as though it were a citation. Requiring `http(s)://` or `file://` is what separates the two, and the label class excludes `[`/`]` so the `[[N]]` wikilink anti-pattern (`citation-formats.md:45`) can never match. Both are asserted.

**The numbered primitives are byte-identical.** `_SUP_CITATION_RE`, `_SUP_MARKER_RE`, `strip_inline_citation_markers`, `_INLINE_CITATION_URL_RE`, `extract_inline_citation_urls` and `renumber_inline_citations` are untouched — `verify-store.py:382` (verbatim prefilter) and `citation-store.py:133,208` (`--ingest-manifest` gate) depend on their exact edge behaviour, and "generalise them in place" was the alternative the issue explicitly rejected. The diff is **purely additive: 288 insertions, 0 deletions.**

## Scope

- **In:** `cogni-knowledge/scripts/_knowledge_lib.py`, `cogni-knowledge/tests/test_knowledge_lib.sh`. Nothing else. New module-level names are purely additive — consumers use explicit `from _knowledge_lib import <names>` and three test harnesses load by path, so neither mechanism enumerates the module surface.
- **Out — child 3's fence (#1749):** `agents/wiki-composer.md`, `agents/wiki-reviewer.md`, `agents/revisor.md`, `skills/knowledge-finalize/SKILL.md`, `skills/knowledge-plan/SKILL.md`, `references/citation-formats.md`, `references/finalize-compose-subprocess.md`, `scripts/citation-store.py`, `scripts/verify-store.py`.
- **Out — the fall-through prose, deliberately.** `citation-formats.md:39` and `knowledge-finalize/SKILL.md` still say apa/mla/harvard fall through to the numbered IEEE render. That stays **true** after this PR and is not "corrected" here: the real reference-row assembly lives as inline `python3 -c` code inside `finalize-compose-subprocess.md`, a file this PR is fenced out of, so a `_knowledge_lib.py`-only change *cannot* alter rendered output. Reconciling that prose is #1749's.
- **No `plugin.json` version touch** — the post-merge workflow owns the bump.

## Test plan

- [x] `python3 scripts/run-plugin-tests.py --filter cogni-knowledge` exits 0 — **79 suites passed, 0 failed**
- [x] `bash cogni-knowledge/tests/test_knowledge_lib.sh` — 47 PASS, 0 FAIL; `klib-44`..`klib-47` green **and** `klib-11` / `klib-16` / `klib-24` / `klib-38` still green with expected values unedited
- [x] Each new case registered in **both** halves (`check(...)` *and* `grade`) — see the note below
- [x] `grep -n 'CITATION_FAMILY' cogni-knowledge/scripts/_knowledge_lib.py` shows an occurrence inside a function body, not only the module-level dict
- [x] No consumer wired — the new names appear only in `_knowledge_lib.py` and `test_knowledge_lib.sh`
- [x] `git diff --name-only origin/main...HEAD` lists only `cogni-knowledge/` paths; `git diff origin/main...HEAD -- '*plugin.json'` is empty; 0 deleted lines
- [x] All four mutation recipes report `guard_verified`

## Mutation recipe

Every new branch was verified red-on-mutation, **not merely recorded**. Run each from the root of your checkout of this branch — `--root` must be the tree that actually contains the change, since `mutation-check.sh` runs `--test` with `cwd=--root` and `test_knowledge_lib.sh` resolves its plugin root from `dirname "$0"`. Pointed at a checkout of `main` the expression matches nothing and the script exits 2 (`expr_no_op`).

```bash
bash ~/.claude/plugins/marketplaces/managed-service/cogni-service/scripts/mutation-check.sh --root . --file cogni-knowledge/scripts/_knowledge_lib.py --case klib-44 --test 'bash cogni-knowledge/tests/test_knowledge_lib.sh' --expr 's/return CITATION_FAMILY\[normalize_citation_format\(value\)\]/return "numbered"/'

bash ~/.claude/plugins/marketplaces/managed-service/cogni-service/scripts/mutation-check.sh --root . --file cogni-knowledge/scripts/_knowledge_lib.py --case klib-45 --test 'bash cogni-knowledge/tests/test_knowledge_lib.sh' --expr 's/_AUTHOR_DATE_MARKER_RE\.sub\("", text\)/text/'

bash ~/.claude/plugins/marketplaces/managed-service/cogni-service/scripts/mutation-check.sh --root . --file cogni-knowledge/scripts/_knowledge_lib.py --case klib-46 --test 'bash cogni-knowledge/tests/test_knowledge_lib.sh' --expr 's/\[a or b for a, b in _AUTHOR_DATE_CITATION_URL_RE\.findall\(text\)\]/[]/'

bash ~/.claude/plugins/marketplaces/managed-service/cogni-service/scripts/mutation-check.sh --root . --file cogni-knowledge/scripts/_knowledge_lib.py --case klib-47 --test 'bash cogni-knowledge/tests/test_knowledge_lib.sh' --expr 's/return \(1, ""\) if not surname else \(0, surname\.casefold\(\)\)/return (0, "")/'
```

All four return `mutated_result: red`, `restored_result: green`, `verdict: guard_verified`. A fifth, replacing the dedup key with `id(entry)`, also reddens `klib-47` — so dedup-by-source-identity has teeth independently of the sort.

Note `--case` takes the bare `klib-NN` token (the leading token of the graded description), not the python `check()` tag.

## A live false-green this PR does not fix

`test_knowledge_lib.sh` grades through **two** halves: a `check("<tag>", …)` inside the python heredoc, and a `grade <tag> "klib-NN …"` line in the bash section. Only `grade` reads the result and increments `errors` — so **a `check` with no `grade` runs, prints, and is never counted**. `run-plugin-tests.py` classifies purely on exit code and never parses stdout, so there is no secondary net.

Two such orphans already exist (`page_type_line`, `parse_distilled_claims_with_backlinks`). All four cases added here are wired in both halves; fixing the two pre-existing orphans is **#1753**, filed rather than folded in because grading them may surface an unrelated pre-existing failure that would then be mis-attributed to this PR.

## Follow-up issues

- **#1753** — cogni-knowledge: two orphaned `check(...)` cases in `test_knowledge_lib.sh` are never graded

## Plan record

[Resolution plan](https://github.com/cogni-work/insight-wave/issues/1748#issuecomment-5501669656) · [issue-time acceptance contract](https://github.com/cogni-work/insight-wave/issues/1748#issuecomment-5501648240)
