### PR TITLE
cogni-workspace: shared stdlib-only brief parser (parse-brief.py)

### DIFF
--- a/cogni-workspace/scripts/parse-brief.py
+++ b/cogni-workspace/scripts/parse-brief.py
@@ -1,0 +1,528 @@
+#!/usr/bin/env python3
+"""parse-brief.py — Parse a presentation brief into one of three machine-readable views.
+
+Reads the presentation-brief grammar (schema 4.1, and the unfenced 4.0 shape with a
+warning) and projects it into `slide-data`, `outline` or `metadata`. The brief is
+parsed exactly once into a lossless model; each emit mode is a pure projection of
+that model, so consumers share one parse instead of each re-deriving it.
+
+Stdlib only — no PyYAML. The grammar the producer writes is a small closed subset
+of YAML (scalars, quoted scalars, two-space nested maps, block lists, short flow
+lists, and `|` block scalars), so a vendored parser would be more machinery than
+the input needs.
+
+The module has no import-time side effects: every entry point is a module-level
+function and all CLI work sits behind `if __name__ == "__main__"`, so a consumer
+can load it through `importlib.util.spec_from_file_location` the way
+`validate-theme-manifest.py` loads its own sibling generator.
+
+Block scalars are preserved byte-for-byte, leading indent included. A consumer that
+wants them dedented can dedent; a consumer handed a dedented value cannot recover
+the original.
+
+Usage:
+    parse-brief.py --brief <path> --emit slide-data|outline|metadata [--output <path>]
+
+Always prints exactly one {"success", "data", "error"} object on stdout, on every
+path, and never a traceback.
+"""
+
+import argparse
+import json
+import re
+import sys
+
+BLOCK_INDICATORS = ("|", "|-", "|+")
+
+# Copied character-for-character from the citation regex in
+# skills/render-html-slides/scripts/generate-html-slides.py so the two cannot
+# drift. A superscript without a URL is prose, not a citation, and must not match.
+CITATION_RE = re.compile(r'<sup>\[(\d+)\]\(([^)]+)\)</sup>')
+
+SLIDE_HEADING_RE = re.compile(r"^##\s+Slide\s+(\d+)\s*:\s*(.*)$")
+QUADRANT_ALIAS_RE = re.compile(r"^Q([1-9]\d*)$")
+STEP_KEY_RE = re.compile(r"^Step-([0-9]+)$")
+
+# The eight keys render-html-slides documents, plus the five 4.1 additions. Every
+# slide carries all thirteen; an absent one is null or [], never omitted. This is
+# the published contract a consumer (and the suite) can read back off the module.
+SLIDE_KEYS = (
+    "number", "headline", "layout", "fields", "speaker_notes", "bottom_banner",
+    "diagram_mermaid", "citations", "slide_kind", "source", "cta", "intent", "visual",
+)
+
+
+class BriefError(Exception):
+    """A brief that cannot be parsed. The message names a 1-based source line."""
+
+
+
+def emit(success: bool, data=None, error: str = "") -> int:
+    print(json.dumps({"success": success, "data": data or {}, "error": error}))
+    return 0 if success else 1
+
+
+def _indent_of(line):
+    return len(line) - len(line.lstrip(" "))
+
+
+def _is_skippable(line):
+    stripped = line.strip()
+    return not stripped or stripped.startswith("#")
+
+
+def _split_flow(body):
+    """Split a flow sequence's inner text on top-level commas."""
+    parts, buf, depth, quote = [], "", 0, None
+    for ch in body:
+        if quote:
+            buf += ch
+            if ch == quote:
+                quote = None
+            continue
+        if ch in ("'", '"'):
+            quote = ch
+            buf += ch
+        elif ch in "[{":
+            depth += 1
+            buf += ch
+        elif ch in "]}":
+            depth -= 1
+            buf += ch
+        elif ch == "," and depth == 0:
+            parts.append(buf)
+            buf = ""
+        else:
+            buf += ch
+    if buf.strip():
+        parts.append(buf)
+    return [p.strip() for p in parts]
+
+
+def _scalar(text):
+    """Resolve one plain or quoted scalar.
+
+    Quoted values stay verbatim strings. Bare int / float / bool / null resolve to
+    their JSON types; everything else stays a string, so `688` is a number while
+    `42%` and a currency amount are not.
+    """
+    text = text.strip()
+    if len(text) >= 2 and text[0] == text[-1] and text[0] in ("'", '"'):
+        return text[1:-1]
+    if text.startswith("[") and text.endswith("]"):
+        return [_scalar(p) for p in _split_flow(text[1:-1])]
+    if text.startswith("{") and text.endswith("}"):
+        out = {}
+        for part in _split_flow(text[1:-1]):
+            key, sep, value = part.partition(":")
+            if sep:
+                out[key.strip()] = _scalar(value)
+        return out
+    if text in ("null", "~", ""):
+        return None
+    if text == "true":
+        return True
+    if text == "false":
+        return False
+    try:
+        return int(text)
+    except ValueError:
+        pass
+    try:
+        return float(text)
+    except ValueError:
+        pass
+    return text
+
+
+def _parse_block_scalar(lines, i, end, parent_indent, indicator):
+    """Collect a `|` block scalar, preserving each source line byte-for-byte.
+
+    The block runs to the first non-blank line indented at or below the parent key;
+    a blank line never terminates it. Leading indent is retained deliberately — see
+    the module docstring.
+    """
+    content, last_nonblank = [], -1
+    while i < end:
+        line = lines[i]
+        if line.strip():
+            if _indent_of(line) <= parent_indent:
+                break
+            last_nonblank = len(content)
+        content.append(line)
+        i += 1
+    if indicator == "|+":
+        kept = content
+    else:
+        kept = content[: last_nonblank + 1]
+    if not kept:
+        return ("" if indicator == "|-" else "\n"), i
+    text = "\n".join(kept)
+    if indicator != "|-":
+        text += "\n"
+    return text, i
+
+
+def _first_content(lines, i, end):
+    while i < end and _is_skippable(lines[i]):
+        i += 1
+    return i if i < end else None
+
+
+def _parse_value_below(lines, i, end, parent_indent):
+    """Parse whatever a bare `key:` introduces — a nested map, a list, or nothing."""
+    probe = _first_content(lines, i, end)
+    if probe is None:
+        return None, i
+    child_indent = _indent_of(lines[probe])
+    if child_indent <= parent_indent:
+        return None, i
+    if lines[probe].strip().startswith("- "):
+        return _parse_list(lines, probe, end, child_indent)
+    return _parse_map(lines, probe, end, child_indent)
+
+
+def _parse_list(lines, i, end, indent):
+    items = []
+    while i < end:
+        line = lines[i]
+        if _is_skippable(line):
+            i += 1
+            continue
+        if _indent_of(line) < indent:
+            break
+        stripped = line.strip()
+        if not stripped.startswith("- "):
+            break
+        rest = stripped[2:]
+        key, sep, _ = rest.partition(":")
+        key = key.strip()
+        # A quoted item is always a scalar, even when its text contains a colon,
+        # and a bare key never contains a space or a quote.
+        is_map_item = bool(sep) and bool(key) and " " not in key \
+            and key[0] not in ("'", '"') and "'" not in key and '"' not in key
+        if not is_map_item:
+            items.append(_scalar(rest))
+            i += 1
+            continue
+        # A list item that opens a map: re-indent its first line to the item's own
+        # column, then absorb every following line indented past the dash.
+        item_indent = indent + 2
+        block = [" " * item_indent + rest]
+        i += 1
+        while i < end and (_is_skippable(lines[i]) or _indent_of(lines[i]) > indent):
+            block.append(lines[i])
+            i += 1
+        parsed, _ = _parse_map(block, 0, len(block), item_indent)
+        items.append(parsed)
+    return items, i
+
+
+def _parse_map(lines, i, end, indent):
+    result = {}
+    while i < end:
+        line = lines[i]
+        if _is_skippable(line):
+            i += 1
+            continue
+        current = _indent_of(line)
+        if current < indent:
+            break
+        if current > indent:
+            i += 1
+            continue
+        stripped = line.strip()
+        if stripped.startswith("- "):
+            break
+        key, sep, rest = stripped.partition(":")
+        if not sep:
+            i += 1
+            continue
+        key, rest = key.strip(), rest.strip()
+        if rest in BLOCK_INDICATORS:
+            # Only a value that is exactly an indicator opens a block scalar, so a
+            # scalar whose text merely contains a pipe stays prose.
+            result[key], i = _parse_block_scalar(lines, i + 1, end, current, rest)
+        elif rest == "":
+            result[key], i = _parse_value_below(lines, i + 1, end, current)
+        else:
+            result[key] = _scalar(rest)
+            i += 1
+    return result, i
+
+
+def parse_yaml_subset(lines):
+    """Parse a list of source lines as the brief's YAML subset."""
+    start = _first_content(lines, 0, len(lines))
+    if start is None:
+        return {}
+    parsed, _ = _parse_map(lines, start, len(lines), _indent_of(lines[start]))
+    return parsed
+
+
+def _scan_sections(lines):
+    """Split the document on `##` headings that sit outside a fence.
+
+    Returns (frontmatter_lines, sections). Raises BriefError naming the opening
+    line of any fence still unclosed at EOF — a structurally broken brief must fail
+    loudly at a locatable line rather than parse to something plausible.
+    """
+    index = 0
+    frontmatter = []
+    if lines and lines[0].strip() == "---":
+        for j in range(1, len(lines)):
+            if lines[j].strip() == "---":
+                frontmatter = lines[1:j]
+                index = j + 1
+                break
+
+    sections, current = [], None
+    fence_open_line = None
+    for n in range(index, len(lines)):
+        line = lines[n]
+        if line.startswith("```"):
+            fence_open_line = None if fence_open_line is not None else n + 1
+        elif fence_open_line is None and line.startswith("## "):
+            current = {"heading": line, "lines": []}
+            sections.append(current)
+            continue
+        if current is not None:
+            current["lines"].append(line)
+    if fence_open_line is not None:
+        raise BriefError(
+            "unclosed fenced block opened at line {0}".format(fence_open_line))
+    return frontmatter, sections
+
+
+def _section_body(section):
+    """Return (body_lines, was_fenced) for one section."""
+    body = section["lines"]
+    for n, line in enumerate(body):
+        if line.startswith("```"):
+            for m in range(n + 1, len(body)):
+                if body[m].startswith("```"):
+                    return body[n + 1:m], True
+            break
+    # No fence: the 4.0 shape. The body is everything up to a `---` separator.
+    plain = []
+    for line in body:
+        if line.strip() == "---":
+            break
+        plain.append(line)
+    return plain, False
+
+
+def _normalize_quadrants(fields, warnings, number):
+    """Rename `Q1`..`Q4` to the `Quadrant-N` names the renderer reads.
+
+    The sub-map passes through verbatim. No `Number` is synthesized for an alias
+    that carries none — inventing one would render a statistic nobody wrote.
+    """
+    if not any(QUADRANT_ALIAS_RE.match(key) for key in fields):
+        return fields
+    out = {}
+    for key, value in fields.items():
+        match = QUADRANT_ALIAS_RE.match(key)
+        if not match:
+            out[key] = value
+            continue
+        canonical = "Quadrant-" + match.group(1)
+        if canonical in fields:
+            warnings.append(
+                "slide {0}: dropped alias {1} because {2} is also present".format(
+                    number, key, canonical))
+            continue
+        warnings.append(
+            "slide {0}: normalized alias {1} to {2}".format(number, key, canonical))
+        out[canonical] = value
+    return out
+
+
+def _order_steps(fields):
+    """Emit `Step-N` keys in ascending numeric order, so Step-10 follows Step-2."""
+    steps = [(int(m.group(1)), k) for k in fields if (m := STEP_KEY_RE.match(k))]
+    if not steps:
+        return fields
+    step_keys = {k for _, k in steps}
+    ordered = {k: v for k, v in fields.items() if k not in step_keys}
+    for _, key in sorted(steps):
+        ordered[key] = fields[key]
+    return ordered
+
+
+def _citations(body_lines):
+    seen, found = set(), []
+    for match in CITATION_RE.finditer("\n".join(body_lines)):
+        pair = (int(match.group(1)), match.group(2))
+        if pair not in seen:
+            seen.add(pair)
+            found.append({"n": pair[0], "url": pair[1]})
+    return found
+
+
+def _bottom_banner(fields):
+    banner = fields.get("Bottom-Banner")
+    if isinstance(banner, dict):
+        return banner.get("Text")
+    return banner
+
+
+def _build_slide(section, match, warnings):
+    number = int(match.group(1))
+    body, fenced = _section_body(section)
+    if not fenced:
+        warnings.append(
+            "slide {0}: parsed an unfenced body (schema 4.0 shape)".format(number))
+    fields = parse_yaml_subset(body)
+    fields = _order_steps(_normalize_quadrants(fields, warnings, number))
+    return {
+        "number": number,
+        "headline": match.group(2).strip(),
+        # The layout is the Layout field. Slide-Kind never overrides it.
+        "layout": fields.get("Layout"),
+        "fields": fields,
+        "speaker_notes": fields.get("Speaker-Notes"),
+        "bottom_banner": _bottom_banner(fields),
+        "diagram_mermaid": fields.get("Diagram"),
+        "citations": _citations(body),
+        "slide_kind": fields.get("Slide-Kind"),
+        "source": fields.get("Source"),
+        "cta": fields.get("cta"),
+        "intent": fields.get("intent"),
+        "visual": fields.get("visual"),
+    }
+
+
+def parse_brief(path):
+    """Parse a brief file into the lossless model every emit mode projects."""
+    with open(path, "r", encoding="utf-8") as handle:
+        lines = handle.read().splitlines()
+
+    warnings = []
+    frontmatter_lines, sections = _scan_sections(lines)
+    frontmatter = parse_yaml_subset(frontmatter_lines)
+
+    slides, cta_summary, generation_metadata, unowned = [], None, None, []
+    for section in sections:
+        heading = section["heading"].strip()
+        slide_match = SLIDE_HEADING_RE.match(heading)
+        if slide_match:
+            slides.append(_build_slide(section, slide_match, warnings))
+            continue
+        body, fenced = _section_body(section)
+        if heading == "## CTA Summary" and fenced:
+            cta_summary = parse_yaml_subset(body)
+        elif heading == "## Generation Metadata" and fenced:
+            generation_metadata = parse_yaml_subset(body)
+        else:
+            # An unfenced trailing section is prose the parser does not own.
+            unowned.append(heading[3:].strip())
+
+    if generation_metadata is None:
+        warnings.append("no Generation Metadata section; emitting null")
+
+    return {
+        "version": frontmatter.get("version"),
+        "frontmatter": frontmatter,
+        "slides": slides,
+        "cta_summary": cta_summary,
+        "generation_metadata": generation_metadata,
+        "unowned_sections": unowned,
+        "warnings": warnings,
+    }
+
+
+def emit_slide_data(model):
+    return {
+        "version": model["version"],
+        "slides": model["slides"],
+        "warnings": model["warnings"],
+    }
+
+
+def emit_outline(model):
+    """A per-slide summary for the Claude Design exporter — never a slide-data dump."""
+    entries = []
+    for slide in model["slides"]:
+        intent = slide["intent"] if isinstance(slide["intent"], dict) else {}
+        entries.append({
+            "number": slide["number"],
+            "headline": slide["headline"],
+            "layout": slide["layout"],
+            "slide_kind": slide["slide_kind"],
+            "role": intent.get("role"),
+            "has_diagram": slide["diagram_mermaid"] is not None,
+            "citation_count": len(slide["citations"]),
+        })
+    return {
+        "version": model["version"],
+        "entries": entries,
+        "warnings": model["warnings"],
+    }
+
+
+def emit_metadata(model):
+    return {
+        "version": model["version"],
+        "frontmatter": model["frontmatter"],
+        "generation_metadata": model["generation_metadata"],
+        "cta_summary": model["cta_summary"],
+        "unowned_sections": model["unowned_sections"],
+        "warnings": model["warnings"],
+    }
+
+
+EMITTERS = {
+    "slide-data": emit_slide_data,
+    "outline": emit_outline,
+    "metadata": emit_metadata,
+}
+
+
+class _EnvelopeParser(argparse.ArgumentParser):
+    """Argument parser that reports usage errors through the JSON envelope."""
+
+    def error(self, message):
+        emit(False, None, "argument error: {0}".format(message))
+        raise SystemExit(1)
+
+
+def main() -> int:
+    parser = _EnvelopeParser(
+        description="Parse a presentation brief into slide-data, an outline, or metadata.")
+    parser.add_argument("--brief", help="Path to the presentation brief")
+    # --emit is validated by hand rather than with choices= so an unlisted value
+    # still answers with an envelope instead of an argparse usage message.
+    parser.add_argument("--emit", help="One of: slide-data, outline, metadata")
+    parser.add_argument("--output", help="Optional path to write the payload to")
+    args = parser.parse_args()
+
+    if not args.brief:
+        return emit(False, None, "--brief is required")
+    if args.emit not in EMITTERS:
+        return emit(False, None, "--emit must be one of: {0}".format(", ".join(EMITTERS)))
+
+    try:
+        model = parse_brief(args.brief)
+    except BriefError as exc:
+        return emit(False, None, str(exc))
+    except OSError as exc:
+        return emit(False, None, "cannot read brief: {0}".format(exc))
+    except Exception as exc:  # never surface a traceback
+        return emit(False, None, "unparseable brief: {0}".format(exc))
+
+    payload = EMITTERS[args.emit](model)
+
+    if args.output:
+        try:
+            with open(args.output, "w", encoding="utf-8") as handle:
+                json.dump(payload, handle, indent=2, ensure_ascii=False)
+                handle.write("\n")
+        except OSError as exc:
+            return emit(False, None, "cannot write output: {0}".format(exc))
+
+    return emit(True, payload, "")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/cogni-workspace/tests/fixtures/brief/unfenced-slides-4.0.md
+++ b/cogni-workspace/tests/fixtures/brief/unfenced-slides-4.0.md
@@ -1,0 +1,33 @@
+---
+type: presentation-brief
+version: "4.0"
+theme: fixture-theme
+customer: "Fixture GmbH"
+provider: "Test AG"
+language: de
+slides: 2
+---
+
+## Slide 1: Ein Brief ohne Einfassung bleibt lesbar
+
+Layout: title-slide
+Title: Schema 4.0
+Subtitle: Ohne Fences, ohne die Zusaetze aus 4.1
+
+## Slide 2: Zwei Spalten reichen fuer den Vergleich
+
+Layout: two-columns-equal
+Slide-Title: Vorher und nachher
+Left-Column:
+  Headline: Heute
+  Bullets:
+    - "Manuelle Kontrolle"
+    - "Keine Historie"
+Right-Column:
+  Headline: Morgen
+  Bullets:
+    - "Laufende Messung"
+    - "Nachvollziehbare Historie"
+Speaker-Notes: |
+  Diese Folie stammt aus dem 4.0-Bestand.
+  Sie traegt keine 4.1-Felder.

