### PR TITLE
cogni-workspace: pin interactive=false in the two agents that dispatch without it

### DIFF
--- a/cogni-workspace/agents/enrich-report.md
+++ b/cogni-workspace/agents/enrich-report.md
@@ -29,10 +29,11 @@ The non-interactive value is not a pass-through parameter — it is fixed at ste
 always sent. The skill defaults it to `true` (`skills/enrich-report/SKILL.md:77`) and Phase 3 is its "Interactive
 Review" checkpoint (`:295`), which branches on the flag at `:299` / `:307`. A subagent has no
 user to answer a prompt, so an unpinned dispatch stalls in Phase 3 rather than returning — which
-is why step 2 above can promise to run "all phases in order" at all. The `AskUserQuestion` grant on the `tools:` line above is deliberately kept: it mirrors the
-skill's own `allowed-tools`, which the skill exercises in this agent's context. See
-`cogni-workspace/references/agent-tool-declarations.md`. The pin, not the grant, is what stops
-the prompt.
+is why step 2 above can promise to run "all phases in order" at all. The `AskUserQuestion` grant on
+the `tools:` line above is deliberately kept: `AskUserQuestion` is itself in the skill's own
+`allowed-tools` (`skills/enrich-report/SKILL.md:17`), and the skill exercises it in this agent's
+context. See `cogni-workspace/references/agent-tool-declarations.md`. The pin, not the grant, is
+what stops the prompt.
 
 6. Return a compact JSON response:
 

--- a/cogni-workspace/agents/enrich-report.md
+++ b/cogni-workspace/agents/enrich-report.md
@@ -14,11 +14,26 @@ You are the enrich-report agent. Your job is to execute the enrich-report skill 
 
 ## Instructions
 
-1. Load and follow the skill at `${CLAUDE_PLUGIN_ROOT}/skills/enrich-report/SKILL.md`
+1. Load and follow the skill at `${CLAUDE_PLUGIN_ROOT}/skills/enrich-report/SKILL.md`, always with `interactive=false`
 2. Execute all phases in order (Phase 0 through Phase 3, then Phase 4 (Step 4a + 4b) through Phase 5, Phase 5b if Browser MCP is available, plus Phase 6 if `formats` includes pdf or docx)
 3. In Phase 4 Step 4a, dispatch the `report-html-writer` agent to produce the scroll HTML. The writer agent handles all HTML assembly (Chart.js configs, inline SVGs, sidebar navigation, markdown-to-HTML conversion) AND runs the Python post-processor for scroll infographic injection and content validation. You receive a JSON response with content-preservation metrics — check that `ok` is true and `preservation.ratio` >= 0.80 before proceeding.
 4. In Phase 4 Step 4b, derive the flipbook variant by copying the scroll HTML and running the post-processor with `--layout flipbook`. This is a fast Python-only step — no agent dispatch needed.
 5. For Phase 5b visual review, dispatch the `enriched-report-reviewer` agent with the scroll HTML output path, design-variables path, and enrichment-plan path. If the reviewer returns score < 8.0 on its first pass, it will auto-fix and re-review (max 2 passes). If Browser MCP is unavailable, skip Phase 5b.
+## Parameters
+
+| Parameter | Required | Default | Notes |
+|---|---|---|---|
+| `interactive` | No | `false` | Always false for agent invocation (agents must not interact with users). Pinned by this agent, not relayed: a supplied value is ignored. |
+
+The non-interactive value is not a pass-through parameter — it is fixed at step 1 above and
+always sent. The skill defaults it to `true` (`skills/enrich-report/SKILL.md:77`) and Phase 3 is its "Interactive
+Review" checkpoint (`:295`), which branches on the flag at `:299` / `:307`. A subagent has no
+user to answer a prompt, so an unpinned dispatch stalls in Phase 3 rather than returning — which
+is why step 2 above can promise to run "all phases in order" at all. The `AskUserQuestion` grant on the `tools:` line above is deliberately kept: it mirrors the
+skill's own `allowed-tools`, which the skill exercises in this agent's context. See
+`cogni-workspace/references/agent-tool-declarations.md`. The pin, not the grant, is what stops
+the prompt.
+
 6. Return a compact JSON response:
 
 ```json

--- a/cogni-workspace/agents/story-to-infographic.md
+++ b/cogni-workspace/agents/story-to-infographic.md
@@ -16,10 +16,27 @@ You orchestrate the `story-to-infographic` skill. Invoke it via the Skill tool:
 
 ```
 Skill: story-to-infographic
