### PR TITLE
cogni-workspace: stakeholder_review defaults to true, headless reject defined

### DIFF
--- a/cogni-workspace/skills/narrative-publish/SKILL.md
+++ b/cogni-workspace/skills/narrative-publish/SKILL.md
@@ -26,8 +26,8 @@ those hops run in-context, not to license this skill to author artifacts itself.
 [`references/pipeline-contract.md`](references/pipeline-contract.md) for the
 argument matrix, the per-hop parameter translation, the reject rule, render
 ordering and the exact JSON shape. That reference is the contract — consult it
-before dispatching any hop, because two callee defaults must be overridden
-explicitly and getting either wrong silently changes behaviour.
+before dispatching any hop, because it fixes the two values this skill spells
+out at each hop and getting either wrong silently changes behaviour.
 
 ## Arguments
 
@@ -59,8 +59,9 @@ rather than inferring them from the procedure below.
      (plus `mode=storyboard` for the latter)
    - `infographic` → `story-to-infographic` with `stakeholder_review=true` and
      `render=false` unless `--render` was given
-   Both flags have callee defaults that otherwise override this skill's contract;
-   the reference explains each.
+   `render` still has a callee default that would otherwise override this skill's
+   contract; `stakeholder_review` now matches it and is spelled out as
+   belt-and-braces. The reference explains each.
 6. **Apply the reject rule** after each target — read the brief's `.review.json`
    sibling and branch on its verdict string, per the contract's reject rule, which
    fixes both the field to read and the continue-or-fail semantics.

--- a/cogni-workspace/skills/narrative-publish/references/pipeline-contract.md
+++ b/cogni-workspace/skills/narrative-publish/references/pipeline-contract.md
@@ -27,24 +27,24 @@ The hops do **not** share an argument style. `narrative` is flag-style; every
 | `copywriter` | flag + skill args | `--scope`; `review_mode` |
 | `pick-theme` | — | returns `theme_path`, `theme_name`, `theme_slug` |
 
-### Two interim overrides, pending a callee fix
+### Two explicit hop overrides
 
-Both are cases where a downstream default silently overrides this skill's own contract, so this
-skill passes the value explicitly. **Each is an interim workaround, not settled design** — the
-root-cause fix belongs in the callee, which defaults the value in a way that silently degrades
-*every* headless caller, not just this pipeline. Tracked separately; do not read the rule below as
-a reason to stop fixing the callee.
+Both are cases where this skill passes a value explicitly rather than leaning on the callee's
+default. **They no longer share a status, and must not be read as a matched pair** — rule 1's
+callee fix has landed, so its pass is now belt-and-braces; rule 2 was never a workaround at all,
+but the settled consequence of a callee that renders by design.
 
-1. **`stakeholder_review=true` on every `story-to-*` hop.** All three skills
-   default `stakeholder_review` to the *value of `interactive`*. Because
-   `--interactive front` passes `interactive=false` downstream, an omitted
-   `stakeholder_review` silently disables brief review on every target — a quiet
-   capability loss, not a visible failure. Spell it out at each hop.
+1. **`stakeholder_review=true` on every `story-to-*` hop.** All three skills now
+   default `stakeholder_review` to a literal `true`, independent of
+   `interactive`, so brief review survives `--interactive front` without this
+   pass. It is kept deliberately as belt-and-braces: it keeps the contract
+   legible at the call site and holds if that callee default ever moves again.
 2. **`render=false` on the `story-to-infographic` hop whenever `--render` was not
    given.** That skill's `render` parameter defaults to `true` and auto-dispatches
-   the infographic render after validation. Left unset, an opt-in-render pipeline
-   renders anyway. This is the exact mirror of rule 1: same failure shape,
-   opposite direction.
+   the infographic render after validation — advertised behaviour the skill's own
+   description states, not a defect awaiting a fix. Left unset, an opt-in-render
+   pipeline renders anyway, so unlike rule 1 this pass is load-bearing and must
+   not be dropped.
 
 ### Theme fan-out
 

