### PR TITLE
test(readme-inventory-sync): derive both digits in every real-README anchor

### DIFF
--- a/tests/test_check_readme_inventory_sync.sh
+++ b/tests/test_check_readme_inventory_sync.sh
@@ -321,6 +321,20 @@ revert_claim() {
   return "$rc"
 }
 
+# try_mutate <file> <old> <new> — mutate() with its abort converted into a
+# return status, for a real-tree mutation whose literal does not reduce to the
+# <prefix>N<suffix> shape revert_claim takes. Same discipline and same reason as
+# that wrapper: a literal that has gone stale must fail its own case, never
+# abort the suite and take every case after it with it.
+try_mutate() {
+  local rc
+  set +e
+  mutate "$1" "$2" "$3"
+  rc=$?
+  set -e
+  return "$rc"
+}
+
 # ---------------------------------------------------------------- case 1
 CONSISTENT="$WORK/consistent"
 consistent_fixture "$CONSISTENT"
@@ -535,11 +549,26 @@ assert d['data']['rollup_present'] is True, d['data']
 # the guard under test enforces on that file, applied to its own suite. An
 # anchor that will not resolve fails its own case here and lets the cases after
 # it run, rather than aborting the suite and taking ris22-ris29 with it.
+#
+# BOTH digits in each anchor are derived, not just the reverted one. Every claim
+# site here states a skills count beside an agents count, and an anchor that
+# reverts one while restating the other as a literal stops matching the day the
+# RESTATED count moves — a plugin retirement that changes only the agent digit
+# then reddens ris21-ris25 on their own stale anchors while the guard they exist
+# to prove is behaving correctly. That is a false red on a correct change, and
+# it is the harder kind to read, because the failure names the guard rather than
+# the anchor. The sibling digit is read through readme_count exactly as the
+# reverted one is; an unresolvable sibling leaves the literal unmatchable, which
+# revert_claim reports as this case's own failure rather than a suite abort.
+WS_AGENTS=$(readme_count 's/.*management\. [0-9]+ skills and ([0-9]+) agents\..*/\1/p') || WS_AGENTS=''
+WS_TABLE_AGENTS=$(readme_count 's/.*\| Workspace Infrastructure \| [0-9]+ \| ([0-9]+) \|.*/\1/p') || WS_TABLE_AGENTS=''
+ROLLUP_AGENTS=$(readme_count 's/.*\*\*[0-9]+ skills, ([0-9]+) agents\*\*.*/\1/p') || ROLLUP_AGENTS=''
+
 REAL_PROSE=$(real_scratch real-prose-reverted)
 ANCHOR_OK=0
 revert_claim "$REAL_PROSE/README.md" \
-  's/.*management\. ([0-9]+) skills and 26 agents\..*/\1/p' \
-  'management. ' ' skills and 26 agents.' || ANCHOR_OK=1
+  's/.*management\. ([0-9]+) skills and [0-9]+ agents\..*/\1/p' \
+  'management. ' " skills and $WS_AGENTS agents." || ANCHOR_OK=1
 run_guard "$REAL_PROSE"
 check "ris21 real README with the workspace prose count reverted exits 1" "$([ "$ANCHOR_OK" -eq 0 ] && [ "$CODE" -eq 1 ] && echo 0 || echo 1)"
 assert_json "ris22 reverted prose reports prose-count-mismatch naming cogni-workspace" "$OUT" "
@@ -553,27 +582,34 @@ assert v[0]['plugin']=='cogni-workspace', v
 REAL_TABLE=$(real_scratch real-table-reverted)
 ANCHOR_OK=0
 revert_claim "$REAL_TABLE/README.md" \
-  's/.*\| Workspace Infrastructure \| ([0-9]+) \| 26 \|.*/\1/p' \
-  '| Workspace Infrastructure | ' ' | 26 |' || ANCHOR_OK=1
+  's/.*\| Workspace Infrastructure \| ([0-9]+) \| [0-9]+ \|.*/\1/p' \
+  '| Workspace Infrastructure | ' " | $WS_TABLE_AGENTS |" || ANCHOR_OK=1
 run_guard "$REAL_TABLE"
 check "ris23 real README with the workspace table cell reverted exits 1" "$([ "$ANCHOR_OK" -eq 0 ] && [ "$CODE" -eq 1 ] && echo 0 || echo 1)"
 
 REAL_ROLLUP=$(real_scratch real-rollup-reverted)
 ANCHOR_OK=0
 revert_claim "$REAL_ROLLUP/README.md" \
-  's/.*\*\*([0-9]+) skills, 88 agents\*\*.*/\1/p' \
-  '**' ' skills, 88 agents**' || ANCHOR_OK=1
+  's/.*\*\*([0-9]+) skills, [0-9]+ agents\*\*.*/\1/p' \
+  '**' " skills, $ROLLUP_AGENTS agents**" || ANCHOR_OK=1
 run_guard "$REAL_ROLLUP"
 check "ris24 real README with the roll-up total reverted exits 1" "$([ "$ANCHOR_OK" -eq 0 ] && [ "$CODE" -eq 1 ] && echo 0 || echo 1)"
 
 # ---------------------------------------------------------------- case 14
 # The singular arm against the real tree: one plugin's claim reads
 # "1 skill and N agents." Pluralising it must redden, which proves the singular
