### PR TITLE
cogni-workspace: business-topic ownership becomes the cut-line test

### DIFF
--- a/cogni-workspace/references/absorption-roadmap.md
+++ b/cogni-workspace/references/absorption-roadmap.md
@@ -72,7 +72,7 @@ absorption-status ledger below for the current state. A further top-level direct
 harness, not a plugin, and is correctly outside this table.
 
 **`cogni-sales` — settled.** This is the boundary case the amended rule was
-written for. `cogni-sales` sits in the "none" row on the measurement above and
+written for. `cogni-sales` was scored `none` on the measurement above and
 owns a single skill (`why-change`), so the structural reading placed it with the
 horizontal set. The topic reading places it with the verticals: selling is a
 distinct business topic a user names as their own work, not a tool other work

--- a/cogni-workspace/references/absorption-roadmap.md
+++ b/cogni-workspace/references/absorption-roadmap.md
@@ -16,13 +16,27 @@ recorded plainly at the point it matters rather than smoothed over.
 
 ## Decision 1 — the cut line: what becomes its own plugin
 
-**Rule.** A capability that owns a full `setup → resume → dashboard` arc is a
-vertical business plugin and keeps its own plugin. A capability that owns none of
-that arc is horizontal infrastructure and belongs in cogni-workspace.
+**Rule.** A capability that owns a distinct business topic — a body of work a
+user would name as their own — is a vertical business plugin and keeps its own
+plugin. A capability that owns no such topic is a tool other plugins call: it is
+horizontal infrastructure and belongs in cogni-workspace. Owning a full
+`setup → resume → dashboard` arc is a **sufficient** condition for vertical
+status, not a **necessary** one — the arc is evidence for topic ownership, not
+the test itself.
 
-The arc is the test because it is the signature of a *project lifecycle*: state
+The arc is evidence because it is the signature of a *project lifecycle*: state
 that a user initializes, returns to across sessions, and inspects. A capability
-with a lifecycle has something to own. One without is a tool other plugins call.
+with a lifecycle has a topic to own. The converse does not follow — a capability
+can own a topic and not yet have built the arc for it — so the arc was always a
+structural proxy for the semantic property, and a proxy mistaken for the rule
+fails at exactly the boundary it was never calibrated on. Where the topic
+reading and the structural reading disagree, topic wins.
+
+Demoting the arc to evidence leaves the calls made under the earlier wording
+standing. The four "none" rows below other than `cogni-sales` — `cogni-claims`,
+`cogni-copywriting`, `cogni-narrative` and `cogni-visual` — each fail the topic
+test as well as the arc test: they are tools other work calls, not bodies of
+work a user would name.
 
 **Measured across the plugin set** — `git ls-tree -r --name-only origin/main`,
 matching `<plugin>/skills/*/SKILL.md` against the `*-setup` / `*-resume` /
@@ -57,10 +71,16 @@ absorption-status ledger below for the current state. A further top-level direct
 `cogni-portfolio-evals/`, ships no `.claude-plugin/plugin.json` — it is an eval
 harness, not a plugin, and is correctly outside this table.
 
-`cogni-sales` sits in the "none" row on the measurement above. It owns a single
-skill (`why-change`) and no lifecycle arc, so the rule places it with the
-horizontal set even though it reads as a business capability by name. Recorded
-explicitly because it is the one row where the rule and the intuition disagree.
+**`cogni-sales` — settled.** This is the boundary case the amended rule was
+written for. `cogni-sales` sits in the "none" row on the measurement above and
+owns a single skill (`why-change`), so the structural reading placed it with the
+horizontal set. The topic reading places it with the verticals: selling is a
+distinct business topic a user names as their own work, not a tool other work
+calls. Topic wins, so `cogni-sales` keeps its own plugin and nothing moves. The
+consolidation epic deferred this case rather than settling it; that deferral is
+discharged here. Noted and not scheduled: `cogni-sales` owns no lifecycle arc,
+unlike its GTM sibling `cogni-marketing` — that reads as underbuilt, not
+misplaced.
 
 ## Absorption status
 


