### PR TITLE
repo + cogni-trends: drop narrative-review's removed 0-100 composite and A-F grade

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Each plugin implements an established framework (Corporate Visions, Double Diamo
 
 > "Create a slide deck from the sales presentation, then enrich the trend report with charts and diagrams"
 
-**Narrative and executive copy.** The `narrative` skill transforms structured content into executive narratives using 11 story arc frameworks with quality scoring (0-100, A-F grades), and the `copywriter` skill polishes any document for executive readability using 7 messaging frameworks (BLUF, Pyramid, SCQA, STAR, PSB, FAB, Inverted Pyramid) with 5 parallel stakeholder personas to catch blind spots.
+**Narrative and executive copy.** The `narrative` skill transforms structured content into executive narratives using 11 story arc frameworks, reviewed by `narrative-review` for a per-gate pass/warn/fail verdict plus the top three actionable fixes, and the `copywriter` skill polishes any document for executive readability using 7 messaging frameworks (BLUF, Pyramid, SCQA, STAR, PSB, FAB, Inverted Pyramid) with 5 parallel stakeholder personas to catch blind spots.
 
 **Source verification.** The `claims` skill verifies whether sourced claims match what their cited sources actually say — catching misquotations, unsupported conclusions, selective omissions, and stale data. Other plugins register claims during generation; cogni-workspace fetches each source and flags deviations for your review.
 

--- a/cogni-trends/skills/trend-synthesis/references/story-arc-loop.md
+++ b/cogni-trends/skills/trend-synthesis/references/story-arc-loop.md
@@ -21,8 +21,8 @@ make that the case.
    sample report — scores the report itself.
 3. Map each of the top three improvements to the SKILL.md sections that
    produced the weak guidance, then edit those sections.
-4. Re-score. The loop terminates when `overall_score >= 75` and no gate is
-   marked `fail`, or when the iteration cap is reached.
+4. Re-score. The loop terminates when no gate is marked `fail`, or when
+   the iteration cap is reached.
 
 ## Iteration log — first pass
 


### PR DESCRIPTION
Closes #1715.

## Summary

- **`README.md:26`** — replaced the `quality scoring (0-100, A-F grades)` parenthetical with the vocabulary `narrative-review` actually emits after #1646: a per-gate pass/warn/fail verdict plus the top three actionable fixes. Everything else in the sentence is preserved verbatim (`11 story arc frameworks`, the `copywriter` skill, `7 messaging frameworks`, the BLUF/Pyramid/SCQA/STAR/PSB/FAB/Inverted Pyramid list, `5 parallel stakeholder personas`).
- **`cogni-trends/skills/trend-synthesis/references/story-arc-loop.md:24-25`** — dropped the `overall_score >= 75` conjunct from the loop-termination predicate, leaving the already-satisfiable sibling conjunct (no gate marked `fail`).

The predicate is **one sentence spanning both lines**, not line 24 alone, so it is re-wrapped in place across the same two lines. That is load-bearing rather than cosmetic: a one-line collapse measures 101 characters (over the file's prose wrap) **and would renumber the iteration log to 26-119**. Because the acceptance criterion names the *range* `27-120`, that shift falsifies it even though the log's bytes are untouched. Two lines in, two lines out holds the log at exactly 27-120.

## Scope decisions

**The re-run instructions at `story-arc-loop.md:122-137` are deliberately left unchanged — a decision, not an omission.** That block never used the stale vocabulary: no `0-100`, no `A-F`, no `overall_score`, no letter grade. `:130` "Persist the scorecard" remains **accurate** — #1646 removed the composite number and the letter grade, not the markdown scorecard artifact `narrative-review` still writes (`narrative-review/SKILL.md:41`, `:120`, and the "narrative scorecard" trigger phrase at `:3`). `:133` "Terminate when the scorecard passes" is already gate-verdict-shaped. That criterion is satisfied by an empty diff in the range; inventing a score-gated predicate there in order to then remove it would introduce the very defect this issue closes.

Two further no-touch decisions inside the protected log, both flagged so they read as adjudicated rather than missed:

- **`:119` `Loop terminated at iteration 3 with score 84/100`** is a surviving composite assertion, but it sits *inside* the byte-identical range and the criterion mandates preserving it. It is a historical record of a run that really did emit that value.
- **`:150` `reviewer score`** is generic historical rationale about a discarded runtime draft, not the literal `overall_score` token, and sits outside the fence.

The iteration log at `:27-120` is left byte-identical, including its `overall_score` values at `:33`/`:69`/`:103`.

## Scope boundary

The diff touches only repo-root `README.md` and `cogni-trends/skills/trend-synthesis/**` — nothing under `cogni-workspace/**` or `docs/**`, which #1646 already reconciled inside its AC10 fence.

A repo-wide sweep (620 raw hits across `0-100`, `A-F`, `overall_score`, `letter grade`, `quality scoring`, `/100`, `composite`) found **no third out-of-fence surface** making this claim, so the two-surface scope is complete. Genuinely different, still-numeric scorers are untouched: `cogni-trends/agents/trend-candidate-reviewer.md`, `brief-review-assessor`, `copy-reader`, `review-brief`, and the cogni-portfolio / cogni-sales review-assessors. The diff adds no new assertion that `narrative-review` emits a composite, 0-100 score, point total, or letter grade.

## Verification (all run on this branch)

| Check | Result |
|---|---|
| `python3 scripts/run-plugin-tests.py --filter cogni-trends` | rc=0, `total=4`, `passed=4`, `failed=0` |
| `python3 scripts/check-breadcrumbs.py` | rc=0, `violations: []` |
| `python3 scripts/check-readme-inventory-sync.py` | rc=0, `success: true` |
| `sed -n '26p' README.md \| grep -E '0-100\|A-F'` | no match |
| `sed -n '26p' README.md` contains `pass`, `warn`, `fail` | all three present |
| `grep -n overall_score story-arc-loop.md` | only `:33`, `:69`, `:103` — all inside the protected log |
| `cmp` of lines 27-120 vs base | **identical**, 3795 bytes |
| `cmp` of lines 122-137 vs base | **identical**, 849 bytes |
| `git diff -U0` hunk range | `@@ -24,2 +24,2 @@` — 2 lines in, 2 lines out |

No `plugin.json` version bump — the post-merge workflow owns it.

Plan record: https://github.com/cogni-work/insight-wave/issues/1715#issuecomment-5507067527