### PR TITLE
test(cogni-workspace): bind the presentation-brief 4.1 slide grammar to an executable suite

### DIFF
--- a/cogni-workspace/tests/fixtures/slide-grammar/slide_grammar.py
+++ b/cogni-workspace/tests/fixtures/slide-grammar/slide_grammar.py
@@ -76,8 +76,9 @@ REQUIRED_SUBKEYS = {"intent": "role", "visual": "kind"}
 
 # Must equal check-brief.py's COLOR_KEYS_SLIDES. Pinned by a case rather than
 # imported, so this fixture stays standalone while a divergence still goes red:
-# that list has already grown twice (COLOR_KEYS_WEB, COLOR_KEYS_INFOGRAPHIC), and
-# a silently stale copy here would narrow this suite's own coverage.
+# check-brief.py derives every other profile's colour set from that tuple, so it
+# is edited under pressure from briefs this suite never grades, and a silently
+# stale copy here would narrow this suite's own coverage.
 COLOUR_FIELDS = {"Background", "Text-Color", "Icon-Color", "Role", "Intensity", "Mood"}
 
 

--- a/cogni-workspace/tests/fixtures/slide-grammar/slide_grammar.py
+++ b/cogni-workspace/tests/fixtures/slide-grammar/slide_grammar.py
@@ -1,0 +1,375 @@
+"""Parser for the schema-4.1 presentation-brief slide grammar.
+
+Written for test-slide-grammar.sh. Deliberately standalone rather than routed
+through scripts/parse-brief.py: two of the three bound surfaces are template
+fragments (no frontmatter, {placeholder} headlines, and slide numbers written
+N / N+1 / N+2) that parse-brief.py's
+SLIDE_HEADING_RE = ^##\\s+Slide\\s+(\\d+)\\s*: rejects by construction, and whose
+strict 1..N numbering its full-brief checklist rejects by design. Loosening that
+checker to admit them would weaken it for real briefs, which is the worse trade.
+
+Two ops:
+
+    <check-name> <role>=<path> ...   grade one check; exit non-zero on findings
+    locate <role>=<path> <selector>  print a 0-based line index (mutation targets)
+"""
+import json
+import re
+import sys
+
+HEADING_RE = re.compile(r"^##\s+Slide\s+(\S+)\s*:")
+ANY_H2_RE = re.compile(r"^##\s+")
+# Deliberately looser than HEADING_RE, and never derived from it: this is the
+# independent recount heading-counts cross-checks the graded set against, so a
+# narrowing of HEADING_RE has to leave it untouched to be detectable.
+LOOSE_SLIDE_RE = re.compile(r"^##\s+Slide\b")
+FENCE_RE = re.compile(r"^```(\S*)\s*$")
+TOPLEVEL_KEY_RE = re.compile(r"^([A-Za-z][A-Za-z0-9_-]*):")
+SLIDE_KIND_ENUM = {"content", "internal-prep", "references"}
+
+# 07-output-template.md:185 — "Three top-level keys are new in 4.1 and appear on
+# every slide: Slide-Kind, intent and visual." Slide-Kind is graded on its own
+# (it carries an enum); these two are the nested sub-keys of the other two.
+REQUIRED_SUBKEYS = {"intent": "role", "visual": "kind"}
+
+# Must equal check-brief.py's COLOR_KEYS_SLIDES. Pinned by a case rather than
+# imported, so this fixture stays standalone while a divergence still goes red:
+# that list has already grown twice (COLOR_KEYS_WEB, COLOR_KEYS_INFOGRAPHIC), and
+# a silently stale copy here would narrow this suite's own coverage.
+COLOUR_FIELDS = {"Background", "Text-Color", "Icon-Color", "Role", "Intensity", "Mood"}
+
+
+def toplevel_key(line):
+    """The line's top-level (unindented) yaml key, or None.
+
+    Indentation is the whole discriminator for the colour scan: `intent.role` is
+    a permitted 4.1 key, a bare top-level `Role:` is the forbidden styling key.
+    """
+    m = TOPLEVEL_KEY_RE.match(line)
+    return m.group(1) if m else None
+
+
+def _fence_map(lines):
+    """Per-line "is inside a fenced block" flags, plus the state at EOF.
+
+    Fence markers themselves are flagged False, so a heading can never be
+    mistaken for a delimiter.
+    """
+    inside = []
+    state = False
+    for line in lines:
+        if FENCE_RE.match(line):
+            inside.append(False)
+            state = not state
+        else:
+            inside.append(state)
+    return inside, state
+
+
+def parse(role, path):
+    """Parse one surface into a graded document record.
+
+    A slide's region runs from its heading to the next H2 -- any H2, not just the
+    next slide heading. Anchoring on the next H2 is what keeps a trailing
+    non-slide block, EXAMPLE_BRIEF.md's `## CTA Summary` fence, from being
+    counted against the last slide.
+    """
+    lines = open(path, encoding="utf-8").read().split("\n")
+    inside, open_at_eof = _fence_map(lines)
+
+    heads = []
+    loose = 0
+    h2s = []
+    for i, line in enumerate(lines):
+        if inside[i]:
+            continue
+        if ANY_H2_RE.match(line):
+            h2s.append(i)
+        if LOOSE_SLIDE_RE.match(line):
+            loose += 1
+        m = HEADING_RE.match(line)
+        if m:
+            heads.append((i, m.group(1)))
+
+    slides = []
+    for start, label in heads:
+        later = [h for h in h2s if h > start]
+        end = later[0] if later else len(lines)
+        region = range(start + 1, end)
+
+        opens = []
+        state = False
+        for i in region:
+            m = FENCE_RE.match(lines[i])
+            if m:
+                if not state:
+                    opens.append((i, m.group(1)))
+                state = not state
+
+        first_content = next((i for i in region if lines[i].strip()), None)
+        fence_open = opens[0][0] if opens else None
+        fence_close = None
+        body = []
+        body_start = None
+        if fence_open is not None:
+            j = fence_open + 1
+            body_start = j
+            while j < len(lines) and not FENCE_RE.match(lines[j]):
+                body.append(lines[j])
+                j += 1
+            fence_close = j if j < len(lines) else None
+
+        slides.append(
+            {
+                "label": label,
+                "line": start + 1,
+                "heading_index": start,
+                "fence_count": len(opens),
+                "fence_tag": opens[0][1] if opens else None,
+                "fence_is_first": fence_open is not None and first_content == fence_open,
+                "fence_open": fence_open,
+                "fence_close": fence_close,
+                "body_start": body_start,
+                "body": body,
+            }
+        )
+    return {"role": role, "path": path, "slides": slides,
+            "open_at_eof": open_at_eof, "loose_slide_count": loose}
+
+
+def slide_kinds(slide):
+    out = []
+    for i, line in enumerate(slide["body"]):
+        if toplevel_key(line) == "Slide-Kind":
+            out.append((slide["body_start"] + i, line.split(":", 1)[1].strip()))
+    return out
+
+
+def colour_hits(slide):
+    """Top-level colour keys inside the slide's yaml body.
+
+    Scoped to fenced body content, never whole-document text: EXAMPLE_BRIEF.md
+    and 07-output-template.md both NAME these fields in prose, documenting that
+    they are forbidden, so a whole-file grep goes red on a correct tree.
+    """
+    return [k for k in map(toplevel_key, slide["body"]) if k in COLOUR_FIELDS]
+
+
+def subkey_counts(slide):
+    """Count each required 4.1 parent key's nested sub-key (intent.role, visual.kind)."""
+    counts = {p: 0 for p in REQUIRED_SUBKEYS}
+    parent = None
+    for line in slide["body"]:
+        key = toplevel_key(line)
+        if key is not None:
+            parent = key if key in REQUIRED_SUBKEYS else None
+            continue
+        if parent and re.match(r"^\s+%s:" % REQUIRED_SUBKEYS[parent], line):
+            counts[parent] += 1
+    return counts
+
+
+CHECKS = {}
+
+
+def check(name):
+    def deco(fn):
+        CHECKS[name] = fn
+        return fn
+    return deco
+
+
+def require(docs, role):
+    """Documents carrying `role`, or an error that makes the check go RED.
+
+    Roles are supplied by the caller rather than sniffed from the filename. A
+    filename-scoped check grades nothing when a surface is renamed -- it
+    self-skips and still reports green, which is the exact failure this suite
+    exists to catch. Returning an error instead is what makes that skip visible.
+    """
+    hits = [d for d in docs if d["role"] == role]
+    if not hits:
+        return None, ["no document supplied for role %r -- check graded nothing" % role]
+    return hits, []
+
+
+def _per_slide(docs, grade):
+    """Run `grade` over every slide, prefixing each message with its location."""
+    return ["%s:%d slide %s %s" % (d["path"], s["line"], s["label"], m)
+            for d in docs for s in d["slides"] for m in grade(s)]
+
+
+@check("fences-balanced")
+def _fences_balanced(docs):
+    return ["%s has an unclosed fence at EOF" % d["path"] for d in docs if d["open_at_eof"]]
+
+
+@check("one-yaml-fence-per-slide")
+def _one_fence(docs):
+    def grade(s):
+        if s["fence_count"] != 1 or s["fence_tag"] != "yaml" or not s["fence_is_first"]:
+            return ["(fences=%d tag=%s first=%s)"
+                    % (s["fence_count"], s["fence_tag"], s["fence_is_first"])]
+        return []
+    return _per_slide(docs, grade)
+
+
+@check("heading-counts")
+def _heading_counts(docs):
+    """Pin how many slides each surface contributes, and cross-check the pin.
+
+    Two independent statements, because they fail differently. The per-role
+    totals catch a narrowing of HEADING_RE -- a digits-only form grades 5 of 8
+    in the template and 0 of 1 in the reference slide, then reports green. The
+    graded-vs-loose comparison catches the same undercount without depending on
+    the absolute numbers, so it still fires on a corpus that legitimately gained
+    a slide (`## Slide 4a:` dropping out of the graded set reads as a count
+    change to the pin, but as a mismatch here).
+    """
+    expected = {"brief": 13, "template": 8, "refslide": 1}
+    bad = []
+    for role, want in expected.items():
+        hits, err = require(docs, role)
+        if err:
+            bad.extend(err)
+            continue
+        got = sum(len(d["slides"]) for d in hits)
+        if got != want:
+            bad.append("role %s graded %d slides, expected %d" % (role, got, want))
+    for d in docs:
+        if len(d["slides"]) != d["loose_slide_count"]:
+            bad.append("%s graded %d slides but %d headings look like slides"
+                       % (d["path"], len(d["slides"]), d["loose_slide_count"]))
+    return bad
+
+
+@check("slide-kind-single")
+def _kind_single(docs):
+    def grade(s):
+        kinds = slide_kinds(s)
+        return [] if len(kinds) == 1 else ["has %d Slide-Kind keys" % len(kinds)]
+    return _per_slide(docs, grade)
+
+
+@check("slide-kind-enum")
+def _kind_enum(docs):
+    def grade(s):
+        return ["Slide-Kind=%r" % v for _, v in slide_kinds(s) if v not in SLIDE_KIND_ENUM]
+    return _per_slide(docs, grade)
+
+
+@check("references-slide-last")
+def _refs_last(docs):
+    hits, err = require(docs, "brief")
+    if err:
+        return err
+    bad = []
+    for d in hits:
+        kinds = [slide_kinds(s)[0][1] for s in d["slides"] if slide_kinds(s)]
+        if not kinds or kinds[-1] != "references":
+            bad.append("%s last slide kind=%r" % (d["path"], kinds[-1] if kinds else None))
+        elif kinds.count("references") != 1:
+            bad.append("%s has %d references slides" % (d["path"], kinds.count("references")))
+    return bad
+
+
+@check("no-colour-fields")
+def _no_colour(docs):
+    return _per_slide(docs, lambda s: ["top-level %s" % k for k in colour_hits(s)])
+
+
+@check("required-4.1-subkeys")
+def _required_subkeys(docs):
+    """Every slide carries intent.role and visual.kind, each exactly once.
+
+    07-output-template.md:185 names Slide-Kind, intent and visual as the three
+    top-level keys new in 4.1 that appear on every slide. Slide-Kind is graded
+    by slide-kind-single/-enum; this is the other two. Grading all three is what
+    keeps the required-key set a grammar rule rather than a single carve-out.
+    """
+    def grade(s):
+        return ["%s.%s count=%d" % (parent, REQUIRED_SUBKEYS[parent], n)
+                for parent, n in sorted(subkey_counts(s).items()) if n != 1]
+    return _per_slide(docs, grade)
+
+
+@check("non-numeric-slide-labels-graded")
+def _non_numeric(docs):
+    """The N / N+1 / N+2 headings are actually in the graded set.
+
+    The membership half of heading-counts' arithmetic. A heading regex borrowed
+    from parse-brief.py -- which requires (\\d+) -- drops these three silently.
+    """
+    hits, err = require(docs, "template")
+    if err:
+        return err
+    for d in hits:
+        missing = {"N", "N+1", "N+2"} - {s["label"] for s in d["slides"]}
+        if missing:
+            return ["%s did not grade slide labels %s" % (d["path"], ",".join(sorted(missing)))]
+    return []
+
+
+def _locate(docs, selector):
+    """Resolve a structural mutation target to a 0-based line index.
+
+    Mutants address their target through the parser rather than by an absolute
+    line number. A hardcoded index silently re-aims whenever anything above it
+    in the corpus is edited, and at least one direction then passes for the
+    wrong reason: a mutant landing on a neighbouring key still turns its check
+    red, so the case reports PASS having corrupted something else entirely.
+    """
+    kind, _, which = selector.partition(":")
+    slides = docs[0]["slides"]
+
+    if kind == "subkey":
+        parent, _, nth = which.partition("/")
+        s = slides[-1] if nth == "last" else slides[int(nth) - 1]
+        seen = None
+        for i, line in enumerate(s["body"]):
+            key = toplevel_key(line)
+            if key is not None:
+                seen = key
+                continue
+            if seen == parent and re.match(r"^\s+%s:" % REQUIRED_SUBKEYS[parent], line):
+                return s["body_start"] + i
+        raise SystemExit("no %s sub-key on slide %s" % (parent, nth))
+
+    s = slides[-1] if which == "last" else slides[int(which) - 1]
+    if kind == "fence-open":
+        return s["fence_open"]
+    if kind == "fence-close":
+        return s["fence_close"]
+    if kind == "body-top":
+        return s["body_start"]
+    if kind == "kind-line":
+        return slide_kinds(s)[0][0]
+    raise SystemExit("unknown selector %r" % selector)
+
+
+def main():
+    op = sys.argv[1]
+    args = sys.argv[2:]
+    if op == "locate":
+        selector = args.pop()
+    docs = []
+    for arg in args:
+        role, sep, path = arg.partition("=")
+        if not sep:
+            print("argument %r is not role=path" % arg)
+            return 1
+        docs.append(parse(role, path))
+    if op == "locate":
+        print(_locate(docs, selector))
+        return 0
+    if op == "dump-colour-fields":
+        print(json.dumps(sorted(COLOUR_FIELDS)))
+        return 0
+    bad = CHECKS[op](docs)
+    for b in bad:
+        print(b)
+    return 1 if bad else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/cogni-workspace/tests/fixtures/slide-grammar/slide_grammar.py
+++ b/cogni-workspace/tests/fixtures/slide-grammar/slide_grammar.py
@@ -10,12 +10,34 @@ checker to admit them would weaken it for real briefs, which is the worse trade.
 
 Two ops:
 
