### PR TITLE
cogni-trends: make stale-detection fixture reach the complete phase its comment claims

### DIFF
--- a/cogni-trends/tests/test-stale-detection.sh
+++ b/cogni-trends/tests/test-stale-detection.sh
@@ -86,10 +86,24 @@ PYEOF
 
 # ---------------------------------------------------------------------------
 # Shared fixture builder — produces a project workspace that has reached
-# "complete" phase: scout-output with 4 candidates (one per dimension/horizon
-# slot the script checks), value-model with one investment theme, and a
-# tips-trend-report.md file (the /trend-synthesis artifact). The hash anchor
-# is then computed and embedded.
+# "complete" phase: scout-output with 2 candidates, a value-model with one
+# investment theme, and a tips-trend-report.md file (the /trend-synthesis
+# artifact). The hash anchor is then computed and embedded.
+#
+# Two candidates is a deliberate minimum, not a balanced pool: the distribution
+# check (project-status.sh:1008-1016) walks 4 dimensions x 3 horizons and wants
+# 5 candidates in every one of those 12 slots, so a run against this fixture
+# reports 12 distribution_imbalance entries (plus one low_confidence) inside
+# stale_warnings. Every case here filters that array on type == "stale_report",
+# so those entries are inert to the assertions. Case 2 appends a third candidate
+# itself, after this builder returns — the builder never writes t-003.
+#
+# The phase is load-bearing. execution.workflow_state is "report-complete",
+# which project-status.sh:509-510 maps to phase "complete". The phase chain
+# tests exact string equality, so a value it does not match falls through to the
+# terminal else at :511-512 and silently resolves to "scouting" instead. The pin
+# below Case 1's build asserts the emitted phase so that regression fails loudly
+# rather than leaving the cases here asserting over another phase's next_actions.
 # ---------------------------------------------------------------------------
 build_project() {
   local proj="$1"
@@ -115,7 +129,7 @@ EOF
       {"id": "t-002", "title": "Second trend", "dimension": "neue-horizonte",  "horizon": "plan", "source": "training"}
     ]
   },
-  "execution": {"workflow_state": "candidates_agreed"}
+  "execution": {"workflow_state": "report-complete"}
 }
 EOF
 
@@ -181,6 +195,20 @@ ok()   { printf 'PASS: %s\n' "$1"; }
 # ---------------------------------------------------------------------------
 P1="$TMPROOT/case1-mirroring"
 build_project "$P1"
+
+# Anti-vacuity pin — the shared fixture must actually reach "complete". Every
+# case here builds its workspace with build_project(), so a fixture that
+# silently stops reaching that phase would leave the cases below asserting over
+# some other phase's next_actions instead of failing. project-status.sh writes
+# nothing, so this extra read-only run cannot disturb the mtime ordering Case 1
+# establishes immediately below it. Precedent: tests/test-project-status.sh,
+# case project-status-01-complete-phase.
+FIXTURE_PHASE="$(run_health "$P1" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("phase"))')"
+if [ "$FIXTURE_PHASE" = "complete" ]; then
+  ok "stale-detection-04-fixture-phase — shared fixture reached phase=complete"
+else
+  fail "stale-detection-04-fixture-phase — shared fixture reached phase=$FIXTURE_PHASE (expected complete)"
+fi
 sleep 1
 touch "$P1/.metadata/trend-scout-output.json"
 


### PR DESCRIPTION
Closes #1738.

## Summary

`cogni-trends/tests/test-stale-detection.sh` claimed its shared `build_project()` fixture "has reached 'complete' phase". It did not: `execution.workflow_state` was `candidates_agreed`, which matches no arm of the phase chain in `project-status.sh` (every arm tests exact string equality), so it fell through to the terminal `else` at `:511-512` and resolved to `scouting` — the first phase, not the last.

Took **option 2** from the issue — fixed the fixture, not the comment. Three changes, all in that one file:

1. **`:118`** — `workflow_state` is now `report-complete`, the value `project-status.sh:509-510` maps to phase `complete`. This is the whole behavioural change.
2. **The comment block `:87-93`** — rewritten. It also carried two further false claims of the identical class, both corrected: the builder writes **2** candidates, not 4 (`t-003` is appended by Case 2 itself at `:209`, *after* the builder returns), and the `(one per dimension/horizon slot the script checks)` parenthetical was false at any candidate count, so it is **restated rather than renumbered** — `project-status.sh:1008-1016` walks 4 dimensions × 3 horizons and expects 5 candidates in each of those 12 slots.
3. **A new anti-vacuity pin** asserting the emitted phase, so the same silent drift fails loudly next time instead of leaving the cases asserting over another phase's `next_actions`.

`cogni-trends/scripts/project-status.sh` is **unmodified** — this is a test-side correction. No version bump.

## Scope decisions

### Why option 2 over option 1

The issue delegates the choice to the resolver. Three grounds, each verified against the base ref:

1. **`candidates_agreed` is a fabricated value.** A tree-wide `git grep` at `origin/main` returns exactly one hit — this fixture line itself. No skill writes it and no arm of the phase chain matches it. `report-complete` is a real state with an unconditional route.
2. **Option 1 would have traded one contradiction for a subtler one.** The same builder writes `trend_report_complete: True`, `trend_report_path`, `trend_report_generated_at` and `report_tier` (`:141-150`) plus `tips-trend-report.md` (`:132`). Documenting that workspace as "scouting" would leave prose describing a scouting-phase project that already holds a finished report and a report hash anchor.
3. **A stale-*report* suite should exercise the state a real user is actually in when scout drift is detected** — which is `complete`. Option 2 makes Case 2 a faithful regression rather than one that passes incidentally.

### Why it is safe

The reasoning below is *why safety was expected*; per the issue's first acceptance criterion the **evidence** is the recorded runs in the next section, and the mutation check at the end.

- The stale detector (`project-status.sh:937-970`) keys only on file existence and the hash anchor; it never reads `PHASE` or `WORKFLOW_STATE`.
- `_scout_content_hash` (`:900`) hashes only `tips_candidates.items`. The `execution` object is not hashed, so flipping `workflow_state` cannot change whether the anchor matches — S1 and S3 are untouched.
- The drift injector (`:1069-1106`) runs last under `$HEALTH_CHECK` and inserts at index 0, so `acts[0]` is `cogni-trends:trend-research` at any phase (S2b). The only phase-gated block (`:1052-1067`) requires `portfolio-context.json`, which this fixture never writes.
- `project-status.sh` performs **no filesystem writes** — its only two `.write(` sites, `:1063` and `:1105`, both target `sys.stdout` — so the pin's extra read-only run cannot disturb the mtime ordering Case 1 establishes immediately below it.

Measured directly: the `stale_warnings` array is **byte-identical before and after** the change — 12 `distribution_imbalance` entries plus one `low_confidence` under both `candidates_agreed`/`scouting` and `report-complete`/`complete`. Every case filters that array on `type == "stale_report"`, so those entries are inert to the assertions. That measured fact is what the rewritten comment now states, rather than the vaguer "no case asserts on them".

### New case id

`stale-detection-04-fixture-phase` — repo-conformant `<suite-slug>-<NN>-<discriminator>`, unique against the suite's existing `S1` / `S2a` / `S2b` / `S3` (verified by **running** the suite and grouping emitted first tokens, not by grepping call sites), passed once as `$1` so the `PASS:` and `FAIL:` arms cannot drift apart, and emitted through the file's existing plain-`printf` `ok()` / `fail()` helpers. Precedent for the assertion itself: `cogni-trends/tests/test-project-status.sh:193-196`, case `project-status-01-complete-phase`.

Nothing deferred — all four acceptance criteria are met by this PR.

## Verification runs

**1. The emitted phase** — a replica of `build_project()`'s post-fix fixture run through `project-status.sh --health-check`, `phase` quoted verbatim from the run's JSON:

```
$ python3 -c '...print(json.load(open(scout_output))["execution"])'
{'workflow_state': 'report-complete'}

$ bash cogni-trends/scripts/project-status.sh "$FIXTURE" --health-check | jq .phase
"complete"
```

