### PR TITLE
cogni-knowledge: share the check/grade census across three suites

### DIFF
--- a/cogni-knowledge/tests/README.md
+++ b/cogni-knowledge/tests/README.md
@@ -52,6 +52,18 @@ via `trap rm -rf "$WORK" EXIT`.
   `[`, `]`, `.` or `*` — a wikilink, a glob, a path. `assert_grep` reads such
   a pattern as a regex, so it can report green against a file that does not
   contain the string at all.
+- `check_grade_census <file>` censuses the two-part check/grade convention in
+  `<file>` — every `check("<tag>", ...)` registration paired with exactly one
+  `grade <tag>` line — and returns a verdict string on stdout: `PASS`, or a
+  diagnostic naming the offending tag(s). Pass the caller's own `"$0"`. It
+  emits no label and increments no `errors`, so the calling suite spells its
+  own case id **literally in both arms** and folds the verdict into `errors`
+  itself. That is what keeps the case addressable: `fixtures/` is one path
+  segment out of reach of `scripts/check-case-id-pairing.py`, and an id that
+  is entirely an expansion is skipped by it, so an arm emitted from the helper
+  — or one whose id arrives only via `$census_desc` — is invisible to the
+  guard. `test_knowledge_lib.sh`, `test_ingest_contract.sh` and
+  `test_pdf_extract.sh` are its three callers.
 - Real Python harness (inline `python3 - <<PY ... PY` heredoc) for
   script-level assertions.
 - Fixtures are minimal — only the files the test actually exercises.

