### PR TITLE
cogni-workspace: move the MCP state rule into shared references

### DIFF
--- a/cogni-workspace/scripts/patch-desktop-config.py
+++ b/cogni-workspace/scripts/patch-desktop-config.py
@@ -81,7 +81,7 @@ def resolve_wrapper_path(server_name: str) -> str | None:
     below turns an unresolvable wrapper into a git server silently omitted from the
     written config. No trimming, so a whitespace-only override is honoured verbatim.
     The override rule itself is stated canonically in
-    skills/workspace-status/SKILL.md section "6. MCP Servers".
+    skills/workspace-status/references/mcp-registry.md.
     """
     mcp_base = os.environ.get("CLAUDE_MCP_DIR") or str(Path.home() / ".claude" / "mcp-servers")
     wrapper = Path(mcp_base) / server_name / "start.sh"

--- a/cogni-workspace/skills/install-mcp/SKILL.md
+++ b/cogni-workspace/skills/install-mcp/SKILL.md
@@ -290,5 +290,5 @@ When invoked that way:
 - If the config being written has invalid JSON, warn the user rather than corrupting it
   further. This applies to `~/.claude.json` as much as to `claude_desktop_config.json`.
 - `patch-desktop-config.py` does not always return per-server rows. The shapes that produce
-  that, and the re-invoke-per-target recovery they share, are in
+  that, and the recovery each one calls for, are in
   `${CLAUDE_PLUGIN_ROOT}/skills/install-mcp/references/result-envelope.md`.

--- a/cogni-workspace/skills/install-mcp/SKILL.md
+++ b/cogni-workspace/skills/install-mcp/SKILL.md
@@ -136,7 +136,8 @@ bash "${CLAUDE_PLUGIN_ROOT}/scripts/install-mcp.sh" \
 `--name` becomes the directory the server is installed into, under `$CLAUDE_MCP_DIR`.
 Which registry key belongs here, how it differs from the one naming the host config
 entry, and what base `$CLAUDE_MCP_DIR` falls back to, are all stated once in
-`${CLAUDE_PLUGIN_ROOT}/skills/workspace-status/SKILL.md` section "6. MCP Servers".
+`${CLAUDE_PLUGIN_ROOT}/skills/workspace-status/references/mcp-registry.md` under
+"## Diagnosing a not-loaded install-mcp server".
 
 The script outputs JSON. On success, `data.action` is `installed` (fresh clone),
 `updated` (a `--force` refetch), `rebuilt` (already cloned but unbuilt, so the build
@@ -198,18 +199,11 @@ The same command covers every environment, because `MCP_TARGET` carries the dete
 `cli` writes the user-scope entry in `~/.claude.json`, `desktop` writes
 `claude_desktop_config.json`, and `both` writes each in turn.
 
-**Reading the result depends on the target.** A single-target run reports a flat
-`data.action` and `data.config_path`. `--target both` reports neither at the top level —
-it returns `data.targets[]`, one `{target, action, config_path, actions}` object per
-config. Branch on the target before reading the envelope, or a `both` run parses as
-though nothing happened.
-
-In both shapes the **per-server** detail is `actions[]`. Every entry carries `server` and
-`action` (`added`, `updated` or `skipped`); an `added` or `updated` entry also carries
-`config_key`, and only a `skipped` entry carries `reason` — so do not expect `reason` on
-every entry. The target-level `action` is `patched`, `noop` (nothing needed) or
-`dry_run`. Build the Summary rows below from `actions[]`, not from the target-level
-verb, or every server collapses into one row and a `noop` reads as a failure.
+**Branch on the target before reading the result**, then build the Summary rows below from
+the per-server `actions[]`. The envelope's full shape — the single-target vs `--target both`
+split, the `actions[]` entry fields, the target-level verbs, and the two shapes that yield
+no rows at all — is in
+`${CLAUDE_PLUGIN_ROOT}/skills/install-mcp/references/result-envelope.md`.
 
 The script:
 - Creates a timestamped backup before modifying an **existing** config. A first-ever write
@@ -295,10 +289,7 @@ When invoked that way:
 - If `patch-desktop-config.py` fails, show the error and suggest manual patching as fallback
 - If the config being written has invalid JSON, warn the user rather than corrupting it
   further. This applies to `~/.claude.json` as much as to `claude_desktop_config.json`.
-  **A `--target both` run stops at the first target it cannot write** (desktop is attempted
-  first) and exits non-zero with `data.target` naming it — the other target is left
-  unwritten. Do not read that as a completed run: re-invoke with `--target <the other one>`
-  so the healthy config is still written, and report the failed target separately
-- If a backup can't be created (permissions), the script exits without emitting a JSON
-  envelope at all — surface the raw error rather than waiting for a payload that never
-  comes, and re-invoke per-target as above
+- Two failure shapes return no per-server rows at all — a `--target both` run stopping at
+  its first unwritable target, and a backup that cannot be created. Both, and the
+  re-invoke-per-target recovery they share, are in
+  `${CLAUDE_PLUGIN_ROOT}/skills/install-mcp/references/result-envelope.md`.

--- a/cogni-workspace/skills/install-mcp/SKILL.md
+++ b/cogni-workspace/skills/install-mcp/SKILL.md
@@ -201,7 +201,7 @@ The same command covers every environment, because `MCP_TARGET` carries the dete
 
 **Branch on the target before reading the result**, then build the Summary rows below from
 the per-server `actions[]`. The envelope's full shape — the single-target vs `--target both`
-split, the `actions[]` entry fields, the target-level verbs, and the two shapes that yield
+split, the `actions[]` entry fields, the target-level verbs, and the shapes that yield
 no rows at all — is in
 `${CLAUDE_PLUGIN_ROOT}/skills/install-mcp/references/result-envelope.md`.
 
@@ -289,7 +289,6 @@ When invoked that way:
 - If `patch-desktop-config.py` fails, show the error and suggest manual patching as fallback
 - If the config being written has invalid JSON, warn the user rather than corrupting it
   further. This applies to `~/.claude.json` as much as to `claude_desktop_config.json`.
-- Two failure shapes return no per-server rows at all — a `--target both` run stopping at
-  its first unwritable target, and a backup that cannot be created. Both, and the
-  re-invoke-per-target recovery they share, are in
+- `patch-desktop-config.py` does not always return per-server rows. The shapes that produce
+  that, and the re-invoke-per-target recovery they share, are in
   `${CLAUDE_PLUGIN_ROOT}/skills/install-mcp/references/result-envelope.md`.

--- a/cogni-workspace/skills/install-mcp/SKILL.md
+++ b/cogni-workspace/skills/install-mcp/SKILL.md
@@ -206,9 +206,9 @@ no rows at all — is in
 `${CLAUDE_PLUGIN_ROOT}/skills/install-mcp/references/result-envelope.md`.
 
 The script:
-- Creates a timestamped backup before modifying an **existing** config. A first-ever write
-  has nothing to back up and reports `backup: null` — omit the `Backup:` row in that case
-  rather than rendering `Backup: None`
+- Creates a timestamped backup before modifying an **existing** config — the first-ever-write
+  case and its `backup: null` are in
+  `${CLAUDE_PLUGIN_ROOT}/skills/install-mcp/references/result-envelope.md` under "## Backups"
 - Preserves every other key in the file — `~/.claude.json` holds unrelated user state
 - Skips servers that are already configured (use `--force` to overwrite)
 - Handles both git-installed servers (resolves wrapper path) and native apps (platform binary)
@@ -242,8 +242,8 @@ Present a compact result:
 
 Name the config actually written, and follow the target for the restart line — a CLI
 write needs a new Claude Code session, not a Claude Desktop restart. The Action cell is
-the `action` verb taken verbatim from that target's `actions[]` (`added`, `updated` or
-`skipped`), never a label composed here:
+the `action` verb taken verbatim from that target's `actions[]`, never a label composed
+here:
 
 ```
 MCP Installation Complete:

--- a/cogni-workspace/skills/install-mcp/references/result-envelope.md
+++ b/cogni-workspace/skills/install-mcp/references/result-envelope.md
@@ -1,8 +1,8 @@
 # `patch-desktop-config.py` result envelope
 
 The output contract of the config writer. This file is the single home of the shape;
-`install-mcp/SKILL.md` and `manage-workspace/SKILL.md` step 5 (Init and Update) both point
-here rather than restating it.
+`install-mcp/SKILL.md` and `manage-workspace/SKILL.md` Init step 5 (which Update step 5
+defers to) both point here rather than restating it.
 
 ## The shape depends on the target
 
@@ -26,18 +26,19 @@ collapses every server into one row and makes a `noop` read as a failure.
 
 Take each row's action verbatim from this envelope.
 
-## Two shapes that yield no rows at all
+## Shapes that yield no rows at all
 
 Neither of these returns a usable `actions[]`, and both are ordinary outcomes rather than
 crashes. Render no rows rather than inventing them:
 
-- **A `--target both` run stops at the first target it cannot write** (desktop is attempted
-  first) and exits non-zero with `data.target` naming it — the other target is left
-  unwritten. Do not read that as a completed run: re-invoke with `--target <the other one>`
-  so the healthy config is still written, and report the failed target separately.
-- **A backup that cannot be created** (permissions) exits with **no JSON envelope at all**.
-  Surface the raw error rather than waiting for a payload that never comes, and re-invoke
-  per-target as above.
+- **A `--target both` run stops at the first target whose existing config will not parse**
+  (desktop is attempted first) and exits non-zero with `data.target` naming it — the other
+  target is left unwritten. Do not read that as a completed run: re-invoke with
+  `--target <the other one>` so the healthy config is still written, and report the failed
+  target separately.
+- **A backup, or the config write itself, that fails on permissions** exits with **no JSON
+  envelope at all**. Surface the raw error rather than waiting for a payload that never
+  comes, and re-invoke per-target as above.
 
 ## Backups
 

--- a/cogni-workspace/skills/install-mcp/references/result-envelope.md
+++ b/cogni-workspace/skills/install-mcp/references/result-envelope.md
@@ -1,8 +1,8 @@
 # `patch-desktop-config.py` result envelope
 
 The output contract of the config writer. This file is the single home of the shape;
-`install-mcp/SKILL.md` and `manage-workspace/SKILL.md` Init step 5 both point here rather
-than restating it.
+`install-mcp/SKILL.md` and `manage-workspace/SKILL.md` step 5 (Init and Update) both point
+here rather than restating it.
 
 ## The shape depends on the target
 
@@ -24,8 +24,7 @@ The **target-level** `action` is `patched`, `noop` (nothing needed) or `dry_run`
 per-server summary rows from `actions[]`, never from the target-level verb: doing otherwise
 collapses every server into one row and makes a `noop` read as a failure.
 
-Take each row's action and status verbatim from this envelope. Never compose a label locally
-— composing one reports a write for a server the writer may have skipped.
+Take each row's action verbatim from this envelope.
 
 ## Two shapes that yield no rows at all
 

--- a/cogni-workspace/skills/install-mcp/references/result-envelope.md
+++ b/cogni-workspace/skills/install-mcp/references/result-envelope.md
@@ -11,7 +11,9 @@ and `data.config_path`.
 
 A **`--target both`** run reports neither at the top level — it returns `data.targets[]`,
 one `{target, action, config_path, actions}` object per config. Branch on the target before
-reading the envelope, or a `both` run parses as though nothing happened.
+reading the envelope, or a `both` run parses as though nothing happened. The one exception
+is a registry with no servers, which returns the flat no-op shape under every target — see
+"## Shapes that yield no rows at all".
 
 ## Per-server detail lives in `actions[]`
 
@@ -30,13 +32,21 @@ Take each row's action verbatim from this envelope.
 
 None of these returns a usable `actions[]`. Render no rows rather than inventing them:
 
+- **A registry whose `servers` object is empty or absent** returns `success: true` with a
+  flat top-level `action: "noop"` and `message: "No servers in registry"`, and no
+  `actions[]`. That check runs before the per-target loop, so this flat shape is what a
+  `--target both` run returns too — the one `both` run with no `data.targets[]`. Nothing
+  was written and no config was even read: fix the registry rather than reporting a clean
+  no-op install.
 - **A `--target both` run stops at the first target whose existing config will not parse**
   and exits non-zero with `data.target` naming it. Read the direction from that field:
-  desktop is attempted first, so a desktop failure leaves cli unwritten, while a cli failure
-  means desktop was **already written** — its per-server actions and its backup path are
-  dropped, because the exit precedes the success envelope. Either way, re-invoke with
-  `--target <the failed one>` once its config parses, and treat a cli-failure run's desktop
-  result as unreported rather than as unwritten.
+  desktop is attempted first, so a desktop failure leaves cli unattempted, while a cli
+  failure means desktop was already **processed** — and processed is a write only where
+  that target patched. A `--dry-run` run, or one where every server was skipped (`noop`),
+  returns before the write and takes no backup. Either way desktop's per-server actions,
+  and its backup path where one was taken, are dropped, because the exit precedes the
+  success envelope. Re-invoke with `--target <the failed one>` once its config parses, and
+  treat a cli-failure run's desktop result as unreported rather than as unwritten.
 - **A backup, or the config write itself, that fails on permissions** exits with **no JSON
   envelope at all** — both raise outside the only handled error class, so the run ends in a
   traceback. Surface the raw error rather than waiting for a payload that never comes, and
@@ -44,6 +54,10 @@ None of these returns a usable `actions[]`. Render no rows rather than inventing
 
 ## Backups
 
-A timestamped backup is created before an **existing** config is modified. A first-ever
-write has nothing to back up and reports `backup: null` — omit the `Backup:` row in that
-case rather than rendering `Backup: None`.
+A `backup` key is present only on a `patched` target. The `noop` and `dry_run` returns
+carry no `backup` key at all, so omit the `Backup:` row entirely for those rather than
+rendering an empty one.
+
+On a `patched` target, a timestamped backup is created before an **existing** config is
+modified. A first-ever write has nothing to back up and reports `backup: null` — omit the
+`Backup:` row in that case too rather than rendering `Backup: None`.

--- a/cogni-workspace/skills/install-mcp/references/result-envelope.md
+++ b/cogni-workspace/skills/install-mcp/references/result-envelope.md
@@ -1,0 +1,47 @@
+# `patch-desktop-config.py` result envelope
+
+The output contract of the config writer. This file is the single home of the shape;
+`install-mcp/SKILL.md` and `manage-workspace/SKILL.md` Init step 5 both point here rather
+than restating it.
+
+## The shape depends on the target
+
+A **single-target** run (`--target cli` or `--target desktop`) reports a flat `data.action`
+and `data.config_path`.
+
+A **`--target both`** run reports neither at the top level — it returns `data.targets[]`,
+one `{target, action, config_path, actions}` object per config. Branch on the target before
+reading the envelope, or a `both` run parses as though nothing happened.
+
+## Per-server detail lives in `actions[]`
+
+In both shapes the per-server detail is `actions[]`. Every entry carries `server` and
+`action` (`added`, `updated` or `skipped`). An `added` or `updated` entry also carries
+`config_key`; only a `skipped` entry carries `reason` — so do not expect `reason` on every
+entry.
+
+The **target-level** `action` is `patched`, `noop` (nothing needed) or `dry_run`. Build
+per-server summary rows from `actions[]`, never from the target-level verb: doing otherwise
+collapses every server into one row and makes a `noop` read as a failure.
+
+Take each row's action and status verbatim from this envelope. Never compose a label locally
+— composing one reports a write for a server the writer may have skipped.
+
+## Two shapes that yield no rows at all
+
+Neither of these returns a usable `actions[]`, and both are ordinary outcomes rather than
+crashes. Render no rows rather than inventing them:
+
+- **A `--target both` run stops at the first target it cannot write** (desktop is attempted
+  first) and exits non-zero with `data.target` naming it — the other target is left
+  unwritten. Do not read that as a completed run: re-invoke with `--target <the other one>`
+  so the healthy config is still written, and report the failed target separately.
+- **A backup that cannot be created** (permissions) exits with **no JSON envelope at all**.
+  Surface the raw error rather than waiting for a payload that never comes, and re-invoke
+  per-target as above.
+
+## Backups
+
+A timestamped backup is created before an **existing** config is modified. A first-ever
+write has nothing to back up and reports `backup: null` — omit the `Backup:` row in that
+case rather than rendering `Backup: None`.

--- a/cogni-workspace/skills/install-mcp/references/result-envelope.md
+++ b/cogni-workspace/skills/install-mcp/references/result-envelope.md
@@ -35,17 +35,17 @@ None of these returns a usable `actions[]`. Render no rows rather than inventing
 - **A registry whose `servers` object is empty or absent** returns `success: true` with a
   flat top-level `action: "noop"` and `message: "No servers in registry"`, and no
   `actions[]`. That check runs before the per-target loop, so this flat shape is what a
-  `--target both` run returns too — the one `both` run with no `data.targets[]`. Nothing
-  was written and no config was even read: fix the registry rather than reporting a clean
-  no-op install.
+  `--target both` run returns too — the only *successful* `both` run with no
+  `data.targets[]`. Nothing was written and no config was even read: fix the registry
+  rather than reporting a clean no-op install.
 - **A `--target both` run stops at the first target whose existing config will not parse**
   and exits non-zero with `data.target` naming it. Read the direction from that field:
   desktop is attempted first, so a desktop failure leaves cli unattempted, while a cli
   failure means desktop was already **processed** — and processed is a write only where
   that target patched. A `--dry-run` run, or one where every server was skipped (`noop`),
-  returns before the write and takes no backup. Either way desktop's per-server actions,
-  and its backup path where one was taken, are dropped, because the exit precedes the
-  success envelope. Re-invoke with `--target <the failed one>` once its config parses, and
+  returns before the write and takes no backup. On a cli failure desktop's per-server
+  actions, and its backup path where one was taken, are dropped, because the exit precedes
+  the success envelope. Re-invoke with `--target <the failed one>` once its config parses, and
   treat a cli-failure run's desktop result as unreported rather than as unwritten.
 - **A backup, or the config write itself, that fails on permissions** exits with **no JSON
   envelope at all** — both raise outside the only handled error class, so the run ends in a

--- a/cogni-workspace/skills/install-mcp/references/result-envelope.md
+++ b/cogni-workspace/skills/install-mcp/references/result-envelope.md
@@ -28,17 +28,19 @@ Take each row's action verbatim from this envelope.
 
 ## Shapes that yield no rows at all
 
-Neither of these returns a usable `actions[]`, and both are ordinary outcomes rather than
-crashes. Render no rows rather than inventing them:
+None of these returns a usable `actions[]`. Render no rows rather than inventing them:
 
 - **A `--target both` run stops at the first target whose existing config will not parse**
-  (desktop is attempted first) and exits non-zero with `data.target` naming it — the other
-  target is left unwritten. Do not read that as a completed run: re-invoke with
-  `--target <the other one>` so the healthy config is still written, and report the failed
-  target separately.
+  and exits non-zero with `data.target` naming it. Read the direction from that field:
+  desktop is attempted first, so a desktop failure leaves cli unwritten, while a cli failure
+  means desktop was **already written** — its per-server actions and its backup path are
+  dropped, because the exit precedes the success envelope. Either way, re-invoke with
+  `--target <the failed one>` once its config parses, and treat a cli-failure run's desktop
+  result as unreported rather than as unwritten.
 - **A backup, or the config write itself, that fails on permissions** exits with **no JSON
-  envelope at all**. Surface the raw error rather than waiting for a payload that never
-  comes, and re-invoke per-target as above.
+  envelope at all** — both raise outside the only handled error class, so the run ends in a
+  traceback. Surface the raw error rather than waiting for a payload that never comes, and
+  re-invoke per-target as above.
 
 ## Backups
 

--- a/cogni-workspace/skills/manage-workspace/SKILL.md
+++ b/cogni-workspace/skills/manage-workspace/SKILL.md
@@ -145,9 +145,10 @@ themselves. Show a row only
 for a registry server whose `required_by` intersects the plugin list confirmed in step 2 —
 install-mcp installs nothing for an absent plugin — and take each row's action and status
 verbatim from install-mcp's returned summary rather than from the registry. The Action
-cell is the per-server verb exactly as the envelope carries it, never a label composed
-here — composing one reports a write for a server the writer may have skipped; the verb
-set and where to read it from live in
+cell is the per-server verb exactly as that summary carries it (install-mcp reads it from
+the config writer's per-server `actions[]`), never a label composed here — composing one
+reports a write for a server the writer may have skipped; the verb set and where to read
+it from live in
 `${CLAUDE_PLUGIN_ROOT}/skills/install-mcp/references/result-envelope.md`. Label each row
 with the entry's `desktop_config_key` as the registry gives it (the server
 `mcp_excalidraw` labels as `excalidraw`, for example), because that key is what lands in

--- a/cogni-workspace/skills/manage-workspace/SKILL.md
+++ b/cogni-workspace/skills/manage-workspace/SKILL.md
@@ -169,8 +169,8 @@ that pairing is fixed here rather than read from the registry, since `claude-in-
 no registry entry to supply it.
 
 install-mcp does not always return per-server rows, and there is nothing to render when it
-does not — the two shapes that produce that are in
-`${CLAUDE_PLUGIN_ROOT}/skills/install-mcp/references/result-envelope.md`. In either case,
+does not — the shapes that produce that are enumerated in
+`${CLAUDE_PLUGIN_ROOT}/skills/install-mcp/references/result-envelope.md`. In every such case,
 render no rows rather than inventing them: report the affected servers as not configured,
 surface the raw error and the target it names when there is one, and send the user to
 `/cogni-workspace:install-mcp` to finish the write before treating workspace setup as

--- a/cogni-workspace/skills/manage-workspace/SKILL.md
+++ b/cogni-workspace/skills/manage-workspace/SKILL.md
@@ -145,9 +145,10 @@ themselves. Show a row only
 for a registry server whose `required_by` intersects the plugin list confirmed in step 2 —
 install-mcp installs nothing for an absent plugin — and take each row's action and status
 verbatim from install-mcp's returned summary rather than from the registry. The Action
-cell is the per-server `action` verb exactly as `actions[]` carries it — `added`,
-`updated` or `skipped` — never a label composed here; composing one reports a write for a
-server the writer may have skipped. Label each row
+cell is the per-server verb exactly as the envelope carries it, never a label composed
+here — composing one reports a write for a server the writer may have skipped; the verb
+set and where to read it from live in
+`${CLAUDE_PLUGIN_ROOT}/skills/install-mcp/references/result-envelope.md`. Label each row
 with the entry's `desktop_config_key` as the registry gives it (the server
 `mcp_excalidraw` labels as `excalidraw`, for example), because that key is what lands in
 the user's config and what the `mcp__<key>__*` tool names derive from; do not label the
@@ -168,13 +169,12 @@ that pairing is fixed here rather than read from the registry, since `claude-in-
 no registry entry to supply it.
 
 install-mcp does not always return per-server rows, and there is nothing to render when it
-does not. Two shapes produce that: a `--target both` run that fails on its first target
-returns `success: false` carrying `error` and `target` but no `targets[]`/`actions[]`, and
-a config whose backup cannot be created exits with no JSON envelope at all. In either
-case, render no rows rather than inventing them: report the affected servers as not
-configured, surface the raw error and the target it names when there is one, and send the
-user to `/cogni-workspace:install-mcp` to finish the write before treating workspace setup
-as complete.
+does not — the two shapes that produce that are in
+`${CLAUDE_PLUGIN_ROOT}/skills/install-mcp/references/result-envelope.md`. In either case,
+render no rows rather than inventing them: report the affected servers as not configured,
+surface the raw error and the target it names when there is one, and send the user to
+`/cogni-workspace:install-mcp` to finish the write before treating workspace setup as
+complete.
 
 Newly written servers load only after a session restart — relay install-mcp's restart
 reminder in the summary rather than presenting "config written" as a finished state.

--- a/cogni-workspace/skills/workspace-dashboard/references/dashboard-sections.md
+++ b/cogni-workspace/skills/workspace-dashboard/references/dashboard-sections.md
@@ -44,7 +44,7 @@ Per-section reference for `workspace-dashboard`: data source, helper(s) reused, 
 
 **Data source**:
 - `<workspace-root>/cogni-workspace/references/mcp-git-registry.json` — declares each server (`type`, `repo`, `desktop_config_key`, `provides_tools[]`, `required_by[]`, platform-specific paths for native servers)
-- Install status check: for git-based servers, existence of `~/.claude/mcp-servers/<name>/start.sh` (base overridable via `$CLAUDE_MCP_DIR`); for native servers, existence of the platform-specific binary path. What `<name>` is, and why it rather than `desktop_config_key`, is stated once in `skills/workspace-status/SKILL.md` section "6. MCP Servers"
+- Install status check: for git-based servers, existence of `~/.claude/mcp-servers/<name>/start.sh` (base overridable via `$CLAUDE_MCP_DIR`); for native servers, existence of the platform-specific binary path. What `<name>` is, and why it rather than `desktop_config_key`, is stated once in `skills/workspace-status/references/mcp-registry.md`
 - Required shape: a top-level `servers` object whose values are themselves objects. A registry that parses but does not match it — root not an object, `servers` absent or not an object, or any entry not an object — is **unreadable**. This section then falls back to the same placeholder a missing registry gets, because either way there are no cards to draw; the Health Snapshot row is where the two are told apart.
 
 **Output**: card per server. Status pill (Installed / Missing / Manual). Type pill (git / native). Required-by chips (one per consuming plugin). For git-based: repo URL truncated. For native: platform path.

--- a/cogni-workspace/skills/workspace-dashboard/scripts/generate-dashboard.py
+++ b/cogni-workspace/skills/workspace-dashboard/scripts/generate-dashboard.py
@@ -516,7 +516,7 @@ def mcp_install_status(server):
     The git-type probe resolves the install directory from the registry `name`,
     never `desktop_config_key`. Which key governs which artifact, and why the
     installer is authoritative for the directory, is stated once in
-    skills/workspace-status/SKILL.md section "6. MCP Servers".
+    skills/workspace-status/references/mcp-registry.md.
     """
     server_type = server.get("type", "")
     if server_type == "git":

