### PR TITLE
cogni-workspace: add narrative --interactive flag

### DIFF
--- a/cogni-workspace/agents/narrative-writer.md
+++ b/cogni-workspace/agents/narrative-writer.md
@@ -39,9 +39,11 @@ You will receive:
 - `research_question` (optional) -- original research question for narrative framing
 - `content_map` (optional) -- YAML map of content category keys to file/directory paths for additional entity context
 
+`interactive` is not among them. This agent always invokes the skill with `--interactive false`, so a caller cannot re-enable a prompt this agent's own rules forbid; a supplied value is ignored rather than relayed.
+
 ## Execution
 
-1. Invoke the `cogni-workspace:narrative` skill using the Skill tool, passing all received parameters as skill arguments
+1. Invoke the `cogni-workspace:narrative` skill using the Skill tool, passing the received parameters as skill arguments, always with `--interactive false` so the skill skips its AskUserQuestion calls (today, the Phase 2 arc confirmation)
 2. The skill handles ALL narrative logic: content loading, arc selection, pattern loading, transformation, validation, and output writing
 3. Follow the skill's complete 6-phase workflow -- do NOT skip phases or override skill decisions
 4. Do NOT ask user questions during execution -- use auto-detection for arc selection if `arc_id` is not provided

--- a/cogni-workspace/agents/narrative-writer.md
+++ b/cogni-workspace/agents/narrative-writer.md
@@ -43,7 +43,7 @@ You will receive:
 
 ## Execution
 
-1. Invoke the `cogni-workspace:narrative` skill using the Skill tool, passing the received parameters as skill arguments, always with `--interactive false` so the skill skips its AskUserQuestion calls (today, the Phase 2 arc confirmation)
+1. Invoke the `cogni-workspace:narrative` skill using the Skill tool, passing the received parameters as skill arguments, always with `--interactive false` so the skill skips every prompt that would wait on a user (today, the Phase 2 arc confirmation)
 2. The skill handles ALL narrative logic: content loading, arc selection, pattern loading, transformation, validation, and output writing
 3. Follow the skill's complete 6-phase workflow -- do NOT skip phases or override skill decisions
 4. Do NOT ask user questions during execution -- use auto-detection for arc selection if `arc_id` is not provided

--- a/cogni-workspace/skills/narrative/SKILL.md
+++ b/cogni-workspace/skills/narrative/SKILL.md
@@ -188,7 +188,7 @@ The arc registry contains the detection algorithm, keyword sets, and content-typ
 
 Present selected arc to user for confirmation using AskUserQuestion. Show the detected arc with detection reason and offer alternatives. For priority-2 picks, label the prompt "Inherited from source research/knowledge project — preserves the long-form report's arc". Accept user confirmation or override.
 
-When `--interactive` is `false`, this confirmation does not run -- keep the arc selected above, record its `detection_reason` unchanged, and continue to Phase 3.
+When `--interactive` is `false`, this confirmation does not run -- keep the arc selected above, store it with its `detection_reason` unchanged as below, then continue to Phase 3.
 
 Store: `arc_id`, `arc_display_name`, `detection_reason`
 

--- a/cogni-workspace/skills/narrative/SKILL.md
+++ b/cogni-workspace/skills/narrative/SKILL.md
@@ -33,6 +33,7 @@ Transform input markdown files into a structured executive narrative using one o
 | `--target-length` | No | Target total word count as a single number (e.g., `2500`). System applies +/-15% band to derive the acceptable range. Default: `1675` (yields ~1,424-1,926 words). Recommended: 800-4,000 — outside this range, arc rhetorical structure may not scale well |
 | `--format` | No | Derivative mode. One of `executive-brief`, `talking-points`, `one-pager`. When set, `--source-path` is a single finished narrative `.md` file, the generation pipeline (Phases 0.5-6) is skipped, and the Derivative Formats section below runs instead. Output defaults to `{source-dir}/{format}.md` |
 | `--content-map` | No | YAML map of content category keys to file/directory paths for additional context |
+| `--interactive` | No | Whether the skill may pause for user input. `true` or `false`. Default: `true`. When `false`, skip all AskUserQuestion calls — today that is the Phase 2 arc confirmation, which keeps its ladder selection and its `detection_reason` and continues straight into Phase 3 with no prompt. Same semantics as the `interactive` parameter in `story-to-slides`, `story-to-web` and `story-to-infographic`, spelled `--interactive` here to match this skill's flag-style argument surface |
 
 **Content map keys:** `executive_summary`, `dimension_syntheses`, `trends_summary`, `trend_entities`, `megatrends_summary`, `megatrend_entities`, `domain_concepts`, `research_hub`, `initial_question`
 
