### PR TITLE
cogni-knowledge: batch — 1 issues (#1877)

### DIFF
--- a/cogni-knowledge/agents/wiki-verifier.md
+++ b/cogni-knowledge/agents/wiki-verifier.md
@@ -33,7 +33,7 @@ You **never fetch URLs**. The wiki has every source body verbatim under `wiki/so
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
-| `PROJECT_PATH` | Yes | Absolute path to the project directory. The draft is at `<PROJECT_PATH>/output/draft-v{DRAFT_VERSION}.md`; the citation manifest is at `<PROJECT_PATH>/.metadata/citation-manifest.json`. |
+| `PROJECT_PATH` | Yes | Absolute path to the project directory. The draft is at `<PROJECT_PATH>/output/draft-v{DRAFT_VERSION}.md`; the citation manifest is at `<PROJECT_PATH>/.metadata/citation-manifest.json`. Phase 0 also reads `<PROJECT_PATH>/.metadata/plan.json` for `citation_format` (fail-soft to `ieee`) — no dispatch parameter carries the format, so that read is the only channel. |
 | `WIKI_ROOT` | Yes | Absolute path to the bound wiki root (the dir containing `.cogni-wiki/config.json` and `wiki/`). Resolved by the orchestrator from `binding.wiki_path`. |
 | `DRAFT_VERSION` | Yes | Integer N. Drives the input `draft-v{N}.md` filename and the default output `verify-v{N}.json` filename. |
 | `REVISION_ROUND` | Yes | Integer (0 on first pass, 1 after first revisor cycle, 2 after second). Echoed into the output JSON; you do not act on it. |
@@ -67,6 +67,8 @@ Phase 0 (load context) → Phase 1 (score per citation) → Phase 2 (write + ver
    - Phase 1's dispatch table reads `page_kind_by_slug[slug]` to decide what to do.
    - Stdlib parsing only — match the same shape the writers emit (`agents/source-ingester.md` Phase 3 for `pre_extracted_claims:`; `scripts/concept-store.py::_render_distilled_claims` for `distilled_claims:`; `scripts/question-store.py::_render_answer_claims` for `answer_claims:` — both render `claim_id: <dcl-|acl->NNN` then `text: <json-quoted>`, two-space indent under the block key). Use line-by-line matching; do NOT import `yaml` (it's not stdlib).
 
+5. **Read the citation format.** `Read` `<PROJECT_PATH>/.metadata/plan.json` and capture `citation_format` (default `ieee` when the file is missing, unreadable, or carries no such field), then resolve its **citation family**: `ieee`/`chicago` → numbered, `apa`/`mla`/`harvard` → author-date, anything else (including the deprecated `wikilink` alias) → numbered. No dispatch parameter carries the format, so this read is the only channel — and Phase 1 step 3's grounding normalization strips markers of the draft's own family, so without it an author-date draft's markers survive into the compared string and depress `grounded` on citations that are in fact grounded. The mapping is the one `scripts/_knowledge_lib.py::CITATION_FAMILY` defines — do not re-derive it. The read is fail-soft: a missing or unparseable plan degrades to `ieee`/numbered, never an abort.
+
 ### Phase 1: Score per citation
 
 Walk `citations[]` in manifest order. For each entry `{id, draft_position, draft_sentence, wiki_slug, claim_id}`:
@@ -84,7 +86,7 @@ Walk `citations[]` in manifest order. For each entry `{id, draft_position, draft
 
 3. **Compute the per-citation `grounded` signal** — a deterministic draft↔excerpt grounding marker, additive on top of the verdict, that the merge step aggregates into a headline grounding rate (grounding L3). It is a hybrid, well-defined for every page kind:
    - **`synthesis` verdict** → `grounded: null` — a synthesis-page citation is not scored, so it is excluded from the grounding denominator.
-   - **Source page with an `excerpt_quote`** for the cited claim → `grounded: true` iff the cited `draft_sentence` grounds in that excerpt: normalize both (NFC, case- and whitespace-folded, inline `[N]`/`<sup>` citation markers stripped) and require the normalized `excerpt_quote` to be a contiguous substring of the normalized `draft_sentence`, OR ≥ 90% lexical token overlap for a long clause. Otherwise `grounded: false`. This is the deterministic `draft_sentence ⊇ excerpt_quote` test for the common source-page case.
+   - **Source page with an `excerpt_quote`** for the cited claim → `grounded: true` iff the cited `draft_sentence` grounds in that excerpt: normalize both (NFC, case- and whitespace-folded, inline citation markers of the draft's **own** family stripped — `[N]`/`<sup>` under the numbered family, and the author-date shapes `([Author, Year](url))`, `([Author](url))` and `([Author Year](url))` under the author-date family, per the family resolved in Phase 0 step 5; the author-date strip is **gated on that family and is never unconditional**, mirroring `_knowledge_lib.strip_citation_markers`, whose numbered branch deliberately lets an author-date-shaped parenthetical survive) and require the normalized `excerpt_quote` to be a contiguous substring of the normalized `draft_sentence`, OR ≥ 90% lexical token overlap for a long clause. Otherwise `grounded: false`. This is the deterministic `draft_sentence ⊇ excerpt_quote` test for the common source-page case.
    - **Text-only claim** (a distilled `concept`/`entity` page or a `question` node — no `excerpt_quote`) → derive from the verdict: `verbatim`/`paraphrase` → `grounded: true`, `unsupported` → `grounded: false`.
    - **Any `unsupported` source-page citation** (page_not_found, composer_dropped_claim, claim_not_found, claim_text_misaligned) → `grounded: false`.
 

--- a/cogni-knowledge/tests/test_verify_contract.sh
+++ b/cogni-knowledge/tests/test_verify_contract.sh
@@ -353,6 +353,19 @@ assert_grep_f '([Author, Year](url))' "$REVISOR" "verify-contract-110-revisor-co
 # unreachable and the assertion would prove nothing.
 assert_grep 'Read the citation format' "$REVISOR" "verify-contract-111-revisor-reads-citation-format revisor: resolves the citation family by reading plan.json under the PROJECT_PATH it already receives — no dispatch parameter carries it"
 
+# --- wiki-verifier: author-date grounding normalization (#1877) -----------
+# Phase 1 step 3's grounding normalization stripped `[N]`/`<sup>` only, so an
+# author-date marker survived into the compared string and the
+# `excerpt_quote` containment test failed on a citation that was in fact
+# grounded — depressing the headline grounding rate `verify-store.py merge`
+# aggregates. Reuses the $VERIFIER bind above rather than adding a second one.
+assert_grep_f '([Author, Year](url))' "$VERIFIER" "verify-contract-112-verifier-strips-author-date-markers wiki-verifier: the grounding normalization strips markers of the draft's own family, including the author-date shapes"
+# That strip needs a reachable source for the family. The Task(wiki-verifier, ...)
+# dispatch threads no CITATION_FORMAT, so the plan read under the PROJECT_PATH
+# it already receives is the only channel — without it the branch above is
+# unreachable and the assertion would prove nothing.
+assert_grep 'Read the citation format' "$VERIFIER" "verify-contract-113-verifier-reads-citation-format wiki-verifier: resolves the citation family by reading plan.json under the PROJECT_PATH it already receives — no dispatch parameter carries it"
+
 if [ $errors -eq 0 ]; then
   green ""
   green "ALL PASS"


### PR DESCRIPTION
<!-- cogni-service:batch v1 issues=#1877 commits=dc07b1d:#1877 -->
Closes #1877

## Issues

| Issue | Commit | Summary | Link |
|---|---|---|---|
| #1877 | `dc07b1d` | Make wiki-verifier's grounding normalization citation-family-aware — strip author-date markers under an author-date format via a new fail-soft plan.json read — and pin both halves with two new contract cases. | Closes |

## Summary

- #1877 — Make wiki-verifier's grounding normalization citation-family-aware — strip author-date markers under an author-date format via a new fail-soft plan.json read — and pin both halves with two new contract cases.

## Scope decisions

### #1877

- **In:** the `grounded` signal's source-page `excerpt_quote` arm, its new format channel, and the two contract cases.
- **Out (deliberately unchanged, no diff hunk):** Phase 1 step 2's verdict bullets — `verbatim` / `paraphrase` / `unsupported` / `synthesis` are scored against the claim, not by marker-stripping; the other three `grounded` arms (`synthesis` → `null`, text-only claim → derived from the verdict, any `unsupported` source-page citation → `false`) keep base semantics; `schema_version` stays `"0.1.1"`; the frontmatter `description` is untouched (894 chars at base, close to the 1024-char platform cap).
- **No new Python.** `_knowledge_lib.citation_family` / `strip_citation_markers` already exist and already dispatch on family; wiki-verifier is a `model: haiku` agent with no Bash, so the change is prose it can apply by reading.
- **No `skills/knowledge-verify/SKILL.md` change.** The `Task(wiki-verifier, PROJECT_PATH=…)` dispatch already threads the channel, so this is a two-file diff.
- **Scope boundary:** every changed path begins `cogni-knowledge/`; no `version` field changes.

## Test plan

- [x] `python3 scripts/run-plugin-tests.py --filter cogni-knowledge` exits 0 — 81/81 suites green.
- [x] `bash cogni-knowledge/tests/test_verify_contract.sh` prints `ALL PASS`, including `PASS: verify-contract-112-verifier-strips-author-date-markers` and `PASS: verify-contract-113-verifier-reads-citation-format`.
- [x] `grep -F '([Author, Year](url))' cogni-knowledge/agents/wiki-verifier.md` matches (exactly once).
- [x] `git diff --name-only origin/main...HEAD` lists only paths beginning `cogni-knowledge/`.
- [x] The mutation recipe below returns `guard_verified` (verified in-run: `mutated_result: red`, `restored_result: green`).

## Mutation recipe

```bash
bash ~/.claude/plugins/marketplaces/managed-service/cogni-service/scripts/mutation-check.sh --root . --file cogni-knowledge/agents/wiki-verifier.md --expr 's/\Q([Author, Year](url))\E//g' --test 'bash cogni-knowledge/tests/test_verify_contract.sh' --case verify-contract-112-verifier-strips-author-date-markers
```

Deleting the author-date marker literal from the new normalization prose reproduces exactly the pre-fix state at `wiki-verifier.md:87`, so `verify-contract-112-verifier-strips-author-date-markers` goes RED and green again on restore. The literal appears exactly once in `wiki-verifier.md`, so the substitution is unambiguous and leaves valid markdown.

## Batch note — one member parked, not shipped

This batch was composed with two members (anchor #1877 plus #1755, same `cogni-knowledge`
domain). Only #1877 is in this PR.

Issue #1755 was triaged and **parked on `svc:needs-info`** rather than built. Its own Motivation
states that its central ask — reversing the "strip and extract share ONE pattern, deliberately"
decision recorded at `scripts/_knowledge_lib.py:702-708` — is "a maintainer go/no-go, not a code
question", and that rationale argues a specific failure mode that has not been superseded. Triage
also found acceptance criterion 2 false at base: it directs new cases to start at `klib-48`
claiming the max is `klib-47`, but `klib-48`/`49`/`50`/`51` all exist on `origin/main` — the next
free id is `klib-52`. Both points are recorded on #1755 with a recommended default.

Nothing in this PR touches the files #1755 would change.