### PR TITLE
cogni-workspace: /render-infographic accepts brief versions 1.0, 1.1 and 1.2

### DIFF
--- a/cogni-workspace/commands/render-infographic.md
+++ b/cogni-workspace/commands/render-infographic.md
@@ -39,10 +39,10 @@ Follow these steps. Do not invent alternative workflows.
 Read the brief and confirm:
 
 - Frontmatter contains `type: infographic-brief`
-- Frontmatter contains `version: "1.0"`
+- Frontmatter contains `version: "1.0"`, `"1.1"`, or `"1.2"` — all three are accepted
 - Frontmatter contains `style_preset: <value>`
 
-If any of these are missing or `type`/`version` do not match, abort with a clear error.
+If any of these are missing, or `type` is not `infographic-brief`, or the version is outside the accepted set, abort with a clear error naming the version found and the three accepted values (`"1.0"`, `"1.1"`, `"1.2"`).
 
 ### Step 3: Route to the right agent
 
@@ -56,6 +56,8 @@ Match the `style_preset` value and dispatch via the `Agent` tool:
   agent. If the user picks hand-drawn without specifying, ask a second `AskUserQuestion` to
   disambiguate between sketchnote and whiteboard — the two traditions have opposite
   discipline rules and the agents refuse to render the wrong preset.
+
+**Hand-drawn version ceiling.** `render-infographic-sketchnote` and `render-infographic-whiteboard` accept only `version: "1.0"` and `"1.1"`. This ceiling binds all four routes above: the `sketchnote` bullet, the `whiteboard` bullet, and both arms of the `AskUserQuestion` fallback — the family choice and the sketchnote/whiteboard disambiguation. If the resolved preset is `sketchnote` or `whiteboard` and the brief version is `"1.2"`, do not dispatch: abort with an error naming the preset and the version found. The editorial route (`render-infographic-pencil`) stays open for all three accepted versions.
 
 Pass the absolute `BRIEF_PATH` and, if the user provided `--output`, the `OUTPUT_PATH`.
 Prompt template:

--- a/cogni-workspace/skills/story-to-infographic/references/05-validation-checklist.md
+++ b/cogni-workspace/skills/story-to-infographic/references/05-validation-checklist.md
@@ -12,7 +12,7 @@ Structural correctness. Every field must exist and conform to its type.
 
 | Check | Pass | Fail |
 |-------|------|------|
-| Brief frontmatter present | `type: infographic-brief`, `version: "1.0"` | Missing or wrong type/version |
+| Brief frontmatter present | `type: infographic-brief`, `version: "1.0"`, `"1.1"`, or `"1.2"` | Missing frontmatter, wrong type, or a version outside the accepted set |
 | Required frontmatter fields | All present: theme, theme_path, language, layout_type, style_preset, orientation, dimensions, governing_thought | Any missing |
 | Block types valid | Every `Block-Type` is one of: title, kpi-card, stat-row, chart, process-strip, text-block, comparison-pair, icon-grid, svg-diagram, cta, footer | Unknown block type |
 | Required block fields | Each block has all required fields per infographic-layouts.md | Missing required field |

--- a/cogni-workspace/skills/story-to-infographic/references/05-validation-checklist.md
+++ b/cogni-workspace/skills/story-to-infographic/references/05-validation-checklist.md
@@ -12,7 +12,7 @@ Structural correctness. Every field must exist and conform to its type.
 
 | Check | Pass | Fail |
 |-------|------|------|
-| Brief frontmatter present | `type: infographic-brief`, `version: "1.0"`, `"1.1"`, or `"1.2"` | Missing frontmatter, wrong type, or a version outside the accepted set |
+| Brief frontmatter present | `type: infographic-brief`, `version: "1.1"` | Missing frontmatter, wrong type, or any version other than `"1.1"` |
 | Required frontmatter fields | All present: theme, theme_path, language, layout_type, style_preset, orientation, dimensions, governing_thought | Any missing |
 | Block types valid | Every `Block-Type` is one of: title, kpi-card, stat-row, chart, process-strip, text-block, comparison-pair, icon-grid, svg-diagram, cta, footer | Unknown block type |
 | Required block fields | Each block has all required fields per infographic-layouts.md | Missing required field |


