### PR TITLE
lint.yml: unmask the version-bump gate's diagnostics with set +e

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -62,7 +62,14 @@ jobs:
 
       - name: Assert no plugin version was touched on this branch
         run: |
+          set +e
           set -uo pipefail
+          # `set +e` above is load-bearing and must stay first. Actions runs this
+          # block as `bash -e {0}`, so -e is inherited before line 1 executes, and
+          # `set -uo pipefail` does NOT clear an inherited -e — only `set +e` does.
+          # Without it the guard's non-zero exit aborts the step at the capture
+          # below: a bare red with no envelope, no violation list, no fix hint.
+          # The failing status is preserved by the terminal `exit "$rc"`, not by -e.
           python3 scripts/check-version-bump.py > version-gate.json 2> version-gate.err
           rc=$?
           cat version-gate.json


### PR DESCRIPTION
Closes #1766.

## Summary

The version-bump gate's `run:` block suppressed its own diagnostics on every non-zero path. GitHub Actions runs a `run:` block as `bash -e {0}`, and `set -uo pipefail` does **not** clear an inherited `-e` — only `set +e` does. So the moment `check-version-bump.py` exited non-zero, `-e` aborted the step at the capture line: `rc=$?`, both `cat`s, the `rc -eq 2` normalization and the terminal `exit "$rc"` never ran. The build went red with an empty log — no envelope, no violation list, no fix hint.

This inserts `set +e` as the block's first executable statement, immediately above the existing `set -uo pipefail`, with the rationale in a comment directly below the pair. The failing status is preserved by the block's existing terminal `exit "$rc"`, not by `-e`, so a failing gate stays red.

Nothing else in the block changes. Both `cat`s, the `rc -eq 2` → `::error::version-bump gate errored` → `exit 1` arm, the degraded-vacuity heredoc with `vrc=$?` and `[ "$vrc" -eq 0 ] || exit 1`, and the terminal `exit "$rc"` are byte-identical; the checkout's `fetch-depth: 0` and `ref:` lines are untouched. `scripts/check-version-bump.py` is not modified. No `shell:` key was added — an explicit `shell: bash` supplies `--noprofile --norc -eo pipefail` and would **re-arm** `-e` — and there is no `continue-on-error:`, no `|| true`, no unconditional `exit 0`.

Changed paths: `.github/workflows/lint.yml` only (7 insertions).

**Ordering note.** The comment sits *below* the two `set` lines deliberately, so `set +e` and `set -uo pipefail` read as one adjacent pair and both stay inside a short `grep -A4` window on the step name. A comment wedged above either one pushes `set -uo pipefail` out of that window.

## Scope decisions

The issue's Scope clause says to check for other `run:` blocks sharing the pattern and "name them here rather than fixing them silently". Two readings exist — attach the negation to *silently* (fix and name), or to the whole clause (name, do not fix). **This PR takes the narrower reading**: the title, the Problem section and all four acceptance criteria are scoped to this one gate, and `cogni-version-bump.yml` "Apply the patch bump" is post-merge *write* behaviour whose fix changes which downstream steps run — that deserves its own verification, not a ride-along in a diagnostics PR.

The other affected blocks are named below **and filed as #1767**, so naming does not mean losing them.

## Sweep — every other `run:` block in `.github/workflows/`

All four workflow files re-enumerated (`cla.yml`, `cogni-version-bump.yml`, `lint.yml`, `workflow-guard.yml`).

| Workflow | Job / step | Lines | Verdict | Action here |
|---|---|---|---|---|
| `lint.yml` | `version-bump-gate` / "Assert no plugin version was touched on this branch" | 63–93 | **Affected** — the reported instance | **Fixed** |
| `lint.yml` | `plugin-test-suites` / "Discover and run every plugin and repo-root test suite" | 116–134 | **Affected** | Named, tracked in #1767 |
| `cogni-version-bump.yml` | `bump` / "Apply the patch bump" | 141–183 | **Affected** | Named, tracked in #1767 |
| `cogni-version-bump.yml` | `bump` / "Commit, verify, and push" | 185–284 | **NOT affected** | Untouched |
| `cogni-version-bump.yml` | `bump` / "Compute the touched-file set" | 88–139 | Not affected — its risky call is guarded by `if ! git diff` | Untouched |
| `lint.yml` (×10), `cla.yml`, `workflow-guard.yml` | single-command guard steps | — | Not affected — `set -euo pipefail` by design, one bare unredirected command as the last statement, so an early abort loses no diagnostics | Untouched |

