### PR TITLE
repo: follow linked skill reference indexes

### DIFF
--- a/scripts/check-skill-spec.py
+++ b/scripts/check-skill-spec.py
@@ -73,12 +73,17 @@ SIX ARMS, in two classes.
       best-practices rule is "keep file references one level deep from
       SKILL.md"; the mechanical proxy is the directory tree, because a file
       two directories down is one the model reaches through an intermediate
-      listing rather than a direct pointer.
+      listing rather than a direct pointer. A directly linked top-level index
+      can make resources discoverable for arm (6), but does not make a nested
+      directory satisfy this separate depth rule; flattening is the remedy.
 
   (6) UNREFERENCED-RESOURCE -- a file under `references/`, `scripts/`,
       `examples/`, `schemas/` or `assets/` whose basename appears nowhere in
-      SKILL.md. The standard's stated failure mode is that the model does not
-      know the file exists. Matching on basename rather than full path is
+      SKILL.md or in a `references/00-index.md` that SKILL.md links directly.
+      The standard's stated failure mode is that the model does not know the
+      file exists. The single index hop supports deliberate progressive
+      disclosure without recursively treating every resource it names as a
+      router. Matching resources on basename rather than full path is
       deliberate: this repo cites both `references/x.md` and bare `x.md` in
       resource tables, and the basename is what both forms share.
 
@@ -225,6 +230,18 @@ def finding(skill, arm, file, detail):
     return {"skill": skill, "arm": arm, "file": file, "detail": detail}
 
 
+def reachable_resource_text(skill_dir, skill_text):
+    """SKILL.md plus one directly linked conventional reference index."""
+    index_ref = "references/00-index.md"
+    if index_ref not in skill_text:
+        return skill_text
+    index_path = os.path.join(skill_dir, "references", "00-index.md")
+    if not os.path.isfile(index_path):
+        return skill_text
+    with open(index_path, encoding="utf-8", errors="replace") as fh:
+        return skill_text + "\n" + fh.read()
+
+
 def grade_skill(root, plugin, skill_dir):
     """All findings for one skill directory, before baseline suppression."""
     skill = os.path.basename(skill_dir)
@@ -279,9 +296,10 @@ def grade_skill(root, plugin, skill_dir):
                 nested = os.path.relpath(os.path.join(dirpath, d), root)
                 out.append(finding(skill, "reference-depth", nested,
                     "a directory nested inside references/ -- the standard keeps file "
-                    "references one level deep from SKILL.md; flatten it or give it an index "
-                    "SKILL.md links directly"))
+                    "references one level deep from SKILL.md; flatten the nested directory "
+                    "(an index can expose resources, but does not change the depth rule)"))
 
+    resource_text = reachable_resource_text(skill_dir, text)
     for sub in RESOURCE_DIRS:
         top = os.path.join(skill_dir, sub)
         if not os.path.isdir(top):
@@ -293,11 +311,12 @@ def grade_skill(root, plugin, skill_dir):
             for fname in sorted(filenames):
                 if fname.startswith(".") or fname.endswith(".pyc"):
                     continue
-                if fname not in text:
+                if fname not in resource_text:
                     out.append(finding(skill, "unreferenced-resource",
                         os.path.relpath(os.path.join(dirpath, fname), root),
-                        "never mentioned in SKILL.md -- the model does not know the file "
-                        "exists; name it in a resource table with when to read it"))
+                        "never mentioned in SKILL.md or its directly linked "
+                        "references/00-index.md -- the model does not know the file exists; "
+                        "name it in a reachable resource table with when to read it"))
     return out
 
 

--- a/tests/test_check_skill_spec.sh
+++ b/tests/test_check_skill_spec.sh
@@ -330,18 +330,34 @@ fi
 T="$(new_tree envelope)"
 add_plugin "$T" cogni-alpha
 add_skill "$T" cogni-alpha good-skill
-mkdir -p "$T/cogni-alpha/skills/good-skill/references"
-printf 'orphan\n' > "$T/cogni-alpha/skills/good-skill/references/orphan.md"
 run_guard "$T"
 if python3 -c "
 import json, sys
 d = json.load(open(sys.argv[1]))
 assert set(d) == {'success', 'data', 'error'}, sorted(d)