**2. The suite:**

```
$ bash cogni-trends/tests/test-stale-detection.sh; echo "exit=$?"
PASS: stale-detection-04-fixture-phase — shared fixture reached phase=complete
PASS: S1 — mirroring did not fire stale_report
PASS: S2a — drift fired with subtype=scout_drift, added={t-003}, changed={t-001}
PASS: S2b — concrete cogni-trends:trend-research action prepended naming the diff
PASS: S3 — legacy project (no anchor) stayed silent

All stale-detection assertions passed.
exit=0
```

**3. The plugin sweep:**

```
$ python3 scripts/run-plugin-tests.py --filter cogni-trends
Running 4 test suite(s) under <repo-root>
  [1/4] cogni-trends/tests/test-agent-frontmatter-names.sh ... ok (0.1s)
  [2/4] cogni-trends/tests/test-project-status.sh ... ok (0.3s)
  [3/4] cogni-trends/tests/test-research-manifest-sections.sh ... ok (0.1s)
  [4/4] cogni-trends/tests/test-stale-detection.sh ... ok (3.1s)

All 4 suite(s) passed.
exit=0
```

**4. Repo guards:**

```
$ python3 scripts/check-case-id-pairing.py       ; echo $?   # 0
$ python3 scripts/check-result-line-plainness.py ; echo $?   # 0
$ git diff --stat origin/main
 cogni-trends/tests/test-stale-detection.sh | 38 ++++++++++++++++++++++++++----
 1 file changed, 33 insertions(+), 5 deletions(-)
```

## Mutation recipe

Run under the shared harness, against a worktree at this PR's head — all five flags are required:

```
bash cogni-service/scripts/mutation-check.sh \
  --root <worktree-at-pr-head> \
  --file cogni-trends/tests/test-stale-detection.sh \
  --expr 's/"workflow_state": "report-complete"/"workflow_state": "candidates_agreed"/' \
  --test 'bash cogni-trends/tests/test-stale-detection.sh' \
  --case stale-detection-04-fixture-phase
```

Executed. Verbatim result:

```
{
  "success": true,
  "data": {
    "case": "stale-detection-04-fixture-phase",
    "file": ".../cogni-trends/tests/test-stale-detection.sh",
    "expr_applied": "s/\"workflow_state\": \"report-complete\"/\"workflow_state\": \"candidates_agreed\"/",
    "mutated_result": "red",
    "restored_result": "green",
    "verdict": "guard_verified",
    "metric_version": "1"
  },
  "error": null
}
```

Reverting the fixture to the old fabricated value turns the new pin red, and *only* it — the suite under mutation emits:

```
FAIL: stale-detection-04-fixture-phase — shared fixture reached phase=scouting (expected complete)
PASS: S1 — mirroring did not fire stale_report
PASS: S2a — drift fired with subtype=scout_drift, added={t-003}, changed={t-001}
PASS: S2b — concrete cogni-trends:trend-research action prepended naming the diff
PASS: S3 — legacy project (no anchor) stayed silent

1 case(s) failed
```

The `FAIL:` line's first token is the case id, so `--case` addresses it as a whole token. The four pre-existing cases staying green under the mutation is also the empirical confirmation of the safety argument above — they are genuinely phase-independent, not merely expected to be.

## Test plan

- [x] `bash cogni-trends/tests/test-stale-detection.sh` exits 0 with five result lines: S1, S2a, S2b, S3 and `stale-detection-04-fixture-phase`.
- [x] `python3 scripts/run-plugin-tests.py --filter cogni-trends` exits 0 over `data.total: 4` (not an empty query).
- [x] `git diff --stat origin/main` shows exactly one changed file; `project-status.sh` untouched; no `plugin.json` / `marketplace.json` version touched.
- [x] An actual `project-status.sh --health-check` run emits `"complete"` — confirmed by running it, not by inspection.
- [x] Every claim remaining in the rewritten comment block re-reads true against `project-status.sh` at the cited line numbers, including the `distribution_imbalance` count, which was measured rather than assumed.
- [x] The mutation recipe reports the new case as genuinely discriminating.