+args: interactive=false
 ```
 
 Pass through all user-provided parameters — e.g. source path, theme, language,
-layout type, or style preset.
+layout type, or style preset — with one exception: `interactive` is never relayed. It is
+hardcoded above, and a caller-supplied value is ignored rather than passed on.
+
+## Parameters
+
+| Parameter | Required | Default | Notes |
+|---|---|---|---|
+| `interactive` | No | `false` | Always false for agent invocation (agents must not interact with users). Pinned by this agent, not relayed: a supplied value is ignored. |
+
+The non-interactive value is not a pass-through parameter — it is fixed at the dispatch above
+and always sent. The skill defaults it to `true` (`skills/story-to-infographic/SKILL.md:74`) and gates its
+`AskUserQuestion` checkpoints on it (`:99`, covering the Step 4 layout/style choice and the CTA
+step). A subagent has no user to answer a prompt, so an unpinned dispatch stalls there rather
+than returning. The `AskUserQuestion` grant on the `tools:` line above is deliberately kept: it mirrors the
+skill's own `allowed-tools`, which the skill exercises in this agent's context. See
+`cogni-workspace/references/agent-tool-declarations.md`. The pin, not the grant, is what stops
+the prompt.
 
 Report `style` in your response — it lets a caller route to the right renderer family
 without re-reading the brief.

--- a/cogni-workspace/tests/test-agent-interactive-flag.sh
+++ b/cogni-workspace/tests/test-agent-interactive-flag.sh
@@ -233,10 +233,12 @@ fi
 #
 # An earlier draft of this case asserted the opposite of the grant conjunct --
 # that no in-scope AGENT may hold an `AskUserQuestion` grant. That was wrong on
-# base facts: `references/agent-tool-declarations.md` records that an agent's
-# `tools:` deliberately mirrors the skill's `allowed-tools`, because the Skill
-# tool runs the skill in the agent's own context, and that a least-privilege
-# trim of exactly this kind was raised and declined on PR #1672. The grant is
+# base facts: `references/agent-tool-declarations.md` records, per agent, why a
+# `tools:` line carries what it does -- `story-to-infographic` mirrors its
+# skill's `allowed-tools`, `narrative-adapter` covers what that skill needs --
+# the common reason being that the Skill tool runs the skill in the agent's own
+# context, and that a least-privilege trim of exactly this kind was raised and
+# declined on PR #1672. The grant is
 # capability the skill exercises, not privilege the agent uses; the pin, not the
 # grant, is what stops the prompt.
 #

--- a/cogni-workspace/tests/test-agent-interactive-flag.sh
+++ b/cogni-workspace/tests/test-agent-interactive-flag.sh
@@ -38,17 +38,23 @@
 #
 #   bash "$HOME/.claude/plugins/marketplaces/managed-service/cogni-service/scripts/mutation-check.sh" \
 #     --root . \
-#     --file cogni-workspace/agents/enrich-report.md \
-#     --expr 's/, always with `interactive=false`//' \
+#     --file cogni-workspace/agents/story-to-infographic.md \
+#     --expr 's/args: interactive=false/args:/' \
 #     --test 'bash cogni-workspace/tests/test-agent-interactive-flag.sh' \
 #     --case A3
 #
 # The search literal occurs exactly once at head and zero times at base, so the
 # expr cannot report expr_no_op; it is a plain non-global s/// with no capture
-# groups, so it is valid for `perl -0pi`; and the replacement is empty, so the
-# mutant cannot re-satisfy A3 — enrich-report loses its only pin and A3 goes red
-# naming that file. A1, A2, A4 and A5 are untouched, so the redness is
-# attributable to A3 alone.
+# groups, so it is valid for `perl -0pi`; and the replacement drops the value
+# while keeping the key, so the mutant cannot re-satisfy A3 — story-to-infographic
+# loses its dispatch-site pin and A3 goes red naming that file. A1, A2, A4 and A5
+# are untouched, so the redness is attributable to A3 alone.
+#
+# The expr carries no shell metacharacter -- no backtick, no $, no parenthesis.
+# The enrich-report mutant is the more obvious one to reach for (delete ", always
+# with `interactive=false`"), and it does redden A3, but its search literal
+# contains backticks and the handoff preflight rejects the whole recipe as not
+# replayable as written. A recipe that cannot be replayed is not evidence.
 
 # set -u but deliberately NOT set -e: a red arm must print its FAIL line and let
 # the run reach the summary, not abort the script at the first failing check.

--- a/cogni-workspace/tests/test-agent-interactive-flag.sh
+++ b/cogni-workspace/tests/test-agent-interactive-flag.sh
@@ -1,7 +1,11 @@
 #!/usr/bin/env bash
 # Agent/interactive-skill pairing guard: every cogni-workspace agent that
-# delegates to an interactive-bearing skill must pin the non-interactive value,
-# and must not hold an AskUserQuestion grant.
+# delegates to an interactive-bearing skill must pin the non-interactive value
+# on its dispatch line (A3); EXEMPT entries are skipped there and policed by
+# A5. An in-scope agent's own AskUserQuestion grant is deliberately NOT
+# asserted on -- the A4 comment below records why. The grant assertions this
+# suite does make run the other way: an interactive-bearing SKILL must keep
+# its grant (A4), and an EXEMPT agent must not regain one (A5).
 #
 # Why this exists. Five cogni-workspace skills expose an `interactive` (or
 # `--interactive`) parameter that defaults to TRUE and gates one or more

--- a/cogni-workspace/tests/test-agent-interactive-flag.sh
+++ b/cogni-workspace/tests/test-agent-interactive-flag.sh
@@ -1,0 +1,298 @@
+#!/usr/bin/env bash
+# Agent/interactive-skill pairing guard: every cogni-workspace agent that
+# delegates to an interactive-bearing skill must pin the non-interactive value,
+# and must not hold an AskUserQuestion grant.
+#
+# Why this exists. Five cogni-workspace skills expose an `interactive` (or
+# `--interactive`) parameter that defaults to TRUE and gates one or more
+# AskUserQuestion sites on it. An agent has no user: reaching such a prompt
+# stalls the subagent rather than returning an error, so the failure is a hang,
+# not a traceback, and it surfaces far from its cause.
+#
+# #1773 closed one instance of this class by adding `--interactive` to the
+# narrative skill, and pinned it with test-narrative-interactive-flag.sh. That
+# guard is narrative-specific: it names one skill and one agent as literals, so
+# it cannot see a new agent, a new interactive-bearing skill, or the two
+# instances (#1836) it never covered. This suite is the general form.
+#
+# The population is DISCOVERED, not enumerated. A1 finds the interactive-bearing
+# skills by reading their own parameter tables; A2 finds the agents that name one
+# of those skills. A sixth skill gaining an `interactive` row, or a new agent
+# delegating to one, is therefore in scope the moment it lands — which is the
+# whole point of replacing a literal-named guard with this one. The only literal
+# roster here is EXEMPT, and it is deliberately small, justified per entry, and
+# asserted non-vacuous by A5.
+#
+# A3 binds PER AGENT -- at least one dispatch site per agent carries the pin --
+# and deliberately not "every args line carries it". agents/story-to-slides.md
+# carries a second `<parameter name="args">` line under "Example with actual
+# values" that does not contain the pin, so the every-line reading would be red
+# at head on a file this change does not touch, and the cheapest reaction to
+# that redness would be to weaken the case rather than fix anything.
+#
+# Mutation recipe (proves A3 has teeth). Every flag value is a literal — the
+# handoff preflight rejects a variable-bearing recipe, and a
+# ${CLAUDE_PLUGIN_ROOT}-relative harness path resolves to one of the two
+# argument-less in-repo copies and replays to a false green. Run from the repo
+# root:
+#
+#   bash "$HOME/.claude/plugins/marketplaces/managed-service/cogni-service/scripts/mutation-check.sh" \
+#     --root . \
+#     --file cogni-workspace/agents/enrich-report.md \
+#     --expr 's/, always with `interactive=false`//' \
+#     --test 'bash cogni-workspace/tests/test-agent-interactive-flag.sh' \
+#     --case A3
+#
+# The search literal occurs exactly once at head and zero times at base, so the
+# expr cannot report expr_no_op; it is a plain non-global s/// with no capture
+# groups, so it is valid for `perl -0pi`; and the replacement is empty, so the
+# mutant cannot re-satisfy A3 — enrich-report loses its only pin and A3 goes red
+# naming that file. A1, A2, A4 and A5 are untouched, so the redness is
+# attributable to A3 alone.
+
+# set -u but deliberately NOT set -e: a red arm must print its FAIL line and let
+# the run reach the summary, not abort the script at the first failing check.
+set -u
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+WS_ROOT="$(cd "$HERE/.." && pwd)"
+SKILLS_DIR="$WS_ROOT/skills"
+AGENTS_DIR="$WS_ROOT/agents"
+
+failures=0
+pass() { echo "PASS: $1"; }
+fail() { echo "FAIL: $1"; failures=$((failures + 1)); }
+
+# ---------------------------------------------------------------------------
+# EXEMPT -- agents that name an interactive-bearing skill but provably cannot
+# reach one of its prompts. Each entry must carry its reason on the same line,
+# and A5 asserts every entry's stated escape route still holds, so an exemption
+# cannot outlive the property that justified it.
+#
+# narrative-adapter: delegates to `narrative` only in `--format` derivative
+# mode. narrative/SKILL.md states that when `--format` is set the generation
+# pipeline (Phases 0.5-6) is skipped entirely, and the skill's sole
+# AskUserQuestion site is the Phase 2 arc confirmation inside that range. The
+# agent also holds no AskUserQuestion grant. Pinning the flag here would be
+# harmless but would assert a coupling that does not exist.
+# ---------------------------------------------------------------------------
+EXEMPT="narrative-adapter"
+
+# ---------------------------------------------------------------------------
+# A0 -- the two directories this suite reasons over must exist. Without this,
+# every later loop iterates an empty set and the whole suite passes vacuously.
+# ---------------------------------------------------------------------------
+if [ -d "$SKILLS_DIR" ] && [ -d "$AGENTS_DIR" ]; then
+  pass "A0 setup skills/ and agents/ are both readable"
+else
+  fail "A0 setup skills/ and agents/ are both readable"
+  echo ""
+  echo "RESULT: $failures agent-interactive case(s) failed."
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# A1 -- discover the interactive-bearing skills: a SKILL.md carrying a
+# parameter-table row for `interactive` or `--interactive`. Binds to the row
+# shape (leading pipe + backticked flag) so a passing mention in prose does not
+# enrol a skill that has no such parameter.
+#
+# Asserted non-empty. A discovery that finds nothing would make A2 and A3 pass
+# over an empty population -- the vacuous-green shape this case exists to stop.
+# ---------------------------------------------------------------------------
+interactive_skills=""
+for skill_md in "$SKILLS_DIR"/*/SKILL.md; do
+  [ -f "$skill_md" ] || continue
+  if grep -qE '^\| `(--)?interactive` \|' "$skill_md"; then
+    skill_name="$(basename "$(dirname "$skill_md")")"
+    interactive_skills="$interactive_skills $skill_name"
+  fi
+done
+
+skill_count=$(printf '%s\n' $interactive_skills | grep -c . || true)
+if [ "$skill_count" -ge 1 ]; then
+  pass "A1 discovered $skill_count interactive-bearing skill(s):$interactive_skills"
+else
+  fail "A1 discovered at least one interactive-bearing skill (found none -- discovery is broken, not the tree)"
+fi
+
+# ---------------------------------------------------------------------------
+# A2 -- discover the agents in scope: an agent that names one of A1's skills.
+# Also asserted non-empty, for the same vacuity reason as A1.
+# ---------------------------------------------------------------------------
+# The tools declaration is read here as well as in A4, so both cases agree on
+# what an agent is allowed to do. Two forms are in use in this directory: the
+# inline `tools: A, B, C` (also seen as a JSON array) and the YAML block
+# sequence under a bare `tools:`.
+read_tools_decl() {
+  awk '
+    /^tools:[[:space:]]*[^[:space:]]/ { print; next }
+    /^tools:[[:space:]]*$/            { inblock = 1; next }
+    inblock && /^[[:space:]]*-[[:space:]]/ { print; next }
+    inblock                           { inblock = 0 }
+  ' "$1"
+}
+
+scoped_agents=""
+for agent_md in "$AGENTS_DIR"/*.md; do
+  [ -f "$agent_md" ] || continue
+  agent_name="$(basename "$agent_md" .md)"
+  # An agent that cannot dispatch cannot reach a prompt. Three agents
+  # (brief-review-assessor, report-html-writer, slides-enrichment-artist) read a
+  # reference file out of a skill's directory without ever invoking the skill;
+  # without this gate they enrol and A3 goes red demanding a pin that would
+  # assert a dispatch they do not perform.
+  case "$(read_tools_decl "$agent_md")" in
+    *Skill*) ;;
+    *) continue ;;
+  esac
+  for s in $interactive_skills; do
+    # A skill REFERENCE, never the bare word: `narrative` is also an ordinary
+    # noun that half these agent bodies use in prose, and matching it enrolled
+    # four agents that dispatch nothing. The three accepted forms are the
+    # plugin-qualified name, the Skill-tool invocation line, and a path to the
+    # skill's own SKILL.md. That last form is deliberately not `skills/$s/` --
+    # reading `skills/$s/references/<file>.md` is ordinary reference loading and
+    # is not a dispatch.
+    if grep -qE "cogni-workspace:$s\b|^[[:space:]]*Skill:[[:space:]]*$s\b|skills/$s/SKILL\.md" "$agent_md"; then
+      scoped_agents="$scoped_agents $agent_name"
+      break
+    fi
+  done
+done
+
+agent_count=$(printf '%s\n' $scoped_agents | grep -c . || true)
+if [ "$agent_count" -ge 1 ]; then
+  pass "A2 discovered $agent_count agent(s) delegating to an interactive-bearing skill:$scoped_agents"
+else
+  fail "A2 discovered at least one delegating agent (found none -- discovery is broken, not the tree)"
+fi
+
+# ---------------------------------------------------------------------------
+# A3 -- every in-scope, non-exempt agent pins the non-interactive value.
+#
+# Both spellings are accepted because both are correct at their own call site:
+# the Skill-tool `args` form takes `interactive=false`, the narrative skill's
+# flag surface takes `--interactive false`. Accepting only one would force a
+# wrong spelling into half the population.
+#
+# This is the case the mutation recipe above drives red.
+# ---------------------------------------------------------------------------
+unpinned=""
+for agent_name in $scoped_agents; do
+  case " $EXEMPT " in *" $agent_name "*) continue ;; esac
+  agent_md="$AGENTS_DIR/$agent_name.md"
+  # Bound to the DISPATCH SITE, not to a bare occurrence anywhere in the file.
+  # The first draft of this case accepted the literal wherever it appeared, and
+  # the recorded mutation below returned `vacuous_guard`: the agents also
+  # document the parameter in prose and in a table row, so deleting the pin from
+  # the actual dispatch left two other copies behind and the case stayed green.
+  # It is the same by-site discipline test-narrative-interactive-flag.sh P3
+  # states, arrived at the same way.
+  #
+  # The pin must share a line with the invocation itself. Four dispatch spellings
+  # are in use and all four satisfy this: the `<parameter name="args">` line, the
+  # `args:` line inside a fenced Skill block, "Load and follow the skill at ...,
+  # always with ...", and "Invoke the ... skill ... always with ...". The
+  # documentation surfaces deliberately do not: the table row states the default
+  # in its own column rather than as the literal, and the explanatory paragraph
+  # names the value in words.
+  if grep -E 'interactive=false|--interactive false' "$agent_md" \
+     | grep -qE 'args|[Ss]kill|[Ii]nvoke|follow'; then
+    continue
+  fi
+  unpinned="$unpinned $agent_name"
+done
+
+if [ -z "$unpinned" ]; then
+  pass "A3 every in-scope non-exempt agent pins interactive=false"
+else
+  fail "A3 every in-scope non-exempt agent pins interactive=false (unpinned:$unpinned)"
+fi
+
+# ---------------------------------------------------------------------------
+# A4 -- the default HUMAN-interactive path survives on every discovered skill.
+#
+# This is the #1773-class wrong-fix direction, and it is the one that costs a
+# real user something. Pinning the agent side makes the skill's prompts look
+# unreachable, and the cheapest-looking cleanup from there is to strip
+# `AskUserQuestion` from a skill's `allowed-tools:` or to delete its
+# `interactive` branch. Either silently breaks the checkpoint for every HUMAN
+# caller while the agent-side pin still reads as correct, so A3 alone would stay
+# green straight through it.
+#
+# An earlier draft of this case asserted the opposite of the grant conjunct --
+# that no in-scope AGENT may hold an `AskUserQuestion` grant. That was wrong on
+# base facts: `references/agent-tool-declarations.md` records that an agent's
+# `tools:` deliberately mirrors the skill's `allowed-tools`, because the Skill
+# tool runs the skill in the agent's own context, and that a least-privilege
+# trim of exactly this kind was raised and declined on PR #1672. The grant is
+# capability the skill exercises, not privilege the agent uses; the pin, not the
+# grant, is what stops the prompt.
+#
+# Asserted by SITE, never by a total occurrence count --
+# test-narrative-interactive-flag.sh P3 records why a pinned total goes red on
+# the legitimate direction of travel (a skill gaining a second gated prompt).
+# ---------------------------------------------------------------------------
+skill_regressions=""
+for s in $interactive_skills; do
+  skill_md="$SKILLS_DIR/$s/SKILL.md"
+  if ! grep -qE '^allowed-tools:.*AskUserQuestion' "$skill_md"; then
+    skill_regressions="$skill_regressions $s(grant-stripped)"
+  fi
+  # The gating statement: a line naming `interactive`, a `When`, and the `false`
+  # arm. Every one of the five discovered skills carries at least one today.
+  if ! grep 'interactive' "$skill_md" | grep -E '[Ww]hen' | grep -q 'false'; then
+    skill_regressions="$skill_regressions $s(branch-deleted)"
+  fi
+done
+
+if [ -z "$skill_regressions" ]; then
+  pass "A4 every interactive-bearing skill keeps its AskUserQuestion grant and its false-branch"
+else
+  fail "A4 every interactive-bearing skill keeps its AskUserQuestion grant and its false-branch (regressions:$skill_regressions)"
+fi
+
+# ---------------------------------------------------------------------------
+# A5 -- every EXEMPT entry is still both in scope and still justified.
+#
+# Two failure directions, and the suite must catch both. An exemption naming an
+# agent no longer in scope is dead roster that silently widens if the name is
+# ever reused. An exemption whose stated escape route has lapsed -- here,
+# narrative gaining a prompt outside the --format-skipped range, or the agent
+# regaining an AskUserQuestion grant -- is an exemption that now hides a live
+# instance, which is exactly what A3 would otherwise have caught.
+# ---------------------------------------------------------------------------
+exempt_problems=""
+for agent_name in $EXEMPT; do
+  case " $scoped_agents " in
+    *" $agent_name "*) ;;
+    *) exempt_problems="$exempt_problems $agent_name(not-in-scope)"; continue ;;
+  esac
+  agent_md="$AGENTS_DIR/$agent_name.md"
+  # The stated escape route: derivative-only delegation, no prompt reachable.
+  if ! grep -q '\-\-format' "$agent_md"; then
+    exempt_problems="$exempt_problems $agent_name(no-longer-format-only)"
+  fi
+  if grep -q 'AskUserQuestion' "$agent_md"; then
+    exempt_problems="$exempt_problems $agent_name(regained-grant)"
+  fi
+done
+
+if [ -z "$exempt_problems" ]; then
+  pass "A5 every EXEMPT entry is in scope and its stated justification still holds"
+else
+  fail "A5 every EXEMPT entry is in scope and its stated justification still holds (problems:$exempt_problems)"
+fi
+
+# ---------------------------------------------------------------------------
+# The summary line begins RESULT:, never FAIL:. A FAIL:-prefixed summary is
+# itself parsed as a case verdict by the shared mutation harness.
+# ---------------------------------------------------------------------------
+echo ""
+if [ "$failures" -gt 0 ]; then
+  echo "RESULT: $failures agent-interactive case(s) failed."
+  exit 1
+fi
+echo "RESULT: all agent-interactive cases passed."
+exit 0


### PR DESCRIPTION
Closes #1836

## Summary

Two cogni-workspace agents delegate to a skill whose `interactive` parameter defaults to `true`
and gates `AskUserQuestion` sites on it, without ever naming the parameter. A subagent has no
user to answer a prompt, so an unpinned dispatch **stalls** rather than returning an error — the
failure is a hang, and it surfaces far from its cause.

- `agents/story-to-infographic.md` → `skills/story-to-infographic/SKILL.md` (`:74` default `true`, `:99` gates the Step 4 layout/style and CTA checkpoints)
- `agents/enrich-report.md` → `skills/enrich-report/SKILL.md` (`:77` default `true`, Phase 3 "Interactive Review" at `:295`, branching at `:299`/`:307`)

## Design decisions

**The precedent could not be copied verbatim.** The three compliant siblings
(`story-to-slides.md:104`, `story-to-web.md:83`, `story-to-storyboard.md:83`) all append
`interactive=false` to an existing `<parameter name="args">` line. Neither gap agent has one:
`story-to-infographic.md` invokes through a bare fenced `Skill:` block, and `enrich-report.md`
inlines the skill with "Load and follow the skill at ...". Each file therefore binds the value in
the dispatch form it already uses — `narrative-writer.md:42`/`:46` is the closer precedent for
`enrich-report`.

**The unqualified pass-through was the other half of the defect.**
`story-to-infographic.md` said "Pass through all user-provided parameters" with no exception.
Adding a pin while leaving that sentence intact would have left two statements in contradiction,
with a caller-supplied `interactive=true` still reaching the skill. It is now qualified in place.

**Both `tools:` grants are deliberately left intact.** The issue's optional step 2 suggested
dropping `AskUserQuestion` once the agents no longer reach a prompt.
`references/agent-tool-declarations.md` records why that is wrong here: the grant mirrors the
skill's own `allowed-tools` because the Skill tool runs the skill *in the agent's context*, so
trimming removes capability rather than privilege — and that exact least-privilege trim was
raised and declined on an earlier review. The pin, not the grant, is what stops the prompt. This
diff briefly removed both grants before that base fact was found; the removal is reverted and the
reasoning is recorded in the guard's A4 comment so it is not re-attempted.

**The guard is the general form, not a second special case.** `#1773` closed one instance of
this class and pinned it with `tests/test-narrative-interactive-flag.sh`, which names one skill
and one agent as literals — so it cannot see a new agent, a new interactive-bearing skill, or
the two instances it never covered. The new suite **discovers** its population instead: A1 finds
interactive-bearing skills from their own parameter tables (5 today), A2 finds the agents that
dispatch one (7 today). Two narrowings were needed and are commented at their sites — matching
the bare word `narrative` enrolled four agents that dispatch nothing, and three agents that read
a `references/` file inside a skill directory are excluded by requiring both a `SKILL.md`-shaped
reference and a `Skill` tool grant.