--- a/cogni-workspace/skills/workspace-status/SKILL.md
+++ b/cogni-workspace/skills/workspace-status/SKILL.md
@@ -237,7 +237,7 @@ means it is not available. The **Install** column decides how a missing server i
   two independent steps, so read two pieces of state before advising:
   - the **config entry** — the server's entry in the config of the host
     **this session runs in**
-  - the **install directory** — the `start.sh` under the MCP base
+  - the **install directory** — the `start.sh` under the MCP server install base
 
   Which key names which artifact, the four-row install-state matrix that turns those two
   readings into advice, and why a restart on its own is rarely the whole answer are all in

--- a/cogni-workspace/skills/workspace-status/SKILL.md
+++ b/cogni-workspace/skills/workspace-status/SKILL.md
@@ -236,36 +236,15 @@ means it is not available. The **Install** column decides how a missing server i
 - **Not loaded**: An `install-mcp` server that is needed but not available. `ToolSearch`
   alone cannot say why — it returns the same no-match in every case — and the install is
   two independent steps, so read two pieces of state before advising:
-  - the **config entry** — the server's `desktop_config_key` (`excalidraw` for the registry
-    server `mcp_excalidraw`) in the config of the host **this session runs in**: the
-    top-level `mcpServers` in `~/.claude.json` under Claude Code, or the same key in
-    `claude_desktop_config.json` under Claude Desktop. Only that host's config feeds the
-    table below — an entry present solely in the *other* host's config leaves this one
-    unconfigured, and counting it lands on the restart row for a write that never happened
-    here
-  - the **install directory** — `$HOME/.claude/mcp-servers/mcp_excalidraw/start.sh`, named
-    for the registry **server name**, not the config key
+  - the **config entry** — the server's `desktop_config_key`, in the config of the host
+    **this session runs in**
+  - the **install directory** — the `start.sh` under the MCP base, named for the registry
+    **server name**, not the config key
 
