### PR TITLE
cogni-knowledge: derive the check/grade caller set, don't list it

### DIFF
--- a/cogni-knowledge/tests/README.md
+++ b/cogni-knowledge/tests/README.md
@@ -62,8 +62,10 @@ via `trap rm -rf "$WORK" EXIT`.
   segment out of reach of `scripts/check-case-id-pairing.py`, and an id that
   is entirely an expansion is skipped by it, so an arm emitted from the helper
   — or one whose id arrives only via `$census_desc` — is invisible to the
-  guard. `test_knowledge_lib.sh`, `test_ingest_contract.sh` and
-  `test_pdf_extract.sh` are its three callers.
+  guard. Every suite that uses the convention must call it — that rule is not
+  a list kept here: `test_check_grade_enrolment.sh` derives the caller set from
+  file content (a registration plus a grade line) and names any suite that
+  carries both and does not call the helper.
 - Real Python harness (inline `python3 - <<PY ... PY` heredoc) for
   script-level assertions.
 - Fixtures are minimal — only the files the test actually exercises.

--- a/cogni-knowledge/tests/fixtures/test_helpers.sh
+++ b/cogni-knowledge/tests/fixtures/test_helpers.sh
@@ -125,20 +125,28 @@ assert_not_grep_f() {
 #      its pipeline, where `sort` and `tr` succeed on empty input — so grep's
 #      exit 1 on a zero-match is already discarded by the pipe. The guards earn
 #      their keep the moment `set -o pipefail` is added: measured again, the
-#      same pipeline without them DOES abort under pipefail. None of the three
-#      callers sets pipefail today. Keep the guards — they are what makes
-#      turning it on later a one-line change rather than a debugging session.
+#      same pipeline without them DOES abort under pipefail. No caller sets
+#      pipefail today. Keep the guards — they are what makes turning it on
+#      later a one-line change rather than a debugging session.
 #   2. It returns 0 on every path. Every call site is
 #      `census_verdict=$(check_grade_census "$0")`, and under `set -e` an
 #      assignment takes its status from the substitution — a body ending in a
 #      failing test would kill the caller instead of reporting a verdict.
-#   3. It mints its own scratch dir and installs NO `EXIT` handler of its own.
-#      test_ingest_contract.sh defines no $WORK at all, so a caller-supplied
-#      scratch dir cannot be assumed; and test_knowledge_lib.sh and
-#      test_pdf_extract.sh each already install an `EXIT` handler that removes
-#      their $WORK. A second one here would silently REPLACE the caller's,
-#      leaking that caller's $WORK with every suite still green, so nothing
-#      would report it. Clean up inline instead, as the body below does.
+#   3. It mints its own scratch dir and installs NO `EXIT` handler of its own,
+#      because callers differ on both counts and neither difference is this
+#      helper's to assume. Some define no $WORK at all, so a caller-supplied
+#      scratch dir cannot be relied on. Others already install an `EXIT`
+#      handler that removes their own $WORK — and bash keeps exactly ONE
+#      handler per signal, so a second one here would silently REPLACE the
+#      caller's, leaking that caller's $WORK with every suite still green, so
+#      nothing would report it. Clean up inline instead, as the body below
+#      does. The caller SET both halves quantify over is derived rather than
+#      listed — tests/test_check_grade_enrolment.sh names any suite carrying
+#      the convention that does not call this helper — so re-checking either
+#      half is a read over that set rather than a hunt for which files are in
+#      it. The two halves themselves are hand-checked against it: nothing
+#      asserts that some caller still defines no $WORK, or that some other
+#      still installs its own EXIT handler.
 #   4. Pass FILE as the caller's own `"$0"`. Pointing it at this helper is
 #      harmless — neither extractor matches its own literal, so the census
 #      comes back `EMPTY - registrations=0 grade lines=0`, which is the honest

--- a/cogni-knowledge/tests/test_check_grade_enrolment.sh
+++ b/cogni-knowledge/tests/test_check_grade_enrolment.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# test_check_grade_enrolment.sh — enrolment census for the two-part check/grade
+# convention.
+#
+# fixtures/test_helpers.sh's check_grade_census closes the INNER loop: inside a
+# suite that calls it, a registration with no matching grade line reddens that
+# suite. Adopting it was still an OUTER loop that nothing read — the caller set
+# was a hand-maintained list restated in prose, so a fourth suite that picked up
+# the convention and never called the helper stayed green with an orphan hidden
+# in it. This suite derives that caller set from file content instead, so the
+# population is self-enrolling rather than self-listing.
+#
+# bash 3.2 + python3 stdlib only (no pytest, no pip). Matches tests/README.md.
+#
+# Three properties are load-bearing.
+#
+#   1. Neither population anchor may be "simplified", for the reason
+#      fixtures/test_helpers.sh property 5 gives one level in — and here the
+#      argument does double duty. The registration literal spells an escaped
+#      paren, never a bare one, so this file's own source carries no bare
+#      registration token and cannot enter the population it polices; and the
+#      grade anchor requires whitespace after the word, so a function
+#      definition line is not counted as a grade line. Relax either and this
+#      suite starts reporting itself.
+#
+#      The grade anchor is spelled [[:space:]] rather than the awk source's
+#      [ \t]: awk reads \t inside a bracket expression as a tab, but grep -E
+#      reads it as the two literal characters \ and t, so the awk spelling
+#      transplanted here would silently stop matching a tab-separated grade
+#      line. [[:space:]] is the grep-correct spelling of the same intent, and
+#      still excludes a `(`, which is what property 5 actually requires.
+#
+#   2. Enrolment is matched in COMMAND POSITION, after comment-stripping —
+#      never as a bare substring. Two of the three current callers name the
+#      helper in a comment directly above the real call, so a substring test
+#      would read a suite that kept the comment and dropped the call as
+#      enrolled, masking exactly the non-adopter this suite exists to name. The
+#      same discipline keeps the helper's own definition line from counting as
+#      a call.
+#
+#      The TRAILING [[:space:]] in that pattern is what makes this file
+#      self-immune: in its own source the next character after the helper's
+#      name is `[`, not whitespace. Dropping it as a redundant-looking
+#      character would make this suite read as its own caller.
+#
+#      Comment-stripping uses sed 's/#.*$//', which also truncates a
+#      ${var#prefix} parameter expansion. No current call line carries one, so
+#      the scan is exact today; a future call sharing its line with such an
+#      expansion would go unreported rather than mis-reported, which is the
+#      safe direction but worth knowing.
+#
+#   3. Collect then pair, per tests/README.md rule 7: offenders accumulate into
+#      one variable inside the loop with NO emission there, and a single
+#      same-id if/else fires after the loop closes, gated on that variable and
+#      never on the shared errors counter, which an unrelated earlier case
+#      could otherwise silence. The FAIL arm still folds into errors — rule 7
+#      forbids gating the PASS on the accumulator, not reporting into it — so
+#      the suite's EXIT STATUS reflects the finding. Without that fold the red
+#      arm prints while the suite exits 0, and run-plugin-tests.py (which reads
+#      only the exit code) would call it a pass.
+#
+# Deliberately NO self-exclusion clause. This file matches neither population
+# predicate by construction (property 1), so an explicit "skip myself" branch
+# would be dead code — and would mask a real finding if this suite ever did
+# adopt the convention. Do not add one.
+
+set -eu
+
+TESTS_DIR="$(cd "$(dirname "$0")" && pwd)"
+HELPER="$TESTS_DIR/fixtures/test_helpers.sh"
+# Argument-driven scan root, per tests/README.md rule 7's forcing clause: the
+# red arm is reached by pointing this at a seeded directory, never by mutating
+# a real suite in place. Stripping a live caller's census assignment instead
+# would leave the following comparison reading an unbound variable, and every
+# caller runs `set -eu`, so that suite would abort for a reason unrelated to
+# enrolment — a red at the wrong locus.
+SCAN_ROOT="${1:-$(cd "$TESTS_DIR/../.." && pwd)}"
+
+. "$HELPER"
+
+errors=0
+
+# The repo's own two globs, copied from scripts/run-plugin-tests.py, which
+# rejects a narrower form by name: "the narrower form would silently skip a
+# future non-cogni- component that ships suites, and report a green sweep while
+# doing it — the same class of silent gap this runner exists to close." Scoping
+# this scan to one plugin would reproduce exactly the gap it exists to close,
+# one level up: tests/README.md records that these conventions were themselves
+# copied in from another plugin's suites, so the convention travels. Widening
+# is free — the population is the same three files either way today.
+#
+# Both globs are non-recursive, so fixtures/ stays out: it holds helpers that
+# carry no registrations and were never meant to enrol, the same reason
+# scripts/check-case-id-pairing.py cannot reach it.
+unenrolled=""
+population=0
+
+for f in "$SCAN_ROOT"/tests/*.sh "$SCAN_ROOT"/*/tests/*.sh; do
+  [ -f "$f" ] || continue
+
+  grep -qE 'check\("[a-z0-9_]+"' "$f" || continue
+  grep -qE '^grade[[:space:]]' "$f" || continue
+
+  population=$((population + 1))
+
+  # Inverted around the single statement it guards, so the accumulator reads
+  # directly rather than through a "skip if enrolled" double negative. NOT
+  # `grep -q … && continue`: under `set -eu` a standalone A && B list whose A
+  # fails returns non-zero and aborts the loop.
+  if ! sed 's/#.*$//' "$f" | grep -qE '(^|[;&|(]|\$\()[[:space:]]*check_grade_census[[:space:]]'; then
+    # Accumulate only — the emission happens once, after the loop.
+    unenrolled="$unenrolled${f##*/}
+"
+  fi
+done
+
+enrolment_desc="check/grade enrolment census - every suite carrying both a registration and a grade line also calls the shared census helper, so adopting the convention is derived from file content rather than read from a maintained list"
+
+if [ -z "$unenrolled" ]; then
+  green "PASS: check-grade-enrolment-01 $enrolment_desc ($population file(s) use the convention; all enrolled)"
+else
+  red "FAIL: check-grade-enrolment-01 $enrolment_desc — suite(s) use the convention without calling the census helper:"
+  printf '%s' "$unenrolled" | sed 's/^/  /'
+  errors=$((errors + 1))
+fi
+
+# Liveness floor, the shape test_plain_result_emitters.sh ships as plain-emit-05.
+# The case above is green by construction while the population is fully enrolled,
+# so it is also green when the population is EMPTY — a broken glob or a relaxed
+# anchor would retire the guard silently and read as a pass. The floor is 1
+# rather than the current 3: consolidating the convention onto fewer suites is a
+# legitimate move that must not redden this, whereas reaching zero means either
+# the convention is gone or the scan stopped reaching it, and both deserve a look.
+if [ "$population" -lt 1 ]; then
+  red "FAIL: check-grade-enrolment-02 no file under $SCAN_ROOT carries both a registration and a grade line — the convention is gone or the scan is not reaching it, so the enrolment case above passed vacuously"
+  errors=$((errors + 1))
+else
+  green "PASS: check-grade-enrolment-02 $population file(s) carry the convention (floor 1), so the enrolment case above has a live population"
+fi
+
+if [ $errors -gt 0 ]; then
+  red "$errors case(s) failed."
+  exit 1
+fi
+
+green ""
+green "All check/grade enrolment cases pass."