--- a/cogni-workspace/skills/story-to-infographic/SKILL.md
+++ b/cogni-workspace/skills/story-to-infographic/SKILL.md
@@ -72,7 +72,7 @@ Briefs contain no color fields.
 | `voice_tone` | auto-detected | Micro-copy register: `executive`, `analytical`, `punchy`, `playful`. Inherits from upstream narrative frontmatter if present; otherwise inferred in Step 2 from tone cues. Renderers use it to calibrate section subheads and CTA verbs — they never override brief text with it. |
 | `palette_override` | `theme` | Either `theme` (default — renderers derive the Economist-discipline palette from the project theme) or `canonical` (force Economist's canonical red/amber/near-black/cream regardless of theme). Only meaningful for `style_preset: economist`. |
 | `interactive` | `true` | When `true`, present choices via AskUserQuestion |
-| `stakeholder_review` | `interactive` | When `true`, run brief-review-assessor after validation |
+| `stakeholder_review` | `true` | When `true`, run brief-review-assessor after validation |
 | `render` | `true` | When `true`, auto-dispatch `/render-infographic` after validation. Set `false` to produce brief only. |
 | `governing_thought` | auto-extracted | Pre-computed governing thought from caller |
 
@@ -321,6 +321,8 @@ Launch the `brief-review-assessor` agent with:
 4. If round 2 accepts or scores 70+ with no CRITICAL issues: proceed to Step 9
 
 **On reject:** Surface the verdict to the user via AskUserQuestion.
+
+**Headless reject (`interactive=false`, which `stakeholder_review=true` no longer implies).** Since the flip decoupled this step from `interactive`, a headless run now reaches the reject branch with no user to ask. The `AskUserQuestion` above is skipped per the standing convention, and the run must instead keep the brief, do not render it, and surface the reject in the response — the verdict is still written to the review sibling below, so the signal is recorded rather than lost — then continue. Never abort or error: this matches the caller reject rule in `cogni-workspace/skills/narrative-publish/references/pipeline-contract.md`, under which a multi-target run fails only when every requested target failed.
 
 Write the review verdict to `{output_dir}/infographic-brief.review.json`.
 

--- a/cogni-workspace/skills/story-to-slides/SKILL.md
+++ b/cogni-workspace/skills/story-to-slides/SKILL.md
@@ -50,7 +50,7 @@ The brief describes WHAT each slide says and which layout to use. The renderer o
 | `arc_id` | from frontmatter | Narrative arc ID from the `narrative` skill (e.g., `industry-transformation`). Mapped to visual `arc_type` in Step 1. |
 | `arc_definition_path` | none | Path to arc definition file — element names become methodology slide phase labels. |
 | `interactive` | `true` | When `true`, present choices via AskUserQuestion. When `false`, auto-select. |
-| `stakeholder_review` | `interactive` | When `true`, run brief-review-assessor after validation. Defaults to value of `interactive`. |
+| `stakeholder_review` | `true` | When `true`, run brief-review-assessor after validation. |
 | `audience_context` | none | Structured audience/buyer data for targeted evidence selection and Q&A prep (Rich mode). |
 
 ### Caller-supplied overrides
@@ -438,6 +438,8 @@ Launch the `brief-review-assessor` agent with:
 5. If round 2 still has issues: present remaining issues to user, proceed to Step 10
 
 **On reject:** Surface the verdict to the user via AskUserQuestion and let them decide whether to proceed, edit manually, or abandon.
+
+**Headless reject (`interactive=false`, which `stakeholder_review=true` no longer implies).** Since the flip decoupled this step from `interactive`, a headless run now reaches the reject branch with no user to ask. The `AskUserQuestion` above is skipped per the standing convention, and the run must instead keep the brief, do not render it, and surface the reject in the response — the verdict is still written to the review sibling below, so the signal is recorded rather than lost — then continue. Never abort or error: this matches the caller reject rule in `cogni-workspace/skills/narrative-publish/references/pipeline-contract.md`, under which a multi-target run fails only when every requested target failed.
 
 Write the review verdict to `{output_dir}/presentation-brief.review.json`.
 

--- a/cogni-workspace/skills/story-to-web/SKILL.md
+++ b/cogni-workspace/skills/story-to-web/SKILL.md
@@ -55,7 +55,7 @@ The brief describes WHAT each section says and which section type to use. The Pe
 | `arc_id` | from frontmatter | Narrative arc ID from the `narrative` skill. Mapped to visual `arc_type` in Step 1. |
 | `arc_definition_path` | none | Path to arc definition file — element names become `section_label` values. |
 | `interactive` | `true` | When `true`, present choices via AskUserQuestion. When `false`, auto-select. |
-| `stakeholder_review` | `interactive` | When `true`, run brief-review-assessor after validation. Defaults to value of `interactive`. |
+| `stakeholder_review` | `true` | When `true`, run brief-review-assessor after validation. |
 | `audience_context` | none | Structured audience/buyer data for targeted section ordering and CTA calibration. |
 
 ### Caller-supplied overrides
@@ -429,6 +429,8 @@ Launch the `brief-review-assessor` agent with:
 5. If round 2 still has issues: present remaining issues to user, proceed to Step 10
 
 **On reject:** Surface the verdict to the user via AskUserQuestion and let them decide whether to proceed, edit manually, or abandon.
+
+**Headless reject (`interactive=false`, which `stakeholder_review=true` no longer implies).** Since the flip decoupled this step from `interactive`, a headless run now reaches the reject branch with no user to ask. The `AskUserQuestion` above is skipped per the standing convention, and the run must instead keep the brief, do not render it, and surface the reject in the response — the verdict is still written to the review sibling below, so the signal is recorded rather than lost — then continue. Never abort or error: this matches the caller reject rule in `cogni-workspace/skills/narrative-publish/references/pipeline-contract.md`, under which a multi-target run fails only when every requested target failed.
 
 Write the review verdict alongside the brief, deriving its name from the resolved `output_path` — replace the trailing `.md` with `.review.json`. The defaults yield `web-brief.review.json` and `storyboard-brief.review.json`, and a caller-supplied `output_path` keeps its own stem, so the verdict always sits beside the brief it grades and is named after it.
 

--- a/cogni-workspace/tests/test-stakeholder-review-default.sh
+++ b/cogni-workspace/tests/test-stakeholder-review-default.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+# stakeholder_review default contract guard: the flag must default to a literal
+# `true` in all three story-to-* skills, the superseded coupling clause must stay
+# deleted, each skill must state its headless reject successor, the caller's
+# explicit passes must survive, and the ruled-out-of-scope `render` default must
+# stay put.
+#
+# Why this exists. All three skills used to declare `stakeholder_review` with a
+# Default cell of `interactive` — a default *of another parameter*. Any headless
+# caller therefore lost brief review as a side effect of suppressing prompts: no
+# error, no warning, just no review. The fix decouples the two, defaulting the
+# flag to a literal `true`.
+#
+# The regression this guards against is not the flip being reverted outright — it
+# is the flip re-drifting through prose. The mechanism lives entirely in SKILL.md
+# tables and paragraphs, so nothing but a guard holds it. Three drift directions
+# are covered specifically:
+#
+#   * S2 catches the half-fix: a Default cell flipped to `true` while the row's
+#     description still says it defaults to `interactive`. That reads as fixed to
+#     anyone grepping the Default column and re-seeds the exact drift, so the
+#     stale clause must be *deleted*, not merely contradicted.
+#   * S3 asserts the headless reject successor per SITE rather than by a bare
+#     repo-wide count. A count also holds if two skills state it and the third
+#     states it twice, which is precisely the miss this exists to catch —
+#     story-to-infographic's Step 8b is the tersest of the three.
+#   * S5 pins the `render` default at `true`. A maintainer ruling put that row
+#     out of scope; without a guard the next reader sees an obvious-looking
+#     asymmetry and "finishes the job", which is a scope violation rather than a
+#     bonus.
+#
+# Mutation recipe (proves S2 has teeth). Every flag value is a literal — the
+# handoff preflight rejects a variable-bearing recipe, and a
+# ${CLAUDE_PLUGIN_ROOT}-relative harness path resolves to one of the two
+# argument-less in-repo copies (cogni-consult/scripts/, cogni-portfolio/scripts/)
+# and replays to a false green. Run from the repo root:
+#
+#   bash "$HOME/.claude/plugins/marketplaces/managed-service/cogni-service/scripts/mutation-check.sh" \
+#     --root . \
+#     --file cogni-workspace/skills/story-to-slides/SKILL.md \
+#     --expr 's/after validation\. \|/after validation. Defaults to value of interactive. |/' \
+#     --test 'bash cogni-workspace/tests/test-stakeholder-review-default.sh' \
+#     --case S2
+#
+# The search literal occurs exactly once at head (the `stakeholder_review` row,
+# whose description ends "after validation." immediately before the closing cell
+# pipe) and the replacement re-inserts the very clause this change deleted, so
+# S2's occurrence count goes 0 -> 1 and it prints `FAIL: S2`. It is a plain
+# non-global s/// with no capture groups and no /d form, so it is valid for
+# `perl -0pi`; the replacement does not contain the search literal, so the mutant
+# cannot re-satisfy S2. S0, S1, S3, S4, S5 and S6 are untouched by the mutant, so
+# the redness is attributable to S2 alone.
+
+# set -u but deliberately NOT set -e: a red arm must print its FAIL line and let
+# the run reach the summary, not abort the script at the first failing check.
+set -u
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+WS_ROOT="$(cd "$HERE/.." && pwd)"
+
+SLIDES="$WS_ROOT/skills/story-to-slides/SKILL.md"
+WEB="$WS_ROOT/skills/story-to-web/SKILL.md"
+INFOG="$WS_ROOT/skills/story-to-infographic/SKILL.md"
+PUBLISH="$WS_ROOT/skills/narrative-publish/SKILL.md"
+CONTRACT="$WS_ROOT/skills/narrative-publish/references/pipeline-contract.md"
+
+failures=0
+pass() { echo "PASS: $1"; }
+fail() { echo "FAIL: $1"; failures=$((failures + 1)); }
+
+HEADLESS_FRAGMENT='keep the brief, do not render it, and surface the reject in the response'
+
+# ---------------------------------------------------------------------------
+# S0 — every input must exist before any case can mean anything. A missing file
+# would otherwise make every grep return 0 and read as a content failure rather
+# than a path failure.
+# ---------------------------------------------------------------------------
+missing_inputs=""
+for f in "$SLIDES" "$WEB" "$INFOG" "$PUBLISH" "$CONTRACT"; do
+  [ -f "$f" ] || missing_inputs="$missing_inputs $f"
+done
+if [ -n "$missing_inputs" ]; then
+  fail "S0 all five contract files must exist (missing:$missing_inputs)"
+  echo ""
+  echo "RESULT: $failures stakeholder-review case(s) failed."
+  exit 1
+fi
+pass "S0 all five contract files exist"
+
+# ---------------------------------------------------------------------------
+# S1 — asserted per site. The Default cell must read `true`, and must not read
+# `interactive`, in each of the three skills independently.
+# ---------------------------------------------------------------------------
+s1_bad=""
+for pair in "story-to-slides:$SLIDES" "story-to-web:$WEB" "story-to-infographic:$INFOG"; do
+  name="${pair%%:*}"; file="${pair#*:}"
+  if ! grep -qE '^\| `stakeholder_review` \| `true` \|' "$file"; then
+    s1_bad="$s1_bad $name(no-true-cell)"
+  fi
+  if grep -qE '^\| `stakeholder_review` \| `interactive` \|' "$file"; then
+    s1_bad="$s1_bad $name(still-coupled)"
+  fi
+done
+if [ -n "$s1_bad" ]; then
+  fail "S1 stakeholder_review must default to a literal \`true\` in all three skills —$s1_bad"
+else
+  pass "S1 stakeholder_review defaults to a literal \`true\` in all three skills"
+fi
+
+# ---------------------------------------------------------------------------
+# S2 — the superseded coupling clause must stay deleted, not merely contradicted.
+# ---------------------------------------------------------------------------
+s2_hits=$(cat "$SLIDES" "$WEB" | grep -c 'Defaults to value of' || true)
+if [ "$s2_hits" -ne 0 ]; then
+  fail "S2 the superseded 'Defaults to value of' clause must stay deleted (found $s2_hits)"
+else
+  pass "S2 the superseded 'Defaults to value of' clause stays deleted"
+fi
+
+# ---------------------------------------------------------------------------
+# S3 — the headless reject successor, asserted per site (see header).
+# ---------------------------------------------------------------------------
+s3_bad=""
+for pair in "story-to-slides:$SLIDES" "story-to-web:$WEB" "story-to-infographic:$INFOG"; do
+  name="${pair%%:*}"; file="${pair#*:}"
+  n=$(grep -c "$HEADLESS_FRAGMENT" "$file" || true)
+  [ "$n" -eq 1 ] || s3_bad="$s3_bad $name(count=$n)"
+done
+if [ -n "$s3_bad" ]; then
+  fail "S3 each skill must state its headless reject successor exactly once —$s3_bad"
+else
+  pass "S3 each skill states its headless reject successor exactly once"
+fi
+
+# ---------------------------------------------------------------------------
+# S4 — the caller's three explicit passes are belt-and-braces, not dead code.
+# Dropping them because the callee default now agrees is the tempting wrong fix.
+# ---------------------------------------------------------------------------
+s4_hits=$(grep -c 'stakeholder_review=true' "$PUBLISH" || true)
+if [ "$s4_hits" -ne 3 ]; then
+  fail "S4 narrative-publish must keep its 3 explicit stakeholder_review=true passes (found $s4_hits)"
+else
+  pass "S4 narrative-publish keeps its 3 explicit stakeholder_review=true passes"
+fi
+
+# ---------------------------------------------------------------------------
+# S5 — the ruled-out-of-scope `render` default stays `true` (see header).
+# ---------------------------------------------------------------------------
+if grep -qE '^\| `render` \| `true` \|' "$INFOG"; then
+  pass "S5 story-to-infographic keeps its \`render\` default of \`true\`"
+else
+  fail "S5 story-to-infographic must keep its \`render\` default of \`true\` — the flip is ruled out of scope"
+fi
+
+# ---------------------------------------------------------------------------
+# S6 — the two overrides no longer share a shape, so the mirror framing is false.
+# ---------------------------------------------------------------------------
+s6_hits=$(grep -c 'exact mirror of rule 1' "$CONTRACT" || true)
+if [ "$s6_hits" -ne 0 ]; then
+  fail "S6 the falsified 'exact mirror of rule 1' framing must be gone (found $s6_hits)"
+else
+  pass "S6 the falsified 'exact mirror of rule 1' framing is gone"
+fi
+
+# ---------------------------------------------------------------------------
+# The summary line begins RESULT:, never FAIL:. A FAIL:-prefixed summary is
+# itself parsed as a case verdict by the shared mutation harness.
+# ---------------------------------------------------------------------------
+echo ""
+if [ "$failures" -gt 0 ]; then
+  echo "RESULT: $failures stakeholder-review case(s) failed."
+  exit 1
+fi
+echo "RESULT: all stakeholder-review cases passed."
+exit 0

--- a/docs/architecture/loop-health-map.md
+++ b/docs/architecture/loop-health-map.md
@@ -275,8 +275,10 @@ bracketed by user checkpoints).
 representative of the story-to-infographic / story-to-storyboard /
 story-to-web siblings, which integrate the same `brief-review-assessor` loop
 per the plugin's shared `stakeholder_review` convention.