-    This is the canonical statement of the key-to-directory rule: the dashboard install
-    probe, `skills/workspace-dashboard/references/dashboard-sections.md` and
-    `skills/install-mcp` all point here rather than restating it. `$CLAUDE_MCP_DIR`, when
-    set to a non-empty value, replaces the `$HOME/.claude/mcp-servers` base.
-
-  | Config entry (this host) | `start.sh` | State | Advise |
-  |---|---|---|---|
-  | absent | absent | never installed | route to `/cogni-workspace:install-mcp` |
-  | absent | present | built but not configured | re-run the config write — `/cogni-workspace:install-mcp` |
-  | present | absent | configured but not built, or the install directory was deleted | re-run `/cogni-workspace:install-mcp` to clone and build — this is the state that surfaces a *failed* server under `/mcp`, because the config entry points at a `start.sh` that is not there |
-  | present | present | configured, but not loaded in this session | advise a session restart |
-
-  A restart *on its own* only fixes the configured-but-not-loaded row: `install-mcp.sh` clones
-  and builds, and nothing is configured until `patch-desktop-config.py` runs — so wherever a
-  step is missing the write or the build comes first and the new session follows it, never
-  instead of it. If a restart does not clear it, first re-check that the entry is in *this*
-  host's config — a server written only with `--target desktop` is absent from
-  `~/.claude.json` and needs a `--target cli` write, not a restart — and only then treat it
-  as a failed spawn (a broken build or a port conflict). Both steps are documented in the
-  `mcp-registry.md` read at the top of this check
+  Which key names which artifact, the four-row install-state matrix that turns those two
+  readings into advice, and why a restart on its own is rarely the whole answer are all in
+  `${CLAUDE_PLUGIN_ROOT}/skills/workspace-status/references/mcp-registry.md` under
+  "## Diagnosing a not-loaded install-mcp server" — the file this check already loads above
 - **Manual**: The MCP is a manual install — the Claude-in-Chrome browser extension or the
   Pencil desktop app. Name what to fetch and inform the user, but don't flag as an error;
   a missing manual server is not the "Not loaded" case above. The two differ in one way that