### PR DESCRIPTION
Closes #1803.

## Summary

- Adds `cogni-knowledge/tests/test_check_grade_enrolment.sh` — two cases — that **derives** the check/grade caller population instead of reading a hand-maintained list. Every suite carrying both a `check("<tag>"` registration and a `^grade` line must also call `check_grade_census`; any that does not is reported by basename (`check-grade-enrolment-01`).
- Enrolment is matched in **command position** after comment-stripping, never as a bare substring. Two of the three current callers name the helper in a comment directly above the real call, so a substring test would read a suite that kept the comment and dropped the call as enrolled — masking exactly the non-adopter this guard exists to name. The same discipline keeps the helper's own `check_grade_census() {` definition line from counting as a call.
- Both population anchors reuse the escaped-paren technique `fixtures/test_helpers.sh` property 5 (lines 146-150) already states one level in, so the host suite's own source carries no bare registration token and sits outside the population it polices. **No self-exclusion clause** — verified empirically, and one would be dead code that could mask a real finding if this suite ever adopted the convention.
- Follows `tests/README.md` rule 7 collect-then-pair (lines 174-177): offenders accumulate into one variable inside the loop, and a single same-id `if`/`else` fires after the loop closes, gated on that variable and never on the shared `errors` accumulator. The FAIL arm still folds into `errors` so the **exit status** reflects the finding — rule 7 forbids gating the PASS on the accumulator, not reporting into it.
- Retires the three-file roster at both prose sites: `tests/README.md:65-66` now states the enrolment rule, and `fixtures/test_helpers.sh` properties 1 and 3 keep their arguments falsifiable without naming callers.