@@ -186,6 +187,8 @@ The arc registry contains the detection algorithm, keyword sets, and content-typ
 5. Fallback: `corporate-visions`. `detection_reason = "default fallback"`.
 
 Present selected arc to user for confirmation using AskUserQuestion. Show the detected arc with detection reason and offer alternatives. For priority-2 picks, label the prompt "Inherited from source research/knowledge project — preserves the long-form report's arc". Accept user confirmation or override.
+
+When `--interactive` is `false`, this confirmation does not run -- keep the arc selected above, record its `detection_reason` unchanged, and continue to Phase 3.
 
 Store: `arc_id`, `arc_display_name`, `detection_reason`
 

--- a/cogni-workspace/skills/narrative/SKILL.md
+++ b/cogni-workspace/skills/narrative/SKILL.md
@@ -33,7 +33,7 @@ Transform input markdown files into a structured executive narrative using one o
 | `--target-length` | No | Target total word count as a single number (e.g., `2500`). System applies +/-15% band to derive the acceptable range. Default: `1675` (yields ~1,424-1,926 words). Recommended: 800-4,000 — outside this range, arc rhetorical structure may not scale well |
 | `--format` | No | Derivative mode. One of `executive-brief`, `talking-points`, `one-pager`. When set, `--source-path` is a single finished narrative `.md` file, the generation pipeline (Phases 0.5-6) is skipped, and the Derivative Formats section below runs instead. Output defaults to `{source-dir}/{format}.md` |
 | `--content-map` | No | YAML map of content category keys to file/directory paths for additional context |
-| `--interactive` | No | Whether the skill may pause for user input. `true` or `false`. Default: `true`. When `false`, skip all AskUserQuestion calls — today that is the Phase 2 arc confirmation, which keeps its ladder selection and its `detection_reason` and continues straight into Phase 3 with no prompt. Same semantics as the `interactive` parameter in `story-to-slides`, `story-to-web` and `story-to-infographic`, spelled `--interactive` here to match this skill's flag-style argument surface |
+| `--interactive` | No | Whether the skill may pause for user input. `true` or `false`. Default: `true`. When `false`, skip all AskUserQuestion calls — today that is the Phase 2 arc confirmation, which keeps its ladder selection and its `detection_reason` and continues straight into Phase 3 with no prompt. Same semantics as the `interactive` parameter in `story-to-slides`, `story-to-web` and `story-to-infographic`, spelled `--interactive` here to match this skill's flag-style argument surface. Any value other than `false` is treated as `true`, so a malformed value fails safe toward the interactive default |
 
 **Content map keys:** `executive_summary`, `dimension_syntheses`, `trends_summary`, `trend_entities`, `megatrends_summary`, `megatrend_entities`, `domain_concepts`, `research_hub`, `initial_question`
 
@@ -188,7 +188,7 @@ The arc registry contains the detection algorithm, keyword sets, and content-typ
 
 Present selected arc to user for confirmation using AskUserQuestion. Show the detected arc with detection reason and offer alternatives. For priority-2 picks, label the prompt "Inherited from source research/knowledge project — preserves the long-form report's arc". Accept user confirmation or override.
 
-When `--interactive` is `false`, this confirmation does not run -- keep the arc selected above, store it with its `detection_reason` unchanged as below, then continue to Phase 3.
+When `--interactive` is `false`, this confirmation does not run -- keep the arc selected above, store it with its `detection_reason` unchanged via the `Store:` line below, then continue to Phase 3.
 
 Store: `arc_id`, `arc_display_name`, `detection_reason`
 

--- a/cogni-workspace/tests/test-narrative-interactive-flag.sh
+++ b/cogni-workspace/tests/test-narrative-interactive-flag.sh
@@ -27,7 +27,7 @@
 # argument-less in-repo copies (cogni-consult/scripts/, cogni-portfolio/scripts/)
 # and replays to a false green. Run from the repo root:
 #