### PR DESCRIPTION
Closes #1774.

## Summary

`/render-infographic`'s Step 2 pinned the brief frontmatter to `version: "1.0"` — a value **no live producer has written in two schema versions**. `story-to-infographic` writes `"1.1"`, `enrich-report` writes `"1.2"`, so the dispatcher rejected every brief its own siblings produced, even though the agent it would have routed to already accepted all three.

- Step 2's version bullet now accepts `"1.0"`, `"1.1"` and `"1.2"`. `"1.0"` is **extended, never replaced**.
- The abort branch survives and now names the version found plus the three accepted values, instead of a bare "do not match".
- Step 3 gains a **Hand-drawn version ceiling** paragraph.
- The stale Layer 1 frontmatter row in `skills/story-to-infographic/references/05-validation-checklist.md` is reconciled — **both cells** — since it pinned `"1.0"` and would reject the `1.1` briefs its own skill emits.

## The ceiling binds four reach-paths, not two

The issue names the two direct preset bullets. Exploration found **four** ways into a hand-drawn agent: the `sketchnote` bullet, the `whiteboard` bullet, **and both arms of the `AskUserQuestion` fallback** (the family choice, then the sketchnote/whiteboard disambiguation). A ceiling stated only on the direct bullets would have left that fallback as an unguarded path into an agent that rejects `1.2`. The inserted paragraph enumerates all four by name.

This is a **widen-plus-fence**, not a plain widening: the dispatcher must accept no version its renderers cannot handle.

## Scope decisions

- **Not touched, deliberately:** every `cogni-workspace/agents/render-infographic-*.md` accept list. They are already correct — the ceiling exists *because* sketchnote and whiteboard stop at `1.1`. "Fixing" them would make the dispatcher consistent by breaking the renderers.
- **Not touched, deliberately:** `commands/render-infographic-handdrawn.md`, already correct at `1.0`/`1.1`. Widening it for symmetry would be both a scope breach and a live bug.
- No `.claude-plugin/*.json` version bump — the post-merge workflow owns that.

## Verification

| Check | Result |
|---|---|
| `python3 scripts/run-plugin-tests.py --filter cogni-workspace` | 21/21 suites pass, discovery non-empty |
| `python3 scripts/check-code-span-nesting.py` | exit 0 |
| `git diff --name-only origin/main...HEAD` | exactly the 2 files above |
| `cogni-workspace/agents/` diff | empty |
| `commands/render-infographic-handdrawn.md` diff | empty |
| `**/.claude-plugin/*.json` diff | empty |
| `#1774` breadcrumb in changed files | none |

`check-code-span-nesting.py` was the one real CI hazard here: unlike `check-breadcrumbs.py` and `check-mcp-tool-grant.py`, which scope only `*/skills/*/SKILL.md` and `*/agents/*.md`, it scans **all** tracked `*.md` — so a `commands/**` edit is inside its population, and the `` `"1.0"`, `"1.1"`, or `"1.2"` `` shape is exactly the adjacent-code-span pattern it flags. The wording was cleared against the guard's own `scan_file()` before it was written (0 findings, even span-parity deltas) and then confirmed by running the guard.

## Open questions

None blocking.

One observation recorded rather than filed: **nothing couples the dispatcher's accept list to the renderers' or the producers'**. None of the 21 `cogni-workspace/tests/*.sh` suites asserts that relationship, which is precisely how the dispatcher drifted three schema versions behind its own siblings. A rejected alternative plan added a 10-case guard suite for it; it was declined here only because its touched set is a strict superset of this one's and the acceptance contract admits a harness without requiring one. Worth a follow-up if this class recurs.

A second residual — the same checklist's "Block types valid" row omits the v1.1 `pull-quote` type — was **not** filed, because #1798 already rewrites all four prose validation checklists and absorbs it. #1798's own body sequences its infographic version reconciliation *"once the `/render-infographic` dispatcher has widened its accept list"*, i.e. after this PR.