### PR TITLE
feat(cogni-workspace): stage narrative validation on --stage body|final (closes #1899)

### DIFF
--- a/cogni-workspace/skills/text-to-narrative/SKILL.md
+++ b/cogni-workspace/skills/text-to-narrative/SKILL.md
@@ -76,7 +76,7 @@ The bundled set is the only copy of these assets: the narrative skill they were 
 | `--target-length` | No | Target total word count of the narrative (e.g., `2500`). The acceptable range is ±15%. Default: `1675` (1,424-1,926 words). Recommended: 800-4,000 — outside that range the arc's proportions stop scaling well |
 | `--content-map` | No | YAML map of content category keys to file/directory paths for additional context |
 | `--audience` | No | Who the narrative is for. Default: senior business decision-makers. Feeds Pass 3 (vocabulary, acronym expansion, explanation depth) together with the inferred knowledge level |
-| `--purpose` | No | The decision the narrative must serve. Default: understand the evidence and its strategic implications. Feeds Pass 2 (TL;DR, emphasis, close) |
+| `--purpose` | No | The decision the narrative must serve. Default: understand the evidence and its strategic implications. Feeds Pass 2 (emphasis, close) and the Phase 5 TL;DR synthesis |
 | `--perspective` | No | Whose voice the narrative speaks in. Default: neutral analyst. Feeds Pass 2 (pronouns, ownership) |
 | `--geography` | No | Market codes from `cogni-workspace/references/supported-markets-registry.json` (`code` values such as `dach`, `de`, `fr`, `eu`), comma-separated, never free text or a country name. Default: source-defined scope. Feeds Pass 1 (evidence priority when sources span markets) |
 | `--interactive` | No | Whether the skill may pause for user input. `true` or `false`. Default: `true`. When `false`, skip all AskUserQuestion calls — there are two sites: the Phase 0 materiality clarification (takes the default instead) and the Phase 2 arc confirmation (keeps its top-ranked arc and its `detection_reason` and continues straight into Phase 3 with no prompt). Phase 7 has no prompt in either mode. Any value other than `false` is treated as `true`, so a malformed value fails safe toward the interactive default |
@@ -168,7 +168,7 @@ brief        bridge         & load      selection    contract     passes        
              (conditional)
 ```
 
-When `--source-path` is a finished narrative (single `.md` with `arc_id` and `word_count` in its frontmatter), Phases 0-6 do not run; validate it once with the Phase 5 command and jump to Phase 7. Phases 3 and 4 read the contract and the techniques before any drafting — those two files are what separate a persuasive narrative from a summary under headings.
+When `--source-path` is a finished narrative (single `.md` with `arc_id` and `word_count` in its frontmatter), Phases 0-6 do not run; validate it once with the Phase 5 final-stage command — it already carries a TL;DR — and jump to Phase 7. Phases 3 and 4 read the contract and the techniques before any drafting — those two files are what separate a persuasive narrative from a summary under headings.
 
 ### Phase 0: Execution brief
 
@@ -242,7 +242,7 @@ Draft in four passes. Each pass has one job; doing two at once is how a narrativ
 
 **Pass 1 — evidence draft.** For each element in order: map the loaded content to the element using its `Evidence sought`; when the sources span markets, weight the evidence by the brief's `--geography`; draft the body from that evidence, every quantitative claim carrying `<sup>[N](source-file.md)</sup>`, numbers assigned by first appearance in the body and reused for a reused source; hold the element's word range. Write the four elements only — no title, no opening yet — to `OUTPUT_PATH`.
 
-**Pass 2 — argument edit.** Apply each element's `Argument move` and `Techniques`; enforce its `Hard rules`; build the transitions from `## Composition`; write the closing per the closing pattern, so that emphasis, implications and close serve the brief's `--purpose` and pronouns and ownership follow its `--perspective`. Then — last, from the finished elements — write the title (arc-specific, never "Insight Summary") and the Executive TL;DR, weighting it as the contract's TL;DR-emphasis line says. Writing the TL;DR after the elements is what makes "synthesizes all four" enforceable rather than aspirational. Finally assemble the `**Sources**` block from the provenance map: one entry per cited `[N]`, in number order, carrying the per-source file and its preserved metadata.
+**Pass 2 — argument edit.** Apply each element's `Argument move` and `Techniques`; enforce its `Hard rules`; build the transitions from `## Composition`; write the closing per the closing pattern, so that emphasis, implications and close serve the brief's `--purpose` and pronouns and ownership follow its `--perspective`. Then — last, from the finished elements — write the title (arc-specific, never "Insight Summary"). Finally assemble the `**Sources**` block from the provenance map: one entry per cited `[N]`, in number order, carrying the per-source file and its preserved metadata. Pass 2 ends with the body stable and **no Executive TL;DR written**: the TL;DR is synthesized in Phase 5 from a body that has already cleared body-stage validation, and gate T0 is what makes that order enforceable rather than aspirational.
 
 **Pass 3 — language edit.** Now, and not earlier, read `references/language-shared.md` and `references/language-{language}.md` (`language-en.md` or `language-de.md`). Localize the four headings from `## Headings` for the output language and make the prose read as executive prose per those two files: one idea per sentence, concrete actors and verbs, specificity over intensifiers, no corporate fog; for `de`, the sentence craft in `language-de.md` — Satzklammer, Mittelfeld, Funktionsverbgefüge, Nominalstil, anglicisms — and proper umlauts and ß throughout. Tune vocabulary, acronym expansion and explanation depth to the brief's `--audience` and inferred knowledge level.
 
@@ -260,14 +260,27 @@ The output uses exactly four `##` headings matching the arc's element names. Pha
 
 ### Phase 5: Validation
 
-Run the deterministic gates first:
+The deterministic gates run in two stages, because the Executive TL;DR is synthesized from a body that has already been graded.
+
+**Stage 1 — the body.** Grade the four elements before any TL;DR exists:
+
+```bash
+python3 "${CLAUDE_PLUGIN_ROOT}/skills/text-to-narrative/scripts/validate-narrative.py" \
+  --narrative "${OUTPUT_PATH}" --stage body --contract "${CLAUDE_PLUGIN_ROOT}/skills/text-to-narrative/references/arc-${ARC_ID}.md" --json
+```
+
+This adds gate T0 (no TL;DR prose above the first `##`), counts E1's citation markers in the body alone — so the floor of 15 is met by the elements' own evidence, never by TL;DR repeats — and withholds T1 and T2, which have nothing to grade yet.
+
+**Stage 2 — synthesize the TL;DR, then run the whole contract.** Once stage 1 is green, write the Executive TL;DR as a synthesis pass over the validated body, per the generation rule in `references/validation.md`. Then run the final stage, which adds T1 and T2 and counts TL;DR markers in E1:
 
 ```bash
 python3 "${CLAUDE_PLUGIN_ROOT}/skills/text-to-narrative/scripts/validate-narrative.py" \
   --narrative "${OUTPUT_PATH}" --contract "${CLAUDE_PLUGIN_ROOT}/skills/text-to-narrative/references/arc-${ARC_ID}.md" --json
 ```
 
-Then read `references/validation.md` and check its judged gates plus the contract's `## Validation` section. Fix any failure and re-run everything — a fix can break a gate that passed. A structural failure is fixed by rewriting against `## Composition`, never by renaming headings. **Attempt bound:** at most three fix-and-re-validate cycles. If a deterministic gate is still red after the third, abandon the run — report `qa_verdict: "fail"` and the error JSON with `phase: "5"` naming the gate — rather than looping.
+When a fix changes the body after the TL;DR exists, discard the TL;DR and re-synthesize it from the changed body rather than patching it, then re-run the final stage.
+
+Then read `references/validation.md` and check its judged gates plus the contract's `## Validation` section. Fix any failure and re-run everything — a fix can break a gate that passed. A structural failure is fixed by rewriting against `## Composition`, never by renaming headings. **Attempt bound:** at most three fix-and-re-validate cycles, spanning both stages rather than three per stage. If a deterministic gate is still red after the third, abandon the run — report `qa_verdict: "fail"` and the error JSON with `phase: "5"` naming the gate — rather than looping.
 
 **Release review (after the gates are green).** Run the banded self-review defined in `references/validation.md`: five dimensions — strategic reasoning, arc integrity, executive language, decision usefulness, execution fit — each `strong` / `adequate` / `weak`, rolled up to `pass`, `needs_revision` (revise once, review once more, then report) or `fail` (a gate could not be cleared and the run was abandoned). The review diagnoses and never rewrites the draft; the revision step acts on its findings. Its rollup is the JSON summary's `qa_verdict`.
 

--- a/cogni-workspace/skills/text-to-narrative/SKILL.md
+++ b/cogni-workspace/skills/text-to-narrative/SKILL.md
@@ -157,7 +157,7 @@ Exactly four `##` headings, byte-equal to the contract's `## Headings` cells for
 }
 ```
 
-`readability_score` is reported when Pass 4 computes it and `null` otherwise. `qa_verdict` is the release review's rollup — exactly one of `pass`, `needs_revision`, `fail`. `brief_qa` is the Phase 7 checker's rollup — `pass` or `fail`. On the finished-narrative entry, `detection_reason` is `"finished narrative"` and `readability_score` is `null`.
+`readability_score` is reported when Pass 4 computes it and `null` otherwise; it is measured at Pass 4 on the body, before the Executive TL;DR exists. `qa_verdict` is the release review's rollup — exactly one of `pass`, `needs_revision`, `fail`. `brief_qa` is the Phase 7 checker's rollup — `pass` or `fail`. On the finished-narrative entry, `detection_reason` is `"finished narrative"` and `readability_score` is `null`.
 
 ## Core Workflow
 
@@ -271,7 +271,7 @@ python3 "${CLAUDE_PLUGIN_ROOT}/skills/text-to-narrative/scripts/validate-narrati
 
 This adds gate T0 (no TL;DR prose above the first `##`), counts E1's citation markers in the body alone — so the floor of 15 is met by the elements' own evidence, never by TL;DR repeats — and withholds T1 and T2, which have nothing to grade yet.
 
