### PR TITLE
render-html-slides: deterministic parse + producer field alignment

### DIFF
--- a/cogni-workspace/skills/render-html-slides/SKILL.md
+++ b/cogni-workspace/skills/render-html-slides/SKILL.md
@@ -29,7 +29,7 @@ all in a single `.html` file.
 | `brief_path` | auto-discovered | Path to presentation-brief.md |
 | `theme` | from brief frontmatter | Path to theme.md (or omit for pick-theme) |
 | `design_variables` | derived from theme | Pre-computed design-variables.json path |
-| `output_path` | `{brief_dir}/{slug}-slides.html` | HTML output path |
+| `output_path` | `{brief_dir}/{slug}-slides.html` | HTML output path. `{slug}` is the deck title Phase 1 assembles into `metadata.title`, lowercased with every run of non-alphanumerics collapsed to a single `-`. |
 | `transition` | `fade` | Slide transition: `fade`, `slide`, `none` |
 | `aspect_ratio` | `16:9` | Slide aspect ratio: `16:9`, `4:3` |
 | `language` | from brief frontmatter | `en` or `de` |
@@ -48,6 +48,7 @@ all in a single `.html` file.
    - `type: presentation-brief` (must match)
    - `version: "4.0"` or `"4.1"` (must match one of these — the 4.1 delta is content-only, so nothing this renderer parses changed)
 5. Extract metadata: `theme`, `theme_path`, `language`, `customer`, `provider`, `arc_type`, `governing_thought`
+6. Resolve `brief_dir` — the project directory that *contains* `cogni-visual/`, which every artifact path below is anchored on. A brief discovered inside a `cogni-visual/` folder (where `story-to-slides` writes it) resolves to that folder's **parent**, not the brief's own directory — otherwise `{brief_dir}/cogni-visual/` doubles the path. An explicit `brief_path` outside any `cogni-visual/` folder resolves to the brief's own directory.
 
 **Theme resolution** (3-stage, same as enrich-report):
 1. If `design_variables` parameter provided → use directly, skip to Phase 1
@@ -62,10 +63,13 @@ Parse the presentation-brief.md body into structured slide data. The brief uses 
 **Parse deterministically.** Run the shared parser rather than reading the brief yourself — it is the same parser the other brief consumers use, so this renderer cannot drift away from them:
 
 ```bash
+mkdir -p "{brief_dir}/cogni-visual"
 python3 "${CLAUDE_PLUGIN_ROOT}/scripts/parse-brief.py" \
   --brief "{brief_path}" --emit slide-data \
   --output "{brief_dir}/cogni-visual/slide-data.json"
 ```
+
+`mkdir -p` runs first because the parser opens `--output` directly without creating its parent.
 
 `--brief` is required (omitting it exits with `--brief is required`). The `{"success": ..., "data": ..., "error": ...}` envelope prints on **stdout**, while `--output` writes only the payload (`{version, slides, warnings}`) to the file.
 
@@ -87,7 +91,9 @@ top-level key alongside `slides`, and write the file out again. Leaving the pars
 `version` and `warnings` keys in place is harmless — the renderer reads only `metadata` and
 `slides`. Surface any `warnings` to the user.
 
-**Fall back to the LLM parse only when the parser fails** — that is, when an envelope comes back with `success: false`, or the script cannot be run at all. A successful parse is authoritative and is never second-guessed or "corrected" by re-reading the brief.
+**Fall back to the LLM parse only when the parser fails to parse** — that is, when an envelope comes back with `success: false` for a parse reason, or the script cannot be run at all. A successful parse is authoritative and is never second-guessed or "corrected" by re-reading the brief.
+
+**A `cannot write output:` envelope is not a parse failure and must not trigger the fallback.** Fix the write — the parent directory is missing or unwritable — and re-run. Falling back on it would hide the broken write behind a silently LLM-parsed deck, which is exactly the outcome the deterministic path exists to retire.
 
 #### LLM fallback parse
 
@@ -104,11 +110,13 @@ For each slide section, extract:
 - `citations` — extracted `<sup>[N](url)</sup>` patterns
 
 Also assemble the top-level `metadata` block by the same mapping the deterministic path uses
-above: the renderer reads `metadata.title` / `.customer` / `.provider` / `.generated` on both
-paths, and omitting it silently yields the title "Presentation" and today's date.
+above — the renderer reads it on both paths, and omitting it carries the same silent
+"Presentation"/today's-date default.
 
-Write the parsed data to `{brief_dir}/cogni-visual/slide-data.json`, in the shape both paths
-share — see the `slide-data.json shape` section of `references/01-layout-renderers.md`.
+Run `mkdir -p "{brief_dir}/cogni-visual"` here too — this branch writes into the same directory
+and must not depend on the deterministic block above having run. Then write the parsed data to
+`{brief_dir}/cogni-visual/slide-data.json`, in the shape both paths share — see the
+`slide-data.json shape` section of `references/01-layout-renderers.md`.
 
 **Parsing rules:**
 - Each slide is separated by `---` (horizontal rule) in the brief
@@ -318,4 +326,4 @@ Apply re-render changes FIRST (they produce a fresh HTML file), then apply HTML-
 
 **Self-contained:** Single HTML file. All CSS inline. All JS inline. Only external dependency is Mermaid.js CDN (conditional, only included when diagrams are present).
 
-**Refinement Loop:** After viewing slides, give feedback on specific slides in natural language. Text and style fixes are applied directly to the HTML (instant). Structural changes (layout swaps, slide additions) trigger a targeted re-render via the Python script. Max 3 rounds by default.
+**Refinement Loop:** Natural-language feedback per slide after viewing — text and style fixes edit the HTML directly, structural changes trigger a targeted re-render. Channels and round cap: Phase 6.

--- a/cogni-workspace/skills/render-html-slides/SKILL.md
+++ b/cogni-workspace/skills/render-html-slides/SKILL.md
@@ -59,6 +59,40 @@ all in a single `.html` file.
 
 Parse the presentation-brief.md body into structured slide data. The brief uses `## Slide N: {headline}` sections with fenced YAML blocks.
 
+**Parse deterministically.** Run the shared parser rather than reading the brief yourself — it is the same parser the other brief consumers use, so this renderer cannot drift away from them:
+
+```bash
+python3 "${CLAUDE_PLUGIN_ROOT}/scripts/parse-brief.py" \
+  --brief "{brief_path}" --emit slide-data \
+  --output "{brief_dir}/cogni-visual/slide-data.json"
+```
+
+`--brief` is required (omitting it exits with `--brief is required`). The `{"success": ..., "data": ..., "error": ...}` envelope prints on **stdout**, while `--output` writes only the payload (`{version, slides, warnings}`) to the file.
+
+**Then add the `metadata` block.** `--emit slide-data` carries no `metadata` key, but the renderer reads `metadata.title` / `.customer` / `.provider` / `.generated` — skip this and every deck silently renders with the title "Presentation" and today's date. Run:
+
+```bash
+python3 "${CLAUDE_PLUGIN_ROOT}/scripts/parse-brief.py" --brief "{brief_path}" --emit metadata
+```
+
+That returns `{version, frontmatter, generation_metadata, cta_summary, unowned_sections, warnings}` — a source to map from, not a ready-made block. Assemble `metadata` and merge it into the written JSON as a top-level key:
+
+- `customer`, `provider`, `language`, `arc_type`, `governing_thought` — from `frontmatter`
+- `generated` — from `frontmatter.generated`, else today's date
+- `title` — slide 1's `fields.Title`, else slide 1's `headline` (the frontmatter carries no title)
+- `subtitle` — slide 1's `fields.Subtitle`
+
+Read `{brief_dir}/cogni-visual/slide-data.json` back, add the assembled `metadata` object as a
+top-level key alongside `slides`, and write the file out again. Leaving the parser's own
+`version` and `warnings` keys in place is harmless — the renderer reads only `metadata` and
+`slides`. Surface any `warnings` to the user.
+
+**Fall back to the LLM parse only when the parser fails** — that is, when an envelope comes back with `success: false`, or the script cannot be run at all. A successful parse is authoritative and is never second-guessed or "corrected" by re-reading the brief.
+
+#### LLM fallback parse
+
+Used only on the failure condition above. Parse the brief body directly.
+
 For each slide section, extract:
 - `number` — slide number
 - `headline` — the assertion headline from the H2 heading