--- a/cogni-knowledge/tests/fixtures/test_helpers.sh
+++ b/cogni-knowledge/tests/fixtures/test_helpers.sh
@@ -119,13 +119,15 @@ assert_not_grep_f() {
 #
 #   Five properties are load-bearing.
 #
-#   1. Every extraction keeps the `|| true` guard #1753 wrote. Measured, it is
-#      belt-and-braces rather than the thing holding the suite up: each guard
-#      sits on the LAST element of its pipeline, where `sort` and `tr` succeed
-#      on empty input, so a zero-match extraction survives `set -eu` without
-#      them — and under `set -o pipefail` too. Keep them anyway: they are the
-#      guard a future edit needs if the grep or awk ever moves to the tail of
-#      its pipeline, which is where the abort #1753 described would be real.
+#   1. Every extraction keeps the `|| true` guard #1753 wrote. Its comment said
+#      an unguarded extraction aborts the suite under `set -eu`; measured, that
+#      is not what happens here, because each guard sits on the LAST element of
+#      its pipeline, where `sort` and `tr` succeed on empty input — so grep's
+#      exit 1 on a zero-match is already discarded by the pipe. The guards earn
+#      their keep the moment `set -o pipefail` is added: measured again, the
+#      same pipeline without them DOES abort under pipefail. None of the three
+#      callers sets pipefail today. Keep the guards — they are what makes
+#      turning it on later a one-line change rather than a debugging session.
 #   2. It returns 0 on every path. Every call site is
 #      `census_verdict=$(check_grade_census "$0")`, and under `set -e` an
 #      assignment takes its status from the substitution — a body ending in a

--- a/cogni-knowledge/tests/fixtures/test_helpers.sh
+++ b/cogni-knowledge/tests/fixtures/test_helpers.sh
@@ -97,3 +97,83 @@ assert_not_grep_f() {
     green "PASS: $description"
   fi
 }
+
+# check_grade_census FILE
+#   Census the two-part check/grade convention in FILE and print a verdict
+#   string on stdout: `PASS`, or a diagnostic naming the offending tag(s). The
+#   caller owns its own case id and both result arms — this function emits no
+#   label and increments no `errors`, so it follows case_slug's return-a-value
+#   shape rather than the assert_* family's emit-and-increment one.
+#
+#   The convention has no structural enforcement of its own: a python-side
+#   registration prints "<tag>: OK"/"<tag>: FAIL" into the suite's $OUT, and
+#   only a bash-side `grade <tag> "..."` line ever reads it, so a registration
+#   with no grade line is never read and can never fail the suite. #1753 found
+#   two such orphans.
+#
+#   The census is bash-side rather than part of the python harness because the
+#   heredoc runs as a subprocess with no handle on the suite's own source, and
+#   half the subject here — the grade lines — is script text that never enters
+#   it. Callers fold the verdict into their own $errors so the rest of the
+#   report still prints; it is not fatal.
+#
+#   Five properties are load-bearing.
+#
+#   1. Every extraction keeps the `|| true` guard #1753 wrote. Measured, it is
+#      belt-and-braces rather than the thing holding the suite up: each guard
+#      sits on the LAST element of its pipeline, where `sort` and `tr` succeed
+#      on empty input, so a zero-match extraction survives `set -eu` without
+#      them — and under `set -o pipefail` too. Keep them anyway: they are the
+#      guard a future edit needs if the grep or awk ever moves to the tail of
+#      its pipeline, which is where the abort #1753 described would be real.
+#   2. It returns 0 on every path. Every call site is
+#      `census_verdict=$(check_grade_census "$0")`, and under `set -e` an
+#      assignment takes its status from the substitution — a body ending in a
+#      failing test would kill the caller instead of reporting a verdict.
+#   3. It mints its own scratch dir and installs NO `EXIT` handler of its own.
+#      test_ingest_contract.sh defines no $WORK at all, so a caller-supplied
+#      scratch dir cannot be assumed; and test_knowledge_lib.sh and
+#      test_pdf_extract.sh each already install an `EXIT` handler that removes
+#      their $WORK. A second one here would silently REPLACE the caller's,
+#      leaking that caller's $WORK with every suite still green, so nothing
+#      would report it. Clean up inline instead, as the body below does.
+#   4. Pass FILE as the caller's own `"$0"`. Pointing it at this helper is
+#      harmless — neither extractor matches its own literal, so the census
+#      comes back `EMPTY - registrations=0 grade lines=0`, which is the honest
+#      answer: this file carries no registrations to pair.
+#   5. Neither anchor may be "simplified". The registration literal spells an
+#      escaped paren, never a bare one, so it cannot match itself; and
+#      `/^grade[ \t]/` requires whitespace after `grade`, so a `grade() {`
+#      definition line is not counted as a grade line. Relaxing either turns a
+#      clean census into a phantom finding.
+#
+#   LC_ALL=C keeps sort and comm byte-collated, since the tags contain `_`.
+check_grade_census() {
+  local file scratch dup_reg dup_graded only_reg only_graded verdict
+  file="$1"
+  scratch=$(mktemp -d)
+
+  grep -oE 'check\("[a-z0-9_]+"' "$file" | sed 's/^check("//; s/"$//' | LC_ALL=C sort > "$scratch/reg" || true
+  awk '/^grade[ \t]/{print $2}' "$file" | LC_ALL=C sort > "$scratch/graded" || true
+  dup_reg=$(LC_ALL=C uniq -d "$scratch/reg" | tr '\n' ' ' || true)
+  dup_graded=$(LC_ALL=C uniq -d "$scratch/graded" | tr '\n' ' ' || true)
+  only_reg=$(LC_ALL=C comm -23 "$scratch/reg" "$scratch/graded" | tr '\n' ' ' || true)
+  only_graded=$(LC_ALL=C comm -13 "$scratch/reg" "$scratch/graded" | tr '\n' ' ' || true)
+
+  verdict="PASS"
+  if [ ! -s "$scratch/reg" ] || [ ! -s "$scratch/graded" ]; then
+    verdict="EMPTY - registrations=$(wc -l < "$scratch/reg") grade lines=$(wc -l < "$scratch/graded"); an extractor matched nothing, so the convention was renamed or the scan is broken"
+  elif [ -n "$dup_reg" ]; then
+    verdict="DUP-REGISTRATION - tag registered more than once: $dup_reg"
+  elif [ -n "$dup_graded" ]; then
+    verdict="DUP-GRADE - tag graded more than once: $dup_graded"
+  elif [ -n "$only_reg" ]; then
+    verdict="ORPHAN-REGISTRATION - registered but never graded, so its result is never read: $only_reg"
+  elif [ -n "$only_graded" ]; then
+    verdict="ORPHAN-GRADE - graded but never registered: $only_graded"
+  fi
+
+  rm -rf "$scratch"
+  printf '%s' "$verdict"
+  return 0
+}

--- a/cogni-knowledge/tests/test_ingest_contract.sh
+++ b/cogni-knowledge/tests/test_ingest_contract.sh
@@ -438,6 +438,20 @@ grade atomic_write_text "ingest-contract-118-atomic-write-text-round atomic_writ
 grade slugify           "ingest-contract-119-slugify-lower-kebab-dash slugify — lower-kebab, dash-collapse, length cap, empty-on-non-alnum"
 grade sanitize_summary  "ingest-contract-120-sanitize-summary-u-2020 sanitize_summary — U+2020 dagger / NBSP -> regular space, accents preserved (#387)"
 
+# --- ingest-contract-125: check/grade census --------------------------------
+# Shared computation in fixtures/test_helpers.sh (check_grade_census); its
+# header carries the rationale. Guards this suite against the silent-orphan
+# class #1753 found in test_knowledge_lib.sh: a python-side registration with
+# no matching bash-side grade line is never read, so it can never fail here.
+census_verdict=$(check_grade_census "$0")
+census_desc="check/grade census - every registered tag has exactly one grade line and every grade line exactly one registration; duplicates on either side and an empty extraction are rejected too, so an orphan cannot hide"
+if [ "$census_verdict" = "PASS" ]; then
+  green "PASS: ingest-contract-125-check-grade-census $census_desc"
+else
+  red "FAIL: ingest-contract-125-check-grade-census $census_desc ($census_verdict)"
+  errors=$((errors + 1))
+fi
+
 if [ $errors -eq 0 ]; then
   green ""
   green "ALL PASS"

--- a/cogni-knowledge/tests/test_knowledge_lib.sh
+++ b/cogni-knowledge/tests/test_knowledge_lib.sh
@@ -1592,47 +1592,20 @@ grade page_type_line "klib-48 page_type_line (#931) — the reader-facing Type: 
 grade parse_distilled_claims_with_backlinks "klib-49 parse_distilled_claims_with_backlinks (#885) — the dual-level retrieval join reader: claim_id + text + backlinks and nothing else, inline list parsed with or without a space after the comma, order preserved, missing/empty backlinks normalized to [] so every claim carries the key, the with_id sibling left byte-identical (additive), and inline []/no key/empty/no-frontmatter -> []"
 
 # --- klib-50: check/grade census -------------------------------------------
-# The convention this file grades through has no structural enforcement: a
-# python-side registration prints "<tag>: OK"/"<tag>: FAIL" into $OUT, and only
-# a bash-side grade line ever reads it, so a registration with no grade line is
-# never read and can never fail the suite. #1753 found two such orphans.
-#
-# Bash-only for the same reason klib-01 (line 43) is: the python heredoc runs as
-# a subprocess with no handle on this script's source, and half the subject here
-# — the grade lines — is script text that never enters it. Unlike klib-01 this
-# case is NON-FATAL, folding into $errors so the rest of the report still prints.
-#
-# Three properties are load-bearing. `set -eu` is on (line 24) and grep exits 1
-# on zero matches, so every extraction is `|| true`-guarded as grade() is at line
-# 1536 — otherwise the suite aborts before this case can report. The extractors
-# are anchored so they match neither their own pattern literals (the bytes here
-# are an escaped paren, never a bare one) nor the grade() definition. LC_ALL=C
-# keeps sort and comm byte-collated, since the tags contain `_`.
-grep -oE 'check\("[a-z0-9_]+"' "$0" | sed 's/^check("//; s/"$//' | LC_ALL=C sort > "$WORK/census_reg" || true
-awk '/^grade[ \t]/{print $2}' "$0" | LC_ALL=C sort > "$WORK/census_graded" || true
-census_dup_reg=$(LC_ALL=C uniq -d "$WORK/census_reg" | tr '\n' ' ' || true)
-census_dup_graded=$(LC_ALL=C uniq -d "$WORK/census_graded" | tr '\n' ' ' || true)
-census_only_reg=$(LC_ALL=C comm -23 "$WORK/census_reg" "$WORK/census_graded" | tr '\n' ' ' || true)
-census_only_graded=$(LC_ALL=C comm -13 "$WORK/census_reg" "$WORK/census_graded" | tr '\n' ' ' || true)
+# The census computation lives in fixtures/test_helpers.sh as
+# check_grade_census; that function's header carries the full rationale — why
+# it is bash-only, why every extraction is `|| true`-guarded under `set -eu`,
+# why it owns its own scratch dir and installs no EXIT trap, and which two
+# anchors must not be simplified. #1753 found two orphans in this file; this
+# case is what keeps a third from hiding. NON-FATAL — it folds into $errors so
+# the rest of the report still prints.
+census_verdict=$(check_grade_census "$0")
 
-census_verdict="PASS"
-if [ ! -s "$WORK/census_reg" ] || [ ! -s "$WORK/census_graded" ]; then
-  census_verdict="EMPTY - registrations=$(wc -l < "$WORK/census_reg") grade lines=$(wc -l < "$WORK/census_graded"); an extractor matched nothing, so the convention was renamed or the scan is broken"
-elif [ -n "$census_dup_reg" ]; then
-  census_verdict="DUP-REGISTRATION - tag registered more than once: $census_dup_reg"
-elif [ -n "$census_dup_graded" ]; then
-  census_verdict="DUP-GRADE - tag graded more than once: $census_dup_graded"
-elif [ -n "$census_only_reg" ]; then
-  census_verdict="ORPHAN-REGISTRATION - registered but never graded, so its result is never read: $census_only_reg"
-elif [ -n "$census_only_graded" ]; then
-  census_verdict="ORPHAN-GRADE - graded but never registered: $census_only_graded"
-fi
-
-census_desc="klib-50 check/grade census - every registered tag has exactly one grade line and every grade line exactly one registration; duplicates on either side and an empty extraction are rejected too, so a third orphan cannot hide"
+census_desc="check/grade census - every registered tag has exactly one grade line and every grade line exactly one registration; duplicates on either side and an empty extraction are rejected too, so a third orphan cannot hide"
 if [ "$census_verdict" = "PASS" ]; then
-  green "PASS: $census_desc"
+  green "PASS: klib-50 $census_desc"
 else
-  red "FAIL: $census_desc ($census_verdict)"
+  red "FAIL: klib-50 $census_desc ($census_verdict)"
   errors=$((errors + 1))
 fi
 

--- a/cogni-knowledge/tests/test_pdf_extract.sh
+++ b/cogni-knowledge/tests/test_pdf_extract.sh
@@ -192,6 +192,20 @@ grade venv_python_resolution "pdf-extract-03 _venv_python — COGNI_WORKSPACE_PY
 grade main_envelope_mapping  "pdf-extract-04 main() reason→envelope mapping — ok/no_text_layer/extract_failed/pypdf_unavailable, install hint on pypdf_unavailable (faked extract_pdf_text, host-independent)"
 grade normalize_pdf_body     "pdf-extract-05 normalize_pdf_body_text — NFKC ligature fold + smart-quote/dash map + hyphenated-wrap rejoin + soft-wrap→space, paragraph breaks preserved (opt-in stored-body cleaner)"
 
+# --- pdf-extract-06: check/grade census -------------------------------------
+# Shared computation in fixtures/test_helpers.sh (check_grade_census); its
+# header carries the rationale. Guards this suite against the silent-orphan
+# class #1753 found in test_knowledge_lib.sh: a python-side registration with
+# no matching bash-side grade line is never read, so it can never fail here.
+census_verdict=$(check_grade_census "$0")
+census_desc="check/grade census - every registered tag has exactly one grade line and every grade line exactly one registration; duplicates on either side and an empty extraction are rejected too, so an orphan cannot hide"
+if [ "$census_verdict" = "PASS" ]; then
+  green "PASS: pdf-extract-06 $census_desc"
+else
+  red "FAIL: pdf-extract-06 $census_desc ($census_verdict)"
+  errors=$((errors + 1))
+fi
+
 if [ $errors -gt 0 ]; then
   red "$errors case(s) failed."
   exit 1


### PR DESCRIPTION
Closes #1758.

## Summary
- Lifts the #1753 check/grade census out of `cogni-knowledge/tests/test_knowledge_lib.sh` (L1594-1637 at base) into `cogni-knowledge/tests/fixtures/test_helpers.sh` as `check_grade_census FILE`, which takes the file to census as an argument and returns the verdict string on stdout.
- All three suites that share the two-part convention now run it: `test_knowledge_lib.sh` (`klib-50`, id spelling unchanged), `test_ingest_contract.sh` (`ingest-contract-125-check-grade-census`), `test_pdf_extract.sh` (`pdf-extract-06`). Each keeps its own `PASS:`/`FAIL:` arms in its own file.
- The verdict computation now exists in exactly one place under `cogni-knowledge/`. All five verdict arms (EMPTY / DUP-REGISTRATION / DUP-GRADE / ORPHAN-REGISTRATION / ORPHAN-GRADE), the `|| true` guards, the self-non-matching anchors and the `LC_ALL=C` collation pin travel with it, along with the substance of the #1753 rationale — including the bash-only paragraph, which the first draft dropped.

## Scope decisions

### Design forks closed here, deliberately not re-opened
- **Shared helper, not a repo-tier `scripts/check-check-grade-pairing.py`.** The issue floats that alternative as "worth an explicit decision". It is already foreclosed by the issue's own **AC1**, which requires the *suite* to exit non-zero and name the tag: a scanner wired into `.github/workflows/lint.yml` fails CI, never the suite. Every changed path here is under `cogni-knowledge/**` — no `scripts/**`, no `.github/**`.
- **Emission arms stay in the suite files; only the computation moves.** `scripts/check-case-id-pairing.py` `discover()` (L144-155) uses two non-recursive globs, `tests/*.sh` and `*/tests/*.sh`, and its docstring (L71-75) names `fixtures/test_helpers.sh` as "one path segment too deep".
- **Named `check_grade_census`, not `assert_check_grade_census`** as the issue proposed. It increments no `errors` and prints no label — it returns a value on stdout, which is `case_slug`'s shape (`test_helpers.sh` L27-29), not `assert_grep`'s. An `assert_` prefix would misdescribe it.
- **No caller `$WORK`, no `EXIT` handler, returns 0 on every path.** `test_ingest_contract.sh` defines no `$WORK` at all while `test_knowledge_lib.sh:66-67` and `test_pdf_extract.sh:28-29` each own a `WORK` + `EXIT`-handler pair, so the helper mints its own `mktemp -d` and cleans up inline. It installs no `EXIT` handler of its own: a second one silently *replaces* the caller's and leaks that caller's `$WORK` with every suite still green. Under `set -e`, `v=$(check_grade_census "$0")` inherits the function's status, so the body ends in an explicit `return 0`.
- **Next-unused ids, no renumbering** (`tests/README.md` rule 3). In `test_ingest_contract.sh` ids 121-124 sit **mid-file at L216-219** while the trailing grade lines at L436-439 carry 117-120 — reading only the trailing lines yields a false max of 120 and would mint a colliding 121. The true next unused id is `ingest-contract-125`; for `test_pdf_extract.sh` it is `pdf-extract-06`. Verified by a full-file id census, not by grepping grade lines.

### Changed during review: the case ids are now spelled literally in both arms

The first draft reproduced the base shape — `census_desc="klib-50 …"` plus `green "PASS: $census_desc"`. The pre-commit `/simplify` review flagged that this makes the case **invisible to `scripts/check-case-id-pairing.py`**, because an id token that is entirely an expansion is skipped. Probed both directions:

| shape | delete the green arm → | 
|---|---|
| `green "PASS: $census_desc"` (base shape) | **0 violations** — the guard cannot see the case |
| `green "PASS: pdf-extract-06 $census_desc"` | `unpaired_fail_id pdf-extract-06` |

So the stated reason for keeping the arms in the suite file was not actually being obtained. Fixed by moving the id out of `census_desc` and spelling it literally in both arms of all three cases. **The emitted lines are byte-identical to before** (verified by diffing captured output), so `mutation-check --case` still resolves and `klib-50`'s output is unchanged from #1753. This also makes the issue's AC4 evidence — `grep -n 'klib-50' test_knowledge_lib.sh` showing a green `PASS: klib-50 …` and a red `FAIL: klib-50 …` arm — pass, which it did **not** at base.

### Two claims corrected rather than relocated

The lift would otherwise have carried two false statements from #1753 into shared infrastructure that 80 suites source:

1. **The `|| true` guards are not what keeps the suite alive.** #1753's comment says an unguarded extraction "aborts the suite before this case can report". Measured: every guard sits on the **last element** of its pipeline, where `sort` and `tr` succeed on empty input, so a zero-match extraction survives `set -eu` without them — and under `set -o pipefail` too. The guards are **kept** (they are the guard a future edit needs if the grep or awk ever moves to a pipeline tail), but the header now says what they actually do.
2. **Pointing the helper at itself is not a trap.** #1758's plan warned it "would census the patterns instead of the convention". Measured: `check_grade_census fixtures/test_helpers.sh` returns `EMPTY - registrations=0 grade lines=0` — neither extractor matches its own literal, and the EMPTY arm gives the honest answer. The header now says so instead.

### Deliberately not touched
- **`grade()` is not byte-identical across the three suites**, contrary to the issue body: `test_knowledge_lib.sh:1533-1542` and `test_pdf_extract.sh:178-188` are, but `test_ingest_contract.sh:424-434` differs in its crash-message text (`(no result line — python crashed?)` vs `(no result line for '$tag' — python subprocess crashed?)`). The census never reads `grade()`, so nothing is changed there and no "byte-identical" claim is relied on. Hoisting `grade()` into the helper was raised by the review and skipped: it is a separate deduplication the issue does not ask for.
- The dead `errors_before=$errors` at `test_ingest_contract.sh:422`, immediately adjacent to the insertion point — a drive-by fix widens the diff for no acceptance-relevant reason.
- Rewriting the pipeline as a single `awk` pass was raised by the review and skipped: it would delete the `|| true` and `LC_ALL=C` surfaces the acceptance bar names, and the measured cost is ~45 ms across a full three-suite run.
- No `plugin.json` version bump — the post-merge workflow owns it.

### Grading note for AC3
`grep -rl 'check\("[a-z0-9_]+"' cogni-knowledge/` is ambiguous: read as a regex it matches every suite carrying a real registration (all three), not just the file carrying the census source. Use the **fixed-string** form — `grep -rlF 'check\("[a-z0-9_]+"' cogni-knowledge/` — which returns exactly one path before this PR (`test_knowledge_lib.sh`) and exactly one after (`fixtures/test_helpers.sh`).

### Balance at base
All three suites are balanced today and would report PASS: `test_knowledge_lib.sh` **48** registrations / 48 grade tags, `test_ingest_contract.sh` 4/4, `test_pdf_extract.sh` 4/4 — measured by running the census pipeline against the origin blobs. Nothing is currently hiding; the exposure this closes is future.

## Test plan

All run at head, all green:

- [x] `bash cogni-knowledge/tests/test_knowledge_lib.sh` — exit 0, prints `PASS: klib-50 …`, both arms in the suite file.
- [x] `bash cogni-knowledge/tests/test_ingest_contract.sh` — exit 0, prints `PASS: ingest-contract-125-check-grade-census …`.
- [x] `bash cogni-knowledge/tests/test_pdf_extract.sh` — exit 0, prints `PASS: pdf-extract-06 …`.
- [x] `python3 scripts/run-plugin-tests.py` — **142/142 suites pass, 0 failed** (guards the other 139 suites, 80 of which source `fixtures/test_helpers.sh`).
- [x] `python3 scripts/check-case-id-pairing.py` — 0 violations. Also probed positively: deleting each census green arm in turn now yields `unpaired_fail_id` naming that id.
- [x] `python3 scripts/check-result-line-plainness.py` — 0 violations.
- [x] `check-breadcrumbs`, `check-external-dispatch`, `check-code-span-nesting`, `check-readme-inventory-sync`, `check-attribution-path-integrity`, `check-mcp-tool-grant`, `check-marketplace-manifest-sync` — all exit 0.
- [x] `grep -rlF 'check\("[a-z0-9_]+"' cogni-knowledge/` returns exactly one path: `cogni-knowledge/tests/fixtures/test_helpers.sh`.
- [x] `grep -n 'trap' cogni-knowledge/tests/fixtures/test_helpers.sh` returns nothing; `grep -c 'klib-5' …/test_helpers.sh` is 0.

**Mutation matrix — 4 directions × 3 suites, all 12 confirmed.** Each mutation applied, the suite run, then restored from a file snapshot; every one exits non-zero with the census case named and the offending tag reported:

| direction | `test_ingest_contract.sh` | `test_pdf_extract.sh` | `test_knowledge_lib.sh` (non-regression) |
|---|---|---|---|
| registration with no grade line | ORPHAN-REGISTRATION `probe_tag` | ORPHAN-REGISTRATION `probe_tag` | ORPHAN-REGISTRATION `probe_tag` |
| grade line with no registration | ORPHAN-GRADE `probe_tag` | ORPHAN-GRADE `probe_tag` | ORPHAN-GRADE `probe_tag` |
| duplicate registration | DUP-REGISTRATION `is_pdf_response` | DUP-REGISTRATION `not_found_subprocess` | DUP-REGISTRATION `parse_synthesis_sources` |
| duplicate grade line | DUP-GRADE `is_pdf_response` | DUP-GRADE `not_found_subprocess` | DUP-GRADE `identity` |

## Mutation recipe

Proves the newly-covered census in `test_pdf_extract.sh` has teeth: deleting the `normalize_pdf_body` grade line orphans its registration, so `pdf-extract-06` must go RED and return GREEN on restore.

```
bash cogni-service/scripts/mutation-check.sh --root . --file cogni-knowledge/tests/test_pdf_extract.sh --expr 's/^grade normalize_pdf_body.*\n//m' --test 'bash cogni-knowledge/tests/test_pdf_extract.sh' --case pdf-extract-06
```

`mutation-check.sh` is **not vendored in insight-wave** — it ships with the managed-service `cogni-service` plugin, so substitute that plugin's `scripts/` directory for the leading `cogni-service/scripts/` above and run from the repo root. The in-repo replayable equivalent, actually run against this commit:

```
perl -0pi -e 's/^grade normalize_pdf_body.*\n//m' cogni-knowledge/tests/test_pdf_extract.sh
bash cogni-knowledge/tests/test_pdf_extract.sh   # rc=1, FAIL: pdf-extract-06 … (ORPHAN-REGISTRATION … normalize_pdf_body)
git checkout -- cogni-knowledge/tests/test_pdf_extract.sh
bash cogni-knowledge/tests/test_pdf_extract.sh   # rc=0, PASS: pdf-extract-06 …
```

Observed exactly that: mutated `rc=1` with `FAIL: pdf-extract-06 … (ORPHAN-REGISTRATION - registered but never graded, so its result is never read: normalize_pdf_body)`, restored `rc=0` with `PASS: pdf-extract-06 …`, working tree clean afterwards.

## Follow-up issues

- **#1803** — cogni-knowledge: adopting the check/grade census is itself an unread manual registration. This PR closes the inner loop (a registration nobody grades); enrolment in the census is still a hand-maintained three-file roster that nothing reads, so a fourth adopter would inherit the pre-#1753 state silently. Coverage is complete today — the population is exactly these three suites and all three call the helper — so it is future exposure, and genuinely separable from the lift.