-**Stage 2 — synthesize the TL;DR, then run the whole contract.** Once stage 1 is green, write the Executive TL;DR as a synthesis pass over the validated body, per the generation rule in `references/validation.md`. Then run the final stage, which adds T1 and T2 and counts TL;DR markers in E1:
+**Stage 2 — synthesize the TL;DR, then run the whole contract.** Once stage 1 is green, write the Executive TL;DR as a synthesis pass over the validated body, per the generation rule in `references/validation.md`, applying to it the same `references/language-shared.md` / `references/language-{language}.md` rules Pass 3 applied to the body — for `de`, that includes the opening-sentence rules `language-de.md` names for the TL;DR's first sentence — and Pass 4's rhythm pass over the result. Then run the final stage, which adds T1 and T2 and counts TL;DR markers in E1:
 
 ```bash
 python3 "${CLAUDE_PLUGIN_ROOT}/skills/text-to-narrative/scripts/validate-narrative.py" \

--- a/cogni-workspace/skills/text-to-narrative/references/execution-brief.md
+++ b/cogni-workspace/skills/text-to-narrative/references/execution-brief.md
@@ -40,10 +40,11 @@ Never ask for what is explicit or safely inferable. Never ask more than one brie
 | Pass | Field | Effect |
 |------|-------|--------|
 | Pass 1 — evidence draft | geography | When sources span markets, evidence from the named markets leads; other markets' evidence is context, not the argument. |
-| Pass 2 — argument edit | purpose | The Executive TL;DR's decision implication, the argumentative emphasis across the four elements and the close all serve the named decision. |
+| Pass 2 — argument edit | purpose | The argumentative emphasis across the four elements and the close serve the named decision. |
 | Pass 2 — argument edit | perspective | Pronouns and ownership follow the voice: a neutral analyst says "operators"; the client's leadership says "we"; an advisor addressing the client says "you". |
 | Pass 3 — language edit | audience, knowledge level | Vocabulary, acronym expansion on first use, and how much a mechanism is explained. `expert` keeps domain terms bare; `general` explains each mechanism once. |
 | Pass 3 — language edit | tone | Register of the prose, within the executive-prose rules of `language-shared.md`. |
+| Phase 5 — TL;DR synthesis | purpose | The Executive TL;DR's decision implication serves the named decision. |
 
 ## Frontmatter
 

--- a/cogni-workspace/skills/text-to-narrative/references/validation.md
+++ b/cogni-workspace/skills/text-to-narrative/references/validation.md
@@ -24,6 +24,14 @@ python3 "${CLAUDE_PLUGIN_ROOT}/skills/text-to-narrative/scripts/validate-narrati
   --contract "${CLAUDE_PLUGIN_ROOT}/skills/text-to-narrative/references/arc-${ARC_ID}.md" --json
 ```
 