-# form was being read as a claim rather than skipped.
+# form was being read as a claim rather than skipped. N is derived for the same
+# reason case 13's siblings are — the singular skills count is what this arm is
+# about, and restating the agents count beside it would make an unrelated
+# agent-inventory change abort this suite through mutate()'s uniqueness assert.
+SINGULAR_AGENTS=$(readme_count 's/.*pitches\. 1 skill and ([0-9]+) agents\..*/\1/p') || SINGULAR_AGENTS=''
 REAL_SINGULAR=$(real_scratch real-singular)
-mutate "$REAL_SINGULAR/README.md" "pitches. 1 skill and 4 agents." "pitches. 2 skills and 4 agents."
+ANCHOR_OK=0
+try_mutate "$REAL_SINGULAR/README.md" \
+  "pitches. 1 skill and $SINGULAR_AGENTS agents." \
+  "pitches. 2 skills and $SINGULAR_AGENTS agents." || ANCHOR_OK=1
 run_guard "$REAL_SINGULAR"
-check "ris25 real README with the singular claim pluralized exits 1" "$([ "$CODE" -eq 1 ] && echo 0 || echo 1)"
+check "ris25 real README with the singular claim pluralized exits 1" "$([ "$ANCHOR_OK" -eq 0 ] && [ "$CODE" -eq 1 ] && echo 0 || echo 1)"
 
 # ---------------------------------------------------------------- case 15
 # Section scoping. A pipe table OUTSIDE the glance section whose first cell is a


### PR DESCRIPTION
## Description

Unblocks #1834, which is red on `Plugin test suites (discover and run tests/*.sh)` through no fault of its own diff.

`tests/test_check_readme_inventory_sync.sh` proves the README inventory guard has teeth by reverting each real claim site in the root README and asserting the guard reddens. Each of those anchors reverted one count while restating **the count sitting beside it** as a literal — `26 agents`, `| 26 |`, `88 agents`, `4 agents`. Those literals bound nothing; they were only there to locate the claim. But they made every anchor sensitive to an inventory it does not grade.

#1834 retires an agent, so the root README moves from `26 agents` to `25` (and the roll-up from `88` to `87`). All three anchors then match zero times, the mutation cannot be planted, the guard correctly reports nothing, and the suite surfaces `AssertionError: []` on ris21–ris24. **The guard is right; the suite proving it has teeth is what goes red — on a correct change.** #1834 does not touch this file, so it cannot fix itself, and being labelled `svc:needs-review` routes it to a merger identity with no `contents:write`. That is the deadlock recorded on cogni-work/managed-service#1058 (6th recurrence).

The suite's own `readme_count` comment already states the principle this PR completes: a restated count goes stale the moment the inventory moves. It was applied to the reverted digit only.

## Changes

- Both digits in each real-tree anchor are now read through `readme_count` at run time. The reverted digit stays a capture group; the sibling digit becomes `[0-9]+` in the sed script and is derived separately for the literal `mutate` passes.
- New `try_mutate` wrapper — `mutate()` with its abort converted into a return status, for a real-tree mutation whose literal does not reduce to the `<prefix>N<suffix>` shape `revert_claim` takes. ris25 moves onto it and folds the result into its own predicate via `ANCHOR_OK`, matching ris21/23/24. Previously a stale literal there would abort the whole suite under `set -e` rather than fail one case.
- Comment at case 13 records why both digits are derived, and case 14 why its sibling is.

No guard, no README and no plugin file is touched — the change is confined to one test file. No `version` field is touched.

## Testing

- `bash tests/test_check_readme_inventory_sync.sh` at `origin/main` (22/26 workspace, 88 roll-up): **58/58 PASS, 0 FAIL, exit 0**.
- Same suite against #1834's head `ec8ab53` (21/25 workspace, 87 roll-up): **58/58 PASS, 0 FAIL, exit 0**. Before this change that tree gave `FAIL: ris21 ris22 ris23 ris24`, byte-identical to the CI log on job 101009164824.
- Mutation, executed both directions: re-hardcoding the four sibling digits reproduces the original `ris21`–`ris24` failures **plus** a red `ris25`, and all 58 result lines are still emitted (`ris26`–`ris58` ran) — so the derivation is load-bearing and `try_mutate` does convert an abort into a case-local failure. Restoring returns the suite to exit 0.
- Anchor liveness is graded, not assumed: `ris21`/`ris23`/`ris24`/`ris25` all fold `ANCHOR_OK` into their predicate, so an anchor that stops resolving fails its case rather than passing vacuously.
- `check-result-line-plainness.py`, `check-case-id-pairing.py`, `check-code-span-nesting.py`, `check-breadcrumbs.py` — all exit 0.
- Case-id uniqueness verified by **running** the suite and grouping emitted first tokens: no duplicates.
- `python3 scripts/run-plugin-tests.py` full sweep: only `cogni-consult/tests/test_resolve_assumptions.sh` and `tests/test_release_bundle_wiki.sh` fail, and both fail identically at `origin/main` in this container. They are root-in-container artifacts (they simulate a write-permission failure, which `chmod` cannot produce for uid 0) — both are green in CI on #1834's run, where the only failing suite was the one this PR fixes.

## Checklist

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md)
- [x] My changes follow the existing code style
- [x] I have updated documentation where applicable
- [x] I have tested my changes

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PxnkdjUzzr5Mnqz5RwBrzJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01PxnkdjUzzr5Mnqz5RwBrzJ)_