### PR TITLE
Correct Excalidraw hook twin plugin name

### DIFF
--- a/cogni-portfolio/hooks/ensure-excalidraw-canvas.sh
+++ b/cogni-portfolio/hooks/ensure-excalidraw-canvas.sh
@@ -14,7 +14,7 @@
 #   No sticky /tmp flags — always checks actual WebSocket state.
 #
 # Start serialisation:
-#   cogni-visual and cogni-portfolio ship byte-identical copies of this script
+#   cogni-workspace and cogni-portfolio ship byte-identical copies of this script
 #   and register the same unqualified mcp__excalidraw__* PreToolUse matcher, so
 #   on a machine carrying both plugins every tool call dispatches two of these
 #   in parallel. The port probe below is a check, not a mutual-exclusion

--- a/cogni-workspace/hooks/ensure-excalidraw-canvas.sh
+++ b/cogni-workspace/hooks/ensure-excalidraw-canvas.sh
@@ -14,7 +14,7 @@
 #   No sticky /tmp flags — always checks actual WebSocket state.
 #
 # Start serialisation:
-#   cogni-visual and cogni-portfolio ship byte-identical copies of this script
+#   cogni-workspace and cogni-portfolio ship byte-identical copies of this script
 #   and register the same unqualified mcp__excalidraw__* PreToolUse matcher, so
 #   on a machine carrying both plugins every tool call dispatches two of these
 #   in parallel. The port probe below is a check, not a mutual-exclusion


### PR DESCRIPTION
Closes #1702

## Summary
- Replace the retired `cogni-visual` name with `cogni-workspace` in both Excalidraw hook copies.
- Preserve the remaining serialization comment and all executable behavior unchanged.
- Keep the two hook scripts byte-identical.

## Scope decisions
- Modify only line 17 in the two existing `ensure-excalidraw-canvas.sh` copies.
- Do not add or modify tests or guards, and leave `scripts/retired-plugins.json` unchanged because its retired-prefix entry remains correct.
- Do not change plugin versions; post-merge automation owns patch bumps.

## Test plan
- [x] Confirm both diffs contain only the identical line-17 comment replacement.
- [x] Run `cmp -s cogni-portfolio/hooks/ensure-excalidraw-canvas.sh cogni-workspace/hooks/ensure-excalidraw-canvas.sh`.
- [x] Run `python3 scripts/check-external-dispatch.py` and confirm zero violations.
- [x] Run `python3 scripts/run-plugin-tests.py` and confirm all plugin suites pass.