**`plugin-test-suites` (116–134)** additionally carries a *false comment* at 118–119: "Not `set -e`: the runner's exit code is the result we report on, so it must be captured rather than abort the step." That is precisely the property the code does not have — not writing `set -e` does not clear an inherited one. The correction belongs with the fix, in #1767.

**`Apply the patch bump` (141–183)** is the highest-stakes of the three: the abort precedes `count` (175) and `deferred_failure` (179) reaching `$GITHUB_OUTPUT`, so the `if:`-gated steps at 186 and 287 evaluate against never-set values and are **silently skipped**.

**Why "Commit, verify, and push" is explicitly not affected.** It uses the same capture idiom, but only inside `verify()` (233–249), which is invoked solely as `if ! verify` (251, 277). Bash exempts an entire function body from `-e` while the call sits in a tested context. Verified empirically. Adding `set +e` there would strip intentional early-abort protection from the step's other commands.

## Verification (AC4)

The block was extracted **programmatically from the shipped `lint.yml`** — never hand-transcribed — and executed under `bash -e` against a stubbed guard on all four exit paths, plus a falsifier.

### Extraction (verbatim, replayable from the repo root)

```bash
mkdir -p /tmp/vg && cat > /tmp/vg/extract.py <<'PY'
import sys
STEP = "- name: Assert no plugin version was touched on this branch"
lines = open(sys.argv[1]).read().split("\n")
i = next(n for n, l in enumerate(lines) if l.strip() == STEP)
j = next(n for n in range(i + 1, len(lines)) if lines[n].strip() == "run: |")
body, ind = [], None
for l in lines[j + 1:]:
    if l.strip() == "":
        body.append(""); continue
    cur = len(l) - len(l.lstrip(" "))
    if ind is None: ind = cur
    elif cur < ind: break
    body.append(l[ind:])
while body and body[-1] == "": body.pop()
sys.stdout.write("\n".join(body) + "\n")
PY
python3 /tmp/vg/extract.py .github/workflows/lint.yml > /tmp/vg/block.sh
```

Integrity assertions (both load-bearing — `<<'PY'` requires its terminator at column 0, so a dedent that left `PY` indented would make every record below a false result):

```bash
grep -qx "python3 - <<'PY'" /tmp/vg/block.sh && grep -qx 'PY' /tmp/vg/block.sh   # -> OK
wc -l < /tmp/vg/block.sh                                                          # -> 36
```

### Falsifier derivation, with non-vacuity assertions

```bash
grep -vxF 'set +e' /tmp/vg/block.sh > /tmp/vg/falsifier.sh
[ "$(( $(wc -l < /tmp/vg/block.sh) - $(wc -l < /tmp/vg/falsifier.sh) ))" -eq 1 ] || exit 1
grep -qxF 'set +e' /tmp/vg/block.sh    || exit 1
grep -qxF 'set +e' /tmp/vg/falsifier.sh && exit 1
```

`grep -v` happily emits an *unchanged* file when nothing matched, so a falsifier identical to the block would "pass" every path and evidence nothing. These three assertions are what rule that out. `-x -F` is whole-line fixed-string, so it removes the bare statement and leaves the comment lines mentioning `set +e` intact.

### Stub harness

The stub is a `python3` **shim on PATH that dispatches on argv**, not a bare replacement interpreter. This matters: the block invokes `python3` twice — once for the guard and once for its own `python3 - <<'PY'` vacuity check — so a stub answering every `python3` call would swallow the vacuity check and make the degraded path unexercisable.

```bash
cat > /tmp/vg/bin/python3 <<'SH'
#!/usr/bin/env bash
if [ "${1:-}" = "scripts/check-version-bump.py" ]; then
  printf '%s' "$STUB_STDOUT"; printf '%s' "$STUB_STDERR" >&2; exit "$STUB_RC"
fi
exec "$REAL_PY" "$@"
SH
```

Payloads are passed through the environment, so no shell quoting or heredoc interpolation can mangle the JSON.

### Observed results