## Scope decisions

**Host: a new dedicated suite.** The corpus convention is one small dedicated suite per cross-cutting property — `test_control_path_flip.sh` (119 lines), `test_plain_result_emitters.sh` (253 lines) — not accretion onto the largest content suite, and `test_knowledge_lib.sh` is already the biggest file in the tree at 1,619 lines. `test_plain_result_emitters.sh` would have donated its `SCAN_ROOT` override for free, but its header explicitly fences its subject to result-line *plainness*; hosting an unrelated census there would make one override serve two different scans. The new suite implements the same one-line override itself.

**Repo-wide scan, not plugin-local.** The scan uses the repo's own two globs, `tests/*.sh` + `*/tests/*.sh`, copied from `scripts/run-plugin-tests.py` — whose docstring rejects a narrower form by name: *"the narrower form would silently skip a future non-`cogni-` component that ships suites, and report a green sweep while doing it — the same class of silent gap this runner exists to close."* Scoping this scan to one plugin would reproduce, one level up, exactly the gap it exists to close, and `tests/README.md:5` records that these conventions were themselves copied in from another plugin's suites, so the convention travels. Widening is free: the population is the same three files either way today.

**A liveness floor (`check-grade-enrolment-02`).** `-01` is green by construction while the population is fully enrolled — which means it is *also* green when the population is **empty**. A broken glob or a relaxed anchor would retire the guard silently and read as a pass. `-02` is the shape `test_plain_result_emitters.sh` already ships as `plain-emit-05`. The floor is 1 rather than the current 3: consolidating the convention onto fewer suites is legitimate and must not redden, whereas reaching zero means the convention is gone or the scan stopped reaching it.

