### PR TITLE
Sync CONTRIBUTING core-plugin roster with marketplace

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,14 +6,16 @@ insight-wave has two types of contributions with different terms. Please read th
 
 Core plugins are maintained by insight-wave and licensed under Apache-2.0:
 
+- cogni-knowledge
+- cogni-consult
 - cogni-workspace
 - cogni-trends
-- cogni-consult
-- cogni-consulting (archived — security patches only)
 - cogni-portfolio
-- cogni-visual
 - cogni-marketing
 - cogni-sales
+- cogni-website
+
+_This list mirrors the core plugins in [`.claude-plugin/marketplace.json`](.claude-plugin/marketplace.json) (8 plugins); update this list, [`CLA.md`](CLA.md), and the marketplace roster together when the roster changes._
 
 ### CLA Requirement
 


### PR DESCRIPTION
Closes #1600.

## Summary
- Replace the stale Apache-2.0 core-plugin list in `CONTRIBUTING.md` with the eight plugins named by `.claude-plugin/marketplace.json`.
- Remove retired or nonexistent roster entries and add the missing marketplace plugins.
- Add the same roster-synchronization declaration used by the CLA so future changes update all three surfaces together.

## Scope decisions
- Treat `.claude-plugin/marketplace.json` `plugins[].name` as the authoritative roster, per the recorded maintainer ruling.
- Keep `CLA.md` unchanged because it already contains the correct eight-plugin set and synchronization declaration.
- Do not add an archived or retired-plugin annex and do not change plugin versions or marketplace metadata.

Plan record: https://github.com/cogni-work/insight-wave/issues/1600#issuecomment-5600237886

## Test plan
- [x] Run `git diff --check`.
- [x] Confirm the `CONTRIBUTING.md` core-plugin bullets match `.claude-plugin/marketplace.json` `plugins[].name` exactly.
- [x] Confirm `CLA.md` remains unchanged and names the same eight plugins.
- [x] Run all 161 repository plugin test suites.