-assert d['success'] is False and d['error'] == ''
+assert d['success'] is True and d['error'] == ''
 s = d['data']['summary']
 for k in ('total', 'plugins_discovered', 'skills_scanned', 'baseline_size', 'suppressed_by_baseline'):
     assert isinstance(s[k], int), k
 assert s['skills_scanned'] == 1, s['skills_scanned']
+" "$OUT" 2>/dev/null; then
+  pass "skill-spec-21-envelope-shape the JSON envelope carries success, data and error"
+else
+  fail "skill-spec-21-envelope-shape the JSON envelope carries success, data and error"
+fi
+
+# --- 22  findings carry their structured diagnostic fields --------------------
+T="$(new_tree findingdetail)"
+add_plugin "$T" cogni-alpha
+add_skill "$T" cogni-alpha good-skill
+mkdir -p "$T/cogni-alpha/skills/good-skill/references"
+printf 'orphan\n' > "$T/cogni-alpha/skills/good-skill/references/orphan.md"
+run_guard "$T"
+rc=$?
+if [ "$rc" -eq 1 ] && python3 -c "
+import json, sys
+d = json.load(open(sys.argv[1]))
+assert d['success'] is False and d['error'] == ''
 findings = d['data']['findings']
 assert len(findings) == 1, findings
 finding = findings[0]
@@ -349,9 +365,9 @@ assert finding['arm'] == 'unreferenced-resource', finding
 assert finding['file'] == 'cogni-alpha/skills/good-skill/references/orphan.md', finding
 assert isinstance(finding['detail'], str) and finding['detail'].strip(), finding
 " "$OUT" 2>/dev/null; then
-  pass "skill-spec-21-envelope-shape the JSON envelope carries success, data, error and structured finding detail"
+  pass "skill-spec-22-finding-detail-shape a finding names its arm, file and non-empty detail"
 else
-  fail "skill-spec-21-envelope-shape the JSON envelope carries success, data, error and structured finding detail"
+  fail "skill-spec-22-finding-detail-shape a finding names its arm, file and non-empty detail"
 fi
 
 printf '%s\n' "---"

--- a/tests/test_check_skill_spec.sh
+++ b/tests/test_check_skill_spec.sh
@@ -221,6 +221,28 @@ printf '\n| **named.md** | 2 | rules |\n' >> "$T/cogni-alpha/skills/good-skill/S
 assert_case "skill-spec-13-basename-counts-as-reference" 0 - "$T" - \
   "a resource cited by bare basename in a table passes"
 
+# --- 13a a directly linked reference index exposes one sibling resource -------
+T="$(new_tree linkedindex)"
+add_plugin "$T" cogni-alpha
+add_skill "$T" cogni-alpha good-skill
+mkdir -p "$T/cogni-alpha/skills/good-skill/references"
+printf 'Route through `routed.md`.\n' > "$T/cogni-alpha/skills/good-skill/references/00-index.md"
+printf 'routed\n' > "$T/cogni-alpha/skills/good-skill/references/routed.md"
+printf '\nREAD: `references/00-index.md`.\n' >> "$T/cogni-alpha/skills/good-skill/SKILL.md"
+assert_case "skill-spec-13a-linked-index-reaches-resource" 0 - "$T" - \
+  "a resource named by a directly linked references index passes"
+
+# --- 13b an unlinked reference index cannot launder a sibling resource --------
+T="$(new_tree unlinkedindex)"
+add_plugin "$T" cogni-alpha
+add_skill "$T" cogni-alpha good-skill
+mkdir -p "$T/cogni-alpha/skills/good-skill/references"
+printf 'Route through `laundered.md`.\n' > "$T/cogni-alpha/skills/good-skill/references/00-index.md"
+printf 'laundered\n' > "$T/cogni-alpha/skills/good-skill/references/laundered.md"
+assert_case "skill-spec-13b-unlinked-index-cannot-launder" 1 \
+  "cogni-alpha/skills/good-skill/references/laundered.md" "$T" - \
+  "a resource named only by an unlinked index is still reported"
+
 # --- 14  a baselined ratchet finding is suppressed ----------------------------
 T="$(new_tree baselined)"
 add_plugin "$T" cogni-alpha