--- a/cogni-workspace/skills/workspace-status/SKILL.md
+++ b/cogni-workspace/skills/workspace-status/SKILL.md
@@ -217,8 +217,7 @@ in the current session.
 Read `${CLAUDE_PLUGIN_ROOT}/skills/workspace-status/references/mcp-registry.md` for the full
 list of ecosystem MCPs and which plugins need them. Read
 `${CLAUDE_PLUGIN_ROOT}/references/mcp-git-registry.json` for any server's `desktop_config_key`
-and install metadata — only `excalidraw`'s key is spelled out inline below, so look `pencil`'s
-up there rather than assuming it.
+and install metadata — look a server's key up there rather than assuming it.
 
 **Detection approach**: Probe each known server's one representative tool with `ToolSearch`
 using the `select:` prefix — a returned tool definition means the MCP is loaded, no match
@@ -236,10 +235,9 @@ means it is not available. The **Install** column decides how a missing server i
 - **Not loaded**: An `install-mcp` server that is needed but not available. `ToolSearch`
   alone cannot say why — it returns the same no-match in every case — and the install is
   two independent steps, so read two pieces of state before advising:
-  - the **config entry** — the server's `desktop_config_key`, in the config of the host
+  - the **config entry** — the server's entry in the config of the host
     **this session runs in**