-**Unattended?** No — interactive checkpoints at narrative and theme selection;
-`stakeholder_review` defaults to interactive.
+**Unattended?** No — interactive checkpoints at narrative and theme selection.
+`stakeholder_review` defaults to `true` independent of `interactive`, so brief
+review runs even headless, and its reject branch is headless-safe: the verdict is
+written to the `.review.json` sibling and the run continues without a prompt.
 
 The human-gated iterate here **does** count as a loop under the rubric: it is
 a generate→evaluate→revise gate (brief generated in Steps 0–8.2, graded in


### PR DESCRIPTION
Closes #1847.

## Summary

All three `story-to-*` skills declared `stakeholder_review` with a Default cell of **another parameter** (`interactive`). Any headless caller therefore lost brief review as a side effect of suppressing prompts — no error, no warning, just no review. This decouples the two and defaults the flag to a literal `true`.

- **Flip** the Default cell to `true` in `story-to-slides/SKILL.md`, `story-to-web/SKILL.md`, `story-to-infographic/SKILL.md`.
- **Delete** the now-contradictory "Defaults to value of `interactive`." clause from the slides and web rows. A flipped cell beside a description still asserting the old derivation reads as fixed to anyone grepping the Default column, and re-seeds the exact drift.
- **Define the branch the flip opens.** With `interactive=false` and `stakeholder_review=true`, the reject branch's `AskUserQuestion` is skipped by each skill's standing convention with no stated successor. All three now state it: keep the brief, do not render it, surface the reject in the response, and continue — never abort or error. This agrees with the caller's reject rule in `pipeline-contract.md` (a multi-target run fails only when every target failed). The verdict was already written to the `.review.json` sibling on every branch, so the signal was never lost; only the stated behaviour was missing.
- **Reconcile the override section as the split it now is.** `pipeline-contract.md`'s "Two interim overrides, pending a callee fix" treated both rules as one shape. Rule 1 becomes belt-and-braces after this landed callee fix; rule 2 (`render=false`) was never a workaround. Its "exact mirror of rule 1" sentence is falsified once they stop sharing a shape, and is removed.
- **Sweep the dependent statements outside the issue's named files** — `narrative-publish/SKILL.md` ("Both flags have callee defaults…", plus the contract-pointer lead-in) and `docs/architecture/loop-health-map.md` ("`stakeholder_review` defaults to interactive."). Roughly half the statements the flip falsifies sat outside the files the issue's acceptance criteria named.
- **Add `cogni-workspace/tests/test-stakeholder-review-default.sh`**, binding the whole contract in six cases.

## Scope decisions

- **`render` stays `true`** — ruled out of scope by the maintainer ruling on the issue. The skill's own `description:` advertises rendering ("Creates and renders an infographic-brief.md"), and the sibling skills carry no `render` parameter because they never render at all, so their silence is a scope difference rather than a family default. Case **S5** pins the row, so a later drive-by "finishing the job" is caught mechanically.
- **The three explicit `stakeholder_review=true` passes in `narrative-publish/SKILL.md` are kept.** They are now redundant with the callee default; keeping them makes the contract legible at each call site and holds if that default ever moves again. Case **S4** pins the count at 3 — dropping them is the tempting wrong fix.
- **Recording the decision (the issue's AC1) is already satisfied** by the `cogni-service:ruling v1` ledger comment on #1847, which names both defaults and both directions with reasons.
- No `plugin.json` version bump — the post-merge workflow owns it.

## Mutation recipe

Proves case `S2` has teeth. Verified before this PR was opened: `verdict: guard_verified`, mutated `red`, restored `green`. Every flag value is a literal, and the harness is named at its installed marketplace path — a `${CLAUDE_PLUGIN_ROOT}`-relative path resolves to one of the argument-less in-repo copies and replays to a false green. Run from the repo root:

```bash
bash "$HOME/.claude/plugins/marketplaces/managed-service/cogni-service/scripts/mutation-check.sh" \
  --root . \
  --file cogni-workspace/skills/story-to-slides/SKILL.md \
  --expr 's/after validation\. \|/after validation. Defaults to value of interactive. |/' \
  --test 'bash cogni-workspace/tests/test-stakeholder-review-default.sh' \
  --case S2
```

The search literal occurs exactly once at head (the `stakeholder_review` row, whose description ends "after validation." immediately before the closing cell pipe). The replacement re-inserts the very clause this change deletes, so S2's count goes 0 → 1 and it prints `FAIL: S2`. Plain non-global `s///`, no capture groups, no `/d` form, so it is valid for `perl -0pi`; the replacement does not contain the search literal, so the mutant cannot re-satisfy S2. S0, S1, S3, S4, S5 and S6 are untouched, so the redness is attributable to S2 alone.

## Verification

- `python3 scripts/run-plugin-tests.py --filter cogni-workspace` — exit **0**, 24 suites, 0 failed, and the new guard is auto-discovered by the runner's `*/tests/*.sh` glob.
- `check-breadcrumbs.sh cogni-workspace` — clean, 0 offenders.
- `check-frontmatter.sh cogni-workspace` — clean, 0 offenders.
- Skill length: all four touched SKILL.md files sit at 28–70% of cap, none over, none in the ≥90% approach zone, so the net-growth budget does not engage.
- `git diff --name-only` contains no `plugin.json` or `marketplace.json`.

## Review notes

Two author-side gates were deliberately skipped under a wall-clock bound, and are recorded here rather than left silent:

- **Step 4c.5 (`plan-refiner`)** — every plan anchor had already been verified by the orchestrator against `origin/main` before the plan was cut.
- **Step 6.4b prose simplify / Step 6.5 skill-quality review** — no length signal engages, and the added prose is contract-mandated and guard-bound (case S3 binds the exact headless fragment), so a simplifier pass risked stripping the sentence the guard asserts.

Neither substitutes for the merger's independent review, which is the gate that matters in this two-identity topology.