### PR TITLE
cogni-knowledge: grade two orphaned klib cases + permanent check/grade census

### DIFF
--- a/cogni-knowledge/tests/test_knowledge_lib.sh
+++ b/cogni-knowledge/tests/test_knowledge_lib.sh
@@ -1588,6 +1588,54 @@ grade citation_family_dispatch "klib-44 citation_family (#1748) — the first fu
 grade strip_author_date_citation_markers "klib-45 strip_author_date_citation_markers (#1748) — APA/MLA/Harvard markers removed with no residue, multiple per sentence, no-op when absent; scheme-anchored so ordinary parenthesized prose links and the [[N]] anti-pattern survive; strip_citation_markers BRANCHES (author-date marker survives under ieee, numbered marker survives under apa)"
 grade extract_author_date_citation_urls "klib-46 extract_author_date_citation_urls (#1748) — the edge set klib-11 pins, transposed: appearance order, file:// first-class, unbracketed file:// with a literal space captured whole, angle-bracketed form, mixed file+http both in order, URL-less marker and ''→[]; scheme-anchored; extract_citation_urls dispatches per family"
 grade build_author_date_reference_list "klib-47 build_author_date_reference_list (#1748) — dedup by SOURCE identity not rendered string, alphabetical by surname across 'Last, First' and 'First Last', un-numbered (no **[N]**/[[N]]), ('','')+surname-less publisher surrogate sort last without raising, slug tiebreak, empty/None→[]"
+grade page_type_line "klib-48 page_type_line (#931) — the reader-facing Type: <Display> · <stage> header: per-type display name and stage word for all seven types, U+00B7 middle dot as the separator and never an ASCII substitute, case-insensitive key, and the fail-safe arms (unknown -> title-cased + raw, None/empty -> Unknown + raw, non-str int coerced) that must never raise"
+grade parse_distilled_claims_with_backlinks "klib-49 parse_distilled_claims_with_backlinks (#885) — the dual-level retrieval join reader: claim_id + text + backlinks and nothing else, inline list parsed with or without a space after the comma, order preserved, missing/empty backlinks normalized to [] so every claim carries the key, the with_id sibling left byte-identical (additive), and inline []/no key/empty/no-frontmatter -> []"
+
+# --- klib-50: check/grade census -------------------------------------------
+# The convention this file grades through has no structural enforcement: a
+# python-side registration prints "<tag>: OK"/"<tag>: FAIL" into $OUT, and only
+# a bash-side grade line ever reads it, so a registration with no grade line is
+# never read and can never fail the suite. #1753 found two such orphans.
+#
+# Bash-only for the same reason klib-01 (line 43) is: the python heredoc runs as
+# a subprocess with no handle on this script's source, and half the subject here
+# — the grade lines — is script text that never enters it. Unlike klib-01 this
+# case is NON-FATAL, folding into $errors so the rest of the report still prints.
+#
+# Three properties are load-bearing. `set -eu` is on (line 24) and grep exits 1
+# on zero matches, so every extraction is `|| true`-guarded as grade() is at line
+# 1536 — otherwise the suite aborts before this case can report. The extractors
+# are anchored so they match neither their own pattern literals (the bytes here
+# are an escaped paren, never a bare one) nor the grade() definition. LC_ALL=C
+# keeps sort and comm byte-collated, since the tags contain `_`.
+grep -oE 'check\("[a-z0-9_]+"' "$0" | sed 's/^check("//; s/"$//' | LC_ALL=C sort > "$WORK/census_reg" || true
+awk '/^grade[ \t]/{print $2}' "$0" | LC_ALL=C sort > "$WORK/census_graded" || true
+census_dup_reg=$(LC_ALL=C uniq -d "$WORK/census_reg" | tr '\n' ' ' || true)
+census_dup_graded=$(LC_ALL=C uniq -d "$WORK/census_graded" | tr '\n' ' ' || true)
+census_only_reg=$(LC_ALL=C comm -23 "$WORK/census_reg" "$WORK/census_graded" | tr '\n' ' ' || true)
+census_only_graded=$(LC_ALL=C comm -13 "$WORK/census_reg" "$WORK/census_graded" | tr '\n' ' ' || true)
+
+census_verdict="PASS"
+if [ ! -s "$WORK/census_reg" ] || [ ! -s "$WORK/census_graded" ]; then
+  census_verdict="EMPTY - registrations=$(wc -l < "$WORK/census_reg") grade lines=$(wc -l < "$WORK/census_graded"); an extractor matched nothing, so the convention was renamed or the scan is broken"
+elif [ -n "$census_dup_reg" ]; then
+  census_verdict="DUP-REGISTRATION - tag registered more than once: $census_dup_reg"
+elif [ -n "$census_dup_graded" ]; then
+  census_verdict="DUP-GRADE - tag graded more than once: $census_dup_graded"
+elif [ -n "$census_only_reg" ]; then
+  census_verdict="ORPHAN-REGISTRATION - registered but never graded, so its result is never read: $census_only_reg"
+elif [ -n "$census_only_graded" ]; then
+  census_verdict="ORPHAN-GRADE - graded but never registered: $census_only_graded"
+fi
+
+census_desc="klib-50 check/grade census - every registered tag has exactly one grade line and every grade line exactly one registration; duplicates on either side and an empty extraction are rejected too, so a third orphan cannot hide"
+if [ "$census_verdict" = "PASS" ]; then
+  green "PASS: $census_desc"
+else
+  red "FAIL: $census_desc ($census_verdict)"
+  errors=$((errors + 1))
+fi
+
 
 if [ $errors -gt 0 ]; then
   red "$errors case(s) failed."


