### PR TITLE
cogni-workspace: batch — 2 issues (#1886, #1887)

### DIFF
--- a/cogni-workspace/agents/reader.md
+++ b/cogni-workspace/agents/reader.md
@@ -20,11 +20,11 @@ tools:
 
 # Reader Agent (Orchestrator)
 
-Delegation orchestrator for stakeholder document review. Invokes reader skill and returns JSON results.
+Delegation orchestrator for stakeholder document review. Invokes the `copy-reader` skill and returns JSON results.
 
 ## Mission
 
-Invoke the reader skill to review a markdown document from multiple stakeholder perspectives and return ONLY JSON to the orchestrator.
+Invoke the `copy-reader` skill to review a markdown document from multiple stakeholder perspectives and return ONLY JSON to the orchestrator.
 
 **Input:**
 
@@ -51,7 +51,7 @@ Invoke the reader skill to review a markdown document from multiple stakeholder 
 
 ### Step 2: Invoke Skill [MANDATORY SKILL DELEGATION]
 
-Invoke the reader skill using the Skill tool with args parameter.
+Invoke the `copy-reader` skill using the Skill tool with args parameter.
 
 <example>
 <invoke name="Skill">

--- a/cogni-workspace/commands/review-doc.md
+++ b/cogni-workspace/commands/review-doc.md
@@ -158,14 +158,14 @@ Valid: executive, technical, legal, marketing, end-user
 ## Integration
 
 **Agents Used:**
-- **reader** - Orchestrates document review by delegating to reader skill
+- **reader** - Orchestrates document review by delegating to the `copy-reader` skill
 
 **Skills Used (via reader agent):**
-- **reader** - Executes parallel persona analysis, synthesis, and improvement
+- **copy-reader** - Executes parallel persona analysis, synthesis, and improvement
 
 **Execution Pattern:**
 1. Command parses arguments and validates file
 2. Command invokes reader agent with parameters
-3. Reader agent invokes reader skill
-4. Reader skill runs parallel persona agents, synthesizes, and improves
+3. Reader agent invokes the `copy-reader` skill
+4. The `copy-reader` skill runs parallel persona agents, synthesizes, and improves
 5. Results flow back: skill -> agent -> command -> user

--- a/cogni-workspace/skills/workspace-status/SKILL.md
+++ b/cogni-workspace/skills/workspace-status/SKILL.md
@@ -227,7 +227,7 @@ means it is not available. The **Install** column decides how a missing server i
 |------------|-----------|-----------|---------|
 | `excalidraw` | `mcp__excalidraw__describe_scene` | cogni-portfolio, cogni-workspace | install-mcp |
 | `claude-in-chrome` | `mcp__claude-in-chrome__tabs_context_mcp` | cogni-website, cogni-workspace | manual (Chrome extension) |
-| `pencil` | `mcp__pencil__get_editor_state` | cogni-website, cogni-workspace | manual (Pencil desktop app) |
+| `pencil` | `mcp__pencil__get_editor_state` | cogni-website, cogni-workspace | manual (Pencil desktop app) — config entry still written by install-mcp; see the Manual bullet |
 
 **Report format**:
 

--- a/cogni-workspace/skills/workspace-status/references/mcp-registry.md
+++ b/cogni-workspace/skills/workspace-status/references/mcp-registry.md
@@ -53,7 +53,7 @@ only once it is actually installed.
 
 ## Manual Install
 
-These MCPs are not written by install-mcp and require user action.
+These MCPs require user action to install — install-mcp does not fetch the app or extension itself.
 
 ### claude-in-chrome
 
@@ -72,6 +72,7 @@ These MCPs are not written by install-mcp and require user action.
 - **Needed by:** cogni-website, cogni-workspace
 - **Type:** Desktop app with bundled MCP server
 - **Install:** Download from https://pencil.dev, open the app — MCP auto-starts
+- **Config entry:** `install-mcp` does write pencil's config entry — it is a registry `native` server with `desktop_config_key: pencil`. Only the desktop-app install is manual.
 - **Probe tool:** `mcp__pencil__get_editor_state`
 - **Skills and agents:** the `web` and `storyboard` agents (web narrative and printed-poster rendering), `render-infographic-pencil` (editorial infographics), website-build (homepage hero rendering)
 - **Note:** Skills that use Pencil tell the user "open Pencil" if the MCP is unavailable.


### PR DESCRIPTION
<!-- cogni-service:batch v1 issues=#1886,#1887 commits=ee8c765:#1886,4fcdf76:#1887 -->
Closes #1886
Closes #1887

## Issues

| Issue | Commit | Summary | Link |
|---|---|---|---|
| #1886 | `ee8c765` | Correct the seven prose sites in cogni-workspace/agents/reader.md and cogni-workspace/commands/review-doc.md that name a non-existent skill `reader`, so every skill name resolves to the real `copy-reader`. | Closes |
| #1887 | `4fcdf76` | Correct mcp-registry.md's Manual Install preamble and `### pencil` entry so they stop asserting install-mcp writes no config entry for pencil, and additively qualify the workspace-status check-6 table row without changing its report-routing selector. | Closes |

## Summary

- #1886 — Correct the seven prose sites in cogni-workspace/agents/reader.md and cogni-workspace/commands/review-doc.md that name a non-existent skill `reader`, so every skill name resolves to the real `copy-reader`.
- #1887 — Correct mcp-registry.md's Manual Install preamble and `### pencil` entry so they stop asserting install-mcp writes no config entry for pencil, and additively qualify the workspace-status check-6 table row without changing its report-routing selector.

## Follow-up issues

### #1886

- 1894

### #1887

- 1895

## Scope decisions worth a reviewer's eye

**#1886 — the issue's own evidence command was unsatisfiable as written.** Its acceptance criterion cites `grep -niE 'reader skill' …` returning nothing, but `copy-reader skill` *contains* the literal substring `reader skill`, so any bare-word fix fails that grep. The six phrase sites therefore name the skill in backticks (`` `copy-reader` skill ``), which satisfies the criterion literally and matches the repo's existing convention (`cogni-workspace/skills/copywriter/references/00-index.md:333`). The seventh site (`review-doc.md:164`) is invisible to that grep entirely — it reads `- **copy-reader** - …` and names the skill only by sitting under the `**Skills Used (via reader agent):**` heading; it was graded by reading, not by grep.

**#1887 — the issue body and its scope-widening comment contradict each other, and the comment is partly wrong.** The comment asks for four sites to agree with the registry. Only three are defective:

- `mcp-registry.md:56` (preamble) and the `### pencil` block — corrected as the body asks.
- `workspace-status/SKILL.md:230` (check-6 table row) — corrected **additively only**. Per `SKILL.md:224` that Install column is the *report-routing selector*: it decides how a missing server is reported. Replacing `manual` with `install-mcp` would have been a functional regression, moving pencil out of the informational **Manual** bucket into the error-flagging **Not loaded** bucket. The cell keeps `manual` first and gains a trailing qualification.
- `SKILL.md:247` and `SKILL.md:326` are **protected controls and are untouched**. 247 sits inside the Manual bullet spanning 246–255, whose closing lines are the most accurate statement of pencil's install shape in the repo — the issue body explicitly forbids weakening it. 326 is a sample-report line for a scenario where the app genuinely is not running.

Ground truth (`cogni-workspace/references/mcp-git-registry.json`, `pencil` = `type: native`, `desktop_config_key: pencil`) is **not** edited: the prose is corrected toward the registry, never the reverse.

## Open questions

- *(Advisory, does not hold this PR.)* #1887's plan-time acceptance criteria materially under-specify the bar. They name only `mcp-registry.md` plus a generic no-contradiction clause, and their verification command `bash cogni-service/scripts/run-tests.sh --dir cogni-workspace/tests` names a path that does not resolve in insight-wave (there is no repo-relative `cogni-service/` directory here). The suite was verified with `python3 scripts/run-plugin-tests.py --filter cogni-workspace` and a direct run of `cogni-workspace/tests/test-mcp-declaration-hygiene.sh` instead. Recorded as a gap in the issue's bar, not a defect in this change.

## Test plan

- `python3 scripts/run-plugin-tests.py --filter cogni-workspace` — **33/33 green**, run after each member's commit.
- `bash cogni-workspace/tests/test-mcp-declaration-hygiene.sh` — all cases green including floors L4/L5 and arms A4–A6.
- `bash cogni-workspace/scripts/check-skill-names.sh` — exit 0.
- `bash cogni-workspace/tests/test-relocated-skill-hygiene.sh` — P1/P2/P3 pass.
- `python3 scripts/check-breadcrumbs.py` — exit 0.
- `python3 scripts/check-version-bump.py` — 8 plugins scanned, 0 touched, 0 violations vs origin/main.