--- a/cogni-workspace/tests/fixtures/brief/valid-slides-4.1.md
+++ b/cogni-workspace/tests/fixtures/brief/valid-slides-4.1.md
@@ -1,0 +1,136 @@
+---
+type: presentation-brief
+version: "4.1"
+theme: fixture-theme
+customer: "Fixture GmbH"
+provider: "Test AG"
+language: de
+arc_type: problem-solution
+governing_thought: "Die Zustandsüberwachung muss messbar größer werden."
+confidence_score: 0.9
+slides: 3
+climax: 2
+design:
+  register: sachlich
+  dark_slides: [1, 3]
+  speaker_notes: ausführlich
+key_figures:
+  - "3 Standorte im Pilotbetrieb"
+  - "12 Wochen bis zum Rollout"
+transformation_notes: |
+  Diese Datei ist eine Testvorlage.
+  Sie deckt Konstrukte ab, die EXAMPLE_BRIEF.md nicht enthält.
+---
+
+## Slide 1: Der Pilotbetrieb ist abgeschlossen
+
+```yaml
+Layout: title-slide
+Slide-Kind: content
+intent:
+  role: hook
+  emphasis: none
+visual:
+  kind: none
+Title: Zustandsüberwachung im Pilotbetrieb
+Subtitle: Ergebnisse aus drei Standorten
+Metadata: Fixture GmbH | Test AG | Februar 2026
+```
+
+## Slide 2: Vier Rollen entscheiden über den Rollout
+
+```yaml
+Layout: four-quadrants
+Slide-Kind: internal-prep
+intent:
+  role: context
+  emphasis: medium
+visual:
+  kind: grid
+Slide-Title: Das Buying Center
+Q1:
+  Label: Economic Buyer
+  Sublabel: CFO Infrastruktur
+  Bullets:
+    - "Führen mit: Kapitalbindung"
+    - "Vermeiden: Technikdetails"
+Q2:
+  Label: Technical Buyer
+  Sublabel: Leiter Instandhaltung
+  Bullets:
+    - "Führen mit: Ausfallzeiten"
+    - "Vermeiden: Vertragsdetails"
+Q3:
+  Label: User Buyer
+  Sublabel: Schichtleitung
+  Bullets:
+    - "Führen mit: Arbeitsalltag"
+    - "Vermeiden: Kennzahlen"
+Q4:
+  Label: Coach
+  Sublabel: Projektleitung
+  Bullets:
+    - "Führen mit: Zeitplan"
+    - "Vermeiden: Grundsatzfragen"
+Bottom-Banner:
+  Text: INTERN — NICHT PRÄSENTIEREN
+Speaker-Notes: |
+  Diese Folie bleibt intern.
+
+  Der Absatz oben ist durch eine Leerzeile getrennt.
+    Diese Zeile ist tiefer eingerückt und muss so bleiben.
+  Quelle mit Fussnote <sup>[1](https://example.invalid/eins)</sup> im Fliesstext.
+  Das Muster <sup>[N]</sup> ist nur eine Beschreibung und keine Fussnote.
+```
+
+## Slide 3: Der Rollout läuft in drei Schritten
+
+```yaml
+Layout: timeline-steps
+Slide-Kind: content
+intent:
+  role: resolution
+  emphasis: high
+visual:
+  kind: diagram
+Slide-Title: Rollout-Fahrplan
+Step-2:
+  Title: Ausweitung
+  Detail: Zwölf weitere Standorte
+Step-10:
+  Title: Abschluss
+  Detail: "Rollout abgeschlossen"
+Step-1:
+  Title: Pilot
+  Detail: Drei Standorte
+Diagram: |
+  graph LR
+    A[Pilot] --> B[Ausweitung]
+    B --> C[Abschluss]
+Bottom-Banner:
+  Text: Rollout in drei Schritten
+```
+
+## Generation Metadata
+
+```yaml
+slides_total: 3
+content_slides: 2
+prep_slides: 1
+avg_confidence: 0.9
+validation:
+  schema: pass
+  messages: pass
+  copy: pass
+  logic: pass
+  integrity: pass
+```
+
+## Notes
+
+| Feld | Zweck |
+|---|---|
+| Step-N | prüft die numerische Sortierung |
+| Q1-Q4 | prüft die Alias-Normalisierung |
+
+Dieser Abschnitt ist bewusst nicht eingefasst und gehört keinem Parser.