**Forcing the red arm.** The issue's own suggested mutation — strip a real suite's `census_verdict=` assignment — leaves the following comparison reading an unbound variable, and all three callers run `set -eu`, so that suite would abort for a reason unrelated to enrolment: a red at the wrong locus, and `--case` would report `case_not_found`. The recorded recipe instead rewrites the assignment to a literal `PASS` with the original call pushed behind a `#`, which keeps the mutated suite runnable *and* removes the command-position call.

**Deliberately not touched.** `test_plain_result_emitters.sh`'s liveness comment (lines 206-215) says "79 files exercise the contract today"; a base sweep finds 81 carriers, so that count is already stale before this branch. The assertion it annotates is a floor of 50 and stays green either way. Correcting a pre-existing count in an unrelated suite would widen the diff past this issue's stated surface.

**Nothing deferred.** Every acceptance criterion of #1803 is met here.

## Open questions

- **Is a plugin-local suite the right tier at all?** _(genuine — for the reviewer, not blocking the diff)_ The issue asserts a `scripts/`-tier guard "cannot" keep the check inside a suite's own output. That premise is **falsified by two shipped precedents in this repo**: README rule 7 is enforced by `scripts/check-case-id-pairing.py` with its teeth in `tests/test_check_case_id_pairing.sh` (CI job at `lint.yml:229`), and result-line plainness by `scripts/check-result-line-plainness.py` + `tests/test_check_result_line_plainness.sh` (`lint.yml:214`). In that shape the guard is still output-bearing, still addressable by literal case id, and still mutation-provable — so every bar the issue's ACs set is met at the `scripts/` tier today, and nothing forced the plugin-local shape. This PR implements the issue as written; moving it to `scripts/` + a root suite is a real alternative a reviewer may prefer, and would additionally supply the standard shipped-fixture equipment noted below.
- **The red arm ships unexercised by CI.** Rule 7 blesses an argument-driven scan root as a forcing mechanism, so this is conformant — but it is the weakest blessed option. After this PR's one-time mutation recipe, nothing re-proves the guard has teeth: a later edit that breaks the offender path leaves the suite green and CI green. The `scripts/`-tier siblings solve this with committed fixture trees (`tests/test_check_case_id_pairing.sh` asserts 29 distinct `FAIL:` arms every run). Fixable at either tier by committing a seeded fixture dir and a case that runs the scan against it; deliberately not done here to keep the diff inside the issue's stated surface.
- _(avoidable — recorded for the escalation metric, not blocking)_ The issue's 6 acceptance criteria materially under-specify the bar: three requirements that actually gate a correct implementation appear nowhere in it — `tests/README.md` rule 7's collect-then-pair shape and its ban on gating a PASS on the shared `errors` accumulator (lines 163-190); the scanner's self-immunity to its own pattern literals (the hazard `fixtures/test_helpers.sh` property 5, lines 146-150, names one level in); and the fact that the guard is green at base by construction, so the forced red arm — not the green run — is the load-bearing evidence. All three were settled from the tree at base and designed for.