-#   bash /Users/stephandehaas/.claude/plugins/marketplaces/managed-service/cogni-service/scripts/mutation-check.sh \
+#   bash "$HOME/.claude/plugins/marketplaces/managed-service/cogni-service/scripts/mutation-check.sh" \
 #     --root . \
 #     --file cogni-workspace/skills/narrative/SKILL.md \
 #     --expr 's/this confirmation does not run/this confirmation always runs/' \
@@ -98,8 +98,13 @@ fi
 # ---------------------------------------------------------------------------
 # P2 -- the Phase 2 non-interactive branch is documented. This is the case the
 # mutation recipe above drives red.
+#
+# The literal spans the CONDITION as well as the consequent. Binding only
+# 'this confirmation does not run' would leave the branch green after the leading
+# 'When `--interactive` is `false`, ' was deleted -- i.e. green on precisely the
+# unconditional-skip over-reach the acceptance contract exists to forbid.
 # ---------------------------------------------------------------------------
-branch_hits=$(grep -c 'this confirmation does not run' "$SKILL")
+branch_hits=$(grep -c 'When `--interactive` is `false`, this confirmation does not run' "$SKILL")
 if [ "$branch_hits" -eq 1 ]; then
   pass "P2 the Phase 2 non-interactive branch is documented exactly once"
 else

--- a/cogni-workspace/tests/test-narrative-interactive-flag.sh
+++ b/cogni-workspace/tests/test-narrative-interactive-flag.sh
@@ -64,14 +64,21 @@ fail() { echo "FAIL: $1"; failures=$((failures + 1)); }
 # otherwise make every grep return 0 and read as a content failure rather than
 # a path failure.
 # ---------------------------------------------------------------------------
+missing_inputs=""
 for f in "$SKILL" "$AGENT"; do
-  if [ ! -f "$f" ]; then
-    echo "FAIL: setup expected file not found: $f"
-    echo ""
-    echo "RESULT: 1 narrative-interactive case(s) failed."
-    exit 1
-  fi
+  [ -f "$f" ] || missing_inputs="$missing_inputs $f"
 done
+
+if [ -n "$missing_inputs" ]; then
+  for m in $missing_inputs; do
+    printf '%s\n' "  missing input: $m"
+  done
+  fail "P0 setup expected files are readable"
+  echo ""
+  echo "RESULT: $failures narrative-interactive case(s) failed."
+  exit 1
+fi
+pass "P0 setup expected files are readable"
 
 # ---------------------------------------------------------------------------
 # P1 -- the flag is documented where every other narrative argument is documented.
@@ -129,6 +136,18 @@ if grep -q 'interactive false' "$AGENT"; then
   pass "P4 narrative-writer passes --interactive false on its skill invocation"
 else
   fail "P4 narrative-writer passes --interactive false on its skill invocation"
+fi
+
+# ---------------------------------------------------------------------------
+# P5 -- the agent must not reference AskUserQuestion at all. The skill keeps the
+# grant (P3); the agent is the non-interactive caller, so a prompt reaching it is
+# the regression this whole change exists to prevent. Asserted here rather than
+# assumed, because this diff adds agent-body prose in exactly that neighbourhood.
+# ---------------------------------------------------------------------------
+if grep -q 'AskUserQuestion' "$AGENT"; then
+  fail "P5 narrative-writer.md must not reference AskUserQuestion"
+else
+  pass "P5 narrative-writer.md must not reference AskUserQuestion"
 fi
 
 # ---------------------------------------------------------------------------