-    <check-name> <role>=<path> ...   grade one check; exit non-zero on findings
+    <check-name> <role>=<path> ...   grade one check; exit 1 on findings
     locate <role>=<path> <selector>  print a 0-based line index (mutation targets)
+
+Exit codes are the harness's whole discriminator, so they are a contract --
+the same 0/1/2 split check-brief.py draws with its CheckError and
+brief-render-qa.py with its QAError, so this fixture reads like its neighbours:
+
+    0  the check ran and found nothing
+    1  the check ran and found something -- the ONLY code that means a finding
+    2  the tool was misused or could not run (unknown check, unreadable
+       surface, malformed argv, bad selector). Never a grammar finding.
+
+Before that split, an unknown check name and a missing file both raised and
+exited 1, indistinguishable from a real finding: every red arm accepted any
+non-zero, so nine cases could assert nothing and still report PASS. Anything
+that widens exit 1 to cover a crash reopens that hole.
 """
 import json
 import re
 import sys
+import traceback
+
+EXIT_USAGE = 2
+
+
+class UsageError(Exception):
+    """The tool was misused or could not run. Exits EXIT_USAGE, never 1."""
+
 
 HEADING_RE = re.compile(r"^##\s+Slide\s+(\S+)\s*:")
 ANY_H2_RE = re.compile(r"^##\s+")
@@ -25,6 +47,26 @@ ANY_H2_RE = re.compile(r"^##\s+")
 LOOSE_SLIDE_RE = re.compile(r"^##\s+Slide\b")
 FENCE_RE = re.compile(r"^```(\S*)\s*$")
 TOPLEVEL_KEY_RE = re.compile(r"^([A-Za-z][A-Za-z0-9_-]*):")
+# The colour scan's own key regex, deliberately NOT shared with TOPLEVEL_KEY_RE.
+# Matches at any indentation and tolerates space before the colon, mirroring
+# check-brief.py's check_no_color_fields, which walks _keys() recursively and
+# flags `Background : x` too. CASE, not indentation, is what separates the
+# permitted nested `role:` from the forbidden `Role:` (check-brief.py:81-82).
+# TOPLEVEL_KEY_RE cannot simply be widened to match: two structural callers
+# (subkey_counts, _locate) read its None-on-an-indented-line as "nested under
+# the last key seen", so an `^\s*` there would zero the intent.role /
+# visual.kind counts and turn sg08 red.
+#
+# Precision boundary, so the next author widening COLOUR_FIELDS knows it: this
+# is a line regex, not a yaml parse, so it cannot tell a nested key from a line
+# inside a `|` block scalar -- and the graded bodies do carry them
+# (Speaker-Notes:, Diagram:). check-brief.py is structurally immune because it
+# walks parsed yaml. The corpus is clean today (the newly-visible keys are all
+# genuine nested ones), but Role, Mood and Intensity are ordinary English words,
+# so a Speaker-Notes line opening `Mood: confident` would false-positive. If
+# that ever bites, the fix is to route the fence body through
+# parse-brief.py's parse_yaml_subset rather than to narrow this back.
+ANY_DEPTH_KEY_RE = re.compile(r"^\s*([A-Za-z][A-Za-z0-9_-]*)\s*:")
 SLIDE_KIND_ENUM = {"content", "internal-prep", "references"}
 
 # 07-output-template.md:185 — "Three top-level keys are new in 4.1 and appear on
@@ -42,10 +84,18 @@ COLOUR_FIELDS = {"Background", "Text-Color", "Icon-Color", "Role", "Intensity", 
 def toplevel_key(line):
     """The line's top-level (unindented) yaml key, or None.
 