--- a/cogni-workspace/tests/test-parse-brief.sh
+++ b/cogni-workspace/tests/test-parse-brief.sh
@@ -1,0 +1,412 @@
+#!/usr/bin/env bash
+#
+# test-parse-brief.sh — suite for cogni-workspace/scripts/parse-brief.py.
+#
+# Parses the real brief (libraries/EXAMPLE_BRIEF.md) plus two authored fixtures
+# under tests/fixtures/brief/, which sit one directory below the runner's
+# non-recursive globs and so are never discovered as suites themselves.
+#
+# Mutation recipe (the discriminator is pb26-fixture-41-parses-clean):
+#
+#   bash "$HOME/.claude/plugins/marketplaces/managed-service/cogni-service/scripts/mutation-check.sh" \
+#     --root . \
+#     --file cogni-workspace/tests/fixtures/brief/valid-slides-4.1.md \
+#     --expr 's{  integrity: pass\n\x60\x60\x60\n}{  integrity: pass\n}' \
+#     --test 'bash cogni-workspace/tests/test-parse-brief.sh' \
+#     --case pb26-fixture-41-parses-clean
+#
+# Verdict: guard_verified. The search text occurs exactly once, and its closing
+# fence is the fixture's LAST fence, so deleting it leaves the Generation
+# Metadata block unclosed at EOF. The parser then returns success:false and
+# pb26 goes red. \x60 is a backtick, written as an escape because the recipe is
+# quoted inside a fenced block in the PR body.
+
+set -u
+
+failures=0
+TMPROOT="$(mktemp -d)"
+trap 'rm -rf "$TMPROOT"' EXIT
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+PB="$ROOT/cogni-workspace/scripts/parse-brief.py"
+EXB="$ROOT/cogni-workspace/libraries/EXAMPLE_BRIEF.md"
+F41="$ROOT/cogni-workspace/tests/fixtures/brief/valid-slides-4.1.md"
+F40="$ROOT/cogni-workspace/tests/fixtures/brief/unfenced-slides-4.0.md"
+
+python3 "$PB" --brief "$EXB" --emit slide-data > "$TMPROOT/sd.json" 2>"$TMPROOT/sd.err"
+python3 "$PB" --brief "$EXB" --emit outline    > "$TMPROOT/ol.json" 2>/dev/null
+python3 "$PB" --brief "$EXB" --emit metadata   > "$TMPROOT/md.json" 2>/dev/null
+python3 "$PB" --brief "$F41" --emit slide-data > "$TMPROOT/f41.json" 2>/dev/null
+python3 "$PB" --brief "$F41" --emit metadata   > "$TMPROOT/f41m.json" 2>/dev/null
+python3 "$PB" --brief "$F40" --emit slide-data > "$TMPROOT/f40.json" 2>/dev/null
+
+# A structurally broken brief: an unclosed fence, built here rather than
+# committed, because a deliberate corruption is not a corpus artifact.
+{
+  printf -- '---\n'
+  printf 'type: presentation-brief\n'
+  printf 'version: "4.1"\n'
+  printf -- '---\n\n'
+  printf '## Slide 1: Diese Folie wird nie geschlossen\n\n'
+  printf '```yaml\n'
+  printf 'Layout: title-slide\n'
+  printf 'Title: Ohne schliessende Einfassung\n'
+} > "$TMPROOT/broken.md"
+python3 "$PB" --brief "$TMPROOT/broken.md" --emit slide-data > "$TMPROOT/broken.json" 2>"$TMPROOT/broken.err"
+
+# --- pb01
+if [ -f "$PB" ]; then
+  echo "PASS: pb01-script-exists"
+else
+  echo "FAIL: pb01-script-exists parse-brief.py is missing"
+  failures=$((failures + 1))
+fi
+
+# --- pb02
+if ! grep -nE '^(import|from) ' "$PB" | grep -qvE '^[0-9]+:(import|from) (argparse|json|re|sys)\b'; then
+  echo "PASS: pb02-stdlib-only-imports"
+else
+  echo "FAIL: pb02-stdlib-only-imports a non-stdlib import is present"
+  failures=$((failures + 1))
+fi
+
+# --- pb03
+if [ -f "$F41" ]; then
+  echo "PASS: pb03-fixture-41-exists"
+else
+  echo "FAIL: pb03-fixture-41-exists valid-slides-4.1.md is missing"
+  failures=$((failures + 1))
+fi
+
+# --- pb04
+if [ -f "$F40" ]; then
+  echo "PASS: pb04-fixture-40-exists"
+else
+  echo "FAIL: pb04-fixture-40-exists unfenced-slides-4.0.md is missing"
+  failures=$((failures + 1))
+fi
+
+# --- pb05
+if python3 -c "import json,sys; d=json.load(open('$TMPROOT/sd.json')); sys.exit(0 if d['success'] else 1)"; then
+  echo "PASS: pb05-example-brief-envelope-success"
+else
+  echo "FAIL: pb05-example-brief-envelope-success EXAMPLE_BRIEF.md did not parse"
+  failures=$((failures + 1))
+fi
+
+# --- pb06
+python3 "$PB" --brief "$EXB" --emit bogus > "$TMPROOT/bad.json" 2>"$TMPROOT/bad.err"
+if python3 -c "import json,sys; d=json.load(open('$TMPROOT/bad.json')); sys.exit(0 if d['success'] is False and d['error'] else 1)"; then
+  echo "PASS: pb06-bad-emit-value-yields-envelope"
+else
+  echo "FAIL: pb06-bad-emit-value-yields-envelope an unlisted --emit did not answer with an envelope"
+  failures=$((failures + 1))
+fi
+
+# --- pb07
+python3 "$PB" --brief "$TMPROOT/does-not-exist.md" --emit slide-data > "$TMPROOT/miss.json" 2>"$TMPROOT/miss.err"
+if python3 -c "import json,sys; d=json.load(open('$TMPROOT/miss.json')); sys.exit(0 if d['success'] is False else 1)"; then
+  echo "PASS: pb07-missing-brief-yields-envelope"
+else
+  echo "FAIL: pb07-missing-brief-yields-envelope a missing --brief did not answer with an envelope"
+  failures=$((failures + 1))
+fi
+
+# --- pb08
+if python3 -c "import json,sys; d=json.load(open('$TMPROOT/broken.json')); e=d.get('error') or ''; sys.exit(0 if d['success'] is False and any(c.isdigit() for c in e) else 1)"; then
+  echo "PASS: pb08-broken-fence-names-a-line"
+else
+  echo "FAIL: pb08-broken-fence-names-a-line an unclosed fence did not return a line number"
+  failures=$((failures + 1))
+fi
+
+# --- pb09
+if ! grep -q 'Traceback' "$TMPROOT/sd.err" "$TMPROOT/bad.err" "$TMPROOT/miss.err" "$TMPROOT/broken.err"; then
+  echo "PASS: pb09-no-traceback-on-any-path"
+else
+  echo "FAIL: pb09-no-traceback-on-any-path a traceback reached stderr"
+  failures=$((failures + 1))
+fi
+
+# --- pb10
+if grep -q -- '--brief' "$PB" && grep -q -- '--emit' "$PB" && grep -q -- '--output' "$PB"; then
+  echo "PASS: pb10-three-flags-present"
+else
+  echo "FAIL: pb10-three-flags-present a documented flag is missing"
+  failures=$((failures + 1))
+fi
+
+# --- pb11
+python3 "$PB" --brief "$EXB" --emit slide-data --output "$TMPROOT/out.json" > "$TMPROOT/out.stdout" 2>/dev/null
+if [ -s "$TMPROOT/out.json" ] && python3 -c "import json,sys; d=json.load(open('$TMPROOT/out.stdout')); sys.exit(0 if d['success'] else 1)"; then
+  echo "PASS: pb11-output-writes-and-stdout-keeps-envelope"
+else
+  echo "FAIL: pb11-output-writes-and-stdout-keeps-envelope --output suppressed the envelope or wrote nothing"
+  failures=$((failures + 1))
+fi
+
+# --- pb12
+if python3 -c "
+import importlib.util, io, sys
+buf = io.StringIO(); saved = sys.stdout; sys.stdout = buf
+spec = importlib.util.spec_from_file_location('pb', '$PB')
+mod = importlib.util.module_from_spec(spec); spec.loader.exec_module(mod)
+sys.stdout = saved
+model = mod.parse_brief('$EXB')
+sys.exit(0 if buf.getvalue() == '' and len(model['slides']) == 13 else 1)"; then
+  echo "PASS: pb12-spec-load-is-silent"
+else
+  echo "FAIL: pb12-spec-load-is-silent importing the module printed or did not expose parse_brief"
+  failures=$((failures + 1))
+fi
+
+# --- pb13
+if python3 -c "import json,sys; d=json.load(open('$TMPROOT/sd.json')); sys.exit(0 if len(d['data']['slides']) == 13 else 1)"; then
+  echo "PASS: pb13-example-brief-has-13-slides"
+else
+  echo "FAIL: pb13-example-brief-has-13-slides the slide count does not match the headings"
+  failures=$((failures + 1))
+fi
+
+# --- pb14
+if python3 -c "
+import json, sys
+s = json.load(open('$TMPROOT/sd.json'))['data']['slides'][3]
+hero = s['fields']['Hero-Stat-Box']; ctx = s['fields']['Context-Box']
+sys.exit(0 if str(hero['Number']) == '688' and len(ctx['Bullets']) == 3 and all(isinstance(b, str) for b in ctx['Bullets']) else 1)"; then
+  echo "PASS: pb14-hero-number-and-context-bullets-intact"
+else
+  echo "FAIL: pb14-hero-number-and-context-bullets-intact the 688 stat or its context bullets were altered"
+  failures=$((failures + 1))
+fi
+
+# --- pb15
+python3 -c "
+import json
+print(json.load(open('$TMPROOT/sd.json'))['data']['slides'][3]['speaker_notes'], end='')" > "$TMPROOT/notes.actual"
+sed -n '268,282p' "$EXB" > "$TMPROOT/notes.expected"
+if cmp -s "$TMPROOT/notes.actual" "$TMPROOT/notes.expected"; then
+  echo "PASS: pb15-speaker-notes-byte-equal"
+else
+  echo "FAIL: pb15-speaker-notes-byte-equal the block scalar was trimmed, re-wrapped or re-indented"
+  failures=$((failures + 1))
+fi
+
+# --- pb16
+if python3 -c "
+import json, sys, re
+slides = json.load(open('$TMPROOT/sd.json'))['data']['slides']
+bad = [k for s in slides for k in s['fields'] if re.match(r'^Q[1-9][0-9]*\$', k)]
+sys.exit(0 if not bad else 1)"; then
+  echo "PASS: pb16-no-q-alias-survives"
+else
+  echo "FAIL: pb16-no-q-alias-survives a Q1..Q4 key is still present in fields"
+  failures=$((failures + 1))
+fi
+
+# --- pb17
+if python3 -c "
+import json, sys
+s = json.load(open('$TMPROOT/sd.json'))['data']['slides'][2]
+quads = [s['fields'].get('Quadrant-%d' % i) for i in range(1, 5)]
+ok = all(isinstance(q, dict) and 'Label' in q and 'Sublabel' in q and 'Bullets' in q for q in quads)
+sys.exit(0 if ok else 1)"; then
+  echo "PASS: pb17-normalized-quadrants-keep-their-subkeys"
+else
+  echo "FAIL: pb17-normalized-quadrants-keep-their-subkeys normalization dropped a sub-key"
+  failures=$((failures + 1))
+fi
+
+# --- pb18
+if python3 -c "
+import json, sys
+s = json.load(open('$TMPROOT/f41.json'))['data']['slides'][1]
+quads = [s['fields'].get('Quadrant-%d' % i) for i in range(1, 5)]
+sys.exit(0 if all(isinstance(q, dict) and 'Number' not in q for q in quads) else 1)"; then
+  echo "PASS: pb18-alias-normalization-invents-no-number"
+else
+  echo "FAIL: pb18-alias-normalization-invents-no-number a Number was synthesized for an alias that carried none"
+  failures=$((failures + 1))
+fi
+
+# --- pb19
+if python3 -c "
+import json, sys
+s = json.load(open('$TMPROOT/sd.json'))['data']['slides'][5]
+got = [s['fields']['Quadrant-%d' % i]['Number'] for i in range(1, 5)]
+sys.exit(0 if [str(g) for g in got] == ['688', '42%', '156%', '€2.8M'] else 1)"; then
+  echo "PASS: pb19-canonical-quadrant-numbers-not-coerced"
+else
+  echo "FAIL: pb19-canonical-quadrant-numbers-not-coerced an opaque Number value was coerced or altered"
+  failures=$((failures + 1))
+fi
+
+# --- pb20
+if python3 -c "
+import json, sys
+s = json.load(open('$TMPROOT/sd.json'))['data']['slides'][3]
+want = [{'n': 1, 'url': 'https://www.eba.bund.de/sicherheitsbericht-2024'},
+        {'n': 2, 'url': 'https://www.bka.de/kriminalstatistik'}]
+sys.exit(0 if s['citations'] == want else 1)"; then
+  echo "PASS: pb20-citations-carry-number-and-url-in-order"
+else
+  echo "FAIL: pb20-citations-carry-number-and-url-in-order a citation number or url was dropped"
+  failures=$((failures + 1))
+fi
+
+# --- pb21
+if python3 -c "
+import json, sys
+s = json.load(open('$TMPROOT/sd.json'))['data']['slides'][12]
+sys.exit(0 if s['citations'] == [] else 1)"; then
+  echo "PASS: pb21-bare-sup-marker-is-not-a-citation"
+else
+  echo "FAIL: pb21-bare-sup-marker-is-not-a-citation a superscript without a url became a citation"
+  failures=$((failures + 1))
+fi
+
+# --- pb22
+if python3 -c "
+import json, sys
+import importlib.util
+spec = importlib.util.spec_from_file_location('pb', '$PB')
+mod = importlib.util.module_from_spec(spec); spec.loader.exec_module(mod)
+keys = set(mod.SLIDE_KEYS)
+slides = json.load(open('$TMPROOT/sd.json'))['data']['slides']
+sys.exit(0 if len(keys) == 13 and all(set(s.keys()) == keys for s in slides) else 1)"; then
+  echo "PASS: pb22-every-slide-carries-all-thirteen-keys"
+else
+  echo "FAIL: pb22-every-slide-carries-all-thirteen-keys a key was omitted instead of being null"
+  failures=$((failures + 1))
+fi
+
+# --- pb23
+if python3 -c "
+import json, sys
+slides = json.load(open('$TMPROOT/sd.json'))['data']['slides']
+declared = [s for s in slides if 'Bottom-Banner' in s['fields']]
+undeclared = [s for s in slides if 'Bottom-Banner' not in s['fields']]
+ok = all(s['bottom_banner'] for s in declared) and all(s['bottom_banner'] is None for s in undeclared)
+sys.exit(0 if ok and declared else 1)"; then
+  echo "PASS: pb23-bottom-banner-surfaces-at-top-level"
+else
+  echo "FAIL: pb23-bottom-banner-surfaces-at-top-level a declared banner did not reach the slide top level"
+  failures=$((failures + 1))
+fi
+
+# --- pb24
+if python3 -c "
+import json, sys
+slides = json.load(open('$TMPROOT/sd.json'))['data']['slides']
+declared = [s for s in slides if 'Diagram' in s['fields']]
+undeclared = [s for s in slides if 'Diagram' not in s['fields']]
+ok = all(s['diagram_mermaid'] and '\n' in s['diagram_mermaid'] for s in declared)
+ok = ok and all(s['diagram_mermaid'] is None for s in undeclared)
+sys.exit(0 if ok and len(declared) >= 2 else 1)"; then
+  echo "PASS: pb24-diagram-retains-its-newlines"
+else
+  echo "FAIL: pb24-diagram-retains-its-newlines a mermaid block was collapsed or lost"
+  failures=$((failures + 1))
+fi
+
+# --- pb25
+if python3 -c "
+import json, sys
+s = json.load(open('$TMPROOT/f41.json'))['data']['slides'][2]
+steps = [k for k in s['fields'] if k.startswith('Step-')]
+sys.exit(0 if steps == ['Step-1', 'Step-2', 'Step-10'] else 1)"; then
+  echo "PASS: pb25-step-keys-sort-numerically"
+else
+  echo "FAIL: pb25-step-keys-sort-numerically Step-10 did not follow Step-2"
+  failures=$((failures + 1))
+fi
+
+# --- pb26
+if python3 -c "import json,sys; d=json.load(open('$TMPROOT/f41.json')); sys.exit(0 if d['success'] else 1)"; then
+  echo "PASS: pb26-fixture-41-parses-clean"
+else
+  echo "FAIL: pb26-fixture-41-parses-clean the 4.1 fixture did not parse"
+  failures=$((failures + 1))
+fi
+
+# --- pb27
+if python3 -c "
+import json, sys
+o = json.load(open('$TMPROOT/ol.json'))['data']['entries']
+s = json.load(open('$TMPROOT/sd.json'))['data']['slides']
+ok = len(o) == len(s) and [e['number'] for e in o] == [x['number'] for x in s]
+ok = ok and all('headline' in e and 'fields' not in e and 'speaker_notes' not in e for e in o)
+sys.exit(0 if ok else 1)"; then
+  echo "PASS: pb27-outline-is-an-ordered-summary"
+else
+  echo "FAIL: pb27-outline-is-an-ordered-summary the outline lost order or is a slide-data dump"
+  failures=$((failures + 1))
+fi
+
+# --- pb28
+if python3 -c "
+import json, sys
+m = json.load(open('$TMPROOT/md.json'))['data']
+fm = m['frontmatter']
+ok = m['generation_metadata'] is None and 'generation_metadata' in m
+ok = ok and isinstance(fm.get('design'), dict) and isinstance(fm.get('key_figures'), list)
+sys.exit(0 if ok else 1)"; then
+  echo "PASS: pb28-metadata-degrades-without-a-generation-block"
+else
+  echo "FAIL: pb28-metadata-degrades-without-a-generation-block metadata errored or flattened the frontmatter"
+  failures=$((failures + 1))
+fi
+
+# --- pb29
+if python3 -c "
+import json, sys
+m = json.load(open('$TMPROOT/f41m.json'))['data']
+gm = m['generation_metadata']
+sys.exit(0 if isinstance(gm, dict) and gm.get('validation', {}).get('integrity') == 'pass' else 1)"; then
+  echo "PASS: pb29-metadata-populated-when-the-block-is-present"
+else
+  echo "FAIL: pb29-metadata-populated-when-the-block-is-present a present Generation Metadata block was not read"
+  failures=$((failures + 1))
+fi
+
+# --- pb30
+if python3 -c "
+import json, sys
+d = json.load(open('$TMPROOT/f40.json'))
+ok = d['success'] and any('unfenced' in w for w in d['data']['warnings'])
+sys.exit(0 if ok else 1)"; then
+  echo "PASS: pb30-unfenced-40-parses-with-a-warning"
+else
+  echo "FAIL: pb30-unfenced-40-parses-with-a-warning the 4.0 shape did not parse or warned about nothing"
+  failures=$((failures + 1))
+fi
+
+# --- pb31
+if python3 -c "
+import json, sys
+s = json.load(open('$TMPROOT/sd.json'))['data']['slides'][0]
+sys.exit(0 if s['fields'].get('Metadata') == 'Deutsche Bahn AG | TechVision Solutions | Februar 2026' else 1)"; then
+  echo "PASS: pb31-pipes-in-a-scalar-stay-prose"
+else
+  echo "FAIL: pb31-pipes-in-a-scalar-stay-prose a value containing a pipe was read as a block scalar"
+  failures=$((failures + 1))
+fi
+
+# --- pb32
+if python3 -c "
+import json, sys
+m = json.load(open('$TMPROOT/md.json'))['data']
+sys.exit(0 if m['unowned_sections'] == ['Key Differences from v2.0/v3.0'] else 1)"; then
+  echo "PASS: pb32-unfenced-trailing-section-is-not-parsed"
+else
+  echo "FAIL: pb32-unfenced-trailing-section-is-not-parsed a trailing markdown section was claimed as yaml"
+  failures=$((failures + 1))
+fi
+
+if [ "$failures" -eq 0 ]; then
+  echo "All parse-brief tests passed."
+  exit 0
+else
+  echo "$failures test(s) failed."
+  exit 1
+fi