--- a/cogni-workspace/tests/test-narrative-interactive-flag.sh
+++ b/cogni-workspace/tests/test-narrative-interactive-flag.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# narrative --interactive contract guard: the flag must be documented, its
+# Phase 2 branch must exist, the default interactive path must survive, and the
+# narrative-writer agent must actually pass the flag.
+#
+# Why this exists. `skills/narrative/SKILL.md` Phase 2 confirms the detected arc
+# through AskUserQuestion. Every non-interactive caller stalled there, because
+# the skill had no argument telling it to stay quiet — `agents/narrative-writer.md`
+# instructed "Do NOT ask user questions during execution" with no skill-side lever
+# to enforce it. The fix is a documented `--interactive` flag (default `true`) plus
+# a Phase 2 branch, and the agent hardcoding `--interactive false`.
+#
+# The regression this guards against is not the feature going missing — it is the
+# feature being "cleaned up" in the wrong direction. The obvious wrong fix is to
+# strip AskUserQuestion from the skill's `allowed-tools:`, which silently breaks
+# the confirmation for every human caller while leaving the flag looking correct.
+# Case P3 is the guard for exactly that, and it asserts by SITE rather than by a
+# bare occurrence count: a count of 2 also holds if someone deletes the frontmatter
+# grant and adds a stray mention somewhere else, so a count alone would stay green
+# through the very regression it exists to catch — and it would go red on the
+# legitimate change of adding a second gated prompt site, which is the direction
+# the sibling skills have already taken.
+#
+# Mutation recipe (proves P2 has teeth). Every flag value is a literal — the
+# handoff preflight rejects a variable-bearing recipe, and a
+# ${CLAUDE_PLUGIN_ROOT}-relative harness path resolves to one of the two
+# argument-less in-repo copies (cogni-consult/scripts/, cogni-portfolio/scripts/)
+# and replays to a false green. Run from the repo root:
+#
+#   bash /Users/stephandehaas/.claude/plugins/marketplaces/managed-service/cogni-service/scripts/mutation-check.sh \
+#     --root . \
+#     --file cogni-workspace/skills/narrative/SKILL.md \
+#     --expr 's/this confirmation does not run/this confirmation always runs/' \
+#     --test 'bash cogni-workspace/tests/test-narrative-interactive-flag.sh' \
+#     --case P2
+#
+# The search literal occurs exactly once at head and zero times at base, so the
+# expr cannot report expr_no_op; it is a plain non-global s/// with no capture
+# groups and no /d form, so it is valid for `perl -0pi`; and the replacement does
+# not contain the search literal, so the mutant cannot re-satisfy P2 — its count
+# goes 1 -> 0 and it prints `FAIL: P2`, a real red rather than case_not_found.
+# The same mutant leaves P1, P3 and P4 untouched, so the redness is attributable
+# to P2 alone.
+
+# set -u but deliberately NOT set -e: a red arm must print its FAIL line and let
+# the run reach the summary, not abort the script at the first failing check.
+set -u
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+WS_ROOT="$(cd "$HERE/.." && pwd)"
+
+# Both targets are workspace-internal, so reach them from WS_ROOT rather than
+# routing back down through the repo root — that is the sibling idiom, and it
+# keeps the plugin directory name out of the suite entirely.
+SKILL="$WS_ROOT/skills/narrative/SKILL.md"
+AGENT="$WS_ROOT/agents/narrative-writer.md"
+
+failures=0
+pass() { echo "PASS: $1"; }
+fail() { echo "FAIL: $1"; failures=$((failures + 1)); }
+
+# ---------------------------------------------------------------------------
+# Both files must exist before any case can mean anything. A missing file would
+# otherwise make every grep return 0 and read as a content failure rather than
+# a path failure.
+# ---------------------------------------------------------------------------
+for f in "$SKILL" "$AGENT"; do
+  if [ ! -f "$f" ]; then
+    echo "FAIL: setup expected file not found: $f"
+    echo ""
+    echo "RESULT: 1 narrative-interactive case(s) failed."
+    exit 1
+  fi
+done
+
+# ---------------------------------------------------------------------------
+# P1 -- the flag is documented where every other narrative argument is documented.
+# Binds to the Parameters-table row shape (leading pipe, the flag, the `No`
+# required column) AND to the stated default, so a Phase 2 branch shipped without
+# a table row does not pass.
+# ---------------------------------------------------------------------------
+# One pipeline, not two conjuncts: the second stage cannot match unless the
+# first produced a row, so a separate row-shape grep would be entailed by this
+# and would only duplicate the pattern literal at a second site.
+if grep '^| `--interactive` | No |' "$SKILL" | grep -q 'Default: `true`'; then
+  pass "P1 the --interactive row exists in the Parameters table and states Default: \`true\`"
+else
+  fail "P1 the --interactive row exists in the Parameters table and states Default: \`true\`"
+fi
+
+# ---------------------------------------------------------------------------
+# P2 -- the Phase 2 non-interactive branch is documented. This is the case the
+# mutation recipe above drives red.
+# ---------------------------------------------------------------------------
+branch_hits=$(grep -c 'this confirmation does not run' "$SKILL")
+if [ "$branch_hits" -eq 1 ]; then
+  pass "P2 the Phase 2 non-interactive branch is documented exactly once"
+else
+  fail "P2 the Phase 2 non-interactive branch is documented exactly once (found $branch_hits)"
+fi
+
+# ---------------------------------------------------------------------------
+# P3 -- the default interactive path survives, asserted by SITE, not by a count.
+#   (i)  the frontmatter grant is still present
+#   (ii) the Phase 2 call site is still present
+#
+# Deliberately NOT a third "AskUserQuestion occurs exactly N times" conjunct.
+# The sibling skills (story-to-slides, story-to-web, story-to-infographic) each
+# gate three or four prompt sites on their `interactive` parameter, so narrative
+# gaining a second legitimate checkpoint is the expected direction of travel. A
+# pinned total would go red on that correct change, and the cheapest reaction to
+# it would be to bump the constant — eroding the by-site discipline this case
+# exists to enforce. The two site conjuncts already carry the regression.
+# ---------------------------------------------------------------------------
+p3_grant=$(grep -c '^allowed-tools:.*AskUserQuestion' "$SKILL")
+p3_site=$(grep -c 'Present selected arc to user for confirmation using AskUserQuestion' "$SKILL")
+if [ "$p3_grant" -eq 1 ] && [ "$p3_site" -eq 1 ]; then
+  pass "P3 the default interactive path survives: allowed-tools grant and Phase 2 call site both intact"
+else
+  fail "P3 the default interactive path survives: allowed-tools grant and Phase 2 call site both intact (grant=$p3_grant site=$p3_site, want 1/1)"
+fi
+
+# ---------------------------------------------------------------------------
+# P4 -- the agent actually passes the flag. Without this the skill-side branch is
+# reachable in principle and unreached in practice, which is the state this whole
+# change exists to leave behind.
+# ---------------------------------------------------------------------------
+if grep -q 'interactive false' "$AGENT"; then
+  pass "P4 narrative-writer passes --interactive false on its skill invocation"
+else
+  fail "P4 narrative-writer passes --interactive false on its skill invocation"
+fi
+
+# ---------------------------------------------------------------------------
+# The summary line begins RESULT:, never FAIL:. A FAIL:-prefixed summary is
+# itself parsed as a case verdict by the shared mutation harness.
+# ---------------------------------------------------------------------------
+echo ""
+if [ "$failures" -gt 0 ]; then
+  echo "RESULT: $failures narrative-interactive case(s) failed."
+  exit 1
+fi
+echo "RESULT: all narrative-interactive cases passed."
+exit 0