-  - the **install directory** — the `start.sh` under the MCP base, named for the registry
-    **server name**, not the config key
+  - the **install directory** — the `start.sh` under the MCP base
 
   Which key names which artifact, the four-row install-state matrix that turns those two
   readings into advice, and why a restart on its own is rarely the whole answer are all in

--- a/cogni-workspace/skills/workspace-status/references/mcp-registry.md
+++ b/cogni-workspace/skills/workspace-status/references/mcp-registry.md
@@ -97,7 +97,11 @@ An install is two independent artifacts, and they are keyed differently:
   below. An entry present solely in the *other* host's config leaves this one unconfigured,
   and counting it lands on the restart row for a write that never happened here.
 - **The install directory** is `$HOME/.claude/mcp-servers/<registry server name>/start.sh` —
-  named for the registry **server name** (`mcp_excalidraw`), not the config key.
+  named for the registry **server name** (`mcp_excalidraw`), not the config key, because
+  `install-mcp.sh` is what creates it: it builds the directory as `$MCP_BASE_DIR/$NAME`
+  from the `--name` it is handed, and `install-mcp` hands it the registry server name. The
+  config key is never passed to the installer at all, so a probe that resolves the
+  directory from `desktop_config_key` looks in a path nothing creates.
 - `$CLAUDE_MCP_DIR`, when set to a non-empty value, replaces the
   `$HOME/.claude/mcp-servers` base.
 