-    Indentation is the whole discriminator for the colour scan: `intent.role` is
-    a permitted 4.1 key, a bare top-level `Role:` is the forbidden styling key.
+    Serves the STRUCTURAL checks -- Slide-Kind extraction, sub-key parenting in
+    subkey_counts, and mutation targeting in _locate -- all of which read the
+    None on an indented line as "this is nested under the last key seen". The
+    colour scan deliberately does not use this: see any_depth_key.
     """
     m = TOPLEVEL_KEY_RE.match(line)
+    return m.group(1) if m else None
+
+
+def any_depth_key(line):
+    """The line's yaml key at any indentation, or None. See ANY_DEPTH_KEY_RE."""
+    m = ANY_DEPTH_KEY_RE.match(line)
     return m.group(1) if m else None
 
 
@@ -146,13 +196,14 @@ def slide_kinds(slide):
 
 
 def colour_hits(slide):
-    """Top-level colour keys inside the slide's yaml body.
+    """Colour keys at any depth inside the slide's yaml body.
 
     Scoped to fenced body content, never whole-document text: EXAMPLE_BRIEF.md
     and 07-output-template.md both NAME these fields in prose, documenting that
     they are forbidden, so a whole-file grep goes red on a correct tree.
+    Depth and spacing tolerance come from any_depth_key.
     """
-    return [k for k in map(toplevel_key, slide["body"]) if k in COLOUR_FIELDS]
+    return [k for k in map(any_depth_key, slide["body"]) if k in COLOUR_FIELDS]
 
 
 def subkey_counts(slide):
@@ -273,9 +324,32 @@ def _refs_last(docs):
     return bad
 
 
+@check("references-slide-kind")
+def _refs_kind(docs):
+    """The refslide surface's single slide must carry Slide-Kind: references.
+
+    references-slide-last is require(docs, "brief")-scoped, so it never reads
+    08b-references-slide.md at all. Without this check the one file whose entire
+    purpose is to document the references slide contributes only "one slide,
+    well-formed" to the binding, and demoting its Slide-Kind to `content` leaves
+    the whole suite green.
+    """
+    hits, err = require(docs, "refslide")
+    if err:
+        return err
+    bad = []
+    for d in hits:
+        for s in d["slides"]:
+            kinds = [v for _, v in slide_kinds(s)]
+            if kinds != ["references"]:
+                bad.append("%s:%d slide %s kind=%r, expected ['references']"
+                           % (d["path"], s["line"], s["label"], kinds))
+    return bad
+
+
 @check("no-colour-fields")
 def _no_colour(docs):
-    return _per_slide(docs, lambda s: ["top-level %s" % k for k in colour_hits(s)])
+    return _per_slide(docs, lambda s: ["colour field %s" % k for k in colour_hits(s)])
 
 
 @check("required-4.1-subkeys")
@@ -333,7 +407,7 @@ def _locate(docs, selector):
                 continue
             if seen == parent and re.match(r"^\s+%s:" % REQUIRED_SUBKEYS[parent], line):
                 return s["body_start"] + i
-        raise SystemExit("no %s sub-key on slide %s" % (parent, nth))
+        raise UsageError("no %s sub-key on slide %s" % (parent, nth))
 
     s = slides[-1] if which == "last" else slides[int(which) - 1]
     if kind == "fence-open":
@@ -344,23 +418,43 @@ def _locate(docs, selector):
         return s["body_start"]
     if kind == "kind-line":
         return slide_kinds(s)[0][0]
-    raise SystemExit("unknown selector %r" % selector)
+    raise UsageError("unknown selector %r" % selector)
 
 
 def main():
+    if len(sys.argv) < 2:
+        print("usage: slide_grammar.py <check-name|locate|dump-colour-fields> <role>=<path> ...")
+        return EXIT_USAGE
     op = sys.argv[1]
     args = sys.argv[2:]
+    # Validate the op before reading a single file: the name is the cheapest
+    # thing to check, and a mis-typed check should report itself rather than
+    # whatever the corpus happens to say.
+    if op not in CHECKS and op not in ("locate", "dump-colour-fields"):
+        print("unknown check %r (known: %s)" % (op, ", ".join(sorted(CHECKS))))
+        return EXIT_USAGE
     if op == "locate":
+        if not args:
+            print("locate needs a selector")
+            return EXIT_USAGE
         selector = args.pop()
     docs = []
     for arg in args:
         role, sep, path = arg.partition("=")
         if not sep:
             print("argument %r is not role=path" % arg)
-            return 1
-        docs.append(parse(role, path))
+            return EXIT_USAGE
+        try:
+            docs.append(parse(role, path))
+        except OSError as e:
+            print("cannot read %s: %s" % (path, e))
+            return EXIT_USAGE
     if op == "locate":
-        print(_locate(docs, selector))
+        try:
+            print(_locate(docs, selector))
+        except UsageError as e:
+            print(e)
+            return EXIT_USAGE
         return 0
     if op == "dump-colour-fields":
         print(json.dumps(sorted(COLOUR_FIELDS)))
@@ -372,4 +466,16 @@ def main():
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    # The backstop that makes the exit-code contract TRUE rather than merely
+    # enumerated. The named arms inside main() are better diagnostics and stay,
+    # but they can only cover the failures someone thought of: a binary surface
+    # (UnicodeDecodeError, not an OSError), an out-of-range locate index and a
+    # locate with no document all used to crash out as exit 1, wearing the
+    # finding code. Exit 1 is produced only by `return 1 if bad` below, never by
+    # an exception, so nothing legitimate passes through here.
+    try:
+        rc = main()
+    except Exception:
+        traceback.print_exc()
+        rc = EXIT_USAGE
+    sys.exit(rc)

--- a/cogni-workspace/tests/test-slide-grammar.sh
+++ b/cogni-workspace/tests/test-slide-grammar.sh
@@ -32,8 +32,9 @@
 # module docstring). This replaces the earlier claim that "no assertion can rot
 # into a tautology unnoticed", which was false when written: every red arm
 # accepted any non-zero, so a crashed parser read as a caught defect. Nine cases
-# were exposed — the eight expect_red sites (sg10-sg16, sg19) plus sg17's
-# then-hand-rolled arm — and could assert nothing while reporting PASS.
+# were exposed — the eight expect_red sites then present (sg10-sg16, sg19)
+# plus sg17's then-hand-rolled arm — and could assert nothing while reporting
+# PASS.
 # sg24/sg25 guard the two enumerated crash arms; sg26 guards the contract
 # itself, so a crash nobody enumerated cannot quietly reclaim exit 1.
 #
@@ -63,6 +64,72 @@
 # the crash code back onto the finding code and so reddens sg25 and sg26
 # alongside its named sg24 — all three assert rc 2 (sg26 through the __main__
 # backstop), and that is the set the collapse breaks.
+#
+# Those ten all mutate slide_grammar.py — the parser this suite ships with —
+# so together they prove the suite reads its own machinery. They cannot show it
+# grades anything else: the three bound surfaces predate the parser and none of
+# the ten touches one. What follows closes that, one recipe per bound surface,
+# because "a guard that passes on a broken corpus is not a guard" is checkable
+# only by breaking the corpus. Treat one-entry-per-surface as the rule rather
+# than the sample: a surface listed at the top of this file with no recipe here
+# is a hole, not an omission.
+#
+# All three use the same harness and the same --test as the ten above, and each
+# rewrites the FIRST occurrence of its search text — mutation-check.sh applies
+# its s{}{} without /g. For the two Slide-Kind recipes that first occurrence is
+# the graded key inside the slide's yaml fence; the later one is a prose mention
+# of the same string, which is why /g would corrupt the wrong thing.
+#
+# Corpus recipe 1 of 3, for the primary brief (the discriminator is
+# sg06-references-slide-last):
+#
+#   bash ~/GitHub/dev/managed-service/cogni-service/scripts/mutation-check.sh \
+#     --root . \
+#     --file cogni-workspace/libraries/EXAMPLE_BRIEF.md \
+#     --expr 's{Slide-Kind: references}{Slide-Kind: content}' \
+#     --test 'bash cogni-workspace/tests/test-slide-grammar.sh' \
+#     --case sg06-references-slide-last
+#
+# Demoting the brief's own references slide leaves the deck with no slide of
+# that kind, so references-slide-last has nothing to find last and sg06 — a
+# clean-corpus green arm — goes RED.
+#
+# Corpus recipe 2 of 3, for the slide template (the discriminator is
+# sg03-heading-counts):
+#
+#   bash ~/GitHub/dev/managed-service/cogni-service/scripts/mutation-check.sh \
+#     --root . \
+#     --file cogni-workspace/skills/story-to-slides/references/07-output-template.md \
+#     --expr 's{## Slide N\+1: }{## Slidez N+1: }' \
+#     --test 'bash cogni-workspace/tests/test-slide-grammar.sh' \
+#     --case sg03-heading-counts
+#
+# This is the load-bearing one on the corpus side, and the mirror of the
+# parser-side heading-counts recipe above: misspelling one heading drops the
+# template's graded count from 8 to 7, so the pinned per-surface counts stop
+# matching and sg03 goes RED. Between the two, heading-counts is now bound from
+# both directions — the parser cannot silently stop counting, and the corpus
+# cannot silently stop being counted.
+#
+# Corpus recipe 3 of 3, for the references-slide template (the discriminator is
+# sg20-refslide-kind-is-references):
+#
+#   bash ~/GitHub/dev/managed-service/cogni-service/scripts/mutation-check.sh \
+#     --root . \
+#     --file cogni-workspace/skills/story-to-slides/references/08b-references-slide.md \
+#     --expr 's{Slide-Kind: references}{Slide-Kind: content}' \
+#     --test 'bash cogni-workspace/tests/test-slide-grammar.sh' \
+#     --case sg20-refslide-kind-is-references
+#
+# The mirror of the parser-targeted sg21, which reddens the same check by
+# breaking the comparison instead of the corpus. Neither substitutes for the
+# other: sg21 stages its own copy and sets the kind line regardless of the
+# file's starting value, so a corpus mutation leaves it green, and sg20 reads
+# the real file, so a parser mutation leaves it green.
+#
+# Verdict at authoring: guard_verified for all three — each went RED under its
+# recipe and green again on restore, replayed against the literal harness path
+# above exactly as written.
 
 set -u
 

--- a/cogni-workspace/tests/test-slide-grammar.sh
+++ b/cogni-workspace/tests/test-slide-grammar.sh
@@ -16,9 +16,13 @@
 # traps it is shaped around and the required-key table it grades live in
 # fixtures/slide-grammar/slide_grammar.py; this file does not restate them.
 #
-# The parser sits under fixtures/ rather than beside this file because the
-# runner's discovery glob is a non-recursive tests/*.sh — a helper at tests/
-# level would be discovered and run as a second suite.
+# The parser sits under fixtures/ because that is where this repo parks test
+# assets that are not themselves suites — tests/fixtures/ already holds brief/,
+# narrative-output/ and narrative-source/. Note the runner's non-recursive
+# tests/*.sh and */tests/*.sh globs are NOT the reason: a .py file matches
+# neither glob at any depth, so this parser would go undiscovered sitting
+# directly at tests/ too. The globs are what keep a sourced-only *bash* helper
+# out of the sweep; for this file the convention is the whole reason.
 #
 # Every case id has both a PASS and a FAIL arm, structurally: expect_green and
 # expect_red each take the id once and own both arms, so the two can never

--- a/cogni-workspace/tests/test-slide-grammar.sh
+++ b/cogni-workspace/tests/test-slide-grammar.sh
@@ -30,10 +30,11 @@
 # addressable by `mutation-check.sh --case`. Most cases get that structurally:
 # every expect_* wrapper delegates to expect_rc, which owns both arms, so naming
 # the id once at the call site cannot leave the two out of step. sg18 is the
-# exception — it grades an equality between two files rather than one command's
-# exit code, so there is no argv for expect_rc to run and its arms are
-# hand-rolled below, spelling the id twice. Both shapes keep the two arms
-# reachable, the property scripts/check-case-id-pairing.py enforces repo-wide.
+# exception — it grades an equality between two files, not one command's exit
+# code, so it hands expect_rc no system-under-test argv: any argv would be
+# scaffolding the case manufactures. Its arms are hand-rolled below, spelling
+# the id twice. Both shapes keep the two arms reachable, the property
+# scripts/check-case-id-pairing.py enforces repo-wide.
 # The sgNN-mutant-* cases corrupt a mktemp copy and assert the matching check
 # goes red. Mutants address their target through the parser's `locate` op rather
 # than by absolute line number; no mutant is ever committed.

--- a/cogni-workspace/tests/test-slide-grammar.sh
+++ b/cogni-workspace/tests/test-slide-grammar.sh
@@ -60,8 +60,9 @@
 # replayed against the literal harness path above exactly as written. The
 # heading-counts one is the load-bearing original: it reinstates the digits-only
 # regex that is this suite's central failure mode. The EXIT_USAGE one collapses
-# the crash code back onto the finding code and so reddens sg25 alongside its
-# named sg24 — both assert rc 2, and that is the pair the collapse breaks.
+# the crash code back onto the finding code and so reddens sg25 and sg26
+# alongside its named sg24 — all three assert rc 2 (sg26 through the __main__
+# backstop), and that is the set the collapse breaks.
 
 set -u
 
@@ -85,12 +86,15 @@ trap 'rm -rf "$TMPROOT"' EXIT
 pass() { printf '%s\n' "PASS: $1"; }
 fail() { printf '%s\n' "FAIL: $1"; failures=$((failures + 1)); }
 
-# Run one check against the real corpus.
-clean() { python3 "$GRAM" "$1" "brief=$BRIEF" "template=$TEMPLATE" "refslide=$REFSLIDE" >/dev/null 2>&1; }
+# Run one check against the real corpus. Output is NOT suppressed here —
+# expect_rc owns the suppression on its first invocation, so its failure replay
+# has something to print. Baking the redirect in here silently emptied that
+# replay for every wrapper-routed case, which is most of them.
+clean() { python3 "$GRAM" "$1" "brief=$BRIEF" "template=$TEMPLATE" "refslide=$REFSLIDE"; }
 
 # Run one check against a staged (mutated) copy. Roles are passed explicitly, so
 # the deliberately different filenames here cannot make a check self-skip.
-mutant() { python3 "$GRAM" "$2" "brief=$1/brief.md" "template=$1/template.md" "refslide=$1/refslide.md" >/dev/null 2>&1; }
+mutant() { python3 "$GRAM" "$2" "brief=$1/brief.md" "template=$1/template.md" "refslide=$1/refslide.md"; }
 
 # Every arm asserts an EXACT exit code, never "zero vs non-zero" — that is the
 # whole mechanism, so it lives in exactly one place here and the wrappers below

--- a/cogni-workspace/tests/test-slide-grammar.sh
+++ b/cogni-workspace/tests/test-slide-grammar.sh
@@ -22,7 +22,9 @@
 # tests/*.sh and */tests/*.sh globs are NOT the reason: a .py file matches
 # neither glob at any depth, so this parser would go undiscovered sitting
 # directly at tests/ too. The globs are what keep a sourced-only *bash* helper
-# out of the sweep; for this file the convention is the whole reason.
+# under fixtures/ out of the sweep — one level deeper than the globs reach —
+# whereas a bash helper sitting directly at tests/ WOULD be swept in. For this
+# file the convention is the whole reason.
 #
 # Every case id has both a PASS and a FAIL arm, structurally: expect_green and
 # expect_red each take the id once and own both arms, so the two can never

--- a/cogni-workspace/tests/test-slide-grammar.sh
+++ b/cogni-workspace/tests/test-slide-grammar.sh
@@ -1,0 +1,220 @@
+#!/usr/bin/env bash
+#
+# test-slide-grammar.sh — binds the schema-4.1 presentation-brief slide grammar
+# to the three surfaces that carry live grammar samples:
+#
+#   cogni-workspace/libraries/EXAMPLE_BRIEF.md                          (13 slides)
+#   cogni-workspace/skills/story-to-slides/references/07-output-template.md  (8)
+#   cogni-workspace/skills/story-to-slides/references/08b-references-slide.md (1)
+#
+# Why this exists alongside test-check-brief.sh: check-brief.py already enforces
+# no-color-fields and deck-references-last, and cb01 / cb04 / pb05 already run it
+# against EXAMPLE_BRIEF.md. What nothing bound before this suite are the two
+# TEMPLATE surfaces. Those are fragments, not briefs — no frontmatter,
+# {placeholder} headlines, slide numbers written N / N+1 / N+2 — so the grammar
+# they document could drift with nothing noticing. The parser rationale, the
+# traps it is shaped around and the required-key table it grades live in
+# fixtures/slide-grammar/slide_grammar.py; this file does not restate them.
+#
+# The parser sits under fixtures/ rather than beside this file because the
+# runner's discovery glob is a non-recursive tests/*.sh — a helper at tests/
+# level would be discovered and run as a second suite.
+#
+# Every case id has both a PASS and a FAIL arm, structurally: expect_green and
+# expect_red each take the id once and own both arms, so the two can never
+# drift apart. The sgNN-mutant-* cases corrupt a mktemp copy and assert the
+# matching check goes red, so no assertion can rot into a tautology unnoticed.
+# Mutants address their target through the parser's `locate` op rather than by
+# absolute line number; no mutant is ever committed.
+#
+# ## Mutation recipe
+#
+# Harness: ~/GitHub/dev/managed-service/cogni-service/scripts/mutation-check.sh
+# Run with:
+#   --root . --file cogni-workspace/tests/fixtures/slide-grammar/slide_grammar.py
+#   --test 'bash cogni-workspace/tests/test-slide-grammar.sh'
+#
+#   --expr 's{Slide\\s\+\(\\S\+\)}{Slide\\s+(\\d+)}'   --case sg03-heading-counts
+#   --expr 's{in COLOUR_FIELDS}{in set()}'              --case sg15-mutant-bare-role-flagged
+#   --expr 's{if not hits:}{if False:}'                 --case sg17-mutant-missing-role-fails-closed
+#   --expr 's{if n != 1}{if False}'                     --case sg19-mutant-missing-required-subkey
+#   --expr 's{"Mood"}{"Mood", "Bogus"}'                 --case sg18-colour-fields-match-check-brief
+#
+# Verdict at authoring: guard_verified for all five — each search text occurs
+# exactly once in slide_grammar.py and each named case went red under its recipe,
+# replayed against the literal harness path above exactly as written. The first
+# is the load-bearing one: it reinstates the digits-only regex that is this
+# suite's central failure mode.
+
+set -u
+
+# Keep CPython from dropping a __pycache__/ into the plugin tree —
+# test-relocated-skill-hygiene.sh P2 flags it as an unresolvable
+# ${CLAUDE_PLUGIN_ROOT} path.
+export PYTHONDONTWRITEBYTECODE=1
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+GRAM="$ROOT/cogni-workspace/tests/fixtures/slide-grammar/slide_grammar.py"
+
+BRIEF="$ROOT/cogni-workspace/libraries/EXAMPLE_BRIEF.md"
+TEMPLATE="$ROOT/cogni-workspace/skills/story-to-slides/references/07-output-template.md"
+REFSLIDE="$ROOT/cogni-workspace/skills/story-to-slides/references/08b-references-slide.md"
+CHECK_BRIEF="$ROOT/cogni-workspace/scripts/check-brief.py"
+
+failures=0
+TMPROOT="$(mktemp -d)"
+trap 'rm -rf "$TMPROOT"' EXIT
+
+pass() { printf '%s\n' "PASS: $1"; }
+fail() { printf '%s\n' "FAIL: $1"; failures=$((failures + 1)); }
+
+# Run one check against the real corpus.
+clean() { python3 "$GRAM" "$1" "brief=$BRIEF" "template=$TEMPLATE" "refslide=$REFSLIDE" >/dev/null 2>&1; }
+
+# Run one check against a staged (mutated) copy. Roles are passed explicitly, so
+# the deliberately different filenames here cannot make a check self-skip.
+mutant() { python3 "$GRAM" "$2" "brief=$1/brief.md" "template=$1/template.md" "refslide=$1/refslide.md" >/dev/null 2>&1; }
+
+# expect_green <case-id> <check> <failure-sentence>
+expect_green() { if clean "$2"; then pass "$1"; else fail "$1 $3"; fi; }
+
+# expect_red <case-id> <staged-dir> <check> <failure-sentence>
+expect_red() { if mutant "$2" "$3"; then fail "$1 $4"; else pass "$1"; fi; }
+
+# Stage a fresh copy of all three surfaces and echo the directory. All three are
+# copied even when one is mutated, so `mutant` can always pass every role.
+stage() {
+  local d="$TMPROOT/$1"
+  mkdir -p "$d"
+  cp "$BRIEF" "$d/brief.md"
+  cp "$TEMPLATE" "$d/template.md"
+  cp "$REFSLIDE" "$d/refslide.md"
+  printf '%s\n' "$d"
+}
+
+# mutate <staged-dir> <role> <selector> <del|set|ins> [text]
+# The selector is resolved by the parser, so a corpus edit above the target
+# cannot silently re-aim the mutation at a neighbouring line.
+mutate() {
+  local d="$1" role="$2" sel="$3" op="$4" txt="${5-}" doc idx
+  case "$role" in
+    brief) doc="brief.md" ;;
+    template) doc="template.md" ;;
+    refslide) doc="refslide.md" ;;
+    *) printf 'unknown role %s\n' "$role" >&2; return 1 ;;
+  esac
+  idx="$(python3 "$GRAM" locate "$role=$d/$doc" "$sel")" || return 1
+  python3 - "$d/$doc" "$idx" "$op" "$txt" <<'PY'
+import sys
+path, idx, op, txt = sys.argv[1], int(sys.argv[2]), sys.argv[3], sys.argv[4]
+lines = open(path, encoding="utf-8").read().split("\n")
+if op == "del":
+    del lines[idx]
+elif op == "set":
+    lines[idx] = txt
+elif op == "ins":
+    lines.insert(idx, txt)
+else:
+    raise SystemExit("unknown op %r" % op)
+open(path, "w", encoding="utf-8").write("\n".join(lines))
+PY
+}
+
+# ---------------------------------------------------------------- clean corpus
+
+expect_green sg01-fences-balanced fences-balanced \
+  "a bound surface has an unbalanced fence at EOF"
+expect_green sg02-one-yaml-fence-per-slide one-yaml-fence-per-slide \
+  "a slide heading is not followed by exactly one yaml fence"
+expect_green sg03-heading-counts heading-counts \
+  "a surface graded a different number of slides than 13/8/1, or disagreed with its own loose recount"
+expect_green sg04-slide-kind-single slide-kind-single \
+  "a slide carries zero or multiple Slide-Kind keys"
+expect_green sg05-slide-kind-enum slide-kind-enum \
+  "a Slide-Kind value is outside content/internal-prep/references"
+expect_green sg06-references-slide-last references-slide-last \
+  "the references slide is not the last slide of EXAMPLE_BRIEF.md"
+expect_green sg07-no-colour-fields no-colour-fields \
+  "a top-level colour field appears inside a slide yaml block"
+expect_green sg08-required-41-subkeys required-4.1-subkeys \
+  "a slide is missing its nested intent.role or visual.kind key"
+expect_green sg09-non-numeric-slide-labels-graded non-numeric-slide-labels-graded \
+  "the N / N+1 / N+2 headings were not graded"
+
+# --------------------------------------------------------------------- mutants
+
+d="$(stage m10)"; mutate "$d" brief fence-close:1 del
+expect_red sg10-mutant-unbalanced-fence "$d" fences-balanced \
+  "a dropped closing fence was not reported"
+
+d="$(stage m11)"; mutate "$d" brief fence-open:1 set '```yml'
+expect_red sg11-mutant-fence-retagged "$d" one-yaml-fence-per-slide \
+  "a slide fence tagged yml instead of yaml was not reported"
+
+d="$(stage m12)"; mutate "$d" brief kind-line:1 ins 'Slide-Kind: content'
+expect_red sg12-mutant-duplicate-slide-kind "$d" slide-kind-single \
+  "a second Slide-Kind key was not reported"
+
+d="$(stage m13)"; mutate "$d" brief kind-line:1 set 'Slide-Kind: bogus'
+expect_red sg13-mutant-slide-kind-out-of-enum "$d" slide-kind-enum \
+  "an out-of-enum Slide-Kind value was not reported"
+
+d="$(stage m14)"; mutate "$d" brief kind-line:last set 'Slide-Kind: content'
+expect_red sg14-mutant-references-not-last "$d" references-slide-last \
+  "a demoted references slide was not reported"
+
+# The prohibitive half of the intent.role carve-out. sg07 proves the scan stays
+# quiet on the prose mentions; this proves it still fires on a real bare key.
+d="$(stage m15)"; mutate "$d" brief body-top:1 ins 'Role: emphasis'
+expect_red sg15-mutant-bare-role-flagged "$d" no-colour-fields \
+  "an injected top-level Role: key was not reported"
+
+# The central regression: if the heading matcher ever narrows to (\d+), the three
+# non-numeric labels leave the parsed set.
+d="$(stage m16)"
+python3 - "$d/template.md" <<'PY'
+import sys
+path = sys.argv[1]
+text = open(path, encoding="utf-8").read()
+text = (text.replace("## Slide N: ", "## Slide 90: ")
+            .replace("## Slide N+1: ", "## Slide 91: ")
+            .replace("## Slide N+2: ", "## Slide 92: "))
+open(path, "w", encoding="utf-8").write(text)
+PY
+expect_red sg16-mutant-non-numeric-labels-removed "$d" non-numeric-slide-labels-graded \
+  "renumbering N/N+1/N+2 away was not reported"
+
+# A role-scoped check handed no document for its role must go red rather than
+# report green having graded nothing — the silent-skip failure this suite exists
+# to prevent, applied to the suite's own plumbing.
+if python3 "$GRAM" references-slide-last "template=$TEMPLATE" >/dev/null 2>&1; then
+  fail "sg17-mutant-missing-role-fails-closed a check with no document for its role reported green"
+else
+  pass "sg17-mutant-missing-role-fails-closed"
+fi
+
+# The forbidden set is copied here rather than imported, to keep the fixture
+# standalone. check-brief.py owns the live prohibition list and has already
+# grown it twice, so a silently stale copy would narrow sg07 without any case
+# going red — this is what makes the divergence visible instead.
+if python3 - "$GRAM" "$CHECK_BRIEF" <<'PY'
+import importlib.util, json, subprocess, sys
+gram, check_brief = sys.argv[1], sys.argv[2]
+spec = importlib.util.spec_from_file_location("check_brief", check_brief)
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+ours = set(json.loads(subprocess.run([sys.executable, gram, "dump-colour-fields"],
+                                     capture_output=True, text=True, check=True).stdout))
+sys.exit(0 if ours == set(mod.COLOR_KEYS_SLIDES) else 1)
+PY
+then
+  pass "sg18-colour-fields-match-check-brief"
+else
+  fail "sg18-colour-fields-match-check-brief the forbidden colour set has diverged from check-brief.py COLOR_KEYS_SLIDES"
+fi
+
+d="$(stage m19)"; mutate "$d" brief subkey:intent/1 del
+expect_red sg19-mutant-missing-required-subkey "$d" required-4.1-subkeys \
+  "a slide stripped of its nested intent.role key was not reported"
+
+exit "$failures"

--- a/cogni-workspace/tests/test-slide-grammar.sh
+++ b/cogni-workspace/tests/test-slide-grammar.sh
@@ -23,9 +23,19 @@
 # Every case id has both a PASS and a FAIL arm, structurally: expect_green and
 # expect_red each take the id once and own both arms, so the two can never
 # drift apart. The sgNN-mutant-* cases corrupt a mktemp copy and assert the
-# matching check goes red, so no assertion can rot into a tautology unnoticed.
-# Mutants address their target through the parser's `locate` op rather than by
-# absolute line number; no mutant is ever committed.
+# matching check goes red. Mutants address their target through the parser's
+# `locate` op rather than by absolute line number; no mutant is ever committed.
+#
+# What keeps a red arm honest is the parser's exit code, not the arm's
+# structure: every case asserts an EXACT code, and 1 alone means "the check
+# found something" (the 0/1/2 contract is stated once, in slide_grammar.py's
+# module docstring). This replaces the earlier claim that "no assertion can rot
+# into a tautology unnoticed", which was false when written: every red arm
+# accepted any non-zero, so a crashed parser read as a caught defect. Nine cases
+# were exposed — the eight expect_red sites (sg10-sg16, sg19) plus sg17's
+# then-hand-rolled arm — and could assert nothing while reporting PASS.
+# sg24/sg25 guard the two enumerated crash arms; sg26 guards the contract
+# itself, so a crash nobody enumerated cannot quietly reclaim exit 1.
 #
 # ## Mutation recipe
 #
@@ -39,12 +49,19 @@
 #   --expr 's{if not hits:}{if False:}'                 --case sg17-mutant-missing-role-fails-closed
 #   --expr 's{if n != 1}{if False}'                     --case sg19-mutant-missing-required-subkey
 #   --expr 's{"Mood"}{"Mood", "Bogus"}'                 --case sg18-colour-fields-match-check-brief
+#   --expr 's{EXIT_USAGE = 2}{EXIT_USAGE = 1}'          --case sg24-unknown-check-exits-usage
+#   --expr 's{compile\(r"\^\\s\*\(}{compile(r"^(}'      --case sg22-mutant-nested-colour-field
+#   --expr 's{\*\)\\s\*:"\)}{*):")}'                    --case sg23-mutant-spaced-colon-colour-field
+#   --expr 's{kinds != \["references"\]}{kinds != kinds}' --case sg21-mutant-refslide-kind-demoted
+#   --expr 's{rc = EXIT_USAGE}{rc = 1}'                  --case sg26-unenumerated-crash-exits-usage
 #
-# Verdict at authoring: guard_verified for all five — each search text occurs
+# Verdict at authoring: guard_verified for all ten — each search text occurs
 # exactly once in slide_grammar.py and each named case went red under its recipe,
-# replayed against the literal harness path above exactly as written. The first
-# is the load-bearing one: it reinstates the digits-only regex that is this
-# suite's central failure mode.
+# replayed against the literal harness path above exactly as written. The
+# heading-counts one is the load-bearing original: it reinstates the digits-only
+# regex that is this suite's central failure mode. The EXIT_USAGE one collapses
+# the crash code back onto the finding code and so reddens sg25 alongside its
+# named sg24 — both assert rc 2, and that is the pair the collapse breaks.
 
 set -u
 
@@ -75,11 +92,34 @@ clean() { python3 "$GRAM" "$1" "brief=$BRIEF" "template=$TEMPLATE" "refslide=$RE
 # the deliberately different filenames here cannot make a check self-skip.
 mutant() { python3 "$GRAM" "$2" "brief=$1/brief.md" "template=$1/template.md" "refslide=$1/refslide.md" >/dev/null 2>&1; }
 
+# Every arm asserts an EXACT exit code, never "zero vs non-zero" — that is the
+# whole mechanism, so it lives in exactly one place here and the wrappers below
+# only bind the code they want.
+
+# expect_rc <wanted-rc> <case-id> <failure-sentence> <cmd...>
+# On failure, replay without the redirect and indent the output — an rc=2 says
+# only "it crashed", and the traceback is the whole diagnosis. Same shape as
+# test-narrative-validate.sh's failure arm.
+expect_rc() {
+  local want="$1" id="$2" msg="$3"; shift 3
+  local rc=0
+  "$@" >/dev/null 2>&1 || rc=$?
+  if [ "$rc" -eq "$want" ]; then
+    pass "$id"
+  else
+    "$@" 2>&1 | sed 's/^/    /'
+    fail "$id $msg (rc=$rc)"
+  fi
+}
+
 # expect_green <case-id> <check> <failure-sentence>
-expect_green() { if clean "$2"; then pass "$1"; else fail "$1 $3"; fi; }
+expect_green() { expect_rc 0 "$1" "$3" clean "$2"; }
 
 # expect_red <case-id> <staged-dir> <check> <failure-sentence>
-expect_red() { if mutant "$2" "$3"; then fail "$1 $4"; else pass "$1"; fi; }
+expect_red() { expect_rc 1 "$1" "$4" mutant "$2" "$3"; }
+
+# expect_usage <case-id> <failure-sentence> <argv...> — the parser must exit 2.
+expect_usage() { local id="$1" msg="$2"; shift 2; expect_rc 2 "$id" "$msg" python3 "$GRAM" "$@"; }
 
 # Stage a fresh copy of all three surfaces and echo the directory. All three are
 # copied even when one is mutated, so `mutant` can always pass every role.
@@ -135,11 +175,13 @@ expect_green sg05-slide-kind-enum slide-kind-enum \
 expect_green sg06-references-slide-last references-slide-last \
   "the references slide is not the last slide of EXAMPLE_BRIEF.md"
 expect_green sg07-no-colour-fields no-colour-fields \
-  "a top-level colour field appears inside a slide yaml block"
+  "a colour field appears inside a slide yaml block"
 expect_green sg08-required-41-subkeys required-4.1-subkeys \
   "a slide is missing its nested intent.role or visual.kind key"
 expect_green sg09-non-numeric-slide-labels-graded non-numeric-slide-labels-graded \
   "the N / N+1 / N+2 headings were not graded"
+expect_green sg20-refslide-kind-is-references references-slide-kind \
+  "08b-references-slide.md's slide does not carry Slide-Kind: references"
 
 # --------------------------------------------------------------------- mutants
 
@@ -187,11 +229,9 @@ expect_red sg16-mutant-non-numeric-labels-removed "$d" non-numeric-slide-labels-
 # A role-scoped check handed no document for its role must go red rather than
 # report green having graded nothing — the silent-skip failure this suite exists
 # to prevent, applied to the suite's own plumbing.
-if python3 "$GRAM" references-slide-last "template=$TEMPLATE" >/dev/null 2>&1; then
-  fail "sg17-mutant-missing-role-fails-closed a check with no document for its role reported green"
-else
-  pass "sg17-mutant-missing-role-fails-closed"
-fi
+expect_rc 1 sg17-mutant-missing-role-fails-closed \
+  "a check with no document for its role did not report a finding" \
+  python3 "$GRAM" references-slide-last "template=$TEMPLATE"
 
 # The forbidden set is copied here rather than imported, to keep the fixture
 # standalone. check-brief.py owns the live prohibition list and has already
@@ -216,5 +256,44 @@ fi
 d="$(stage m19)"; mutate "$d" brief subkey:intent/1 del
 expect_red sg19-mutant-missing-required-subkey "$d" required-4.1-subkeys \
   "a slide stripped of its nested intent.role key was not reported"
+
+# The refslide surface's defining property. references-slide-last is brief-scoped
+# and never reads this file, so before sg20/sg21 the one document whose whole
+# purpose is the references slide contributed only "one slide, well-formed".
+d="$(stage m21)"; mutate "$d" refslide kind-line:1 set 'Slide-Kind: content'
+expect_red sg21-mutant-refslide-kind-demoted "$d" references-slide-kind \
+  "a demoted references-slide Slide-Kind was not reported"
+
+# Depth. check-brief.py's check_no_color_fields walks _keys() recursively, and
+# it cannot parse either template surface at all, so a nested styling key there
+# is guarded by this scan alone.
+d="$(stage m22)"; mutate "$d" template subkey:visual/1 ins '  Background: "#ff0000"'
+expect_red sg22-mutant-nested-colour-field "$d" no-colour-fields \
+  "a colour key nested under visual: was not reported"
+
+# Spacing. `Background : x` is a real yaml key that check-brief.py flags; a
+# regex requiring the colon to follow the key immediately misses it entirely.
+d="$(stage m23)"; mutate "$d" template body-top:1 ins 'Background : "#ff0000"'
+expect_red sg23-mutant-spaced-colon-colour-field "$d" no-colour-fields \
+  "a colour key written with a space before its colon was not reported"
+
+# The two cases below guard the crash-vs-finding split itself, replaying the two
+# reproductions that falsified this suite's own header claim. Both previously
+# yielded 19 PASS and exit 0, because expect_red accepted any non-zero.
+expect_usage sg24-unknown-check-exits-usage \
+  "an unknown check name did not exit 2, so a mis-typed check reads as a caught defect" \
+  no-such-checkZZZ "brief=$BRIEF" "template=$TEMPLATE" "refslide=$REFSLIDE"
+
+expect_usage sg25-unreadable-surface-exits-usage \
+  "an unreadable surface did not exit 2, so a failed stage() reads as a caught defect" \
+  fences-balanced "brief=$TMPROOT/does-not-exist.md"
+
+# sg24 and sg25 pin the two ENUMERATED arms. This one pins the contract
+# sentence: a crash nobody enumerated must still not wear the finding code.
+# `locate` with no document raises IndexError on docs[0]; before the __main__
+# backstop it exited 1.
+expect_usage sg26-unenumerated-crash-exits-usage \
+  "an unhandled parser exception did not exit 2, so an unenumerated crash still reads as a finding" \
+  locate "kind-line:1"
 
 exit "$failures"

--- a/cogni-workspace/tests/test-slide-grammar.sh
+++ b/cogni-workspace/tests/test-slide-grammar.sh
@@ -26,11 +26,17 @@
 # whereas a bash helper sitting directly at tests/ WOULD be swept in. For this
 # file the convention is the whole reason.
 #
-# Every case id has both a PASS and a FAIL arm, structurally: expect_green and
-# expect_red each take the id once and own both arms, so the two can never
-# drift apart. The sgNN-mutant-* cases corrupt a mktemp copy and assert the
-# matching check goes red. Mutants address their target through the parser's
-# `locate` op rather than by absolute line number; no mutant is ever committed.
+# Every case id reaches both a PASS and a FAIL arm, which is what makes it
+# addressable by `mutation-check.sh --case`. Most cases get that structurally:
+# every expect_* wrapper delegates to expect_rc, which owns both arms, so naming
+# the id once at the call site cannot leave the two out of step. sg18 is the
+# exception — it grades an equality between two files rather than one command's
+# exit code, so there is no argv for expect_rc to run and its arms are
+# hand-rolled below, spelling the id twice. Both shapes keep the two arms
+# reachable, the property scripts/check-case-id-pairing.py enforces repo-wide.
+# The sgNN-mutant-* cases corrupt a mktemp copy and assert the matching check
+# goes red. Mutants address their target through the parser's `locate` op rather
+# than by absolute line number; no mutant is ever committed.
 #
 # What keeps a red arm honest is the parser's exit code, not the arm's
 # structure: every case asserts an EXACT code, and 1 alone means "the check
@@ -310,10 +316,10 @@ expect_rc 1 sg17-mutant-missing-role-fails-closed \
   "a check with no document for its role did not report a finding" \
   python3 "$GRAM" references-slide-last "template=$TEMPLATE"
 
-# The forbidden set is copied here rather than imported, to keep the fixture
-# standalone. check-brief.py owns the live prohibition list and has already
-# grown it twice, so a silently stale copy would narrow sg07 without any case
-# going red — this is what makes the divergence visible instead.
+# The forbidden set is copied into the fixture rather than imported, to keep it
+# standalone; the rationale lives at slide_grammar.py's COLOUR_FIELDS. This case
+# is what makes a divergence visible — without it a stale copy would narrow sg07
+# with no case going red.
 if python3 - "$GRAM" "$CHECK_BRIEF" <<'PY'
 import importlib.util, json, subprocess, sys
 gram, check_brief = sys.argv[1], sys.argv[2]


### PR DESCRIPTION
Closes #1821

## What this does

Binds the schema-4.1 presentation-brief slide grammar to an executable suite — `cogni-workspace/tests/test-slide-grammar.sh` (26 cases, `sg01`–`sg26`) plus its parser at `cogni-workspace/tests/fixtures/slide-grammar/slide_grammar.py`. No existing file is modified; the three bound surfaces are read-only targets.

## Why a standalone parser rather than `check-brief.py`

`check-brief.py` already enforces `no-color-fields` and `deck-references-last`, and `test-check-brief.sh` (cb01/cb04) plus `test-parse-brief.sh` (pb05) already run it against `libraries/EXAMPLE_BRIEF.md`. **The surfaces nothing bound are the two templates** — `07-output-template.md` and `08b-references-slide.md`.

Those are fragments, not briefs: no frontmatter, `{placeholder}` headlines, and slide numbers written `N` / `N+1` / `N+2`. `parse-brief.py`'s `SLIDE_HEADING_RE = ^##\s+Slide\s+(\d+)\s*:` rejects them by construction, and its full-brief checklist rejects their numbering by design. Loosening that checker to admit them would weaken it for real briefs, which is the worse trade — so this ships a small standalone scanner instead.

## What it asserts

Across all three surfaces: fences balanced at EOF · exactly one `yaml` fence immediately following each slide heading · one `Slide-Kind` per slide, each within `content` / `internal-prep` / `references` · the references slide last in `EXAMPLE_BRIEF.md` · no top-level colour field inside a slide's yaml, while permitting the nested `intent.role` key · `intent.role` and `visual.kind` present once per slide · the forbidden colour set still equal to `check-brief.py`'s `COLOR_KEYS_SLIDES`.

## Three traps it is shaped around

Each would yield a guard that is green for the wrong reason:

1. **A digits-only heading regex** grades 5 of 8 slides in `07-output-template.md` and **0 of 1** in `08b-references-slide.md` (whose single heading is literally `## Slide N:`), then reports green. `sg03` pins the per-surface totals *and* cross-checks them against an independent loose recount that the mutation deliberately does not touch; `sg09` pins label membership; `sg16` is the mutant.
2. **Non-slide fenced blocks** exist in both templates (yaml under other headings, an untagged fence, a `text` listing) and `EXAMPLE_BRIEF.md` has a trailing `## CTA Summary` block. Each slide's region is anchored to the *next H2*, so none is attributed to a slide.
3. **Colour fields named in prose.** `EXAMPLE_BRIEF.md:718` and `07-output-template.md:5` both name forbidden fields in prose, as documentation of what is forbidden (all six at `07-output-template.md:5`; a table row naming `Background:` and `Text-Color:` at `EXAMPLE_BRIEF.md:718`). **A whole-file grep goes red on the current, correct tree.** The scan is scoped to content inside `yaml` fences; `sg07` proves it stays quiet on the prose, `sg15` that it still fires on a real bare `Role:`.

## Teeth

Every case id carries both arms **structurally**: `expect_green` / `expect_red` take the id once and own the `PASS` and `FAIL` branches, so the two cannot drift apart. Each assertion has a mutant twin that corrupts a `mktemp -d` copy and requires the check to go red. No mutant is committed.

Mutants address their target through the parser's `locate` op rather than by absolute line number. That was a review finding worth acting on: with hardcoded indices, any edit above line 644 of `EXAMPLE_BRIEF.md` silently re-aims every mutant, and at least one direction then **passes for the wrong reason** — a mutation landing on a neighbouring key still turns its check red, so the case reports `PASS` having corrupted something else.

What makes a red arm *honest* is the parser's exit code, not the arm's structure. Every case asserts an **exact** code: `1` alone means "the check found something", `2` means the tool crashed or was misused. Before the revision every red arm accepted any non-zero, so an unknown check name or an unreadable surface exited `1` exactly like a genuine finding — nine cases (the eight `expect_red` sites plus `sg17`'s then-hand-rolled arm) could assert nothing and still report `PASS`. The split matches `check-brief.py`'s `CheckError` and `brief-render-qa.py`'s `QAError`. A `__main__` backstop makes it a contract rather than an enumeration, and `sg24` / `sg25` / `sg26` guard the split itself.

## Mutation recipe

```
bash ~/GitHub/dev/managed-service/cogni-service/scripts/mutation-check.sh --root . --file cogni-workspace/tests/fixtures/slide-grammar/slide_grammar.py --expr 's{Slide\\s\+\(\\S\+\)}{Slide\\s+(\\d+)}' --test 'bash cogni-workspace/tests/test-slide-grammar.sh' --case sg03-heading-counts
```

Harness: `~/GitHub/dev/managed-service/cogni-service/scripts/mutation-check.sh` (literal path, not `${CLAUDE_PLUGIN_ROOT}`). This recipe is the load-bearing one on the parser side — it reinstates the digits-only regex that is this suite's central failure mode. The further parser-targeted recipes are recorded in the suite header, which is the single source for the roster; **all replay `guard_verified`**, extracted verbatim from the committed file.

Those all mutate `slide_grammar.py`, the parser this suite ships with, so together they prove the suite reads its own machinery — not that it grades anything else. The header therefore also records **one corpus-targeted recipe per bound surface**, because "a guard that passes on a broken corpus is not a guard" is checkable only by breaking the corpus. The load-bearing one of those:

```
bash ~/GitHub/dev/managed-service/cogni-service/scripts/mutation-check.sh --root . --file cogni-workspace/skills/story-to-slides/references/07-output-template.md --expr 's{## Slide N\+1: }{## Slidez N+1: }' --test 'bash cogni-workspace/tests/test-slide-grammar.sh' --case sg03-heading-counts
```

Misspelling one heading drops the template's graded count from 8 to 7 (`role template graded 7 slides, expected 8`), so `sg03` goes RED from the corpus side — the mirror of the parser-side recipe above. `EXAMPLE_BRIEF.md` → `sg06-references-slide-last` and `08b-references-slide.md` → `sg20-refslide-kind-is-references` cover the other two surfaces. All three replay `guard_verified`, extracted verbatim from the committed file rather than retyped.

## Verification

- Suite: **26/26 `PASS`, exit 0**. Ids unique, uniform `sg` slug, `<slug>-<NN>` shape, no ANSI escapes in the output path.
- `python3 scripts/run-plugin-tests.py --filter cogni-workspace` → **`total: 32, passed: 32, failed: 0`, exit 0**. Base was 31, so the increment is exactly one (the revision adds cases, not suites).
- Every recorded mutation recipe replays `guard_verified` — the parser-targeted set, plus one corpus-targeted recipe per bound surface, each extracted verbatim from the committed header and replayed rather than retyped.

## Open questions

**1. AC1 and AC2 name a surface that does not exist — no README was authored.**

Both criteria list "the `story-to-slides` README sample" as a fourth surface to bind. There is no `README.md` under `cogni-workspace/skills/story-to-slides/` (the directory holds `SKILL.md`, `evals/`, `references/`, `scripts/`), and no other document in the repo carries a `## Slide N:` + fenced-yaml sample. This PR binds the **three real surfaces** and deliberately does **not** author a README to satisfy the criterion — inventing the artifact under test would make the guard vacuous, which is the opposite of what the issue asks for.

If the intent was that such a README *should* exist, that is separate authoring work and wants its own issue. Flagging rather than silently narrowing.

**2. AC5's baseline is stale.** The issue says the suite total is 20; `origin/main` has 31. AC5 is satisfied as its invariant — discovered, counted, total increments by exactly one, run exits 0 — not as the literal figure.

**3. Judgment call a human should sanity-check.** Whether the encoded rules match the 4.1 grammar's *intent*, rather than a snapshot of three files, is not gradeable from the diff. `sg03` mitigates it by cross-checking the pinned counts against an independent recount, but the required-key set (`Slide-Kind`, `intent`, `visual`) is taken from `07-output-template.md:185`, and if that table is itself incomplete the suite inherits the gap.