### PR DESCRIPTION
Closes #1773.

## Summary

- Adds `--interactive` (optional, default `true`) as a row of the narrative skill's Parameters table, in the table's house style.
- Phase 2 gains one sentence: when `--interactive` is `false`, the arc-confirmation prompt does not run — the ladder's selection and its `detection_reason` are kept unchanged and Phase 3 continues.
- `agents/narrative-writer.md` now passes `--interactive false` on its skill invocation, matching the rule its own body already stated but could not enforce, and documents that `interactive` is not a caller-settable parameter.
- One new suite, `cogni-workspace/tests/test-narrative-interactive-flag.sh`, pins six properties: the input files are readable (P0, the liveness floor), the flag is documented (P1), the Phase 2 branch exists and is conditioned on the flag (P2), the default interactive path survives (P3), the agent passes the flag (P4), and the agent never references `AskUserQuestion` (P5).

**The SKILL.md diff is purely additive — zero deletions.** The original Phase 2 confirmation sentence survives verbatim; the new branch is stated after it rather than wrapping it. That was a deliberate revision (see Review notes) and it is what makes acceptance criterion 3 checkable by inspection.

## Scope decisions

**Corrected, not propagated — a false premise in the issue.** The issue's `## Use case` states that `agents/narrative-writer.md` grants `AskUserQuestion` in its frontmatter, and its `## Proposed solution` asks for that grant to be dropped from the `tools:` block. Both are false at `origin/main`:

```
$ grep -c 'AskUserQuestion' cogni-workspace/agents/narrative-writer.md
0
```

The agent's `tools:` block is at lines 18-24 and reads `Read, Write, Glob, Grep, Bash, Skill`. The grant that does exist is on the **skill** (`skills/narrative/SKILL.md:4`), and it is deliberately **kept** — the default interactive path still calls it, and removing it would break every human caller. That is the highest-probability regression in this change, so case P3 asserts it rather than assuming it. No agent-frontmatter edit is made; a reviewer expecting that hunk should read its absence as intentional.