### PR DESCRIPTION
Closes #1791.

## Summary

- Adds `cogni-workspace/scripts/parse-brief.py` — stdlib-only (no PyYAML, no vendored parser). One parse of the brief, three projections: `--brief <path> --emit slide-data|outline|metadata [--output <path>]`, behind the repo's `{"success","data","error"}` envelope. Exactly one envelope reaches stdout on every path — success, bad `--emit`, missing `--brief`, malformed brief — and never a traceback.
- The module has no import-time side effects, so a consumer can load it through `importlib.util.spec_from_file_location` the way `validate-theme-manifest.py:217-226` loads its own sibling. That importability is the point: it is what stops #1792 / #1794 / #1795 / #1796 each re-deriving the parse.
- `slide-data` stays drop-in for `generate-html-slides.py` — every slide carries all eight keys `render-html-slides/SKILL.md:62-70` documents (`number`, `headline`, `layout`, `fields`, `speaker_notes`, `bottom_banner`, `diagram_mermaid`, `citations`), null or `[]` when absent rather than omitted, plus the five 4.1 additions `slide_kind`, `source`, `cta`, `intent`, `visual`.
- Adds `cogni-workspace/tests/test-parse-brief.sh` (32 cases, `pb01`–`pb32`) and two fixtures under `cogni-workspace/tests/fixtures/brief/`.
- Rewires nothing: no file under `cogni-workspace/skills/**` or `cogni-workspace/libraries/**`, and no `plugin.json`.