+The stage may also be named explicitly; the two forms are identical:
+
+```bash
+python3 "${CLAUDE_PLUGIN_ROOT}/skills/text-to-narrative/scripts/validate-narrative.py" \
+  --narrative "${OUTPUT_PATH}" --stage final \
+  --contract "${CLAUDE_PLUGIN_ROOT}/skills/text-to-narrative/references/arc-${ARC_ID}.md" --json
+```
+
 The stage that ran is reported as `data.stage`. A gate a stage withholds is **absent** from `data.gates`, never reported as passing — a green verdict on a TL;DR that does not exist yet would be unfalsifiable.
 
 **Structural (check first):**
@@ -75,7 +83,7 @@ The narrative opens with an answer, not a tension. Between the `*{Subtitle}*` li
 - It introduces no fact, number or recommendation absent from the body.
 - Every material number it carries reuses the body's citation — same source, same `[N]`.
 - It reads as complete if the reader stops there.
-- **Generation rule.** It is written only after the body has cleared body-stage validation, and it is an LLM synthesis pass over that validated body — never a deterministic extraction, and never a concatenation of the elements' opening sentences. If the body changes after the TL;DR exists, discard the TL;DR and re-synthesize it from the changed body rather than patching it, then re-run the final stage (SKILL.md Pass 2 and Phase 5).
+- **Generation rule.** It is written only after the body has cleared body-stage validation, and it is an LLM synthesis pass over that validated body — never a deterministic extraction, and never a concatenation of the elements' opening sentences. If the body changes after the TL;DR exists, discard the TL;DR and re-synthesize it from the changed body rather than patching it, then re-run the final stage (SKILL.md Phase 5).
 
 **Rejected and rewritten when it:** reads as a teaser with no decision implication; summarizes only the first section; mechanically summarizes all four topics one after another; introduces evidence the body lacks; restates the title; or grows its own heading.
 

--- a/cogni-workspace/skills/text-to-narrative/references/validation.md
+++ b/cogni-workspace/skills/text-to-narrative/references/validation.md
@@ -6,11 +6,25 @@ Two kinds of check live here. The **deterministic gates** are mechanical and are
 
 ## Deterministic gates (run `validate-narrative.py` first)
 
+The script runs in **two stages**, because the Executive TL;DR is written last, from the finished elements. Run the body stage while the four elements are being stabilized and no TL;DR exists yet; run the final stage once the TL;DR has been synthesized from the validated body.
+
+**Body stage** — grades the four-element argument before a TL;DR exists. It adds T0, counts E1's citation markers in the body alone, and omits T1 and T2:
+
+```bash
+python3 "${CLAUDE_PLUGIN_ROOT}/skills/text-to-narrative/scripts/validate-narrative.py" \
+  --narrative "${OUTPUT_PATH}" --stage body \
+  --contract "${CLAUDE_PLUGIN_ROOT}/skills/text-to-narrative/references/arc-${ARC_ID}.md" --json
+```
+
+**Final stage** — the whole contract, and the default, so an invocation that names no stage keeps the meaning it has always had:
+
 ```bash
 python3 "${CLAUDE_PLUGIN_ROOT}/skills/text-to-narrative/scripts/validate-narrative.py" \
   --narrative "${OUTPUT_PATH}" \
   --contract "${CLAUDE_PLUGIN_ROOT}/skills/text-to-narrative/references/arc-${ARC_ID}.md" --json
 ```
+
+The stage that ran is reported as `data.stage`. A gate a stage withholds is **absent** from `data.gates`, never reported as passing — a green verdict on a TL;DR that does not exist yet would be unfalsifiable.
 
 **Structural (check first):**
 
@@ -29,11 +43,11 @@ If S1 or S2 fails, rewrite against the arc's `## Composition` rather than renami
 
 **Evidence:**
 