This makes acceptance criterion 4's second conjunct (`grep AskUserQuestion` in the agent "returns nothing") a **do-not-INTRODUCE gate rather than a removal** — it already holds at base, but a diff that ADDS the token falsifies it, which is a live risk here because this PR adds agent-body prose in exactly that neighbourhood. Case P5 guards that add-path. Its first conjunct, `grep -n 'interactive false'`, is load-bearing and is what the PR satisfies.

**Line numbers in the issue are off by a few.** The issue cites the selection ladder as "lines 181-188". At `origin/main`, 181 is the `**Selection priority:**` header, the five rungs are 182-186, 187 is blank, and 188 is the confirmation sentence. The change was built against the real anchors.

**`detection_reason` is not added to the JSON summary.** Acceptance criterion 2's evidence phrase reads "emits its JSON summary with `detection_reason` populated", but that key is absent from the generation-mode summary block at base (its nine keys are `success`, `output_path`, `arc_id`, `arc_display_name`, `target_length`, `word_count`, `citation_count`, `elements`, `language`). Resolved from the issue's own `## Proposed solution` — "recording the same `detection_reason` string it would otherwise have recorded" — as the Phase 2 `Store:` line, not a schema change. Adding the key would have put a hunk in the Output section, outside the Phase-2 fence.

**Hardcoded, not relayed.** `--interactive false` is fixed at the agent's invocation. The agent's `## Parameters` is a closed enumeration with no passthrough clause, and its no-questions rule is unconditional — a relayed value would let a caller re-enable a prompt the agent's own body forbids.

**Not touched:** the Derivative Formats section (`--format` skips Phases 0.5-6, so a conditional there would be dead code); `plugin.json` / `marketplace.json` `version` (the post-merge workflow owns the bump).

## Review notes

**Three revisions came out of the pre-commit passes, and they changed the shape of the diff.**

1. *Phase 2 ordering.* The first draft put the exception before the rule — `When --interactive is false, this confirmation does not run` appeared above the sentence introducing the confirmation, leaving "this confirmation" without an antecedent, and it required rewriting the existing line to `Otherwise, present ...`. Stating the default first and the exception second reads correctly, and makes the SKILL.md diff purely additive.

2. *The Parameters row states the rule skill-wide,* "skip all AskUserQuestion calls", rather than Phase-2-only. This is the verbatim sentence three sibling skills already use (`story-to-slides/SKILL.md:91`, `story-to-web/SKILL.md:96`, `story-to-infographic/SKILL.md:99`), so a future second prompt site inherits the rule with no doc edit. The row names the parameter `--interactive` rather than the siblings' bare `interactive` because narrative's whole argument surface is flag-style; the row says so explicitly so a caller copying from a sibling does not write `interactive false` and have it silently ignored.

3. *Test case P3 does not pin an occurrence count.* An earlier version asserted `AskUserQuestion` occurs exactly twice. Two reviewers independently objected: a count of 2 also holds if someone deletes the frontmatter grant and adds a stray mention elsewhere, and it would go **red on the correct change** of adding a second gated prompt site — which is the direction the sibling skills have already taken. P3 now binds the two sites by name instead.

**Pre-existing, not introduced here (no action taken):** `skills/narrative/SKILL.md` runs 428 lines / ~4,000 words, above the skill-development guide's 1,500-2,000-word target though inside its 5k ceiling. This 3-line diff did not cause it and does not meaningfully move it (75.4% → 77.5% of the measured character budget, well below the 90% approach zone, so the net-growth budget does not engage). Flagged for a future dedicated pass rather than bundled here.

**Revision round (2026-09-04), addressing the first automated verdict.** Two majors and four smaller items:

1. *The suite's liveness floor emitted an unpaired `FAIL:` from inside a loop* (contract item 14), which `scripts/check-case-id-pairing.py` classifies `unpaired_abort_in_loop` — reddening two blocking CI jobs via the guard's own `R1 the repository as it stands is clean` meta-case. Rewritten to accumulate offenders in the loop then gate a script-scope `fail "P0 ..."` / `pass "P0 ..."` pair, the resident shape at `cogni-workspace/tests/test-arc-reference-sync.sh:123-137`. Both suggested remedies were applied together deliberately: a same-id green twin short-circuits in `scan_file` *before* the abort/scope test, so the fix does not rest on the `script_scope_aborts_exempt` arm the guard's docstring says may be deleted rather than adjusted.
2. *No case asserted `AskUserQuestion` ABSENT from the agent* (contract item 13(e)). Case **P5** added, written as an if/else so both arms carry the id — the reviewer's literal `! grep -q` one-liner would have reproduced the very unpaired class item 14 is about.
3. *P2 was under-bound.* It grepped only `this confirmation does not run`, which sits **after** the conditional clause — so deleting `` When `--interactive` is `false`, `` left P2 green, i.e. green on precisely the unconditional-skip over-reach the contract forbids. The literal now spans the condition. Verified both ways: on a prefix-deleted mutant the old literal still counts 1 (would have passed) while the widened one counts 0 and P2 goes red.
4. *The recorded mutation recipe in the suite header hardcoded a machine-local `/Users/...` path* — the only file under `cogni-workspace/tests/` that did. Swapped for the `"$HOME/..."` idiom its five recipe-bearing siblings already use. Flag values stay literal; only the harness path changed, and the PR-body recipe (which `check-preflight` parses) is untouched.
5. *Phase 2 wording*: the non-interactive branch now names the `Store:` step before the Phase 3 jump.
6. *Three false counts in this body* were corrected: the `AskUserQuestion` line-count (2 -> 3, since this PR's own Parameters row also names the tool), the suite's PASS-line count (4 -> 6), and the net-growth head figure (77.2% -> 77.5%).

**Prose-simplify pass:** the Step 6.4b gate fired on the touched `SKILL.md` and `agents/*.md`, but the net-growth budget did not engage (no unit at or above 90% of cap), and the prose this diff adds had just been reviewed from four angles by the Step 6.4 pass, whose findings are applied above. An Edit-capable whole-file simplifier was deliberately **not** dispatched, because it would have produced hunks outside the Phase-2-and-Parameters-table fence the acceptance contract sets.

**Revision round 2 (2026-09-04), addressing the second automated verdict** (NEEDS_REVISION at head `08790434`). Three un-waived findings: two fixed, one declined.

1. *`--interactive` third-value behaviour was unstated* (`SKILL.md:36`). The row enumerated `true`/`false` and gave behaviour for `false` and for absent, but not for a third value — so an executing model had to guess, and guessing "not `true`, therefore skip" would suppress a confirmation the user asked for. The row now states: any value other than `false` is treated as `true`, so a malformed value fails safe toward the interactive default. Deliberately **not** mirrored as an Error Handling row like `--format`'s: an unrecognised `--format` halts, whereas an unrecognised `--interactive` resolves to the default and continues, so a halt row would assert the opposite behaviour.

2. *`as below` did ambiguous pointer work* (`SKILL.md:191`). It sat directly after "unchanged", where it could read as modifying the *manner* of storage rather than naming the *destination*. Now reads `unchanged via the \`Store:\` line below`. **This is convergence, not a third lap of the round-1 disagreement:** round 1's own note (item 5 above) recorded the requirement as "names the `Store:` step before the Phase 3 jump", but the text it produced only *pointed* at it. Naming it satisfies the earlier reviewer's stated property more fully than the previous head did, restores no pre-round-1 wording, and keeps every element `plugin-validator` quoted under its item 9. The P2-pinned literal `` When `--interactive` is `false`, this confirmation does not run `` is byte-identical, so test P2 and the recorded mutation recipe both still bind.

3. *Missing `## When to invoke` on `agents/narrative-writer.md` — declined, waived as out of scope.* Verified pre-existing: `grep -c 'When to invoke'` returns **0 at `origin/main` and 0 at head**, and this PR touches that file only in `## Parameters` and `## Execution`, never the frontmatter description or any heading. The same reviewer's structurally identical pre-existing finding on the same file (the `tools:` Write grant vs the body's "DO NOT write files directly") was already waived "Out of scope for this PR"; applying the opposite disposition here would be inconsistent.

*Simplify pass:* the Step 6.4 code pass flagged the first draft of the finding-1 sentence as ~32 words where ~9 carried the fact, the tail restating why a default is a default. Trimmed to the reviewer's own suggested wording. Net effect of round 2 on the length signal: 24420 -> 24554 chars_body against a 31500 cap (77.5% -> 77.9%), still well below the 90% approach zone.