## Scope decisions

**Block scalars are preserved byte-for-byte, indent included.** The acceptance bar calls for `speaker_notes` "byte-equal to the block scalar in the source, blank lines and leading two-space structure preserved" and lists "re-indented" among its falsifiers. All 12 non-blank lines of the Slide-4 block sit at exactly 2 spaces, so a YAML-style dedent would erase the structure the item names. The value therefore keeps its source bytes; `pb15` proves it with `cmp` against a plain `sed -n '268,282p'` slice, not a transformed one. The trailing blank at `EXAMPLE_BRIEF.md:283` is clipped out of the value and the dedented `Source:` at :284 terminates the block.

**The `Q1`/`Quadrant-1` defect is closed in the parser, never in the brief.** `EXAMPLE_BRIEF.md:171/179/187/195` writes `Q1:`–`Q4:` while `generate-html-slides.py:341` reads only `Quadrant-{i}`, so that slide renders four empty cards today. The alias is renamed in place; the sub-map passes through verbatim and **no `Number` is synthesized** for an alias that carries none — inventing one would render a statistic nobody wrote. A slide already using canonical names is left alone. Editing the brief instead would have fixed one file and left every future producer-written brief broken.

**No numeric coercion of opaque values.** `Number` is `688` on one slide and `42%`, `156%`, `€2.8M` on another, so quoted scalars stay verbatim strings and only bare numerics resolve. `pb19` pins all four.