-- E1 — 15-25 citations at the default length, in the form `Claim text<sup>[N](source-file.md)</sup>`, counted as markers in the TL;DR and the body. The floor of 15 holds at every length; the ceiling of 25 applies at or below the default target, and a longer narrative may carry more.
+- E1 — 15-25 citations at the default length, in the form `Claim text<sup>[N](source-file.md)</sup>`, counted as markers. **The final stage counts the TL;DR and the body; the body stage counts the body alone**, so the floor is met by evidence the four elements actually carry rather than by TL;DR repeats of a number the body already has. The floor of 15 holds at every length; the ceiling of 25 applies at or below the default target, and a longer narrative may carry more.
 - E2 — citation numbers run sequentially from 1 in order of first appearance **in the body**; a reused source reuses its number, so a narrative built on five sources carries five numbers and many markers. The TL;DR is written last and reuses the body's numbers, so its own order is free — a TL;DR opening on `[3]` is correct when `[3]` is the third source the body introduces.
 - E3 — one number per source file and one source file per number: the same source never carries two numbers, and a number never points at two files.
 - E4 — every element carries at least one citation marker.
-- X1 — the `**Sources**` block is present after the fourth element and mutually complete with the body: every `[N]` in the body has exactly one entry, every entry is cited at least once, and no number appears twice. A narrative with no block fails, because the block is what makes the narrative self-verifying.
+- X1 — the `**Sources**` block is present after the fourth element and mutually complete with the body: every `[N]` in the body has exactly one entry, every entry is cited at least once, and no number appears twice. The cited set is the **body's** numbers at both stages, so a number carried only by the TL;DR never keeps a Sources entry alive. A narrative with no block fails, because the block is what makes the narrative self-verifying.
 
 **Language (when `language: de`):**
 
@@ -41,8 +55,11 @@ If S1 or S2 fails, rewrite against the arc's `## Composition` rather than renami
 
 **Executive TL;DR:**
 
-- T1 — the prose between the subtitle and the first `##` is 2-4 sentences and 60-100 words. The band is absolute: it does not scale with `--target-length`, because a summary a reader skims does not get longer when the report does.
-- T2 — every `[N]` marker in the TL;DR also appears below the first `##`, with the same source and the same number.
+- T0 — **body stage only:** no TL;DR prose sits between the `*{Subtitle}*` line and the first `##`. T0 is what makes the documented write order enforceable rather than aspirational — the body is graded on its own evidence before any summary of it exists.
+- T1 — **final stage only:** the prose between the subtitle and the first `##` is 2-4 sentences and 60-100 words. The band is absolute: it does not scale with `--target-length`, because a summary a reader skims does not get longer when the report does.
+- T2 — **final stage only:** every `[N]` marker in the TL;DR also appears below the first `##`, with the same source and the same number.
+
+At the body stage T1 and T2 are absent from `data.gates`; at the final stage T0 is.
 
 ## Executive TL;DR contract
 
@@ -58,7 +75,7 @@ The narrative opens with an answer, not a tension. Between the `*{Subtitle}*` li
 - It introduces no fact, number or recommendation absent from the body.
 - Every material number it carries reuses the body's citation — same source, same `[N]`.
 - It reads as complete if the reader stops there.
-- It is written last, from the finished elements (SKILL.md Pass 2).
+- **Generation rule.** It is written only after the body has cleared body-stage validation, and it is an LLM synthesis pass over that validated body — never a deterministic extraction, and never a concatenation of the elements' opening sentences. If the body changes after the TL;DR exists, discard the TL;DR and re-synthesize it from the changed body rather than patching it, then re-run the final stage (SKILL.md Pass 2 and Phase 5).
 
 **Rejected and rewritten when it:** reads as a teaser with no decision implication; summarizes only the first section; mechanically summarizes all four topics one after another; introduces evidence the body lacks; restates the title; or grows its own heading.
 
@@ -79,7 +96,7 @@ Gate X1 above checks mutual completeness mechanically.
 **Content:**
 
 - J1 — the title is arc-specific and could not head a different narrative. "Insight Summary" and any generic label fail.
-- J2 — the Executive TL;DR follows the answer-first sequence, emphasizes what the arc's `## Composition` TL;DR line says, and none of the rejection modes above applies.
+- J2 — **final stage only:** the Executive TL;DR follows the answer-first sequence, emphasizes what the arc's `## Composition` TL;DR line says, and none of the rejection modes above applies.
 - J3 — the arc's own `## Validation` assertions hold, and the techniques the arc names for each element are visibly applied.
 - J4 — transitions between elements follow the arc's transition patterns and read as consequences, not topic labels.
 
@@ -87,7 +104,7 @@ Gate X1 above checks mutual completeness mechanically.
 
 - F1 — the narrative is recognizably written for the target audience.
 - F2 — terminology and explanation depth match the inferred knowledge level.
-- F3 — the Executive TL;DR, the emphasis across elements, the implications and the close serve the decision purpose.
+- F3 — the emphasis across elements, the implications and the close serve the decision purpose. Its Executive TL;DR half is **final stage only**, since there is no TL;DR to read at the body stage.
 - F4 — perspective and pronouns are consistent with the stated voice throughout.
 - F5 — geographic emphasis matches the scope: evidence from the named markets leads.
 - F6 — where the brief asked for evidence and interpretation to be kept apart, the separation is visible in the prose.

--- a/cogni-workspace/skills/text-to-narrative/scripts/validate-narrative.py
+++ b/cogni-workspace/skills/text-to-narrative/scripts/validate-narrative.py
@@ -16,9 +16,10 @@ Gates:
   C2  each element within [proportion*lower, proportion*upper]
   C3  required frontmatter fields present; arc_id matches the contract;
       frontmatter word_count equals the measured body word count