--- a/cogni-workspace/skills/workspace-status/references/mcp-registry.md
+++ b/cogni-workspace/skills/workspace-status/references/mcp-registry.md
@@ -79,3 +79,47 @@ These MCPs are not written by install-mcp and require user action.
 - **Troubleshooting:**
   - If not available: open the Pencil desktop app
   - Pencil registers its MCP automatically when running
+
+## Diagnosing a not-loaded install-mcp server
+
+This section is the canonical home of the key-to-directory rule and the install-state
+matrix. `workspace-status` check 6, the `workspace-dashboard` install probe, `install-mcp`
+and `patch-desktop-config.py` all point here rather than restating it.
+
+### Which key names which artifact
+
+An install is two independent artifacts, and they are keyed differently:
+
+- **The config entry** is keyed by the registry entry's `desktop_config_key` — `excalidraw`
+  for the registry server `mcp_excalidraw` — in the config of the host **this session runs
+  in**: the top-level `mcpServers` in `~/.claude.json` under Claude Code, or the same key in
+  `claude_desktop_config.json` under Claude Desktop. Only that host's config feeds the table
+  below. An entry present solely in the *other* host's config leaves this one unconfigured,
+  and counting it lands on the restart row for a write that never happened here.
+- **The install directory** is `$HOME/.claude/mcp-servers/<registry server name>/start.sh` —
+  named for the registry **server name** (`mcp_excalidraw`), not the config key.
+- `$CLAUDE_MCP_DIR`, when set to a non-empty value, replaces the
+  `$HOME/.claude/mcp-servers` base.
+
+### Install-state matrix
+
+Read both pieces of state, then take the matching row:
+
+| Config entry (this host) | `start.sh` | State | Advise |
+|---|---|---|---|
+| absent | absent | never installed | route to `/cogni-workspace:install-mcp` |
+| absent | present | built but not configured | re-run the config write — `/cogni-workspace:install-mcp` |
+| present | absent | configured but not built, or the install directory was deleted | re-run `/cogni-workspace:install-mcp` to clone and build — this is the state that surfaces a *failed* server under `/mcp`, because the config entry points at a `start.sh` that is not there |
+| present | present | configured, but not loaded in this session | advise a session restart |
+
+### Why a restart is rarely the whole answer
+
+A restart *on its own* only fixes the configured-but-not-loaded row. `install-mcp.sh` clones
+and builds, and nothing is configured until `patch-desktop-config.py` runs — so wherever a
+step is missing, the write or the build comes first and the new session follows it, never
+instead of it.
+
+If a restart does not clear it, first re-check that the entry is in *this* host's config — a
+server written only with `--target desktop` is absent from `~/.claude.json` and needs a
+`--target cli` write, not a restart — and only then treat it as a failed spawn (a broken
+build or a port conflict).