**`--emit metadata` degrades rather than erroring.** `EXAMPLE_BRIEF.md` carries no `## Generation Metadata` section — the block is defined at `07-output-template.md:385-405` but absent from the only real brief — so `generation_metadata` is present and `null`, with the frontmatter's nested `design` map and `key_figures` list still structured.

**A value containing a pipe is prose, not a block scalar.** Only a value token that is exactly `|`, `|-` or `|+` opens a block, so `Metadata: Deutsche Bahn AG | TechVision Solutions | Februar 2026` stays a scalar (`pb31`).

**Unowned sections are skipped, not parsed.** The trailing `## Key Differences from v2.0/v3.0` markdown table is recorded under `unowned_sections` and never read as YAML (`pb32`).

**Fixtures.** `valid-slides-4.1.md` carries the constructs `EXAMPLE_BRIEF.md` cannot: out-of-order `Step-2`/`Step-10`/`Step-1`, `Q1`–`Q4` aliases with no `Number`, a `## Generation Metadata` block, and a Speaker-Notes block with an interior blank line and a deeper-indented line. `unfenced-slides-4.0.md` is an authored, faithful 4.0 brief — not a de-fenced 4.1 file — because no unfenced brief exists anywhere in the repo to exercise the warning path. The broken-fence input is built in the suite's own `mktemp -d`: a deliberate corruption is not an artifact worth committing. Both fixtures sit one directory below the runner's two non-recursive globs (`run-plugin-tests.py:92-93`), so neither can be discovered as a suite.