@@ -69,38 +103,12 @@ For each slide section, extract:
 - `diagram_mermaid` — the Diagram field content if it contains Mermaid syntax
 - `citations` — extracted `<sup>[N](url)</sup>` patterns
 
-Write the parsed data to `{brief_dir}/cogni-visual/slide-data.json`:
+Also assemble the top-level `metadata` block by the same mapping the deterministic path uses
+above: the renderer reads `metadata.title` / `.customer` / `.provider` / `.generated` on both
+paths, and omitting it silently yields the title "Presentation" and today's date.
 
-```json
-{
-  "metadata": {
-    "title": "...",
-    "subtitle": "...",
-    "customer": "...",
-    "provider": "...",
-    "language": "de",
-    "arc_type": "why-change",
-    "generated": "2026-02-09",
-    "governing_thought": "..."
-  },
-  "slides": [
-    {
-      "number": 1,
-      "headline": "Assertion headline",
-      "layout": "title-slide",
-      "fields": {
-        "Title": "...",
-        "Subtitle": "...",
-        "Metadata": "..."
-      },
-      "speaker_notes": null,
-      "bottom_banner": null,
-      "diagram_mermaid": null,
-      "citations": []
-    }
-  ]
-}
-```
+Write the parsed data to `{brief_dir}/cogni-visual/slide-data.json`, in the shape both paths
+share — see the `slide-data.json shape` section of `references/01-layout-renderers.md`.
 
 **Parsing rules:**
 - Each slide is separated by `---` (horizontal rule) in the brief
@@ -108,8 +116,8 @@ Write the parsed data to `{brief_dir}/cogni-visual/slide-data.json`:
 - Nested structures (Hero-Stat-Box, Context-Box, Detail-Grid) must be preserved as nested objects
 - Speaker-Notes is a multi-line YAML string (after `|`) — preserve the full text
 - Mermaid diagrams appear in the `Diagram:` field as multi-line strings
-- IS/DOES/MEANS labels come from the `Label:` field inside each box — but the Python script handles localization, so just pass the text content
-- Bottom-Banner can be a dict with `Text:` key or a plain string. Write it to the top-level `bottom_banner` field — the renderer emits it as a shared footer on **every** layout. The legacy nested form (`Bottom-Banner` inside `fields`) is also accepted.
+- IS/DOES/MEANS labels come from each box's `Label:` field — pass it through. The renderer prefers that `Label:` for the badge and falls back to its own `--language` localization only when it is absent
+- Bottom-Banner can be a dict with a `Text:` key or a plain string. Write it to the **top-level** `bottom_banner` field, not inside `fields` (the legacy nested form is also accepted) — footer contract in `references/01-layout-renderers.md`.
 
 ### Phase 2: Theme → Design Variables
 
@@ -194,7 +202,7 @@ If error, read the error message and attempt to fix the input data. Common issue
 
 Tier-1 tokens are wired today. Pass `theme_slug: cogni-work` to import that theme's canonical CSS custom properties. Tier-3 deck-component primitives (`title-slide.html`, `content-slide.html`, etc.) are the next increment — the loader infrastructure is in place at `cogni-workspace/scripts/load-theme-component.py` (see `cogni-workspace/references/theme-component-loader.md`), but `cogni-work` does not yet ship a `tiers.components.deck` family, so component-substitution is gated on a follow-up issue. Today's behavior: every layout renderer uses its inline template; tomorrow's behavior (after deck primitives ship): the renderer prefers theme-supplied primitives and falls back to inline on miss.
 
-**Backwards-compat contract.** Omitting `--theme-slug` preserves the legacy (pre-Theme-System-v2) rendering path byte-for-byte — `theme.md`-derived design variables still apply; only the tier-1 `tokens.css` import is skipped. With `--theme-slug` set, themes without `tiers.tokens` (and tier-0 themes generally) exercise the same fallback path — there is no failure case for unmigrated themes. `evals/run.py` enforces this with three regression cases: tier-0 baseline, tier-1 cogni-work tokens.css imported, tier-0 `_template` with `--theme-slug` set (graceful fallback).
+**Backwards-compat contract.** Omitting `--theme-slug` preserves the legacy (pre-Theme-System-v2) rendering path byte-for-byte — `theme.md`-derived design variables still apply; only the tier-1 `tokens.css` import is skipped. With `--theme-slug` set, themes without `tiers.tokens` (and tier-0 themes generally) exercise the same fallback path — there is no failure case for unmigrated themes. `evals/run.py` enforces this with dedicated regression cases — among them a tier-0 baseline, tier-1 cogni-work tokens.css imported, and tier-0 `_template` with `--theme-slug` set (graceful fallback).
 
 **Fallback diagnostics.** When `--theme-slug` is set, the output envelope's `theme_slug_resolution` field names *why* the tier-1 path was (or wasn't) taken. It is always a **bare reason code** — exact-matchable: `imported` on success, or a fallback code — `manifest_missing` (tier-0 theme), `manifest_unreadable`, `tokens_tier_absent`, `tokens_css_missing`, or `themes_dir_unresolved` (workspace not found — e.g. `$COGNI_WORKSPACE_ROOT` unset or unexported). The field is `null` when `--theme-slug` is omitted. A companion `theme_slug_resolution_detail` field carries an optional human-readable hint for the cases that warrant one (today, `themes_dir_unresolved`); it is `null` otherwise. Machines branch on `theme_slug_resolution`; humans read `theme_slug_resolution_detail`. This distinguishes "this theme is tier-0" from "I couldn't find the workspace" without re-walking the resolution. Add `--verbose` to additionally write a one-line `themes_dir=… manifest_path=… tokens_css=… resolution=…` diagnostic (using the bare reason code) to stderr (off by default; the stdout JSON contract is unchanged).
 
@@ -284,6 +292,13 @@ Apply re-render changes FIRST (they produce a fresh HTML file), then apply HTML-
 3. Increment refinement counter
 4. If counter < `max_refinements`: return to Step 6.1
 5. If counter >= `max_refinements`: inform the user the refinement cap is reached
+
+## Additional Resources
+
+- **`references/01-layout-renderers.md`** — per-layout field contracts (including the accepted
+  aliases for each slot), the Bottom-Banner footer contract, and the shared `slide-data.json` shape
+- **`references/02-slide-navigation.md`** — navigation, transitions and keyboard behaviour
+- **`references/03-speaker-notes.md`** — speaker-notes parsing and the notes-panel format
 
 ## Features
 

--- a/cogni-workspace/skills/render-html-slides/evals/run.py
+++ b/cogni-workspace/skills/render-html-slides/evals/run.py
@@ -300,11 +300,20 @@ def case_5_example_brief_end_to_end():
         failures.append("case 5: no closing-slide found in the parsed fixture")
     else:
         subtitle = closing["fields"].get("Subtitle", "")
-        if subtitle and subtitle not in html:
+        # Pinned: without this the check below no-ops the moment the producer
+        # stops emitting Subtitle at all, which is the regression it guards.
+        if not subtitle:
+            failures.append("case 5: closing slide carries no Subtitle — the fixture must parse one")
+        elif subtitle not in html:
             failures.append("case 5: closing subtitle {!r} absent from the render".format(subtitle))
 
     # One source footer per Source-carrying slide, each an actual link.
     with_source = [s for s in slides if s.get("source") or s.get("fields", {}).get("Source")]
+    # Pinned: a bare count comparison comes out 0 == 0 and passes when the
+    # producer emits no Source at all, so require the fixture to carry some.
+    if len(with_source) < 2:
+        failures.append("case 5: {} Source-carrying slide(s) parsed, expected at least 2".format(
+            len(with_source)))
     if html.count('class="source-footer') != len(with_source):
         failures.append("case 5: {} source footer(s) for {} Source-carrying slide(s)".format(
             html.count('class="source-footer'), len(with_source)))