--- a/tests/test_check_skill_spec.sh
+++ b/tests/test_check_skill_spec.sh
@@ -239,9 +239,19 @@ add_skill "$T" cogni-alpha good-skill
 mkdir -p "$T/cogni-alpha/skills/good-skill/references"
 printf 'Route through `laundered.md`.\n' > "$T/cogni-alpha/skills/good-skill/references/00-index.md"
 printf 'laundered\n' > "$T/cogni-alpha/skills/good-skill/references/laundered.md"
-assert_case "skill-spec-13b-unlinked-index-cannot-launder" 1 \
-  "cogni-alpha/skills/good-skill/references/laundered.md" "$T" - \
-  "a resource named only by an unlinked index is still reported"
+run_guard "$T"
+rc=$?
+if [ "$rc" -eq 1 ] && python3 -c "
+import json, sys
+d = json.load(open(sys.argv[1]))
+want = ('unreferenced-resource', 'cogni-alpha/skills/good-skill/references/laundered.md')
+got = {(f.get('arm'), f.get('file')) for f in d['data']['findings']}
+assert want in got, (want, sorted(got))
+" "$OUT" 2>/dev/null; then
+  pass "skill-spec-13b-unlinked-index-cannot-launder a resource named only by an unlinked index is still reported"
+else
+  fail "skill-spec-13b-unlinked-index-cannot-launder the finding must name both the unreferenced-resource arm and laundered sibling path"
+fi
 
 # --- 14  a baselined ratchet finding is suppressed ----------------------------
 T="$(new_tree baselined)"
@@ -320,20 +330,28 @@ fi
 T="$(new_tree envelope)"
 add_plugin "$T" cogni-alpha
 add_skill "$T" cogni-alpha good-skill
+mkdir -p "$T/cogni-alpha/skills/good-skill/references"
+printf 'orphan\n' > "$T/cogni-alpha/skills/good-skill/references/orphan.md"
 run_guard "$T"
 if python3 -c "
 import json, sys
 d = json.load(open(sys.argv[1]))
 assert set(d) == {'success', 'data', 'error'}, sorted(d)
-assert d['success'] is True and d['error'] == ''
+assert d['success'] is False and d['error'] == ''
 s = d['data']['summary']
 for k in ('total', 'plugins_discovered', 'skills_scanned', 'baseline_size', 'suppressed_by_baseline'):
     assert isinstance(s[k], int), k
 assert s['skills_scanned'] == 1, s['skills_scanned']
+findings = d['data']['findings']
+assert len(findings) == 1, findings
+finding = findings[0]
+assert finding['arm'] == 'unreferenced-resource', finding
+assert finding['file'] == 'cogni-alpha/skills/good-skill/references/orphan.md', finding
+assert isinstance(finding['detail'], str) and finding['detail'].strip(), finding
 " "$OUT" 2>/dev/null; then
-  pass "skill-spec-21-envelope-shape the JSON envelope carries success, data and error"
+  pass "skill-spec-21-envelope-shape the JSON envelope carries success, data, error and structured finding detail"
 else
-  fail "skill-spec-21-envelope-shape the JSON envelope carries success, data and error"
+  fail "skill-spec-21-envelope-shape the JSON envelope carries success, data, error and structured finding detail"
 fi
 
 printf '%s\n' "---"


### PR DESCRIPTION
Closes #1879.

## Summary
- Grade resource reachability against `SKILL.md` plus one directly linked `references/00-index.md`.
- Keep the reference-depth rule separate and truthful: an index exposes resources but does not excuse nested directories.
- Add linked-index and unlinked-index-laundering fixtures without changing existing controls.

## Scope decisions
The implementation recognizes only the conventional `references/00-index.md` hop. Existing direct-basename behavior remains intact, traversal does not recurse, and the shipped baseline needs no changes.

Plan record: https://github.com/cogni-work/insight-wave/issues/1879#issuecomment-5606020831

## Test plan
- [x] `bash tests/test_check_skill_spec.sh`
- [x] `python3 scripts/check-skill-spec.py --root .`
- [x] `python3 scripts/run-plugin-tests.py` (161/161 suites)

## Mutation recipe
```bash
bash "$HOME/.claude/plugins/marketplaces/managed-service/cogni-service/scripts/mutation-check.sh" \
  --root . \
  --file scripts/check-skill-spec.py \
  --expr 's/resource_text = reachable_resource_text\(skill_dir, text\)/resource_text = text/' \
  --test 'bash tests/test_check_skill_spec.sh' \
  --case skill-spec-13a-linked-index-reaches-resource
```