## Note on property 3

`fixtures/test_helpers.sh` property 3 previously named all three callers as the evidence for why the helper installs no `EXIT` handler of its own. Retiring that roster mechanically would have stripped the argument's grounds, so the rewrite keeps both halves stated and checkable ("some define no `$WORK`"; "others already install an `EXIT` handler" — plus the generalizing reason, that bash keeps exactly one handler per signal). Both halves were verified true at head: `test_ingest_contract.sh` defines no `$WORK`; `test_knowledge_lib.sh` and `test_pdf_extract.sh` each install an `EXIT` handler. The forward pointer is deliberately narrow — it claims only that the caller **set** is derived, and says explicitly that the two halves are hand-checked against it, because the new suite derives membership and nothing more.

## Test plan

- [x] `bash cogni-knowledge/tests/test_check_grade_enrolment.sh` exits 0, printing `PASS: check-grade-enrolment-01 … (3 file(s) use the convention; all enrolled)` and `PASS: check-grade-enrolment-02 3 file(s) carry the convention (floor 1) …`.
- [x] It lists no offender — in particular not itself, and not `test_refresh_resweep_contract.sh`, `test_knowledge_wiki_probe.sh` or `test_control_path_flip.sh`, none of which carries either population marker.
- [x] `-01` red arm forced via the argument-driven scan root: a `mktemp -d` seeded with `tests/test_fake_adopter.sh` (a registration plus a grade line, no census call) and `tests/test_immune.sh` — exits 1, names `test_fake_adopter.sh`, leaves the immune file unflagged.
- [x] `-02` red arm forced against a scan root whose only suite carries neither marker — exits 1 with the vacuous-pass diagnostic.
- [x] `python3 scripts/check-case-id-pairing.py` — 0 violations, exit 0.
- [x] `python3 scripts/run-plugin-tests.py` — 144/144 suites pass, 0 failures.
- [x] Neither `cogni-knowledge/tests/README.md` nor `cogni-knowledge/tests/fixtures/test_helpers.sh` still names the three callers (`grep -c test_ingest_contract.sh` → 0 in both).
- [x] The mutation recipe below returns `guard_verified`.

## Mutation recipe

```sh
bash /Users/stephandehaas/GitHub/dev/managed-service/cogni-service/scripts/mutation-check.sh --root . --file cogni-knowledge/tests/test_pdf_extract.sh --expr 's/^census_verdict=/census_verdict="PASS" #/m' --test 'bash cogni-knowledge/tests/test_check_grade_enrolment.sh' --case check-grade-enrolment-01
```

Replayed on this branch and returns `"verdict": "guard_verified"` — `"mutated_result": "red"`, `"restored_result": "green"`.

Run it **from the repository root of this branch's checkout**: `--test` runs with `cwd` set to `--root`, and `--file` is root-relative. The harness path is the author's local `managed-service` checkout and is deliberately literal — not `${CLAUDE_PLUGIN_ROOT}`-rooted (which resolves to the host plugin's argument-less copy and replays to a false green), and not the in-repo `cogni-portfolio/scripts/mutation-check.sh` / `cogni-consult/scripts/mutation-check.sh`, which `cogni-knowledge/tests/README.md:79-84` records as different bespoke scripts.

The `--expr` is a `perl -0pi -e` expression, hence the `/m` flag: it matches the single line-anchored `census_verdict=` in that file and rewrites it to a literal `PASS` with the original call pushed behind a `#`. The mutant keeps its registrations, its grade lines and the comment mention — so `test_pdf_extract.sh` stays inside the derived population and stays runnable, and the only thing it loses is its command-position enrolment.