@@ -402,6 +411,23 @@ def case_6_field_aliases_direct():
              "fields": {"Source": "[SRCTEXT](https://example.invalid/doc)",
                         "Left-Column": {"Headline": "L", "Bullets": ["b"]},
                         "Right-Column": {"Headline": "R", "Bullets": ["c"]}}},
+            # Slide 6 covers only the Step-N map shape; the Steps[] list form is
+            # the other live shape and was untested.
+            {"number": 13, "layout": "timeline-steps", "headline": "steps list form",
+             "fields": {"Steps": [{"Title": "LISTSTEPA", "Detail": "LISTDETA",
+                                   "Bullets": ["listbullet-a"]},
+                                  {"Title": "LISTSTEPB", "Detail": "LISTDETB"}]}},
+            # Slide 6 uses Label; Title is the older name that must win over it.
+            {"number": 14, "layout": "timeline-steps", "headline": "steps old name wins",
+             "fields": {"Step-1": {"Number": "02", "Title": "OLDSTEPTITLE",
+                                   "Label": "NEWSTEPLABEL", "Detail": "OLDSTEPDETAIL",
+                                   "Duration": "NEWSTEPDUR"}}},
+            # Slide 7 tests only the Label-wins direction of the badge contract.
+            # With no Label anywhere, --language de must supply the defaults.
+            {"number": 15, "layout": "is-does-means", "headline": "idm no label",
+             "fields": {"IS-Box": {"Text": "nolabel-is"},
+                        "DOES-Box": {"Text": "nolabel-does"},
+                        "MEANS-Box": {"Text": "nolabel-means"}}},
         ],
     }
     # German, so a badge falling back to --language would read IST/MACHT/BEDEUTET.
@@ -447,10 +473,22 @@ def case_6_field_aliases_direct():
     for needle in ("01", "STEPLABEL", "STEPDESC", "STEPDUR"):
         want(6, needle)
 
+    # The Steps[] list form is the other live shape and must render the same slots.
+    for needle in ("LISTSTEPA", "LISTDETA", "listbullet-a", "LISTSTEPB", "LISTDETB"):
+        want(13, needle)
+    # Within a Step-N map the older Title/Detail win over Label/Duration.
+    want(14, "OLDSTEPTITLE")
+    want(14, "NEWSTEPLABEL", present=False, why="Title must keep precedence over Label")
+    want(14, "OLDSTEPDETAIL")
+    want(14, "NEWSTEPDUR", present=False, why="Detail must keep precedence over Duration")
+
     # The authored badge beats the --language default.
     for needle in ("CUSTOMIS", "CUSTOMDOES", "CUSTOMMEANS"):
         want(7, needle)
     want(7, "IST", present=False, why="--language fallback must not override an authored Label")
+    # ...and the untested direction: with no Label at all, --language de supplies them.
+    for needle in ("IST", "MACHT", "BEDEUTET"):
+        want(15, needle, why="Label-less box must fall back to the --language default badge")
 
     # slide_kind routing: WITH a payload it routes...
     want(8, "references-list")

--- a/cogni-workspace/skills/render-html-slides/evals/run.py
+++ b/cogni-workspace/skills/render-html-slides/evals/run.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
-"""evals/run.py — Regression eval for render-html-slides Theme System v2 wiring.
+"""evals/run.py — Regression eval for render-html-slides.
 
-Stdlib-only. Three test cases, run end-to-end against the real
-``generate-html-slides.py`` script:
+Stdlib-only. Every case runs end-to-end against the real
+``generate-html-slides.py`` script; ``main()``'s ``cases`` list is the
+authoritative roster. The Theme System v2 cases are:
 
 1. **Tier-0 baseline (regression).** No ``--theme-slug`` flag. Asserts the
    rendered HTML contains the inline ``:root`` token block and does NOT
@@ -31,6 +32,7 @@ on stdout for machine consumption.
 
 import json
 import os
+import re
 import subprocess
 import sys
 import tempfile
@@ -70,14 +72,19 @@ MINIMAL_SLIDE_DATA = {
 }
 
 
-def run_render(theme_slug=None, themes_dir=None):
-    """Invoke generate-html-slides.py with optional --theme-slug. Returns the
-    rendered HTML body as a string and the JSON status the script printed."""
+def run_render(theme_slug=None, themes_dir=None, slide_data=None, language=None):
+    """Invoke generate-html-slides.py. Returns the rendered HTML body as a
+    string and the JSON status the script printed.
+
+    Defaults to ``MINIMAL_SLIDE_DATA``; pass ``slide_data`` to render a
+    different deck.
+    """
     with tempfile.TemporaryDirectory() as tmpdir:
         tmp = Path(tmpdir)
         slide_data_path = tmp / "slide-data.json"
         output_path = tmp / "out.html"