### PR DESCRIPTION
Closes #1858.

## Summary
- Moves the config-vs-`start.sh` state table, the key-to-directory rule (`desktop_config_key` names the config entry, the registry server name names the install directory, `$CLAUDE_MCP_DIR` overrides the base) and the restart reasoning out of `workspace-status/SKILL.md` check 6 into `workspace-status/references/mcp-registry.md` — the file the check already tells the reader to load. The check keeps its procedure, its probe table and a pointer.
- Extracts `patch-desktop-config.py`'s output-envelope contract into a new `install-mcp/references/result-envelope.md`, cited by both `install-mcp` and `manage-workspace`.
- Repoints all **four** citations of `workspace-status/SKILL.md` section "6. MCP Servers" — `install-mcp/SKILL.md`, `workspace-dashboard/references/dashboard-sections.md`, `workspace-dashboard/scripts/generate-dashboard.py`, and `cogni-workspace/scripts/patch-desktop-config.py`.
- `manage-workspace` Init step 5 drops its ~16 lines of restated envelope/error semantics for a pointer, keeping its own row-selection, labelling and manual-pairing rules.

`workspace-status/SKILL.md` goes 408 → 387 lines. No behaviour changes; every edit is prose or a docstring.

## Scope decisions

**In.** All four citation sites, including `cogni-workspace/scripts/patch-desktop-config.py:84`, which is outside `cogni-workspace/skills/` and therefore invisible to the issue's AC2 grep and — not being a SKILL.md — to AC1 as well. Leaving it would keep a live pointer at a heading that no longer holds the rule.

