### PR TITLE
Clarify external-dispatch mutation-test comments

### DIFF
--- a/scripts/check-external-dispatch.py
+++ b/scripts/check-external-dispatch.py
@@ -213,10 +213,10 @@ def load_registry(path):
 
     prefixes = data.get("retired_prefixes") if isinstance(data, dict) else None
 
-    # Mutation-recipe invariant: keep the next line exactly as written, on ONE
-    # physical line, and do not repeat its text anywhere else in this file — the
-    # recorded recipe rewrites the FIRST match only (perl -0pi, no /g), so a second
-    # occurrence would mutate the wrong site and report the guard as decorative.
+    # Guard-maintenance invariant: keep the next line on ONE physical line, and do
+    # not repeat its text anywhere else in this file. Its uniqueness keeps this
+    # validation gate unambiguous to inspect, while ed14 behaviorally exercises
+    # empty-list rejection.
     if not isinstance(prefixes, list) or not prefixes:
         raise RuntimeError(
             "retired-plugin registry {} must carry a non-empty "

--- a/tests/test_check_external_dispatch.sh
+++ b/tests/test_check_external_dispatch.sh
@@ -322,8 +322,8 @@ assert d['error'], d
 "
 
 # --- R3: empty prefix list -> exit 2 ---------------------------------------
-# Kept as its own case rather than folded into R4's table: the recorded mutation
-# recipe targets `--case ed14`, which needs a separately-labelled line.
+# Kept as its own case rather than folded into R4's table: the separately-labelled
+# ed14 line makes empty-list anti-vacuity failures independently identifiable.
 run_reg r3 '{"retired_prefixes": []}' "$CLEAN_REL"
 check "ed14 empty registry exits 2 and never 0 (base exits 0 here)" \
   "$([ "$CODE" -eq 2 ] && echo 0 || echo 1)"
@@ -429,10 +429,9 @@ assert o['match']=='cogni-beta:no-such-thing', o
 assert o['target']=='no-such-thing', o
 "
 
-# ed22 is the recorded mutation-recipe case. It asserts the arm PRODUCED a
-# finding, so neutering the resolvability test (every slug looks resolvable,
-# the arm empties) turns this line red. A case asserting a clean zero would
-# stay green under that mutation and prove nothing.
+# ed22 attributes the produced finding to the unresolved-target arm rather than
+# the retired-prefix arm. Its positive-finding shape makes that attribution
+# observable; a case asserting only a clean zero would not.
 assert_json "ed22 the finding is attributed to the unresolved-target arm" "$OUT" "
 import json,sys
 d=json.load(sys.stdin)


### PR DESCRIPTION
Closes #1844.

## Summary

- Replace the unsupported mutation-recipe claim above the retired-prefixes validation gate with truthful maintenance guidance.
- Describe `ed14` as an independently identifiable anti-vacuity assertion and `ed22` as an arm-attribution assertion.
- Preserve executable behavior, every existing `edNN` id, both unique gate literals, and the valid `ed34` mutation control.

## Scope decisions

This is a comment-only correction in the guard and its focused test. Adding recipes for the three stale claims would add maintenance surface without improving the requested truthfulness fix.

Resolution plan: https://github.com/cogni-work/insight-wave/issues/1844#issuecomment-5605203879

## Test plan

- [x] `bash tests/test_check_external_dispatch.sh` — 41/41 passed.
- [x] `python3 scripts/run-plugin-tests.py` — 161/161 suites passed.
- [x] The recorded `ed34` mutation went red and restored green.
- [x] Both protected guard literals occur exactly once.

## Mutation recipe

```bash
bash /Users/stephandehaas/.codex/plugins/cache/managed-service/cogni-service/0.0.518/scripts/mutation-check.sh --root . \
  --file scripts/check-external-dispatch.py \
  --expr 's/if slug in resolvable\.get\(plugin, \(\)\):/if any(slug in owned for owned in resolvable.values()):/' \
  --test 'bash tests/test_check_external_dispatch.sh' --case ed34
```