### PR DESCRIPTION
Closes #1753.

## Summary

- Add `grade page_type_line "klib-48 …"` and `grade parse_distilled_claims_with_backlinks "klib-49 …"` to the grade-call block of `cogni-knowledge/tests/test_knowledge_lib.sh`, so the two registrations at base lines 1504 and 1515 finally drive the suite's `errors` total instead of being silently invisible.
- Add **klib-50**, a permanent in-suite census that runs on every invocation and folds into `errors`: it extracts the registration-tag set and the grade-tag set from the suite's own source (`$0`) and fails on any registration-without-grade, any grade-without-registration, any duplicate on either side, or an empty extraction on either side.
- New ids continue the allocation counter — klib-01 … klib-47 exist at base (contiguous, max 47), so 48/49/50 are the next free ids. No existing klib-02 … klib-47 grade line is modified, and no registration is removed.

One file, 48 added lines, nothing deleted.

## Why the census is permanent rather than a one-time check

The issue's Desired behavior is *"no third orphan can hide"*. That is false under a one-time verification: a census run once during development constrains nothing about the next case someone adds — which is exactly how these two arose. So the census ships as a case in the suite, not as a command in this PR body.

It is **bash-only**, placed after the grade-call block and before the final `if [ $errors -gt 0 ]` arm. The python heredoc runs as a subprocess (`OUT=$(python3 - "$SCRIPTS_DIR" "$WORK" <<'PY' … PY)`) with no handle on the shell script's own source path — and more decisively, half the census's subject, the `grade` lines, exists *only* as script text and never enters that subprocess at all. `klib-01` (base 43-64) is the file's own precedent for a bash-only case. Unlike `klib-01` this one is **non-fatal**: it increments `errors` rather than `exit 1`, so the rest of the report still prints.

## The three traps it is written against

1. **`set -eu` (base line 24).** A zero-match `grep` exits 1, which under `set -e` would abort the whole suite *before* the census could print its own FAIL line — and would also leave `mutation-check.sh` with no result line to classify, reporting `case_not_found` instead of a red verdict. Every extraction is `|| true`-guarded, following the file's own precedent at base line 1536 (`… | grep "^${tag}:" || true`).
2. **Self-matching extractors.** A bare `check\(` also matches the `def check(tag, fn):` definition and a prose comment (50 hits vs the correct 48); a bare `grade` matches the `grade() {` definition at base 1533 and four comment lines using the English word "grades"/"degrades". The anchored forms give exactly 48 and 46 at base, 48 and 48 at HEAD. They also cannot match the census's *own* pattern literals: the source bytes there are an escaped paren, never a bare `check(`, and no census line begins at column 0 with `grade` followed by whitespace.
3. **Locale collation.** `comm` compares bytewise while `sort` is locale-sensitive, and the tags contain `_`, whose collation weight differs between a UTF-8 locale and C. Both sorts and both `comm` invocations are pinned to `LC_ALL=C` so the two streams cannot desynchronise on a differently-configured runner.

The two extracted sets land as files in the suite's existing `$WORK` temp dir (base line 66, already `trap`-cleaned on EXIT) rather than in shell variables. That is what lets emptiness be `[ ! -s … ]` and lets `uniq -d` / `comm` read the files directly — a variable round-trip through `printf '%s\n'` emits a phantom blank line for an empty set, which every consumer would then have to scrub separately.

## Scope decisions