-        slide_data_path.write_text(json.dumps(MINIMAL_SLIDE_DATA), encoding="utf-8")
+        payload = MINIMAL_SLIDE_DATA if slide_data is None else slide_data
+        slide_data_path.write_text(json.dumps(payload), encoding="utf-8")
 
         cmd = [
             sys.executable,
@@ -89,6 +96,8 @@ def run_render(theme_slug=None, themes_dir=None):
             cmd += ["--theme-slug", theme_slug]
         if themes_dir:
             cmd += ["--themes-dir", str(themes_dir)]
+        if language:
+            cmd += ["--language", language]
 
         proc = subprocess.run(cmd, capture_output=True, text=True)
         if proc.returncode != 0:
@@ -191,12 +200,301 @@ def case_4_themes_dir_unresolved():
     return len(failures) == 0, failures
 
 
+PARSER = PLUGIN_ROOT / "scripts" / "parse-brief.py"
+EXAMPLE_BRIEF = PLUGIN_ROOT / "libraries" / "EXAMPLE_BRIEF.md"
+
+
+def want_in_section(failures, label, html, number, needle, present=True, why=""):
+    """Assert a substring is (or is not) inside one slide's section."""
+    section = _slide_section(html, number)
+    if (needle in section) != present:
+        failures.append("{}: slide {}: {} {!r}{}".format(
+            label, number,
+            "missing" if present else "unexpectedly present",
+            needle,
+            " ({})".format(why) if why else ""))
+
+
+def _slide_section(html, number):
+    """The markup of one ``<section class="slide" data-slide="N">`` block."""
+    marker = 'data-slide="{}"'.format(number)
+    start = html.find(marker)
+    if start == -1:
+        return ""
+    end = html.find("</section>", start)
+    return html[start:end if end != -1 else len(html)]
+
+
+def case_5_example_brief_end_to_end():
+    """Render the real producer fixture through the real parser.
+
+    Asserts by shape, so a producer/renderer field mismatch fails loudly here
+    instead of rendering blank cards the way it does today.
+    """
+    failures = []
+    if not PARSER.exists() or not EXAMPLE_BRIEF.exists():
+        return False, ["case 5: missing parser or fixture ({} / {})".format(PARSER, EXAMPLE_BRIEF)]
+
+    def emit(mode):
+        proc = subprocess.run(
+            [sys.executable, str(PARSER), "--brief", str(EXAMPLE_BRIEF), "--emit", mode],
+            capture_output=True, text=True,
+        )
+        try:
+            return json.loads(proc.stdout)
+        except json.JSONDecodeError:
+            return {"success": False, "error": proc.stderr or proc.stdout}
+
+    sd_env = emit("slide-data")
+    md_env = emit("metadata")
+    if not sd_env.get("success"):
+        return False, ["case 5: --emit slide-data failed: {}".format(sd_env.get("error"))]
+    if not md_env.get("success"):
+        return False, ["case 5: --emit metadata failed: {}".format(md_env.get("error"))]
+
+    slides = sd_env["data"]["slides"]
+
+    # Slide count must equal the fixture's own heading count — derived, never hardcoded.
+    brief_text = EXAMPLE_BRIEF.read_text(encoding="utf-8")
+    heading_count = len(re.findall(r"^## Slide", brief_text, re.MULTILINE))
+    if len(slides) != heading_count:
+        failures.append("case 5: parsed {} slides, brief has {} '## Slide' headings".format(
+            len(slides), heading_count))
+
+    # Assemble metadata exactly as SKILL.md Phase 1 states.
+    fm = md_env["data"].get("frontmatter", {}) or {}
+    first = slides[0]["fields"] if slides else {}
+    slide_data = {
+        "metadata": {
+            "title": first.get("Title") or (slides[0].get("headline") if slides else ""),
+            "subtitle": first.get("Subtitle", ""),
+            "customer": fm.get("customer", ""),
+            "provider": fm.get("provider", ""),
+            "generated": fm.get("generated", ""),
+        },
+        "slides": slides,
+    }
+    html, status = run_render(slide_data=slide_data, language=fm.get("language") or "de")
+    if html is None:
+        return False, ["case 5: render failed: {}".format(status.get("error"))]
+    if status.get("status") != "ok":
+        failures.append("case 5: renderer status={} (expected ok)".format(status.get("status")))
+
+    # The Buying Center slide: four quadrant cards, each carrying a real label.
+    buying = next((s for s in slides if "Quadrant-1" in s.get("fields", {})
+                   or "Q1" in s.get("fields", {})), None)
+    if buying is None:
+        failures.append("case 5: no quadrant slide found in the parsed fixture")
+    else:
+        section = _slide_section(html, buying.get("number"))
+        if section.count('class="quad-card"') != 4:
+            failures.append("case 5: buying-center slide rendered {} quad-card(s), expected 4".format(
+                section.count('class="quad-card"')))
+        if section.count('class="quad-label"') != 4:
+            failures.append("case 5: buying-center slide rendered {} non-empty quad-label(s), expected 4".format(
+                section.count('class="quad-label"')))
+
+    # The closing slide's Subtitle must reach the page.
+    closing = next((s for s in slides if s.get("layout") == "closing-slide"), None)
+    if closing is None:
+        failures.append("case 5: no closing-slide found in the parsed fixture")
+    else:
+        subtitle = closing["fields"].get("Subtitle", "")
+        if subtitle and subtitle not in html:
+            failures.append("case 5: closing subtitle {!r} absent from the render".format(subtitle))
+
+    # One source footer per Source-carrying slide, each an actual link.
+    with_source = [s for s in slides if s.get("source") or s.get("fields", {}).get("Source")]
+    if html.count('class="source-footer') != len(with_source):
+        failures.append("case 5: {} source footer(s) for {} Source-carrying slide(s)".format(
+            html.count('class="source-footer'), len(with_source)))
+    for s in with_source:
+        section = _slide_section(html, s.get("number"))
+        if "source-footer" in section and "<a href" not in section:
+            failures.append("case 5: slide {} source footer has no anchor (escaped instead of linked)".format(
+                s.get("number")))
+
+    # Badges come from each box's Label even though the deck is German.
+    idm = next((s for s in slides if s.get("layout") == "is-does-means"), None)
+    if idm is not None:
+        section = _slide_section(html, idm.get("number"))
+        for box in ("IS-Box", "DOES-Box", "MEANS-Box"):
+            label = (idm["fields"].get(box) or {}).get("Label")
+            if label:
+                want_in_section(
+                    failures, "case 5", html, idm.get("number"),
+                    '<span class="idm-badge">{}</span>'.format(label),
+                    why="{} badge is not the authored Label".format(box))
+
+    # Falsifier for the guarded slide_kind routing: a slide declaring
+    # Slide-Kind: references with no References payload must KEEP its own
+    # layout. Without this an unconditional override would still pass above.
+    for s in slides:
+        f = s.get("fields", {})
+        kind = s.get("slide_kind") or f.get("Slide-Kind")
+        if kind == "references" and not (f.get("References") or f.get("Citations")):
+            section = _slide_section(html, s.get("number"))
+            if 'data-layout="{}"'.format(s.get("layout")) not in section:
+                failures.append(
+                    "case 5: slide {} was rerouted to the references renderer despite carrying "
+                    "no References/Citations payload".format(s.get("number")))
+            for col in ("Left-Column", "Right-Column"):
+                for bullet in (f.get(col) or {}).get("Bullets", []):
+                    if bullet.split(" ")[0] not in section:
+                        failures.append(
+                            "case 5: slide {} lost {} content on routing".format(s.get("number"), col))
+
+    return len(failures) == 0, failures
+
+
+def case_6_field_aliases_direct():
+    """Prove the renderer-side aliases on slide-data the parser never touched.
+
+    This case exists because ``parse-brief.py`` normalizes ``Q{n}`` to
+    ``Quadrant-{n}`` upstream, so an end-to-end assertion renders four
+    populated cards with or without the renderer change — a vacuous green.
+    Building the slide-data here is what lets these assertions actually fail.
+    """
+    slide_data = {
+        "metadata": {"title": "Alias Deck", "customer": "C", "provider": "P", "generated": "2026-01-01"},
+        "slides": [
+            {"number": 1, "layout": "four-quadrants", "headline": "Q alias",
+             "fields": {"Q{}".format(i): {"Label": "QL{}".format(i), "Bullets": ["qb{}".format(i)]}
+                        for i in range(1, 5)}},
+            {"number": 2, "layout": "four-quadrants", "headline": "canonical wins",
+             "fields": {"Quadrant-1": {"Label": "CANON", "Bullets": ["x"]},
+                        "Q1": {"Label": "ALIAS", "Bullets": ["y"]}}},
+            {"number": 3, "layout": "closing-slide", "headline": "closing new",
+             "fields": {"Title": "NEWHEAD", "Subtitle": "NEWSUB", "Metadata": "NEWMETA"}},
+            {"number": 4, "layout": "closing-slide", "headline": "closing old wins",
+             "fields": {"Headline": "OLDHEAD", "Title": "NEWHEAD2",
+                        "Key-Takeaway": "OLDTAKE", "Subtitle": "NEWSUB2",
+                        "CTA": "OLDCTA", "Metadata": "NEWMETA2"}},
+            {"number": 5, "layout": "three-options", "headline": "options new",
+             "fields": {"Option-1": {"Name": "OPTNAME", "Price": "OPTPRICE",
+                                     "Badge": "BADGETEXT", "Features": ["feat-a"]},
+                        "Option-2": {"Name": "PLAIN", "Price": "P2", "Features": ["feat-b"]}}},
+            {"number": 6, "layout": "timeline-steps", "headline": "steps new",
+             "fields": {"Step-1": {"Number": "01", "Label": "STEPLABEL",
+                                   "Description": "STEPDESC", "Duration": "STEPDUR"}}},
+            {"number": 7, "layout": "is-does-means", "headline": "idm label",
+             "fields": {"IS-Box": {"Label": "CUSTOMIS", "Text": "t1"},
+                        "DOES-Box": {"Label": "CUSTOMDOES", "Text": "t2"},
+                        "MEANS-Box": {"Label": "CUSTOMMEANS", "Text": "t3"}}},
+            {"number": 8, "layout": "two-columns-equal", "headline": "refs with payload",
+             "slide_kind": "references",
+             "fields": {"Slide-Kind": "references",
+                        "References": ["REFONE", "REFTWO"]}},
+            {"number": 9, "layout": "two-columns-equal", "headline": "refs without payload",
+             "slide_kind": "references",
+             "fields": {"Slide-Kind": "references",
+                        "Left-Column": {"Headline": "LCOL", "Bullets": ["LEFTBULLET"]},
+                        "Right-Column": {"Headline": "RCOL", "Bullets": ["RIGHTBULLET"]}}},
+            {"number": 10, "layout": "two-columns-equal", "headline": "LONGHEADLINE",
+             "fields": {"Slide-Title": "SHORTTITLE",
+                        "Left-Column": {"Headline": "L", "Bullets": ["b"]},
+                        "Right-Column": {"Headline": "R", "Bullets": ["c"]}}},
+            {"number": 11, "layout": "unknown-layout-kind", "headline": "generic",
+             "fields": {"intent": "INTENTVAL", "visual": "VISUALVAL", "cta": "CTAVAL",
+                        "Slide-Kind": "KINDVAL", "Source": "SOURCEVAL",
+                        "Slide-Title": "TITLEVAL", "Real": "REALVAL"}},
+            {"number": 12, "layout": "two-columns-equal", "headline": "source link",
+             "fields": {"Source": "[SRCTEXT](https://example.invalid/doc)",
+                        "Left-Column": {"Headline": "L", "Bullets": ["b"]},
+                        "Right-Column": {"Headline": "R", "Bullets": ["c"]}}},
+        ],
+    }
+    # German, so a badge falling back to --language would read IST/MACHT/BEDEUTET.
+    html, status = run_render(slide_data=slide_data, language="de")
+    if html is None:
+        return False, ["case 6: render failed: {}".format(status.get("error"))]
+
+    failures = []
+
+    def want(number, needle, present=True, why=""):
+        want_in_section(failures, "case 6", html, number, needle, present, why)
+
+    # Q1..Q4 accepted — the assertion the end-to-end case cannot make.
+    s1 = _slide_section(html, 1)
+    if s1.count('class="quad-card"') != 4:
+        failures.append("case 6: literal Q1..Q4 rendered {} quad-card(s), expected 4".format(
+            s1.count('class="quad-card"')))
+    for i in range(1, 5):
+        want(1, "QL{}".format(i), why="Q{} alias not read".format(i))
+
+    # Canonical Quadrant-N keeps precedence over the Q-alias.
+    want(2, "CANON")
+    want(2, "ALIAS", present=False, why="alias must not override the canonical name")
+
+    # Closing slide reaches the producer's Subtitle/Metadata...
+    want(3, "NEWSUB")
+    want(3, "NEWMETA")
+    # ...while the old names still win when both are present.
+    want(4, "OLDTAKE")
+    want(4, "NEWSUB2", present=False, why="old name must keep precedence")
+    want(4, "OLDCTA")
+    want(4, "NEWMETA2", present=False, why="old name must keep precedence")
+
+    # Three options: producer names, and a non-empty Badge means recommended.
+    want(5, "OPTNAME")
+    want(5, "OPTPRICE")
+    want(5, "feat-a")
+    want(5, "BADGETEXT")
+    if _slide_section(html, 5).count("option-recommended") != 1:
+        failures.append("case 6: expected exactly one option-recommended card on slide 5")
+
+    # Every Step-N sub-field reaches the output.
+    for needle in ("01", "STEPLABEL", "STEPDESC", "STEPDUR"):
+        want(6, needle)
+
+    # The authored badge beats the --language default.
+    for needle in ("CUSTOMIS", "CUSTOMDOES", "CUSTOMMEANS"):
+        want(7, needle)
+    want(7, "IST", present=False, why="--language fallback must not override an authored Label")
+
+    # slide_kind routing: WITH a payload it routes...
+    want(8, "references-list")
+    want(8, "REFONE")
+    # ...and WITHOUT one it must not, or the column content is destroyed.
+    want(9, "LEFTBULLET", why="content dropped by an unguarded slide_kind reroute")
+    want(9, "RIGHTBULLET", why="content dropped by an unguarded slide_kind reroute")
+    want(9, "references-list", present=False, why="rerouted with no References payload")
+
+    # Slide-Title overrides the long assertion headline.
+    want(10, "SHORTTITLE")
+    want(10, "LONGHEADLINE", present=False, why="Slide-Title must win over the H2 headline")
+
+    # Non-content keys are suppressed by the generic fallback renderer. The
+    # test is the labelled-paragraph form that renderer emits — not the bare
+    # value, because two of the six legitimately reach the page by another
+    # route: Slide-Title becomes the H2, and Source becomes the footer.
+    for key in ("intent", "visual", "cta", "Slide-Kind", "Source", "Slide-Title"):
+        want(11, "<strong>{}:</strong>".format(key), present=False,
+             why="non-content key leaked into the generic slide body")
+    for needle in ("INTENTVAL", "VISUALVAL", "CTAVAL", "KINDVAL"):
+        want(11, needle, present=False, why="non-content value leaked into the slide body")
+    want(11, "<strong>Real:</strong>", why="a genuine content field must still render")
+    want(11, "REALVAL", why="a genuine content field must still render")
+    # The two that do have another home land there, and only there.
+    want(11, "SHORTTITLE", present=False)
+    want(11, "TITLEVAL", why="Slide-Title supplies the H2")
+    want(11, "SOURCEVAL", why="Source supplies the footer")
+
+    # A Source renders as a real link, not escaped markdown.
+    want(12, '<a href="https://example.invalid/doc"')
+    want(12, "[SRCTEXT]", present=False, why="markdown link was escaped instead of converted")
+
+    return len(failures) == 0, failures
+
+
 def main():
     cases = [
         ("tier-0 baseline (regression)", case_1_tier0_baseline),
         ("tier-1 cogni-work tokens.css", case_2_tier1_cogni_work),
         ("tier-0 _template with --theme-slug (graceful fallback)", case_3_tier0_theme_with_slug),
         ("themes_dir_unresolved diagnostic (#241 footgun)", case_4_themes_dir_unresolved),
+        ("EXAMPLE_BRIEF end-to-end through parse-brief.py", case_5_example_brief_end_to_end),
+        ("renderer field aliases on direct slide-data", case_6_field_aliases_direct),
     ]
     results = []
     failed = 0

--- a/cogni-workspace/skills/render-html-slides/references/01-layout-renderers.md
+++ b/cogni-workspace/skills/render-html-slides/references/01-layout-renderers.md
@@ -126,7 +126,9 @@ Option-3: ...
 ```
 
 Accepted aliases: the producer writes `Name` / `Price` / `Features`, which map to
-`Title` / `Subtitle` / `Bullets`; the old names keep precedence when both are present.
+`Title` / `Subtitle` / `Bullets`; the title slot takes a third name, `Label`, between
+those two. In every group the older name wins when more than one is present, so the
+title slot resolves `Title`, then `Label`, then `Name`.
 A non-empty `Badge:` string also means recommended, and is rendered as the badge text
 in place of the default star.
 
@@ -245,8 +247,20 @@ are harmless.
       "speaker_notes": null,
       "bottom_banner": null,
       "diagram_mermaid": null,
-      "citations": []
+      "citations": [],
+      "slide_kind": null,
+      "source": null,
+      "cta": null,
+      "intent": null,
+      "visual": null
     }
   ]
 }
 ```
+
+`SLIDE_KEYS` in `parse-brief.py` is the published contract for that per-slide object:
+every slide carries every key it names, and an absent one is `null` or `[]`, never
+omitted. Of the keys past `citations`, the renderer reads `slide_kind` and `source`
+from the top level and falls back to the legacy nested `Slide-Kind` / `Source` under
+`fields`; `cta`, `intent` and `visual` are carried for other consumers and this
+renderer reads neither form.

--- a/cogni-workspace/skills/render-html-slides/references/01-layout-renderers.md
+++ b/cogni-workspace/skills/render-html-slides/references/01-layout-renderers.md
@@ -65,6 +65,9 @@ Quadrant-3: ...
 Quadrant-4: ...
 ```
 
+Accepted alias: the producer may write `Q1:`..`Q4:` instead of `Quadrant-1:`..`Quadrant-4:`.
+The canonical `Quadrant-N` name keeps precedence when both are present.
+
 Rendered as: CSS Grid 2x2. Each card with accent left-border.
 
 ### two-columns-equal
@@ -101,8 +104,9 @@ MEANS-Box:
   Text: "What it means"
 ```
 
-Rendered as: 3 horizontal bands with localized badges. The Python script uses the
-`--language` parameter for badge labels, not the Label field.
+Rendered as: 3 horizontal bands with badges. Each box's `Label:` supplies its badge
+when present; the `--language` parameter supplies the fallback (IS/DOES/MEANS,
+IST/MACHT/BEDEUTET) only for a box that authored no `Label:`.
 
 ### three-options
 
@@ -121,6 +125,11 @@ Option-2:
 Option-3: ...
 ```
 
+Accepted aliases: the producer writes `Name` / `Price` / `Features`, which map to
+`Title` / `Subtitle` / `Bullets`; the old names keep precedence when both are present.
+A non-empty `Badge:` string also means recommended, and is rendered as the badge text
+in place of the default star.
+
 Rendered as: 3-column pricing cards. Recommended option has accent border and scale bump.
 
 ### timeline-steps
@@ -135,7 +144,11 @@ Steps:
     Detail: "Q2 2026"
 ```
 
-Alternative format: `Step-1:`, `Step-2:`, etc. as separate fields.
+Alternative format: `Step-1:`, `Step-2:`, etc. as separate fields, each a map of
+`Number` / `Label` / `Description` / `Duration`. `Title` and `Label` share the title
+slot; `Detail`, `Date` and `Duration` share the detail slot; `Bullets` keeps precedence
+over a scalar `Description`, which fills the same slot only when no `Bullets` is given.
+In every pair the older name wins when both are present.
 
 Rendered as: Horizontal timeline with connected accent dots and labels below.
 
@@ -171,10 +184,13 @@ Same structure as process-flow (Diagram field only). Uses Mermaid `gantt`.
 ### closing-slide
 
 ```yaml
-Headline: "Call to action headline"
-Key-Takeaway: "One-sentence takeaway"
-CTA: "Action text"          # optional
+Title: "Call to action headline"
+Subtitle: "One-sentence takeaway"
+Metadata: "Contact or closing detail"    # optional
 ```
+
+Accepted aliases: `Headline`, `Key-Takeaway` (or `Takeaway`) and `CTA` are the older
+names for those three slots and keep precedence when both are present.
 
 Rendered as: Full-viewport dark background matching title-slide. Accent underline.
 
@@ -190,4 +206,47 @@ References:
 
 Alternative: plain text list or numbered items.
 
+A slide may also reach this renderer through `Slide-Kind: references` — but only when it
+actually carries a `References` or `Citations` payload. A slide that declares that kind
+while holding its content in some other shape (two columns, say) keeps its own `Layout:`
+renderer, so nothing it authored is dropped.
+
 Rendered as: Numbered citation list with clickable links, auto-counted via CSS counter.
+
+## slide-data.json shape
+
+Both Phase 1 parse paths — the deterministic `parse-brief.py` run and the LLM fallback —
+write `{brief_dir}/cogni-visual/slide-data.json` in this shape. The renderer reads only
+`metadata` and `slides`; extra top-level keys the parser emits (`version`, `warnings`)
+are harmless.
+
+```json
+{
+  "metadata": {
+    "title": "...",
+    "subtitle": "...",
+    "customer": "...",
+    "provider": "...",
+    "language": "de",
+    "arc_type": "why-change",
+    "generated": "2026-02-09",
+    "governing_thought": "..."
+  },
+  "slides": [
+    {
+      "number": 1,
+      "headline": "Assertion headline",
+      "layout": "title-slide",
+      "fields": {
+        "Title": "...",
+        "Subtitle": "...",
+        "Metadata": "..."
+      },
+      "speaker_notes": null,
+      "bottom_banner": null,
+      "diagram_mermaid": null,
+      "citations": []
+    }
+  ]
+}
+```

--- a/cogni-workspace/skills/render-html-slides/scripts/generate-html-slides.py
+++ b/cogni-workspace/skills/render-html-slides/scripts/generate-html-slides.py
@@ -183,6 +183,37 @@ def convert_inline(text):
     return text
 
 
+# Keys the producer writes that are metadata about a slide rather than content
+# to print. The generic fallback renderer skips them; without this they leak
+# into the deck as visible labelled paragraphs. The lowercase/capitalized split
+# is deliberate and matches what the parser emits.
+NON_CONTENT_FIELDS = (
+    "Speaker-Notes",
+    "Bottom-Banner",
+    "intent",
+    "visual",
+    "cta",
+    "Slide-Kind",
+    "Source",
+    "Slide-Title",
+)
+
+
+def _first_present(mapping, names, default=None):
+    """Return ``mapping[name]`` for the first name that is PRESENT.
+
+    Presence, not truthiness, is the test: an authored-but-empty old name must
+    keep rendering empty rather than falling through to a newer alias. Callers
+    list names old-first, so an existing brief never changes what it renders.
+    """
+    if not isinstance(mapping, dict):
+        return default
+    for name in names:
+        if name in mapping:
+            return mapping[name]
+    return default
+
+
 def render_bullets(bullets, css_class=""):
     """Render a list of bullet strings to an HTML <ul>."""
     if not bullets:
@@ -192,19 +223,65 @@ def render_bullets(bullets, css_class=""):
     return f"      <ul{cls}>\n{items}\n      </ul>"
 
 
-def render_bottom_banner(slide):
-    """Render a bottom banner if present.
+def _annotation_text(slide, top_key, field_key):
+    """Text of a slide-level annotation, or "" when it has none.
 
-    Accepts the canonical top-level ``bottom_banner`` and the legacy
-    ``fields["Bottom-Banner"]`` so the banner renders on every layout.
+    Both annotations accept the canonical top-level key and the legacy nested
+    ``fields[...]`` form, and either a plain string or a dict with ``Text``.
+    Stating that shape once keeps the two renderers from drifting apart.
     """
-    banner = slide.get("bottom_banner") or slide.get("fields", {}).get("Bottom-Banner")
-    if not banner:
+    value = slide.get(top_key) or slide.get("fields", {}).get(field_key)
+    if not value:
         return ""
-    text = banner.get("Text", "") if isinstance(banner, dict) else str(banner)
+    return value.get("Text", "") if isinstance(value, dict) else str(value)
+
+
+def render_bottom_banner(slide):
+    """Render a bottom banner if present, on every layout."""
+    text = _annotation_text(slide, "bottom_banner", "Bottom-Banner")
     if not text:
         return ""
     return f'      <div class="bottom-banner">{convert_inline(text)}</div>'
+
+
+def render_source_footer(slide):
+    """Render a per-slide source attribution if present.
+
+    Layout-agnostic, like ``render_bottom_banner`` — the producer writes
+    ``Source`` on whichever slides cite one, independently of their layout.
+    The value is a markdown link, so it goes through ``convert_inline`` (which
+    builds the anchor) rather than ``escape_html`` (which would show the raw
+    brackets). A slide that also carries a bottom banner gets a raised variant
+    so the two never overlap.
+    """
+    text = _annotation_text(slide, "source", "Source")
+    if not text:
+        return ""
+    # Ask whether a banner exists, rather than rendering one to find out.
+    raised = " source-footer-raised" if _annotation_text(slide, "bottom_banner", "Bottom-Banner") else ""
+    return f'      <div class="source-footer{raised}">{convert_inline(text)}</div>'
+
+
+def effective_layout(slide):
+    """The layout a slide actually renders as.
+
+    ``parse-brief.py`` owns the parsed ``layout`` field and deliberately never
+    lets ``Slide-Kind`` overwrite it. This is a render-time routing decision
+    layered on top of that field, not a change to it — the parsed value is left
+    alone, and ``data-layout`` reports whatever actually rendered.
+
+    ``Slide-Kind: references`` reroutes to the references renderer, but ONLY
+    when a reference payload is actually there. A slide that declares the kind
+    while carrying its content in some other shape (columns, say) must keep its
+    own ``Layout:`` renderer — rerouting it would resolve the reference list to
+    empty and silently drop everything the author wrote, which is the very
+    failure this alignment exists to close.
+    """
+    fields = slide.get("fields", {}) or {}
+    kind = slide.get("slide_kind") or fields.get("Slide-Kind")
+    if kind == "references" and _first_present(fields, ("References", "Citations"), None):
+        return "references"
+    return slide.get("layout", "generic")
 
 
 # ---------------------------------------------------------------------------
@@ -338,8 +415,9 @@ def render_four_quadrants(slide, dv):
     f = slide["fields"]
     quads = []
     for i in range(1, 5):
-        key = f"Quadrant-{i}"
-        q = f.get(key, {})
+        # The producer writes ``Q1``..``Q4``; ``Quadrant-1``..``Quadrant-4`` is
+        # the canonical name and keeps precedence when both are present.
+        q = _first_present(f, (f"Quadrant-{i}", f"Q{i}"), {})
         if not q:
             continue
         number = escape_html(q.get("Number", ""))
@@ -400,6 +478,9 @@ def render_is_does_means(slide, dv, language="en"):
     for key, badge in [("IS-Box", is_l), ("DOES-Box", does_l), ("MEANS-Box", means_l)]:
         box = f.get(key, {})
         text = convert_inline(box.get("Text", "")) if isinstance(box, dict) else convert_inline(str(box))
+        # The badge the author wrote wins; --language supplies the fallback.
+        if isinstance(box, dict) and box.get("Label"):
+            badge = escape_html(str(box["Label"]))
         bands.append(f"""
           <div class="idm-band">
             <span class="idm-badge">{badge}</span>
@@ -421,12 +502,17 @@ def render_three_options(slide, dv):
         opt = f.get(key, {})
         if not opt:
             continue
-        title = escape_html(opt.get("Title", opt.get("Label", f"Option {i}")))
-        subtitle = escape_html(opt.get("Subtitle", ""))
-        bullets = opt.get("Bullets", [])
-        is_recommended = opt.get("Recommended", False)
+        # Old names keep precedence; the producer's Name/Price/Badge/Features
+        # are accepted after them so no existing brief changes what it renders.
+        title = escape_html(_first_present(opt, ("Title", "Label", "Name"), f"Option {i}"))
+        subtitle = escape_html(_first_present(opt, ("Subtitle", "Price"), ""))
+        bullets = _first_present(opt, ("Bullets", "Features"), [])
+        badge_text = opt.get("Badge", "")
+        # A non-empty Badge string means recommended, as does a truthy Recommended.
+        is_recommended = bool(opt.get("Recommended", False)) or bool(badge_text)
         rec_class = " option-recommended" if is_recommended else ""
-        rec_badge = '<span class="rec-badge">&#9733;</span>' if is_recommended else ""
+        badge_inner = escape_html(str(badge_text)) if badge_text else "&#9733;"
+        rec_badge = f'<span class="rec-badge">{badge_inner}</span>' if is_recommended else ""
 
         options.append(f"""
           <div class="option-card{rec_class}">
@@ -459,21 +545,35 @@ def render_timeline_steps(slide, dv):
     nodes = []
     for i, step in enumerate(steps):
         if isinstance(step, dict):
-            title = escape_html(step.get("Title", step.get("Label", f"Step {i+1}")))
-            detail = escape_html(step.get("Detail", step.get("Date", "")))
-            bullets = step.get("Bullets", [])
+            title = escape_html(_first_present(step, ("Title", "Label"), f"Step {i+1}"))
+            # Detail/Date keep precedence; the producer's Duration is accepted
+            # after them.
+            detail = escape_html(_first_present(step, ("Detail", "Date", "Duration"), ""))
+            # Bullets keeps precedence; a scalar Description fills the same slot
+            # only when no Bullets list was authored.
+            if "Bullets" in step:
+                bullets = step["Bullets"]
+            elif step.get("Description"):
+                bullets = [str(step["Description"])]
+            else:
+                bullets = []
+            number = step.get("Number", "")
         else:
             title = escape_html(str(step))
             detail = ""
             bullets = []
+            number = ""
 
         bullets_html = render_bullets(bullets, "step-bullets") if bullets else ""
+        number_html = (
+            f'<span class="timeline-number">{escape_html(str(number))}</span>' if number else ""
+        )
 
         nodes.append(f"""
           <div class="timeline-node">
             <div class="timeline-dot"></div>
             <div class="timeline-label">
-              <strong>{title}</strong>
+              {number_html}<strong>{title}</strong>
               <span class="timeline-detail">{detail}</span>
               {bullets_html}
             </div>
@@ -546,9 +646,11 @@ def render_process_flow(slide, dv):
 def render_closing_slide(slide, dv):
     """Layout: closing-slide — Full dark background with CTA headline."""
     f = slide["fields"]
-    headline = escape_html(f.get("Headline", f.get("Title", "")))
-    takeaway = convert_inline(f.get("Key-Takeaway", f.get("Takeaway", "")))
-    cta = convert_inline(f.get("CTA", ""))
+    headline = escape_html(_first_present(f, ("Headline", "Title"), ""))
+    # Old names keep precedence; the producer's Subtitle and Metadata fill the
+    # same two slots, so no new CSS class is needed.
+    takeaway = convert_inline(_first_present(f, ("Key-Takeaway", "Takeaway", "Subtitle"), ""))
+    cta = convert_inline(_first_present(f, ("CTA", "Metadata"), ""))
 
     cta_html = f'<p class="closing-cta">{cta}</p>' if cta else ""
 
@@ -566,7 +668,7 @@ def render_closing_slide(slide, dv):
 def render_references_slide(slide, dv):
     """Layout: references — Numbered citation list with clickable links."""
     f = slide["fields"]
-    refs = f.get("References", f.get("Citations", []))
+    refs = _first_present(f, ("References", "Citations"), [])
 
     if isinstance(refs, list):
         items = []
@@ -594,7 +696,7 @@ def render_generic_slide(slide, dv):
     f = slide["fields"]
     content_parts = []
     for key, val in f.items():
-        if key in ("Speaker-Notes", "Bottom-Banner"):
+        if key in NON_CONTENT_FIELDS:
             continue
         if isinstance(val, dict):
             content_parts.append(f"<h3>{escape_html(key)}</h3>")
@@ -633,9 +735,10 @@ LAYOUT_RENDERERS = {
 }
 
 
-def render_slide(slide, dv, language="en"):
+def render_slide(slide, dv, language="en", layout=None):
     """Dispatch to the appropriate layout renderer."""
-    layout = slide.get("layout", "generic")
+    if layout is None:
+        layout = effective_layout(slide)
     renderer = LAYOUT_RENDERERS.get(layout, render_generic_slide)
 
     # Special case: is-does-means needs language
@@ -777,6 +880,26 @@ def generate_css(dv, transition="fade", aspect_ratio="16:9"):
     font-weight: 600;
     text-align: center;
     letter-spacing: 0.03em;
+  }}
+
+  /* ---- Source Footer ---- */
+  .source-footer {{
+    position: absolute; bottom: 0; left: 0; right: 0;
+    padding: 0.8vh 5vw;
+    color: var(--text-muted);
+    font-size: clamp(0.65rem, 0.85vw, 0.8rem);
+    text-align: right;
+    font-style: italic;
+  }}
+
+  /* Clear the bottom banner, which is itself pinned to bottom: 0. */
+  .source-footer-raised {{
+    bottom: 4.2vh;
+  }}
+
+  .source-footer a {{
+    color: inherit;
+    text-decoration: underline;
   }}
 
   /* ======== LAYOUT: Title Slide ======== */