-  E1  citation markers (TL;DR and body) >= 15, and <= 25 when the target is
-      at or below the default; a reused source reuses its number, so markers
-      are counted, not distinct numbers
+  E1  citation markers >= 15, and <= 25 when the target is at or below the
+      default; a reused source reuses its number, so markers are counted, not
+      distinct numbers. The final stage counts the TL;DR and the body; the body
+      stage counts the body alone, so the floor cannot be met by TL;DR repeats
   E2  citation numbers sequential from 1 by first appearance IN THE BODY; the
       TL;DR is written last and reuses body numbers, so its own order is free
   E3  one number per source file and one file per number (dedup by identity)
@@ -26,15 +27,26 @@ Gates:
   L1  (de only) no ASCII umlaut fallback anywhere below the frontmatter —
       title, subtitle, TL;DR, headings and body; fenced code, code spans,
       citation markers and the Sources block (ASCII file names) are excluded
-  T1  the opening TL;DR is 2-4 sentences and 60-100 words
-  T2  every citation number in the TL;DR also appears below the first `##`
+  T0  (body stage only) no TL;DR prose sits between the subtitle and the first
+      `##` — the body is graded before the TL;DR is written
+  T1  (final stage only) the opening TL;DR is 2-4 sentences and 60-100 words
+  T2  (final stage only) every citation number in the TL;DR also appears below
+      the first `##`
   X1  a `**Sources**` block is present after the fourth element, every body
       citation number has exactly one entry and every entry is cited at least
       once
 
 Usage:
   validate-narrative.py --narrative FILE --contract ARC_DEFINITION.md
-                        [--language en|de] [--target-length N] [--json]
+                        [--language en|de] [--target-length N]
+                        [--stage body|final] [--json]
+
+Two stages, because the Executive TL;DR is written last, from the finished
+elements. `--stage body` grades the four-element argument before a TL;DR exists:
+it adds T0, counts E1's markers in the body alone, and omits T1 and T2 from the
+reported gates entirely. `--stage final` is the default and the whole contract:
+T1 and T2 run and E1 counts the TL;DR and the body. The stage that ran is
+reported as `data.stage`.
 
 Exit 0 when every gate passes, 1 when any gate fails, 2 on a usage or read
 error. Output is the repo's script envelope:
@@ -202,6 +214,13 @@ def main(argv):
     ap.add_argument("--language")
     ap.add_argument("--target-length", type=int)
     ap.add_argument("--json", action="store_true")
+    ap.add_argument(
+        "--stage", choices=("body", "final"), default="final",
+        help="validation stage: `body` grades the four-element argument before a "
+             "TL;DR exists (adds T0, counts E1 markers in the body alone, omits "
+             "T1 and T2); `final` is the default and also runs T1 and T2 and "
+             "counts TL;DR markers in E1",
+    )
     args = ap.parse_args(argv)
 
     try:
@@ -214,6 +233,7 @@ def main(argv):
     fm, raw_body = split_frontmatter(narrative)
     body = strip_fences(raw_body)
     cfm, sections = contract_sections(contract)
+    stage = args.stage
     language = (args.language or fm.get("language") or "en").lower()
     try:
         target = int(args.target_length or fm.get("target_length") or DEFAULT_TARGET)
@@ -279,12 +299,16 @@ def main(argv):
          "missing %s; arc_id %s vs contract %s; word_count %s vs measured body %d"
          % (missing, fm.get("arc_id"), cfm.get("arc_id"), fm.get("word_count"), band_total))
 
-    # E1 counts markers in the TL;DR and the body; E2 orders by first appearance in the
-    # body alone, because the TL;DR is written last and reuses whatever numbers the body
-    # already carries.
+    # E1's operand is stage-dependent: the final stage counts markers in the TL;DR and
+    # the body, the body stage in the body alone, so the floor of 15 cannot be met by
+    # TL;DR repeats of a number the body already carries. E2 orders by first appearance
+    # in the body at both stages, because the TL;DR is written last and reuses whatever
+    # numbers the body already carries.
     body_for_cites = "\n".join(t for _, t in elements)
     body_cites = CITATION_RE.findall(body_for_cites)
-    cites = CITATION_RE.findall(opening) + body_cites
+    body_nums = {int(n) for n, _ in body_cites}
+    opening_cites = CITATION_RE.findall(opening)
+    cites = body_cites if stage == "body" else opening_cites + body_cites
     distinct = []
     for n, _ in body_cites:
         if int(n) not in distinct:
@@ -321,14 +345,20 @@ def main(argv):
         hits = sorted({w for w in DE_ASCII_FALLBACKS if re.search(r"\b%s" % w, scan)})
         gate("L1", not hits, "ASCII fallbacks found: %s" % hits)
 