## Test plan

- [x] `bash cogni-workspace/tests/test-parse-brief.sh` — 32/32 pass, exit 0
- [x] `python3 scripts/run-plugin-tests.py --filter cogni-workspace` — 21/21 suites pass, 0 failed
- [x] `--list` names the new suite and no path under `tests/fixtures/`
- [x] `check-case-id-pairing.py`, `check-result-line-plainness.py`, `check-external-dispatch.py`, `check-version-bump.py`, `check-code-span-nesting.py`, `check-breadcrumbs.py` — all exit 0
- [x] `--emit slide-data` on `EXAMPLE_BRIEF.md` → `success: true`, `len(data.slides) == 13`; `--emit outline` → 13 ordered entries; `--emit metadata` → `generation_metadata: null`
- [x] `git diff --name-only origin/main` shows only `cogni-workspace/scripts/parse-brief.py` and paths under `cogni-workspace/tests/`

## Mutation recipe

The discriminator is `pb26-fixture-41-parses-clean`. Verdict: **guard_verified** — replayed on this branch, `mutated_result: red`, `restored_result: green`.

```
bash "$HOME/.claude/plugins/marketplaces/managed-service/cogni-service/scripts/mutation-check.sh" \
  --root . \
  --file cogni-workspace/tests/fixtures/brief/valid-slides-4.1.md \
  --expr 's{  integrity: pass\n\x60\x60\x60\n}{  integrity: pass\n}' \
  --test 'bash cogni-workspace/tests/test-parse-brief.sh' \
  --case pb26-fixture-41-parses-clean
```