@@ -1104,6 +1227,12 @@ def generate_css(dv, transition="fade", aspect_ratio="16:9"):
   .timeline-label {{
     text-align: center;
     padding: 0 0.5vw;
+  }}
+  .timeline-number {{
+    display: block;
+    color: var(--accent);
+    font-weight: 700;
+    font-size: clamp(0.8rem, 1vw, 1rem);
   }}
   .timeline-label strong {{
     display: block;
@@ -1719,12 +1848,21 @@ def assemble_html(slide_data, dv, transition="fade", aspect_ratio="16:9", langua
 
     for slide in slides:
         num = slide.get("number", 0)
-        headline = escape_html(slide.get("headline", ""))
-        layout = slide.get("layout", "generic")
+        # The authored short Slide-Title wins over the long assertion headline.
+        headline = escape_html(
+            slide.get("fields", {}).get("Slide-Title") or slide.get("headline", "")
+        )
+        # One resolution for dispatch, the title guard and data-layout, so the
+        # three can never disagree about what this slide actually rendered as.
+        layout = effective_layout(slide)
         notes = slide.get("speaker_notes", "")
 
         # Render slide content
-        content_html = render_slide(slide, dv, language)
+        content_html = render_slide(slide, dv, language, layout=layout)
+        source_html = render_source_footer(slide)
+        # Contribute nothing at all when there is no source, so a source-less
+        # slide's markup stays byte-identical to what it was before.
+        source_block = f"\n{source_html}" if source_html else ""
         banner_html = render_bottom_banner(slide)
 
         # Slide title (not shown on title-slide or closing-slide)
@@ -1736,7 +1874,7 @@ def assemble_html(slide_data, dv, transition="fade", aspect_ratio="16:9", langua
   <section class="slide" data-slide="{num}" data-layout="{layout}">
     <div class="slide-content">
 {title_html}
-{content_html}
+{content_html}{source_block}
 {banner_html}
     </div>
   </section>""")

--- a/cogni-workspace/skills/render-html-slides/scripts/generate-html-slides.py
+++ b/cogni-workspace/skills/render-html-slides/scripts/generate-html-slides.py
@@ -10,7 +10,9 @@ Usage:
         --aspect-ratio <16:9|4:3> \
         --language <en|de>
 
-Input:  slide-data.json (parsed from presentation-brief.md by LLM)
+Input:  slide-data.json, produced from presentation-brief.md by
+        `parse-brief.py --emit slide-data`; the LLM free-parse is the
+        documented fallback, used only when that parser fails.
 Output: Self-contained HTML file with themed slides, navigation, speaker notes panel.
 Returns JSON: {"status": "ok", "path": "<output-path>", "slides": N} or {"error": "..."}
 """


### PR DESCRIPTION
Closes #1795.

## Summary

- **Phase 1 is deterministic.** `render-html-slides` now runs the shared `parse-brief.py` (`--emit slide-data`, plus `--emit metadata` for the block that emitter does not carry) and falls back to the LLM free-parse **only** when the envelope returns `success: false`. The free-parse prose is **relocated** into an explicit `#### LLM fallback parse` subsection, not deleted.
- **The renderer reads what the producer writes**, with old names keeping precedence so no existing brief regresses: `Slide-Title`, a `Source` footer link, `Q1`..`Q4`, closing `Title`/`Subtitle`/`Metadata`, three-options `Name`/`Price`/`Badge`/`Features`, timeline `Step-N{Number,Label,Description,Duration}`, and IS/DOES/MEANS badges from each box's `Label:`. `render_generic_slide` stops printing six non-content keys.
- **Two new eval cases** — one end-to-end through the parser, one on direct slide-data.
- `references/01-layout-renderers.md` documents the producer names and corrects the claim this change makes false.

## The two decisions I took from the files rather than the issue text

**1. `slide_kind: references` routes conditionally.** `EXAMPLE_BRIEF.md` slide 13 declares `Slide-Kind: references` while carrying `Layout: two-columns-equal` with `Left-Column`/`Right-Column` and **no** `References`/`Citations` field. Routing it unconditionally resolves the reference list to `[]` and destroys three visible source strings — re-committing the exact silent-content-drop class this issue exists to close. Routing therefore fires only when a reference payload is actually present. See `## Open questions`.

**2. The `Q1`..`Q4` alias is proven on direct slide-data, not end-to-end.** `parse-brief.py`'s `_normalize_quadrants` rewrites `Q{n}` to `Quadrant-{n}` *upstream*, so an end-to-end `EXAMPLE_BRIEF` assertion renders four populated cards **with zero renderer change** — a vacuous green. Eval case 6 builds its slide-data directly so the assertion can actually fail. Confirmed by mutation M1 below, which reddens **only** case 6.

## One acceptance criterion was already satisfied at base

The AC asks that a `version: "4.1"` brief pass Phase 0 and a `version: "4.0"` brief still do. `SKILL.md:49` already read ``version: "4.0"`` or ``"4.1"`` at `origin/main` — a sibling landed it ahead of this issue. **This diff deliberately leaves line 49 untouched**; it is a preserve-invariant, not work. Please grade it as passing rather than as a missing edit.

## Guard verification — the new cases can actually fail

Each mutation was applied to `generate-html-slides.py` alone, the suite re-run, then the file restored:

| Mutation | Suite result |
|---|---|
| M1 — drop the `Q{i}` arm of the quadrant alias | case 6 red (case 5 stays green — the vacuous-green point) |
| M2 — make `slide_kind` routing unconditional | cases 5 + 6 red |
| M3 — drop `Subtitle` from the closing takeaway chain | cases 5 + 6 red |
| M4 — disable the `Source` footer | cases 5 + 6 red |
| M5 — revert the IS/DOES/MEANS `Label` priority | cases 5 + 6 red |
| M6 — revert the `Slide-Title` H2 override | case 6 red |
| restored | 6/6 green |

## Regression evidence

`generate-html-slides.py` was run at `origin/main` and at HEAD over an old-name-only slide-data covering all six affected layouts, in both `en` and `de`:

- **The slide markup is byte-identical in both languages**, and **no line is removed** from the output.
- The only difference is **+26 lines of new CSS** (`.source-footer`, `.source-footer-raised`, `.source-footer a`, `.timeline-number`), which is unavoidable for a new visual element — the stylesheet is emitted unconditionally. Worth knowing when reading the AC's "byte-identical" wording: it holds exactly for the slide markup, and the stylesheet gains rules without losing any.

`_first_present()` is presence-based, not truthiness-based, so an authored-but-empty old name keeps rendering empty rather than falling through to a newer alias.

## Gates

- `evals/run.py` — 6/6, exit 0
- `run-plugin-tests.py --filter cogni-workspace` — 21/21 suites, exit 0
- `check-external-dispatch.py`, `check-breadcrumbs.py`, `check-version-bump.py` — exit 0, no `version-touched` finding
- `check-frontmatter.sh`, `check-breadcrumbs.sh` (cogni-workspace) — exit 0
- Every import in both scripts is stdlib; no `plugin.json` in the diff

No `*/tests/test[-_]*.sh` and no `check-*` guard file is touched, so no `## Mutation recipe` section applies; the mutations above are recorded for the reviewer's benefit.

## Review notes

- **Pre-existing, not introduced here.** The skill-quality gate flagged the `## Features` section (~19 lines) as user-facing copy duplicating the Parameters table and Phase 5/6. Marked `introduced_by_change: false`, so it is annotated rather than re-planned. Body is 17,559 chars against a 21,000 cap (78%).
- The skill-quality gate returned `needs_revision` on three auto-fixable findings, all applied: the LLM-fallback branch now also assembles `metadata` (it previously would have produced the exact "Presentation"-titled deck the deterministic branch warns about), the merge step now names its mechanism, and a `## Additional Resources` section now names all three bundled references.
- Token-scope preflight reports `over_scoped` — extra `gist`, `read:org`, `workflow`, with `workflow` classified **forbidden**. Cleared with the settled `--allow-overscoped` opt-out, flagged here because the posture is a runner-level fact a reviewer may want to revisit, not something this PR changes.

## Open questions

- **`parse-brief.py:381` states, on the field it sets: "The layout is the Layout field. Slide-Kind never overrides it."** This PR's `effective_layout()` makes `Slide-Kind` override `Layout` at *render* time (guarded on payload presence). The parser's own comment stays literally true — the parsed `layout` field is untouched — but the two files now express opposite routing intents, and the issue's AC explicitly asked for the `slide_kind` routing. If the parser's rule is meant to bind consumers too, the right fix is to teach `render_references_slide` a `Left-Column`/`Right-Column` shape instead and drop `effective_layout()` entirely.
- **The defect class is narrowed, not closed.** This PR fixes the reported instances; a quality pass found `Icon` (7 occurrences in `EXAMPLE_BRIEF.md`), `visual.chart` (real chart data), and the per-slide `cta` block still authored and still read nowhere — two of them now *deliberately* suppressed by `NON_CONTENT_FIELDS`, so they degrade silently by design. The rejected alternative plan's answer was an unread-authored-key report in the output envelope (precedent: `theme_slug_resolution`). I did **not** add it — it is a new public output-envelope key and outside this issue's acceptance bar — but it is the change that would close the class.
- **Alias ownership is split.** `parse-brief.py` already owns the quadrant alias with a warn-and-drop rule; this PR adds a second, silent owner in the renderer. Consolidating into the parser would also benefit the pptx consumer. Genuinely a separate PR.
- Not filed as issues: the three items above are recorded here rather than on the board, because they surfaced from the quality pass rather than from planned deferred scope. Say the word and I will file them.