### PR TITLE
cogni-trends: expose complete token-set coupling

### DIFF
--- a/cogni-trends/scripts/project-status.sh
+++ b/cogni-trends/scripts/project-status.sh
@@ -855,6 +855,8 @@ case "$PHASE" in
   revision)
     add_action "cogni-trends:verify-trend-report" "${REVISION_CHANGES:-0} claims resolved — re-enter the verify pipeline to apply corrections and removals"
     ;;
+  # cogni-trends/tests/test-project-status.sh case
+  # project-status-04-next-actions-token-set pins this arm's complete dispatch set.
   complete)
     if [ "$HAS_BOOKLET" = "false" ]; then
       add_action "cogni-trends:trend-booklet" "Build the comprehensive TIPS catalog of all candidates as a companion to the report"


### PR DESCRIPTION
Closes #1740

## Summary
- Keep the maintainer-ruled whole-array equality for the `complete)` next-actions set.
- Add a code-side comment at the `complete)` arm naming the pinning suite and case.
- Leave the assertion shape and dispatch behavior unchanged.

## Verification
- `bash cogni-trends/tests/test-project-status.sh` — passed.
- Case-id uniqueness census — empty.
- `python3 scripts/run-plugin-tests.py --filter cogni-trends` — 4/4 suites passed.
- `python3 scripts/check-breadcrumbs.py` — zero violations.
- `python3 scripts/check-version-bump.py` — clean.
- `git diff --check` — clean.
- Mutation probes — copywriter typo, sibling rename, and sibling drop each made the pinned case red and restored green.