The search text occurs exactly once, and its closing fence is the fixture's **last** fence, so deleting it leaves the Generation Metadata block unclosed at EOF; the parser then returns `success: false` and `pb26` goes red. `\x60` is a backtick, written as an escape so the recipe survives being quoted inside this fenced block.

## Open questions

- **The `--emit outline` shape has no consumer at base.** #1794 and #1795 are unbuilt, so the acceptance bar can only gate its structural floor (one ordered entry per slide, number + headline). Shipped as a per-slide summary — `{number, headline, layout, slide_kind, role, has_diagram, citation_count}` — deliberately excluding `fields` and `speaker_notes` so it is a summary rather than a slide-data dump. No gate in the repo can decide whether that field set is right for the Claude Design exporter; worth a human eyeball before #1794 builds against it.
- **Four pre-existing renderer/brief mismatches are deliberately left alone.** The scope fence forbids touching the renderer, and parser-side aliasing would hide them rather than fix them: `three-options` briefs write `Name`/`Price`/`Badge`/`Features` while `render_three_options` reads `Title|Label`/`Subtitle`/`Bullets`/`Recommended`; the `Step-N` docs say `Description` while `render_timeline_steps` reads `Detail`; `Quadrant-N.Sublabel` and `.Icon` are carried by every brief and read by no renderer; and `render_references_slide` is unreachable because dispatch keys on `Layout` and no brief ever sets `Layout: references`. Each is a candidate follow-up, not part of this change.
- **A quality-pass finding worth a second opinion, not applied here.** Sibling suites (`test-sanitize-theme.sh`, `test-check-contrast.sh`) define shared `pass`/`fail`/`assert_json` helpers; this suite open-codes 32 `if/else` blocks so each case id appears as its own quoted literal. Both shapes pass `check-case-id-pairing.py`. Converting to the shared helpers is a legitimate cleanup, but a 32-case refactor after the suite was already green is a regression risk taken for style, so it is flagged rather than done.
- **An untested latent gap.** An unfenced `## CTA Summary` in a 4.0 brief lands in `unowned_sections` with `cta_summary: null` and no warning, because the fenced/unfenced policy lives per-slide. No acceptance item covers it and no fixture exercises it, so it is recorded here rather than fixed without a test.

## Token-scope note

`check-token-scope.sh --strict` reports `over_scoped` for the runner token (extra: `gist`, `read:org`, `workflow`). This is a pre-existing property of the host credential, not something this change introduces; the push proceeded under the settled `--allow-overscoped` opt-out flag.