-    # T1 / T2 — the Executive TL;DR
-    sentences = [s for s in re.split(r"(?<=[.!?])\s+", opening.strip()) if s.strip()]
-    t1_ok = TLDR_WORDS[0] <= opening_words <= TLDR_WORDS[1] and TLDR_SENTENCES[0] <= len(sentences) <= TLDR_SENTENCES[1]
-    gate("T1", t1_ok, "TL;DR %d words, %d sentences (want %d-%d words, %d-%d sentences)"
-         % (opening_words, len(sentences), TLDR_WORDS[0], TLDR_WORDS[1], TLDR_SENTENCES[0], TLDR_SENTENCES[1]))
-    tldr_nums = {int(n) for n, _ in CITATION_RE.findall(opening)}
-    body_nums = {int(n) for n, _ in body_cites}
-    gate("T2", tldr_nums <= body_nums, "TL;DR citations %s not in body: %s" % (sorted(tldr_nums), sorted(tldr_nums - body_nums)))
+    # T0 / T1 / T2 — the Executive TL;DR. T0 asserts the TL;DR is not written yet, so it
+    # is emitted at the body stage alone; T1 and T2 grade a TL;DR that exists, so at the
+    # body stage they are omitted from `gates` entirely rather than reported as passing.
+    if stage == "body":
+        gate("T0", not opening,
+             "TL;DR prose above the first `##`: %d words (want none at the body stage)"
+             % opening_words)
+    if stage == "final":
+        sentences = [s for s in re.split(r"(?<=[.!?])\s+", opening.strip()) if s.strip()]
+        t1_ok = TLDR_WORDS[0] <= opening_words <= TLDR_WORDS[1] and TLDR_SENTENCES[0] <= len(sentences) <= TLDR_SENTENCES[1]
+        gate("T1", t1_ok, "TL;DR %d words, %d sentences (want %d-%d words, %d-%d sentences)"
+             % (opening_words, len(sentences), TLDR_WORDS[0], TLDR_WORDS[1], TLDR_SENTENCES[0], TLDR_SENTENCES[1]))
+        tldr_nums = {int(n) for n, _ in opening_cites}
+        gate("T2", tldr_nums <= body_nums, "TL;DR citations %s not in body: %s" % (sorted(tldr_nums), sorted(tldr_nums - body_nums)))
 
     # X1 — the Sources block is mandatory and mutually complete with the body
     if sources_block is None:
@@ -336,7 +366,7 @@ def main(argv):
     else:
         entries = [int(m.group(1)) for m in (SOURCES_ENTRY_RE.match(l) for l in sources_block.splitlines()) if m]
         dup = sorted({n for n in entries if entries.count(n) > 1})
