### PR TITLE
Document retirement-ledger scope decision

### DIFF
--- a/scripts/check-retirement-ledger.py
+++ b/scripts/check-retirement-ledger.py
@@ -11,6 +11,17 @@ phrase (it was re-claimed, so nothing was lost), or
 a non-empty `reason` (the retirement was recorded). A phrase in neither is a
 violation.
 
+SCOPE IS DELIBERATELY COGNI-WORKSPACE-ONLY. Other plugin skill trees are out
+of scope because every skill retirement observed in this repository has so far
+occurred in cogni-workspace. Per-plugin ledgers would add empty records before
+those plugins have retirement events to account for; one shared repo-wide
+ledger would instead break the current co-location and the consumers bound to
+the workspace ledger's path. Either expansion would add machinery for a
+hypothetical second case and dilute this guard's useful hard clean zero. Revisit
+the boundary when a plugin outside cogni-workspace first retires a skill or
+drops a trigger phrase; that concrete second case can then determine whether
+per-plugin ledgers or a shared ledger is the better generalization.
+
 WHY THIS IS A SEPARATE GUARD AND NOT ANOTHER ARM OF C10. Case C10 in
 `cogni-workspace/tests/test-skill-trigger-phrases.sh` cross-checks the ledger
 against the live tree in both directions: `comm -23` finds a phrase recorded


### PR DESCRIPTION
Closes #1763.

Resolution plan: https://github.com/cogni-work/insight-wave/issues/1763#issuecomment-5603562356

## Summary
- Record that the retirement-ledger gate intentionally covers only `cogni-workspace`.
- Document why per-plugin ledgers and a shared repo-wide ledger are rejected for the current repository state.
- State the concrete event that should trigger reconsideration of the boundary.

## Scope decisions
- Modify only the module docstring in `scripts/check-retirement-ledger.py`; all constants and executable behavior remain unchanged.
- Keep every plugin tree outside `cogni-workspace` deliberately out of scope because no other plugin has yet exercised this retirement pattern, widening now would add empty-ledger or path-binding machinery and dilute the guard's hard clean zero.
- Keep the rationale single-sited in the guard docstring, where the root registry already directs readers for mechanics.
- Defer nothing.

## Deviations from acceptance criteria
- The extension-only criterion is not applicable because the recorded decision is to keep the gate scoped to `cogni-workspace`.

## Test plan
- [ ] Confirm the diff changes only the module docstring in `scripts/check-retirement-ledger.py`.
- [ ] Run `bash tests/test_check_retirement_ledger.sh`.
- [ ] Confirm `SKILLS_REL`, `LEDGER_REL`, executable behavior, CI configuration, and plugin versions are unchanged.

## Mutation recipe
```sh
bash "$HOME/.claude/plugins/marketplaces/managed-service/cogni-service/scripts/mutation-check.sh" --root . \
  --file scripts/check-retirement-ledger.py \
  --expr 's/if keys is not UNPARSEABLE //' \
  --test 'bash tests/test_check_retirement_ledger.sh' \
  --case retirement-ledger-14-unparseable-live-at-head
```