**A4 asserts the opposite direction on purpose.** Pinning the caller makes the skill's prompts
look unreachable, and the cheapest-looking cleanup from there is to strip `AskUserQuestion` from
a skill's `allowed-tools` or delete its `interactive` branch — which silently breaks the
checkpoint for every *human* caller while the agent-side pin still reads as correct. A4 asserts
both survive, by site rather than by occurrence count.

**`narrative-adapter` is resolved explicitly, not omitted.** It wraps the same `narrative` skill
as `narrative-writer` and does not pin the flag — but it runs only `--format` derivative mode,
and `narrative/SKILL.md:34`/`:115` state that mode skips Phases 0.5-6, which hold the skill's
only `AskUserQuestion` site. It is in `EXEMPT` with that reason, and A5 asserts the stated
justification still holds, so the exemption cannot outlive it.

## Verification

- `run-tests.sh` over `cogni-workspace/tests`: **23 discovered, 23 passed, 0 failed, 0 skipped** (22 suites at base).
- `check-frontmatter.sh` clean (47 files, 223 companions); `check-breadcrumbs.sh` clean (47 files).
- `measure-agent-length.sh`: description 332/1024, system prompt 3384/28000 — no cap approached.

## Mutation recipe

Proves A3 has teeth. Every flag value is a literal and the harness path is the installed
marketplace copy — a `${CLAUDE_PLUGIN_ROOT}`-relative path resolves to an argument-less in-repo
copy and replays to a false green. Run from the repo root:

```
bash "$HOME/.claude/plugins/marketplaces/managed-service/cogni-service/scripts/mutation-check.sh" \
  --root . \
  --file cogni-workspace/agents/story-to-infographic.md \
  --expr 's/args: interactive=false/args:/' \
  --test 'bash cogni-workspace/tests/test-agent-interactive-flag.sh' \
  --case A3
```

Verified `guard_verified` (mutated red, restored green). Two further mutants were run and also
returned `guard_verified`: stripping `allowed-tools`' `AskUserQuestion` from
`skills/story-to-infographic/SKILL.md` reddens **A4**, and adding an `AskUserQuestion` grant to
`agents/narrative-adapter.md` reddens **A5**.

The obvious enrich-report mutant — deleting ", always with `interactive=false`" — also reddens
A3, but its search literal contains backticks and the handoff preflight rejects the recipe as not
replayable as written. It was the first recorded form and is replaced above; the header records
why, so it is not swapped back.

**A first draft of A3 returned `vacuous_guard`** — it accepted the literal anywhere in the file,
so deleting the pin from the dispatch left the table row and the prose copy behind and the case
stayed green. A3 is now bound to the dispatch site, and the explanatory prose no longer repeats
the literal. Recorded because the green was indistinguishable from a real one.

## Open questions

- **(avoidable)** The issue cites `skills/enrich-report/SKILL.md:76` for the `interactive`
  default row; it is at **`:77`** (`:76` is the `formats` row). Substance unaffected.
- **(avoidable)** `agents/enrich-report.md:13` says the agent executes "the enrich-report skill
  from **cogni-visual**" — a plugin no longer in the marketplace. Unrelated to this defect and
  left untouched; recorded so it is not lost.
- **(genuine)** `agents/story-to-storyboard.md:82` dispatches `cogni-workspace:story-to-web` with
  `mode=storyboard` rather than a `story-to-storyboard` skill. The guard resolves it correctly
  because it matches on the referenced skill name rather than the agent's own, but a reviewer
  should confirm that is the intended reading of that pair.