```
SHIPPED BLOCK (36 lines, extracted from .github/workflows/lint.yml)

Path 1 clean — stub exit 0
  stdout (124 bytes):
    {"success": true, "data": {"status": "clean", "violations": []}, "error": ""}version-bump gate ran for real (status: clean)
  stderr (25 bytes):
    version-bump gate: clean
  block exit: 0

Path 2 violation — stub exit 1
  stdout (175 bytes):
    {"success": false, "data": {"status": "clean", "violations": [{"plugin":"cogni-trends","kind":"version-touched"}]}, "error": ""}version-bump gate ran for real (status: clean)
  stderr (180 bytes):
    FAIL: 1 version violation(s):
      - cogni-trends/.claude-plugin/plugin.json: version touched on a feature branch
    Fix: revert the version line; the post-merge workflow owns the bump.
  block exit: 1

Path 3 script-error — stub exit 2
  stdout (106 bytes):
    {"success": false, "data": null, "error": "marketplace.json not found"}::error::version-bump gate errored
  stderr (0 bytes):
    (empty)
  block exit: 1

Path 4 degraded — stub exit 0
  stdout (136 bytes):
    {"success": true, "data": {"status": "degraded", "degraded_reason": "base ref origin/main unresolvable", "violations": []}, "error": ""}  stderr (218 bytes):
    version-bump gate: base ref unresolvable
    version-bump gate is VACUOUS (status: degraded) — base ref origin/main unresolvable
    It compared nothing. This usually means fetch-depth: 0 was removed from the checkout step.
  block exit: 1

FALSIFIER (identical, set +e removed)

Path 1 clean — stub exit 0
  stdout (124 bytes):
    {"success": true, "data": {"status": "clean", "violations": []}, "error": ""}version-bump gate ran for real (status: clean)
  stderr (25 bytes):
    version-bump gate: clean
  block exit: 0

Path 2 violation — stub exit 1
  stdout (0 bytes):
    (empty)
  stderr (0 bytes):
    (empty)
  block exit: 1

Path 3 script-error — stub exit 2
  stdout (0 bytes):
    (empty)
  stderr (0 bytes):
    (empty)
  block exit: 2

Path 4 degraded — stub exit 0
  stdout (136 bytes):
    {"success": true, "data": {"status": "degraded", "degraded_reason": "base ref origin/main unresolvable", "violations": []}, "error": ""}  stderr (218 bytes):
    version-bump gate: base ref unresolvable
    version-bump gate is VACUOUS (status: degraded) — base ref origin/main unresolvable
    It compared nothing. This usually means fetch-depth: 0 was removed from the checkout step.
  block exit: 1

```

### Reading the falsifier

| path | shipped block | `set +e` removed |
|---|---|---|
| 1 clean (guard rc 0) | envelope + summary, **exit 0** | unchanged, exit 0 |
| 2 violation (guard rc 1) | envelope + FAIL list + Fix hint, **exit 1** | **0 bytes stdout, 0 bytes stderr**, exit 1 |
| 3 script error (guard rc 2) | envelope + `::error::` annotation, **exit 1** | **0 bytes stdout, 0 bytes stderr**, exit **2** |
| 4 degraded (guard rc 0) | envelope + VACUOUS message, **exit 1** | unchanged, exit 1 |

Exactly the two non-zero guard paths flip, which is the reported defect reproduced; path 3 additionally shows the lost 2-to-1 exit normalization. Paths 1 and 4 are expected to be identical — the stub exits 0 on both, so nothing aborts — and recording them is what shows the falsifier is not simply breaking everything.

## Test plan

- [x] `python3 scripts/check-workflow-yaml.py` — exit 0 (this is the repo's own workflow-YAML guard; the repo ships no PyYAML dependency, so this, not `yaml.safe_load`, is the parse check).
- [x] `python3 scripts/check-version-bump.py` — exit 0.
- [x] `python3 scripts/run-plugin-tests.py` — exit 0, 139 suites, `failed_suites: []`.
- [x] `python3 scripts/check-result-line-plainness.py` — exit 0.
- [x] `python3 scripts/check-case-id-pairing.py` — exit 0.
- [x] `git diff --name-only origin/main...HEAD` → `.github/workflows/lint.yml` only; nothing under `scripts/**`, no `plugin.json` / `marketplace.json` version line.
- [x] `grep -n -A4 'Assert no plugin version was touched' .github/workflows/lint.yml` shows `set +e` then `set -uo pipefail` on consecutive lines.

## Mutation recipe

Not applicable, stated rather than omitted: the mutation-recipe check fires when the touched set adds a guard under a `scripts/` directory. This diff touches only `.github/workflows/lint.yml` and adds no guard and no test case, so there is no committed case id to drive RED→GREEN. The attribution role a mutation recipe would play is carried here by the falsifier transcript above, which is derived from the shipped file and asserted to be a one-line delta.

## Note for the reviewer

This diff touches only a repo-root file, so `check-preflight.sh` resolves to **no plugin** and its plugin-scoped instruments grade nothing. A green preflight on this PR is not evidence about this change — the path records and the falsifier are. Please weigh those, not the preflight's exit code.

## Follow-up issues

- **#1767** — repo: two more workflow `run:` blocks suppress their diagnostics on the inherited `-e` (the two AFFECTED rows named in the sweep table above, plus the false comment at `lint.yml` 118–119).