### PR DESCRIPTION
Closes #1700.

## Summary

- `cogni-workspace/references/absorption-roadmap.md` §"Decision 1 — the cut line": the **Rule** (base lines 19-21) now states business-topic ownership as the primary test, and states explicitly that owning a full `setup → resume → dashboard` arc is a **sufficient** condition for vertical status, not a **necessary** one.
- The arc-justification paragraph (base lines 23-25) is rewritten rather than left standing: it presents the arc as *evidence* for the topic property, records that the proxy fails at the boundary it was never calibrated on, and carries the unhedged ruling — where the topic reading and the structural reading disagree, **topic wins**.
- A short paragraph confirms the amendment leaves every prior absorption call intact: the four "none" rows other than `cogni-sales` — `cogni-claims`, `cogni-copywriting`, `cogni-narrative`, `cogni-visual` — fail the topic test as well as the arc test.
- The `cogni-sales` paragraph (base lines 60-63) is replaced by a settled record: `cogni-sales` keeps its own plugin, nothing moves, the consolidation epic's deferral is discharged, and its missing lifecycle arc is recorded as noted-and-not-scheduled — underbuilt, not misplaced.

## Scope decisions

- **In:** exactly three edit sites, all inside §"Decision 1" (base 17-64), in one file. Base lines 23-25 are in scope on the strength of the committed review contract (item 11), even though no acceptance criterion names them: leaving the "The arc is the test because…" justification standing beside a topic-primary rule would preserve the contradiction the ruling exists to remove.
- **Left exactly as measured:** the measurement preamble and scoring table (base 27-43), per AC5 — it is the point-in-time record and is explicitly not re-scored. The `cogni-workspace` exemption note (45-47) and the "**On the plugin count.**" paragraph (49-58) are likewise byte-identical.
- **Out:** no plugin moves and no plugin-count claim anywhere in the repo is altered — `.claude-plugin/marketplace.json`, `CLAUDE.md`, `CONTRIBUTING.md`, `README.md`, both wiki trees and `docs/**` are untouched, so the roster stays at 8 by construction (AC6). `cogni-sales/**` is untouched.
- **Out (noted, not scheduled):** the structural-rule restatements at `cogni-workspace/CLAUDE.md:7`, `concept-four-layer-architecture.md:13` in **both** wiki trees, and `docs/architecture/er-diagram.md:9` are outside the fence the acceptance criteria set. They are not edited and no follow-up pointer is planted for them — the ruling is explicit that no follow-up issue should be filed.
- **No `plugin.json` version bump** — the patch bump is post-merge.

## Verification run against this branch

| Check | Result |
|---|---|
| `git diff --stat origin/main` | exactly 1 file changed, +30 −10 |
| Table untouched (AC5): `git diff origin/main -- <file> \| grep -E '^[-+]\|'` | no output — and the diff is non-empty (`30 10` numstat), so the green is not vacuous |
| Frozen region base 27-58 byte-identical | `diff` against `git show origin/main:<file>` — identical |
| Highest **base** line actually removed | 63 (§"Absorption status" starts at 65, so nothing at or after it is touched) |
| Numeric plugin-count claim in any changed line | none |
| Follow-up pointer (`#N` / TODO / backlog) added | none |
| `python3 scripts/run-plugin-tests.py --filter cogni-workspace` | 20/20 suites pass — including `test-de-ascii-orthography.sh`, which scans this file, and `test-layering-claim-reconciled.sh`, which allowlists it |

Anchor integrity: each of the three replaced blocks was asserted to occur **exactly once** at `origin/main@07ef9f9c` before the replacement, and zero times after.

## Notes for the reviewer

- The `plan-refiner` pass caught a false claim in the first-pass prose: it had listed `cogni-help` among plugins failing "the arc test", but `cogni-help` has no row in the scoring table and was never arc-tested. The shipped enumeration is anchored to the table's own four non-`cogni-sales` "none" rows.
- Open #1756 targets the same file at base line 73 (the `cogni-help` row in §"Absorption status"). Content-disjoint from this diff; mechanical conflict risk only if both land concurrently.