**Pre-existing, not introduced here (no action taken) — element word-count tolerance contradicts itself.** The Step 6.5 gate surfaced a genuine defect in Phase 5 that this diff did not cause and does not touch: `SKILL.md:263` reads "Element word counts within computed proportional ranges (+/-10% of section midpoint)" but the operative formula in the same sentence is `[proportion * total_lower, proportion * total_upper]`, and `total_lower`/`total_upper` are the **+/-15%** band (`SKILL.md:156`: `target * 0.85` / `target * 1.15`). `SKILL.md:233` repeats the "+/-10% tolerance" claim while `SKILL.md:86` independently states "+/-15% band". So a model validating a narrative reads two conflicting gates in one sentence with no stated precedence. Evidence points to +/-15% being authoritative (stated twice, including by the formula itself), making the mechanical repair the two "+/-10%" parentheticals — but choosing which figure is authoritative **alters the skill's validation contract**, and Phase 5 is outside this PR's `--interactive` fence. Confirmed present at `origin/main`; this PR's diff to the file touches zero lines containing either figure. Flagged for a dedicated follow-up rather than bundled here.

## Test plan

- [x] `bash cogni-workspace/tests/test-narrative-interactive-flag.sh` — 6 `PASS:` lines (P0-P5), exits 0.
- [x] `python3 scripts/run-plugin-tests.py --filter cogni-workspace` — exits 0, 22 suites discovered, 22 passed, 0 failed. The new suite is auto-discovered by the `*/tests/*.sh` glob with no registration step.
- [x] `grep -n 'interactive false' cogni-workspace/agents/narrative-writer.md` matches (acceptance criterion 4).
- [x] `grep -c 'AskUserQuestion' cogni-workspace/skills/narrative/SKILL.md` returns `3` — the `allowed-tools:` grant (line 4), the new `--interactive` Parameters row (line 36), and the Phase 2 prompt (line 189), all intact. (`grep -c` counts matching LINES; the count is 3 rather than the 2 originally recorded because this PR's own Parameters row also names the tool. Base is 2.)
- [x] `git diff --name-only origin/main...HEAD` lists exactly the three fenced files (acceptance criterion 7).
- [x] `check-breadcrumbs.sh` and `check-frontmatter.sh` over `cogni-workspace/` — both `clean: true`, 0 offenders.
- [x] Mutation recipe below returns `guard_verified`.

## Mutation recipe

Reverts the Phase 2 conditional so the confirmation always runs, and expects case P2 to go red — acceptance criterion 5. Every flag value is a literal, and the harness path names the cogni-service marketplace copy: the two in-repo copies (`cogni-consult/scripts/mutation-check.sh`, `cogni-portfolio/scripts/mutation-check.sh`) are argument-less plugin-local harnesses that accept none of these flags, so naming either — or a `${CLAUDE_PLUGIN_ROOT}`-relative path that resolves to one — replays to a false green. Run from the repo root:

```
bash /Users/stephandehaas/.claude/plugins/marketplaces/managed-service/cogni-service/scripts/mutation-check.sh --root . --file cogni-workspace/skills/narrative/SKILL.md --expr 's/this confirmation does not run/this confirmation always runs/' --test 'bash cogni-workspace/tests/test-narrative-interactive-flag.sh' --case P2
```

Observed: `{"verdict": "guard_verified", "mutated_result": "red", "restored_result": "green"}`. The search literal occurs exactly once at head and zero times at base, so the expr cannot report `expr_no_op`; it is a plain non-global `s///` valid for `perl -0pi`; and the replacement does not contain the search literal, so the mutant cannot re-satisfy P2. P1, P3 and P4 are untouched by the mutant, so the redness is attributable to P2 alone.

## Follow-up issues

- **#1835** — document `narrative-writer`'s `tools:` shape in `cogni-workspace/references/agent-tool-declarations.md`. The agent's deliberate omission of `AskUserQuestion` is undocumented in the one file the repo designates for that rationale, which is the plausible origin of this issue's false premise. Out of the three-file fence.
- **#1836** — two other cogni-workspace agents (`story-to-infographic.md`, `enrich-report.md`) dispatch `interactive`-bearing skills without passing `interactive=false`, and grant themselves `AskUserQuestion` instead. Same defect class as this issue, still live in two places. Found by this branch's altitude review and verified against `origin/main`.

## Open questions

- The issue's `## Use case` premise about the agent's `AskUserQuestion` grant is false at base, and its `## Proposed solution` asks for an edit that has no target. No `tools:` edit was made and none of the acceptance criteria require one. Flagged so the absent hunk is not read as a missed one.



