### PR TITLE
External-dispatch guard: cover */scripts/* dispatch tokens

### DIFF
--- a/cogni-workspace/tests/test-relocated-skill-hygiene.sh
+++ b/cogni-workspace/tests/test-relocated-skill-hygiene.sh
@@ -27,9 +27,8 @@
 #   - No retired-plugin dispatch token may survive in the adopted copies. The
 #     obvious candidate guard, scripts/check-external-dispatch.py, reaches only
 #     part of that surface: its globs cover SKILL.md, agents, commands, hooks,
-#     and a skill's own scripts/*.sh and scripts/*.py, while that skill's evals/,
-#     references/ and every other file type under scripts/ match none of them.
-#     P1 below walks every file in both trees instead — the gap is one of
+#     while a skill's own scripts/, evals/ and references/ files match none of
+#     them. P1 below walks every file in both trees instead — the gap is one of
 #     file-type coverage, not of what scripts/retired-plugins.json carries.
 #   - Every `${CLAUDE_PLUGIN_ROOT}`-relative path documented in those trees must
 #     resolve under cogni-workspace. Most such paths are skill-relative and

--- a/cogni-workspace/tests/test-relocated-skill-hygiene.sh
+++ b/cogni-workspace/tests/test-relocated-skill-hygiene.sh
@@ -27,8 +27,9 @@
 #   - No retired-plugin dispatch token may survive in the adopted copies. The
 #     obvious candidate guard, scripts/check-external-dispatch.py, reaches only
 #     part of that surface: its globs cover SKILL.md, agents, commands, hooks,
-#     while a skill's own scripts/, evals/ and references/ files match none of
-#     them. P1 below walks every file in both trees instead — the gap is one of
+#     and a skill's own scripts/*.sh and scripts/*.py, while that skill's evals/,
+#     references/ and every other file type under scripts/ match none of them.
+#     P1 below walks every file in both trees instead — the gap is one of
 #     file-type coverage, not of what scripts/retired-plugins.json carries.
 #   - Every `${CLAUDE_PLUGIN_ROOT}`-relative path documented in those trees must
 #     resolve under cogni-workspace. Most such paths are skill-relative and

--- a/docs/contributing/plugin-absorption-slicing.md
+++ b/docs/contributing/plugin-absorption-slicing.md
@@ -111,8 +111,11 @@ edit generated wiki output for any other purpose in an absorption — regenerate
 
 `scripts/check-external-dispatch.py` enforces a hard clean-zero — no ratchet, no
 baseline — for every prefix listed in `scripts/retired-plugins.json`, across
-`*/skills/*/SKILL.md`, `*/agents/*.md`, `*/commands/*.md` and `*/hooks/**`. Directories
+`*/skills/*/SKILL.md`, `*/agents/*.md`, `*/commands/*.md`, `*/hooks/**`,
+`*/scripts/*.sh` and `*/scripts/*.py`. Directories
 named `references/` and `docs/` are excluded by design, so lineage prose is safe.
+The scripts surface is enumerated by executable extension rather than as a bare
+`*/scripts/*`; the guard's own header says why.
 
 Add the source prefix to the registry **in stage 3, never earlier**. Register it while
 stage 2 is still in flight and every not-yet-rewritten consumer becomes a build failure.

--- a/scripts/check-external-dispatch.py
+++ b/scripts/check-external-dispatch.py
@@ -70,8 +70,20 @@ Scope — the surfaces a running session actually dispatches FROM:
   - */agents/*.md         (agent prompts)
   - */commands/*.md       (slash-command definitions)
   - */hooks/**            (lifecycle hooks: *.sh / *.py / *.json)
+  - */scripts/*.sh        (plugin- and skill-owned shell scripts)
+  - */scripts/*.py        (plugin- and skill-owned python scripts)
 
 Excluded, by design (NOT live-dispatch surfaces):
+
+  - any OTHER file type under */scripts/
+                                    the scripts surface is enumerated by
+                                    executable extension, so a README or a data
+                                    file beside a script is out of scope. Note
+                                    this is NOT a general file-type rule: a
+                                    hooks *.json IS a dispatch surface, which is
+                                    why */hooks/** stays type-agnostic above.
+                                    The distinction is config-that-dispatches
+                                    versus data, not extension.
 
   - cogni-knowledge/                its delegation-contract / references
                                     legitimately NAME the retired plugins as
@@ -118,12 +130,39 @@ import subprocess
 import sys
 
 # git ls-files pathspec globs for the live-dispatch surfaces.
+#
+# The scripts surface is enumerated by executable extension rather than as a bare
+# */scripts/* glob. The primary reason is scope: an executable script is a caller,
+# while a README or a data file sitting beside it is not.
+#
+# It also sidesteps a decode hazard on this surface, though only on this one. A
+# git pathspec * crosses /, so */scripts/* would also match the two bytecode
+# files tracked under cogni-portfolio-evals/scripts/__pycache__/, and scan_file()
+# re-raises the resulting UnicodeDecodeError as a RuntimeError that main() renders
+# as exit 2 — one tracked binary would take the whole run down on a decode error
+# instead of reporting a dispatch finding. Do NOT read that as a property this
+# enumeration establishes guard-wide: */hooks/* and */hooks/*/* are already
+# type-agnostic and already carry the identical exposure, verified by observation.
+# Closing it properly means changing scan_file()'s decode policy, which is out of
+# scope here and filed separately.
+#
+# The remedy lives in discovery, not in scan_file(): an explicit-file invocation
+# naming an undecodable path still exits 2, by design.
+#
+# Mutation-recipe invariant: the two extension entries in the list below are each
+# anchored by a recorded recipe in tests/test_check_external_dispatch.sh, and
+# mutation-check.sh substitutes the FIRST match only. Do not repeat either entry's
+# text anywhere else in this file — a second occurrence is mutated instead of the
+# glob, and the recipe then reports a live assertion as decorative. State the
+# invariant positionally, as this comment does; never spell an entry's text.
 DEFAULT_GLOBS = [
     "*/skills/*/SKILL.md",
     "*/agents/*.md",
     "*/commands/*.md",
     "*/hooks/*",
     "*/hooks/*/*",
+    "*/scripts/*.sh",
+    "*/scripts/*.py",
 ]
 
 # Path-prefix excludes (own trees + the history-bearing FMO plugin).

--- a/tests/test_check_external_dispatch.sh
+++ b/tests/test_check_external_dispatch.sh
@@ -38,7 +38,7 @@
 # registry cases R1-R6 (R1 -> ed10/ed11, R2 -> ed12/ed13, R3 -> ed14,
 # R4 -> ed15, R5 -> ed16/ed17, R6 -> ed18/ed19), `ed20`-`ed33` for the
 # unresolved-target arm, `ed34`-`ed36` for its per-plugin pair binding and
-# `ed37`-`ed39` for the scripts-surface discovery cases.
+# `ed37`-`ed41` for the scripts-surface discovery cases.
 # `R1`-`R6` remain the names of
 # the LOGICAL case groups in the header notes and the section dividers below;
 # they are not ids and must never be emitted as one. Never introduce an
@@ -47,7 +47,7 @@
 # `R`-stemmed id in this file would be ambiguous in any harness run whose
 # `--test` captures both suites. The whole-token matching rule the ids depend
 # on is stated once, with the regex, above the registry cases below. A new
-# assertion takes the next free id — `ed40` onward — never a renumbering and
+# assertion takes the next free id — `ed42` onward — never a renumbering and
 # never an `R`-stemmed id.
 #
 # Mutation recipe (proves the per-plugin pair binding is load-bearing):
@@ -712,6 +712,12 @@ printf -- '#!/usr/bin/env python3\n"""Dispatches cogni-foo:s, which resolves."""
 # on it today: it is a regression fence against a future widening, not a file
 # the guard actively skips. The ed37 recipe in the header is what gives it teeth.
 printf '\377\376\000\001' > "$SXC/cogni-foo/scripts/blob.bin"
+# The head incident as filed, placement and extension included: the two tracked
+# files are cogni-portfolio-evals/scripts/__pycache__/*.cpython-314.pyc. A git
+# pathspec *.py does not match a *.pyc suffix, so the extension-scoped globs
+# never discover this either — which is the property ed37's exit 1 pins.
+mkdir -p "$SXC/cogni-foo/scripts/__pycache__"
+printf '\377\376\000\001' > "$SXC/cogni-foo/scripts/__pycache__/mod.cpython-314.pyc"
 git -C "$SXC" add -A >/dev/null 2>&1
 git -C "$SXC" commit -qm init >/dev/null 2>&1
 
@@ -743,6 +749,55 @@ import json,sys
 d=json.load(sys.stdin)
 assert d['data']['scanned']['files']==3, d['data']['scanned']
 assert d['data']['scanned']['tokens']==2, d['data']['scanned']
+"
+
+# --- ed40-ed41: the clean-tree controls. This tree carries NO violation, which
+# --- is what lets ed40 assert total==0 — the fixture above cannot, since its
+# --- whole point is to produce a finding.
+SXC2="$WORK/scriptsxc2"
+mkdir -p "$SXC2/.claude-plugin"
+git -C "$SXC2" init -q
+git -C "$SXC2" config user.email t@t.test
+git -C "$SXC2" config user.name test
+mkdir -p "$SXC2/cogni-foo/skills/s" "$SXC2/cogni-foo/scripts" "$SXC2/cogni-knowledge/scripts"
+printf '%s' '{"plugins":[{"name":"cogni-foo","source":"./cogni-foo"},{"name":"cogni-knowledge","source":"./cogni-knowledge"}]}' \
+  > "$SXC2/.claude-plugin/marketplace.json"
+printf -- '---\nname: s\n---\nNo dispatch token here, so the token count below is attributable to the script.\n' \
+  > "$SXC2/cogni-foo/skills/s/SKILL.md"
+# AC3 control, co-located as the acceptance bar requires: the colonless slash
+# command and a genuinely RESOLVABLE token share one file, and the tree produces
+# no finding — so total==0 is the slash command being correctly ignored, while
+# tokens>=1 proves the file was actually read rather than skipped.
+printf -- '#!/usr/bin/env bash\n# Prose: run /copywrite to polish the report.\nadd_action "cogni-foo:s" "resolves"\n' \
+  > "$SXC2/cogni-foo/scripts/clean.sh"
+# EXCLUDE_PREFIXES is newly load-bearing under the widened globs: this file
+# matches */scripts/*.py and carries a RETIRED-arm token, so without the
+# cogni-knowledge/ prefix exclude it would fire. Pinned explicitly rather than
+# left to ride on some other case exiting 0.
+printf -- '# Vendored engine history: cogni-wiki:wiki-ingest was dispatched here.\n' \
+  > "$SXC2/cogni-knowledge/scripts/vendored.py"
+git -C "$SXC2" add -A >/dev/null 2>&1
+git -C "$SXC2" commit -qm init >/dev/null 2>&1
+
+set +e
+OUT2=$(python3 "$GUARD" --root "$SXC2" 2>/dev/null)
+set -e
+assert_json "ed40 a colonless slash command beside a resolvable token yields no finding on a read file" "$OUT2" "
+import json,sys
+d=json.load(sys.stdin)
+assert d['data']['summary']['total']==0, d['data']['violations']
+assert d['data']['scanned']['tokens']>=1, d['data']['scanned']
+"
+# files==2 is the attribution: cogni-foo/skills/s/SKILL.md and
+# cogni-foo/scripts/clean.sh were discovered, while
+# cogni-knowledge/scripts/vendored.py matched */scripts/*.py and was dropped by
+# EXCLUDE_PREFIXES before scan_file() ever opened it. A third file here would
+# mean the exclude stopped holding under the widened globs.
+assert_json "ed41 a retired-arm token under cogni-knowledge/scripts is excluded under the widened globs" "$OUT2" "
+import json,sys
+d=json.load(sys.stdin)
+assert d['data']['scanned']['files']==2, d['data']['scanned']
+assert d['data']['summary']['total']==0, d['data']['violations']
 "
 
 echo ""

--- a/tests/test_check_external_dispatch.sh
+++ b/tests/test_check_external_dispatch.sh
@@ -2,7 +2,8 @@
 # test_check_external_dispatch.sh — self-test for the external-dispatch guard.
 #
 # The guard asserts a HARD clean-zero: no live-dispatch surface
-# (*/skills/*/SKILL.md, */agents/*.md, */commands/*.md, */hooks/**) may carry a
+# (*/skills/*/SKILL.md, */agents/*.md, */commands/*.md, */hooks/**,
+# */scripts/*.sh, */scripts/*.py) may carry a
 # dispatch token for a prefix listed in scripts/retired-plugins.json. Cases:
 #   1. Negative controls (bare noun "cogni-research" with no colon) -> exit 0.
 #   2. Dispatch-laden fixture (cogni-wiki: + cogni-research:) -> exit 1, naming
@@ -36,7 +37,8 @@
 # this file is `edNN`: `ed01`-`ed09` for cases 1-5, `ed10`-`ed19` for the
 # registry cases R1-R6 (R1 -> ed10/ed11, R2 -> ed12/ed13, R3 -> ed14,
 # R4 -> ed15, R5 -> ed16/ed17, R6 -> ed18/ed19), `ed20`-`ed33` for the
-# unresolved-target arm and `ed34`-`ed36` for its per-plugin pair binding.
+# unresolved-target arm, `ed34`-`ed36` for its per-plugin pair binding and
+# `ed37`-`ed39` for the scripts-surface discovery cases.
 # `R1`-`R6` remain the names of
 # the LOGICAL case groups in the header notes and the section dividers below;
 # they are not ids and must never be emitted as one. Never introduce an
@@ -45,7 +47,7 @@
 # `R`-stemmed id in this file would be ambiguous in any harness run whose
 # `--test` captures both suites. The whole-token matching rule the ids depend
 # on is stated once, with the regex, above the registry cases below. A new
-# assertion takes the next free id — `ed37` onward — never a renumbering and
+# assertion takes the next free id — `ed40` onward — never a renumbering and
 # never an `R`-stemmed id.
 #
 # Mutation recipe (proves the per-plugin pair binding is load-bearing):
@@ -62,6 +64,30 @@
 # the guard — an invariant the guard's own comment above the line states.
 # ed22 CANNOT carry this recipe: its token `cogni-beta:no-such-thing` resolves
 # under no plugin, so it stays green when the binding is loosened back.
+#
+# Mutation recipe (proves the scripts-surface glob is load-bearing):
+#   scripts/mutation-check.sh --root . \
+#     --file scripts/check-external-dispatch.py \
+#     --expr 's/\*\.sh",/*.shx",/' \
+#     --test 'bash tests/test_check_external_dispatch.sh' --case ed38
+#
+# The substitution renames the shell-script glob entry to a suffix nothing
+# matches, so the fixture's scripts/helper.sh stops being discovered, its
+# unresolved token disappears, `summary.total` drops to 0 and ed38 goes red.
+# Both recipes here substitute the first match only, which is safe only while
+# each entry's text occurs exactly once in the guard — an invariant stated
+# positionally above DEFAULT_GLOBS.
+#
+# Mutation recipe (proves the EXTENSION-SCOPING is load-bearing):
+#   scripts/mutation-check.sh --root . \
+#     --file scripts/check-external-dispatch.py \
+#     --expr 's/"\*\/scripts\/\*\.py",/"*\/scripts\/*",/' \
+#     --test 'bash tests/test_check_external_dispatch.sh' --case ed37
+#
+# The substitution widens the python-script entry to a bare */scripts/* glob,
+# which a git pathspec's * makes match the fixture's scripts/blob.bin too. The
+# guard then opens that binary and the run exits 2 instead of 1 — ed37 goes red.
+# This is what gives the binary fixture teeth.
 
 set -eu
 
@@ -654,6 +680,69 @@ assert d['data']['scanned']['tokens']==3, d['data']['scanned']
 matches=[o['match'] for o in d['data']['violations']]
 assert 'cogni-beta:beta-only' not in matches, matches
 assert 'cogni-alpha:xcaller' not in matches, matches
+"
+
+# --- ed37-ed39: the scripts surface is discovered. Everything here runs in
+# --- DISCOVER mode (no explicit file argument) on purpose: collect() takes the
+# --- explicit-files branch whenever one is passed, skipping discover_files()
+# --- and therefore DEFAULT_GLOBS entirely — so an explicit-file case would pass
+# --- byte-identically at base and prove nothing about the widening. This is its
+# --- own git-initialized tree; the non-git fixtures above cannot be discovered
+# --- at all, and the shared ones carry hard equality assertions a new file flips.
+SXC="$WORK/scriptsxc"
+mkdir -p "$SXC/.claude-plugin"
+git -C "$SXC" init -q
+git -C "$SXC" config user.email t@t.test
+git -C "$SXC" config user.name test
+mkdir -p "$SXC/cogni-foo/skills/s" "$SXC/cogni-foo/scripts"
+printf '%s' '{"plugins":[{"name":"cogni-foo","source":"./cogni-foo"}]}' \
+  > "$SXC/.claude-plugin/marketplace.json"
+printf -- '---\nname: s\n---\nThe only resolvable target in this tree.\n' \
+  > "$SXC/cogni-foo/skills/s/SKILL.md"
+# The dangling token lives ONLY here, in a shell script — the shape that was
+# structurally invisible before the widening. The slash-command line is the AC3
+# negative control: it carries no colon, so it is never dispatch-shaped.
+printf -- '#!/usr/bin/env bash\nadd_action "cogni-foo:no-such-thing" "dangling"\n# Prose: run /copywrite to polish the report.\n' \
+  > "$SXC/cogni-foo/scripts/helper.sh"
+printf -- '#!/usr/bin/env python3\n"""Dispatches cogni-foo:s, which resolves."""\n' \
+  > "$SXC/cogni-foo/scripts/tool.py"
+# Undecodable bytes directly under scripts/ — NOT under __pycache__, so this
+# fixture falsifies a bare */scripts/* glob AND a __pycache__-only exclude.
+# The extension-scoped globs never discover it, so no assertion here can go red
+# on it today: it is a regression fence against a future widening, not a file
+# the guard actively skips. The ed37 recipe in the header is what gives it teeth.
+printf '\377\376\000\001' > "$SXC/cogni-foo/scripts/blob.bin"
+git -C "$SXC" add -A >/dev/null 2>&1
+git -C "$SXC" commit -qm init >/dev/null 2>&1
+
+set +e
+OUT=$(python3 "$GUARD" --root "$SXC" 2>/dev/null)
+CODE=$?
+set -e
+# Exit 1 also proves nothing discovered here hit scan_file()'s decode path,
+# which exits 2 — so exit 1 is incompatible with blob.bin having been read.
+check "ed37 a dangling token in a */scripts/*.sh file is discovered and flagged (exit 1, so nothing hit the decode path)" \
+  "$([ "$CODE" -eq 1 ] && echo 0 || echo 1)"
+assert_json "ed38 the finding names the scripts file, the unresolved arm and the token" "$OUT" "
+import json,sys
+d=json.load(sys.stdin)
+assert d['data']['summary']['total']==1, d['data']['violations']
+o=d['data']['violations'][0]
+assert o['file']=='cogni-foo/scripts/helper.sh', o
+assert o['arm']=='unresolved-target', o
+assert o['match']=='cogni-foo:no-such-thing', o
+"
+# tokens: scan_file increments tokens_examined for EVERY target_re match, before
+# the resolvability gate — so helper.sh's unresolved token and tool.py's
+# resolvable cogni-foo:s contribute one each, while the SKILL.md and the
+# colonless /copywrite prose line contribute none. Without this count the case
+# could not tell 'the slash command was correctly ignored' from 'the file was
+# never read'. files==3 is the positive pin that blob.bin was never discovered.
+assert_json "ed39 both script extensions are examined and the slash-command prose contributes no token" "$OUT" "
+import json,sys
+d=json.load(sys.stdin)
+assert d['data']['scanned']['files']==3, d['data']['scanned']
+assert d['data']['scanned']['tokens']==2, d['data']['scanned']
 "
 
 echo ""


### PR DESCRIPTION
Closes #1718.

## Summary

- Add `*/scripts/*.sh` and `*/scripts/*.py` to `DEFAULT_GLOBS` in `scripts/check-external-dispatch.py`, so a `plugin:skill` token emitted from a shell or python script reaches the unresolved-target arm instead of being structurally invisible to it. That blind spot is what let the stale `cogni-workspace:copywrite` token in `cogni-trends/scripts/project-status.sh` survive PR #1695.
- Add three discover-mode cases (`ed37`–`ed39`) on their own git-initialized fixture, plus two recorded mutation recipes.
- Refresh the four prose surfaces that enumerate the glob list.

## Why extension-scoped, not a bare `*/scripts/*`

**The primary reason is scope.** An executable script is a caller; a README or a data file sitting beside it is not.

It **also** sidesteps a decode hazard, but only on this surface. A git pathspec `*` crosses `/`, so `*/scripts/*` would match the two bytecode files tracked under `cogni-portfolio-evals/scripts/__pycache__/`, and `scan_file()` re-raises the `UnicodeDecodeError` as a `RuntimeError` that `main()` renders as **exit 2** — one tracked binary would take the whole run down on a decode error rather than reporting a dispatch finding. Measured at head: the 100 matching files as-is → exit 2; the same set minus `__pycache__` (98 files) → exit 0.

**That hazard is not unique to `scripts/`, and this PR does not claim to close it.** `*/hooks/*` and `*/hooks/*/*` are already type-agnostic and already carry the identical exposure. Reproduced against the guard **as it stands on `main`**, with none of this PR's changes applied:

```
$ python3 scripts/check-external-dispatch.py --root /tmp/hooktest ; echo "EXIT=$?"
{"success": false, "data": {}, "error": "cannot read cogni-foo/hooks/sub/blob.bin: 'utf-8' codec can't decode byte 0xff in position 0: invalid start byte"}
EXIT=2
```

An earlier draft of this PR's comment called the extension scoping "a correctness requirement" that protects the guard from that hazard. That was an overclaim, caught by the pre-commit `/simplify` altitude pass and corrected; closing the class properly means changing the decode policy, which is filed as #1771 rather than done here.

Three alternatives were considered and rejected: `errors="replace"` on `scan_file()` (a repo-wide philosophy shift — the curated-surface guards `check-breadcrumbs.py:115` and `check-workflow-yaml.py:278` all raise hard; only the broad-surface ones use `errors="replace"`), a `__pycache__/` segment exclude (fixes two known files, does not generalize), and per-glob decode tolerance (no precedent in any of the 12 sibling guards).

**The remedy lives in discovery, not in `scan_file()`** — an explicit-file invocation naming an undecodable path still exits 2, by design.

## Why the new cases run in discover mode

`collect()` takes the explicit-files branch whenever a file argument is passed, skipping `discover_files()` and therefore `DEFAULT_GLOBS` entirely. An explicit-file case would pass **byte-identically at base** and prove nothing about the widening. The fixture is its own tree: the suite's other fixtures are either never `git init`-ed (so `git ls-files` returns nothing) or carry hard equality assertions a new file would flip.

`ed39` asserts `scanned.tokens == 2` **and** `scanned.files == 3`. The token count is the AC3 control — a zero-violation assertion alone cannot distinguish "the `/copywrite` prose was correctly ignored" from "the file was never read". The file count is the positive pin that `blob.bin` was never discovered.

`blob.bin` is a **regression fence**, not a file the guard actively skips: under today's globs it is never discovered, so no assertion can go red on it. Recipe 2 is what gives it teeth.

## Scope decisions

**The fence conflict — attempted in scope, then reverted.** `cogni-workspace/tests/test-relocated-skill-hygiene.sh:28-32` carries a rationale comment this change falsifies (its `scripts/` clause, not its conclusion). An earlier revision of this PR corrected it in place, arguing that a comment-only edit touching no assertion was harmless. The author self-grade against this issue's committed contract graded that a **scope-boundary violation**: the path is in neither the boundary's IN set nor its narrow OUT exception, and the PR's own text conceded as much before arguing past it. The hunk has been reverted and the stale clause filed as **#1780**. Tracking it beats shipping it inside a fence it breaks.

**Deliberately out.** No workflow edit (`.github/workflows/lint.yml:41` invokes the guard argument-free). No new exclude for `cogni-knowledge/scripts/**` — `EXCLUDE_PREFIXES` already strips that tree before `scan_file()` runs, which is load-bearing over 11 `cogni-wiki:` retired-arm tokens across 8 files there. No `plugin.json` version touched.

## Test plan — all executed, none taken on report

| Check | Result |
|---|---|
| `bash tests/test_check_external_dispatch.sh` | 39 PASS, 0 FAIL, exit 0 (incl. new `ed37`–`ed39`) |
| `python3 scripts/check-external-dispatch.py` (the exact CI command) | exit 0, **0 violations** |
| Widening does work rather than matching nothing | files 207 → **301** (+94), tokens 231 → **271** (+40) |
| `bash cogni-workspace/tests/test-relocated-skill-hygiene.sh` | exit 0, green after the comment-only correction |
| `python3 scripts/run-plugin-tests.py` | **140 suites, 0 failures** |
| Repo guards: breadcrumbs, result-line-plainness, case-id-pairing, code-span-nesting, workflow-yaml, attribution-path-integrity, retirement-ledger | all exit 0 |
| Both mutation recipes | `red` / `green` → **`guard_verified`** |

## Mutation recipe

Proves the new glob is load-bearing:

```bash
scripts/mutation-check.sh --root . \
  --file scripts/check-external-dispatch.py \
  --expr 's/\*\.sh",/*.shx",/' \
  --test 'bash tests/test_check_external_dispatch.sh' --case ed38
```

Renames the shell-script glob entry to a suffix nothing matches, so `scripts/helper.sh` stops being discovered, `summary.total` drops to 0 and `ed38` goes red.

Proves the extension-scoping is load-bearing:

```bash
scripts/mutation-check.sh --root . \
  --file scripts/check-external-dispatch.py \
  --expr 's/"\*\/scripts\/\*\.py",/"*\/scripts\/*",/' \
  --test 'bash tests/test_check_external_dispatch.sh' --case ed37
```

Widens the python entry to a bare `*/scripts/*`, which reaches `blob.bin`; the run exits 2 instead of 1 and `ed37` goes red.

Both substitutions are non-global, which is safe only while each entry's text occurs exactly once in the guard — verified (1 occurrence each), and stated positionally above `DEFAULT_GLOBS` so no comment reintroduces a second occurrence.

## Follow-up issues

- **#1770** — untrack the two `.pyc` build artifacts under `cogni-portfolio-evals/scripts/__pycache__/`, tracked despite `.gitignore:3`. Precondition for ever widening beyond `.sh`/`.py`.
- **#1771** — `scan_file()` exits 2 on any undecodable tracked file under a discovered surface; `*/hooks/**` is already exposed.
- **#1780** — the stale `scripts/` clause in `cogni-workspace/tests/test-relocated-skill-hygiene.sh`'s header, reverted out of this PR on the scope boundary above.

## Author self-grade against the issue-time contract

Graded against the 18-item contract committed to #1718 at triage time (2026-09-02T18:52:22Z), before any branch was cut — diff-blind by chronology. Advisory only: no verdict label, no `post-verdict` surface, no `reviewed-head-sha` marker. The merger's independent review is the gate.

First pass: **14 of 18 satisfied, 4 violated** (items 7, 11, 12, 13). All four were mechanical and landed in files the plan already touched, so a single bounded fix pass ran and was pushed as `134bb560`:

| Item | Was | Fix |
|---|---|---|
| 7 (scope boundary) | The hygiene-file edit fell outside the IN set | Hunk reverted; clause filed as #1780 |
| 11 `[fidelity: literal]` | Fixture binary was `scripts/blob.bin`, not the filed `scripts/__pycache__/*.pyc` placement | Added a `*.cpython-314.pyc` under `scripts/__pycache__/`, keeping the bare-glob fence alongside |
| 12 | Slash command was co-located with an *unresolved* token; no `total==0` assertion existed | New `ed40` on a clean tree: slash command + a *resolvable* token in one file, asserting `total==0` AND `tokens>=1` |
| 13 | `EXCLUDE_PREFIXES` rode implicitly on `ed09` exiting 0 | New `ed41` plants a retired-arm token at `cogni-knowledge/scripts/vendored.py` and pins `files==2` |

Both new cases were proven falsifiable rather than assumed. `ed41` goes red under a mutation removing the `cogni-knowledge/` exclude (`guard_verified`). `ed40`'s two conjuncts were each driven red on a scratch fixture: dropping the resolvable token takes `tokens` to 0, and giving the slash command a colon takes `total` to 1.

**Residual for the merger: none.** All four violations were fixed, not carried.

**Coverage caveat.** `check-preflight` resolved `touched_plugins: ["cogni-workspace"]`, so its `run-tests` instrument graded that one plugin's suites — the repo-root files resolve to no plugin. Coverage was established independently: `python3 scripts/run-plugin-tests.py` reports **140 suites, 0 failures** at head. Four of the seven instruments skipped as `not_applicable` (frontmatter, breadcrumbs, skill-length, agent-length — this diff touches no `SKILL.md` or `agents/*.md`).