**Out, deliberately.** The check-6 **probe table** does not move: `tests/test-mcp-declaration-hygiene.sh` pins it via `PROBE_TABLE_REL`, a hardcoded path to `workspace-status/SKILL.md` (line 130), so relocating the probe table would drop `probe_rows` to 0 and red floors L4/A4. (Corrected in review: `parse_table` accumulates rows from *every* table carrying a `Needed by` header, not just the first — the conclusion stands, the earlier mechanism did not.) Only the state table moves. Both copies of `concept-mcp-server-map.md` are untouched (neither cites check 6 nor restates the rule), so guard D1 is unaffected. `references/wiki-tree-reconciliation.md:533` names `workspace-status/SKILL.md` but is a dated record its own Decision 5 forbids rewriting, and it cites row 7e rather than check 6. `manage-workspace` Update-mode step 5 keeps its removal-key rule. No `plugin.json` version touch — the post-merge workflow owns the bump.

**Nothing this change relocated is duplicated.** Each *relocated* definition ends up at exactly one address; every other site is a pointer. Scoped in review: the claim is about the definitions this PR moved, not about the touched files as a whole — `manage-workspace/SKILL.md` carries a pre-existing two-site statement of the `desktop_config_key` labelling rule (Init step 5 and Update step 5) that this PR neither created nor touches.

## Corrections to the issue's own claims

| Issue claim | Actual at `a4217684` |
|---|---|
| `workspace-status/SKILL.md` is 409 lines | **408** |
| manage-workspace Init step 5 restates "~40 lines" | 55-line step, only **~16** restate install-mcp; deleting 40 would have removed that skill's own rules |
| "three documents rot together" | **four** files cite the heading |
| "the dashboard MCP-count suites read these files" | the binding suite is `test-mcp-declaration-hygiene.sh`; `test-dashboard-mcp-counts.sh` binds only `dashboard-sections.md` |

## Hazard found beyond the issue-time contract

`test-dashboard-mcp-counts.sh` M17 asserts over `dashboard-sections.md` that `mcp-servers/<name>/start.sh` is present and `mcp-servers/<desktop_config_key>` is absent — **both operands sit on line 47**, the exact line being repointed. Only the trailing citation clause was changed; the path literal is preserved byte-for-byte. M17 is green.

## Open questions

- *(avoidable — decided here, recorded rather than asked.)* The issue's **AC1** ("No skill's SKILL.md cites a section heading of another skill's SKILL.md as the home of a definition") contradicts its own **Desired-behavior bullet 3**, which prescribes exactly such a pointer for `manage-workspace` step 5. Resolved by extracting the envelope contract into `install-mcp/references/result-envelope.md` so the pointer names a *file* — satisfying both statements. If the maintainer prefers the cheaper bullet-3 form (a bare section pointer, with AC1 scoped to only the MCP state rule), that new reference folds back into `install-mcp/SKILL.md` without touching anything else in this PR.

## Test plan

- [x] `python3 scripts/run-plugin-tests.py --filter cogni-workspace` — **34/34 suites green**
- [x] `test-mcp-declaration-hygiene.sh` — 15/15, incl. L4/A4 (probe table), L5/A5 (mcp-registry relation lines), L6/A6 (install-mcp plan example), D1 (wiki twins)
- [x] `test-dashboard-mcp-counts.sh` — 10/10, incl. M11 and M17
- [x] `grep -rn "workspace-status/SKILL.md" cogni-workspace/skills/` returns nothing
- [x] `grep -rn '6\. MCP Servers' cogni-workspace/` returns only the heading in `workspace-status/SKILL.md` itself
- [x] `git diff --stat` shows no change to `cogni-workspace/.claude-plugin/plugin.json` and no change under either `wiki/` tree