-        cited = set(all_numbers)
+        cited = set(body_nums)
         uncited = sorted(set(entries) - cited)
         dangling = sorted(cited - set(entries))
         gate("X1", not dup and not uncited and not dangling,
@@ -345,6 +375,7 @@ def main(argv):
     failed = [g["id"] for g in gates if g["status"] == "fail"]
     data = {
         "gates": gates,
+        "stage": stage,
         "word_count": band_total,
         "citation_count": marker_count,
         "source_count": len(all_numbers),

--- a/cogni-workspace/tests/test-narrative-validate.sh
+++ b/cogni-workspace/tests/test-narrative-validate.sh
@@ -19,6 +19,20 @@
 #
 # Contract: runs as `bash <path>` with no arguments, from any cwd, touches no network,
 # needs bash + coreutils + python3, and exits non-zero on failure.
+#
+# Mutation recipes (generic harness:
+# ~/GitHub/dev/managed-service/cogni-service/scripts/mutation-check.sh):
+#   --file cogni-workspace/skills/text-to-narrative/scripts/validate-narrative.py \
+#     --expr 's{cites = body_cites if stage == "body" else opening_cites \+ body_cites}{cites = opening_cites + body_cites}' \
+#     --test 'bash cogni-workspace/tests/test-narrative-validate.sh' --case NV21
+#   --file cogni-workspace/skills/text-to-narrative/scripts/validate-narrative.py \
+#     --expr 's{gate\("T0", not opening,}{gate\("T0", True,}' \
+#     --test 'bash cogni-workspace/tests/test-narrative-validate.sh' --case NV19
+#
+# The first reverts the body-stage E1 restriction so it counts TL;DR markers again: the
+# 14-body-marker narrative then clears the floor of 15 on 2 TL;DR repeats, NV21 goes RED
+# and every other case stays green. The second defeats T0's absence assertion, so NV19
+# (T0 red while TL;DR prose is still present) goes RED while NV20 stays green.
 
 set -u
 
@@ -44,10 +58,16 @@ for f in "$VALIDATOR" "$FIXTURE" "$CONTRACT"; do
 done
 pass "NV0 inputs readable"
 
-# run <narrative> -> sets OUT (json) and RC
+# run <narrative> [stage] -> sets OUT (json) and RC. An empty or absent stage invokes the
+# validator with no --stage flag at all, so every pre-existing call site is unchanged.
 run() {
-  OUT="$(python3 "$VALIDATOR" --narrative "$1" --contract "$CONTRACT" --json 2>&1)"
-  RC=$?
+  if [ -n "${2:-}" ]; then
+    OUT="$(python3 "$VALIDATOR" --narrative "$1" --contract "$CONTRACT" --stage "$2" --json 2>&1)"
+    RC=$?
+  else
+    OUT="$(python3 "$VALIDATOR" --narrative "$1" --contract "$CONTRACT" --json 2>&1)"
+    RC=$?
+  fi
 }
 
 # gate_status <json> <gate id> -> pass|fail|absent
@@ -75,9 +95,10 @@ else
   fail "NV1 the conforming fixture passes every gate (exit $RC)"
 fi
 
-# expect_red <id> <gate> <mutant path> — the mutant must exit non-zero AND name the gate red
+# expect_red <id> <gate> <mutant path> [stage] — the mutant must exit non-zero AND name
+# the gate red
 expect_red() {
-  run "$3"
+  run "$3" "${4:-}"
   status="$(gate_status "$OUT" "$2")"
   if [ "$RC" -ne 0 ] && [ "$status" = "fail" ]; then
     pass "$1 mutant turns $2 red"
@@ -234,6 +255,117 @@ filler = " ".join("Filler word number %d keeps the element growing." % i for i i
 open(dst, "w", encoding="utf-8").write(head.rstrip("\n") + "\n\n" + filler + "\n" + sep + tail)
 PY5
 expect_red NV18 C2 "$TMPROOT/fatelement.md"
+
+# expect_gate <id> <gate> <narrative> <want status> [stage] — assert one gate's status by
+# name. Used where the discriminating signal is a single gate and the exit code is not: a
+# body-stage mutant reddens several gates at once, and `absent` has no exit code at all.
+expect_gate() {
+  run "$3" "${5:-}"
+  status="$(gate_status "$OUT" "$2")"
+  if [ "$status" = "$4" ]; then
+    pass "$1 $2 is $4 on $(basename "$3")${5:+ at the $5 stage}"
+  else
+    printf '%s\n' "    gate=$2 want=$4 got=$status exit=$RC"
+    fail "$1 $2 is $4 on $(basename "$3")${5:+ at the $5 stage}"
+  fi
+}
+
+# ---------------------------------------------------------------- NV19 / NV20 T0 both ways
+# T0 is the body stage's whole point: the four-element argument is graded BEFORE the
+# Executive TL;DR exists. The tracked fixture carries a TL;DR, so it must go red; the same
+# narrative with only that prose removed must go green. A T0 that cannot do both is not a
+# gate. The mutant keeps the H1, the italic subtitle and the `---` rule — only the TL;DR
+# paragraph between the subtitle and the first `##` is dropped.
+python3 - "$FIXTURE" "$TMPROOT/notldr.md" <<'PY6'
+import sys
+src, dst = sys.argv[1], sys.argv[2]
+lines = open(src, encoding="utf-8").read().splitlines()
+idx = 1
+while idx < len(lines) and lines[idx].strip() != "---":
+    idx += 1
+fm_end = idx
+h2 = [k for k, l in enumerate(lines) if l.startswith("## ")]
+if not h2:
+    sys.exit(1)
+first_h2 = h2[0]
+out = []
+for k, line in enumerate(lines):
+    if fm_end < k < first_h2:
+        s = line.strip()
+        keep = (s == "" or s == "---" or s.startswith("# ")
+                or (s.startswith("*") and s.endswith("*") and s.count("*") == 2))
+        if not keep:
+            continue
+    out.append(line)
+open(dst, "w", encoding="utf-8").write("\n".join(out) + "\n")
+PY6
+expect_gate NV19 T0 "$FIXTURE" fail body
+expect_gate NV20 T0 "$TMPROOT/notldr.md" pass body
+
+# ---------------------------------------------------------------- NV21 / NV22 the E1 discriminator
+# The defect the two stages exist to separate: a narrative whose BODY is under-evidenced,
+# padded over the floor of 15 by TL;DR repeats. The tracked fixture carries 19 body markers
+# and 2 TL;DR repeats of [1]; dropping the last 5 body markers leaves 14 + 2 = 16. The body
+# stage must fail E1 on the body's 14, the final stage must pass on the total of 16. The
+# assertion is per gate id, never on the exit code: deleting markers also reddens E4 and X1.
+python3 - "$FIXTURE" "$TMPROOT/fourteen.md" <<'PY7'
+import sys, re
+src, dst = sys.argv[1], sys.argv[2]
+t = open(src, encoding="utf-8").read()
+marker = "\n## "
+if marker not in t:
+    sys.exit(1)
+cut = t.index(marker)
+head, body = t[:cut], t[cut:]
+cit = re.compile(r"<sup>\[(\d+)\]\(([^)]+)\)</sup>")
+found = list(cit.finditer(body))
+if len(found) != 19:
+    sys.exit(1)
+for m in reversed(found[-5:]):
+    body = body[:m.start()] + body[m.end():]
+open(dst, "w", encoding="utf-8").write(head + body)
+PY7
+expect_gate NV21 E1 "$TMPROOT/fourteen.md" fail body
+expect_gate NV22 E1 "$TMPROOT/fourteen.md" pass
+
+# ---------------------------------------------------------------- NV23 / NV24 T1 and T2 withheld
+# At the body stage T1 and T2 are ABSENT from data.gates, not reported as passing — a gate
+# that green-lights a TL;DR which does not exist yet is an unfalsifiable pass.
+expect_gate NV23 T1 "$FIXTURE" absent body
+expect_gate NV24 T2 "$FIXTURE" absent body
+
+# ---------------------------------------------------------------- NV25 / NV26 data.stage
+# stage_value <json> -> the reported stage, or `missing`
+stage_value() {
+  printf '%s' "$1" | python3 -c '
+import json, sys
+try:
+    data = json.load(sys.stdin)
+except Exception:
+    print("unparseable"); sys.exit(0)
+print(data.get("data", {}).get("stage", "missing"))
+'
+}
+for pair in ":final:NV25" "body:body:NV26"; do
+  st="${pair%%:*}"; rest="${pair#*:}"; want="${rest%%:*}"; cid="${rest#*:}"
+  run "$FIXTURE" "$st"
+  got="$(stage_value "$OUT")"
+  if [ "$got" = "$want" ]; then
+    pass "$cid data.stage is $want${st:+ under --stage $st}"
+  else
+    printf '%s\n' "    want=$want got=$got"
+    fail "$cid data.stage is $want${st:+ under --stage $st}"
+  fi
+done
+
+# ---------------------------------------------------------------- NV27 --help documents the flag
+HELP_OUT="$(python3 "$VALIDATOR" --help 2>&1)"
+if printf '%s' "$HELP_OUT" | grep -q -- "--stage" && printf '%s' "$HELP_OUT" | grep -q "final"; then
+  pass "NV27 --help documents --stage and names final as the default"
+else
+  printf '%s\n' "$HELP_OUT" | sed 's/^/    /'
+  fail "NV27 --help documents --stage and names final as the default"
+fi
 
 # ---------------------------------------------------------------- NV14 / NV15 the two end-to-end fixtures pass
 for pair in "strategic-choice-en.md:strategic-choice:NV14" "consulting-problem-solving-de.md:consulting-problem-solving:NV15"; do


### PR DESCRIPTION
Closes #1899.

## Summary
- `validate-narrative.py` gains `--stage body|final`, defaulting to `final`, so every existing invocation and all three tracked fixtures are unchanged.
- New gate **T0** (body stage only): no TL;DR prose sits between the `*{Subtitle}*` line and the first `##`. This is what makes the documented "TL;DR written last" order enforceable rather than aspirational.
- At `--stage body`, E1 counts **body** markers only — the floor of 15 must be met by the four `##` elements alone — and T1/T2 are **absent** from `data.gates`, not reported as passing and not given a `skipped` status.
- X1's `cited` set is narrowed to the body's citation numbers. `all_numbers` (and therefore `data.source_count`) is deliberately left untouched, so no unmodified fixture shifts. The change is equivalent whenever T2 passes and strictly more honest when it does not — and it makes the code match the docstring, which already said "every body citation number".
- `data.stage` is emitted in the JSON envelope for both stages; an unrecognized `--stage` is rejected by argparse and exits 2.
- `references/validation.md` documents T0, marks T1/T2/J2 and the TL;DR half of F3 final-stage-only, carries both staged invocation snippets, and states the TL;DR **generation rule**: an LLM synthesis pass over the validated body, never deterministic extraction, discarded and re-synthesized if the body changes afterwards.
- `SKILL.md` Pass 2 no longer writes the TL;DR — it ends with the body stable — and Phase 5 became two stages. The three-cycle attempt bound survives and now explicitly spans both stages rather than allowing three per stage.
- `tests/test-narrative-validate.sh` gains NV19-NV27 and its first mutation-recipe header block.

## Verification actually run on this branch
- **Fixture parity, default stage:** all three fixtures under `tests/fixtures/narrative-output/` report **identical gate ids, identical statuses, identical exit codes and identical `source_count`** against the base validator. Compared programmatically, not by eye.
- **T0 goes both ways:** `fail` on the unmodified fixture at body stage, `pass` on the same narrative with only the TL;DR paragraph removed.
- **T1/T2 withheld:** `absent` at body stage, `pass` at final stage.
- **The discriminator:** the fixture with its last 5 body markers deleted (14 body markers + 2 TL;DR repeats of `[1]`) reports E1 `fail` at body stage and E1 `pass` at final stage.
- **Couplings preserved:** `tests/test-brief-density-sync.sh` still imports `DEFAULT_TARGET` / `TLDR_WORDS` / `TLDR_SENTENCES` as module-level names, and the literal `target * 0.85, target * 1.15` still matches its source-text regex.
- `bash cogni-workspace/tests/test-narrative-validate.sh` → 28/28 cases pass, exit 0.
- `python3 scripts/run-plugin-tests.py --filter cogni-workspace` → **33/33 suites pass**, exit 0.

## Scope decisions
- **In:** exactly the four files the issue names. No version bump (the post-merge workflow owns it), no `marketplace.json`, no arc contracts, no `references/density-ceilings.md`.
- **Full scope** — every acceptance criterion is delivered here; nothing deferred.
- **Out (hard fence, verified):** `copywriter` still named as `copywriter`; Pass 4 still calls `readability.sh` against the `readability.yml` band; no `${CLAUDE_PLUGIN_ROOT}` → `<skill-root>` rewrite; `allowed-tools` frontmatter and `evals/evals.json` intact; `--geography` still bound to `supported-markets-registry.json` codes; `arc-registry.md` keeps its `## Contents` block; no `agents/openai.yaml`, no `assets/icon.svg`.
- **Overlap note:** open issue #1903 edits the same `references/validation.md` region (the TL;DR contract, J2, F3). This PR lands that section first, so #1903's eventual change must preserve the stage marks added here rather than restore the pre-change paragraph.

## Open questions

- **This PR was composed as a 10-member batch and collapsed to a single member.** The maintainer ruled at 18:37-18:49Z that #1899-#1904 are "**Not batched — one PR each**" (10-11 acceptance criteria apiece, S2/S3 feature work on the `text-to-narrative` pipeline; folding them into a batch would produce an unreviewable PR), and separately reassigned #1890/#1891/#1895 to batch B3, and ruled #1892 cross-repo. Nine of ten composed members were therefore skipped and only #1899 was authored. This is a **standalone single-issue PR** and closes nothing but #1899 — not a batch PR, and the nine skipped issues are not members of it.
- No question is open on the change itself; every acceptance criterion of #1899 is delivered here.

## Mutation recipe

```bash
bash ~/GitHub/dev/managed-service/cogni-service/scripts/mutation-check.sh --root . \
  --file cogni-workspace/skills/text-to-narrative/scripts/validate-narrative.py \
  --expr 's{cites = body_cites if stage == "body" else opening_cites \+ body_cites}{cites = opening_cites + body_cites}' \
  --test 'bash cogni-workspace/tests/test-narrative-validate.sh' --case NV21
```

```bash
bash ~/GitHub/dev/managed-service/cogni-service/scripts/mutation-check.sh --root . \
  --file cogni-workspace/skills/text-to-narrative/scripts/validate-narrative.py \
  --expr 's{gate\("T0", not opening,}{gate\("T0", True,}' \
  --test 'bash cogni-workspace/tests/test-narrative-validate.sh' --case NV19
```

Both were replayed on this branch and returned `verdict: guard_verified` (`mutated_result: red`, `restored_result: green`). Each mutation was also applied by hand and the full suite re-run: the first reddens **only** NV21, the second reddens **only** NV19 — so each new case is proven load-bearing and neither recipe is a blunt instrument that reddens the suite wholesale.