- **In:** one file, `cogni-knowledge/tests/test_knowledge_lib.sh`.
- **Out:** no `_knowledge_lib.py` change, no other test file, no `plugin.json` (the patch bump is post-merge).
- **Neither orphaned assertion is weakened to reach green.** `assert_page_type_line` (base 274-293) and `assert_parse_distilled_claims_with_backlinks` (base 596-638) are byte-identical in this diff — the diff adds 48 lines and deletes none. They were already passing under the python subprocess; grading them simply makes their result count.
- **The issue's "fix any pre-existing failure surfaced by grading" criterion is vacuous here**, and that is a finding rather than an omission: the suite is exit 0 / 47 PASS / 0 FAIL at base, and exit 0 / 50 PASS / 0 FAIL with all three new cases wired. Grading the two orphans surfaced nothing red, so nothing is being re-silenced.

## Verification

Run at the branch head:

- `bash cogni-knowledge/tests/test_knowledge_lib.sh` → exit 0, **50 PASS / 0 FAIL** (47 at base + klib-48/49/50).
- Each new case prints its id as the second whitespace-separated token, per the invariant recorded at base line 49 — confirmed for `klib-48`, `klib-49`, `klib-50`.
- `grep -c '^grade page_type_line ' cogni-knowledge/tests/test_knowledge_lib.sh` → 1 at HEAD, 0 at `origin/main`; same for `'^grade parse_distilled_claims_with_backlinks '`.
- Registration-tag count and grade-tag count are both **48** at HEAD (48 / 46 at base).
- `git diff --name-only origin/main...HEAD` lists only `cogni-knowledge/tests/test_knowledge_lib.sh`; `git diff origin/main...HEAD -- '*plugin.json'` is empty.

**All five verdict arms were driven red by hand and each reported its own named bucket** — re-run after the pre-commit `/simplify` pass rewrote the block, not only before it. The file was restored between each, and the suite returns to exit 0 / 50 PASS afterwards:

| Mutation applied | Suite rc | Verdict reported |
|---|---|---|
| delete the existing `grade identity …` line | 1 | `ORPHAN-REGISTRATION … : identity` |
| add `grade nonexistent_tag "klib-98 …"` with no registration | 1 | `ORPHAN-GRADE … : nonexistent_tag` |
| duplicate the `grade identity …` line | 1 | `DUP-GRADE … : identity` |
| duplicate the `check("identity", …)` registration | 1 | `DUP-REGISTRATION … : identity` |
| rename `grade()` and all its call sites so the grade-side extractor matches nothing | 1 | `EMPTY - registrations=48 grade lines=0` |

That last row is also the direct proof of trap 1: with the extraction returning nothing, the suite *reports* rather than aborting under `set -eu`.

## Mutation recipe

Deletes the existing `grade identity …` line (base 1545). `identity` is unique as both a registration tag and a grade tag, so removing it makes the registration side strictly larger and must flip klib-50 green → red without touching any other case's grading.

Run from the root of a checkout of this branch. `mutation-check.sh` ships with `cogni-service` in the `managed-service` repo — `insight-wave`'s own `cogni-consult/scripts/mutation-check.sh` and `cogni-portfolio/scripts/mutation-check.sh` are different, bespoke scripts and are not this harness, per `cogni-knowledge/tests/README.md:69-72`:

```
bash ~/.claude/plugins/marketplaces/managed-service/cogni-service/scripts/mutation-check.sh \
  --root . \
  --file cogni-knowledge/tests/test_knowledge_lib.sh \
  --expr 's{^grade identity[ \t][^\n]*\n}{}m' \
  --test 'bash cogni-knowledge/tests/test_knowledge_lib.sh' \
  --case klib-50
```

Expected: `guard_verified` — `PASS: klib-50 …` at HEAD, `FAIL: klib-50 …` under the mutation.

## Follow-up issues

- **#1758** — cogni-knowledge: the check/grade census guards one of the three suites that share the convention.

`test_ingest_contract.sh` and `test_pdf_extract.sh` carry the same two-part convention, each with its own byte-identical `grade()`, and neither is guarded by this census. Both are balanced 4/4 today, so nothing is hiding — the exposure is future. Deliberately not folded in here: it would ship a shared helper whose only motivated caller is this file, and the repo-tier variant (`scripts/check-check-grade-pairing.py`, alongside the existing CI-wired `check-case-id-pairing.py`) lands outside this issue's `cogni-knowledge/` scope fence.

Not in scope for that follow-up, and checked: `test_refresh_resweep_contract.sh` and `test_knowledge_wiki_probe.sh` use `assert_grep` / inline `green`+`red`, where the call *is* both registration and grading; `test_control_path_flip.sh` self-grades via `sys.exit(1 if failures else 0)`. All three are structurally immune to this defect class.

## Plan record

Resolution plan: https://github.com/cogni-work/insight-wave/issues/1753#issuecomment-5504677493