### PR TITLE
docs: re-home the command reference and plugin-selection guide from the retired wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,8 @@ insight-wave/
 ├── docs/                                   # User documentation
 │   ├── getting-started.md                  # Forwarder → workflows/install-to-infographic.md
 │   ├── ecosystem-overview.md               # Plugin landscape and data flow
+│   ├── plugin-selection.md                 # Which plugin handles which task
+│   ├── command-reference.md                # Slash commands and skills per plugin
 │   ├── plugin-guide/                       # Per-plugin deep dives (8 guides)
 │   ├── workflows/                          # Cross-plugin pipeline guides (7 workflows)
 │   ├── architecture/                       # Design philosophy, plugin anatomy, ER diagram

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -1,0 +1,54 @@
+# Command reference: how each plugin is invoked
+
+The one-screen refresher for a plugin you have used before but cannot remember the exact invocation for. It answers *how to call it*; [Plugin selection](plugin-selection.md) answers *which plugin*. Each plugin's full guide under [docs/plugin-guide/](plugin-guide/) covers every skill in depth; this page carries the invocation surface only.
+
+> Hand-maintained from the live tree. A plugin's skills are its `skills/*/SKILL.md` directories and its slash commands are its `commands/*.md` files; when either changes, this page is updated in the same change.
+
+## Two invocation surfaces, and most plugins use only one
+
+Skills are the primary surface across the ecosystem. A skill is invoked by its qualified name, `cogni-trends:trend-scout` for example, or simply by describing the task, since each skill's description carries its own trigger phrases. Slash commands are a thin optional wrapper that only some plugins ship.
+
+Five of the eight plugins ship **no** commands directory at all: cogni-knowledge, cogni-consult, cogni-trends, cogni-portfolio and cogni-website are skill-invoked entirely. Expecting a slash command for one of those is the most common source of "the command does not exist" confusion. [Plugin anatomy](architecture/plugin-anatomy.md) shows how the two surfaces sit on disk.
+
+## Slash commands, by plugin
+
+| Plugin | Slash commands |
+|---|---|
+| cogni-workspace | `/claims`, `/copywrite`, `/review-doc`, `/text-to-narrative`, `/troubleshoot` |
+| cogni-marketing | `/abm`, `/campaign`, `/content-calendar`, `/content-strategy`, `/demand-gen`, `/lead-gen`, `/marketing-dashboard`, `/marketing-resume`, `/marketing-setup`, `/sales-enablement`, `/thought-leadership` |
+| cogni-sales | `/why-change` |
+| cogni-knowledge, cogni-consult, cogni-trends, cogni-portfolio, cogni-website | none, skill-invoked |
+
+## Skills, by plugin
+
+**cogni-knowledge** (21) — `knowledge-setup`, `knowledge-plan`, `knowledge-curate`, `knowledge-fetch`, `knowledge-ingest`, `knowledge-ingest-source`, `knowledge-distill`, `knowledge-compose`, `knowledge-verify`, `knowledge-finalize`, `knowledge-run`, `knowledge-query`, `knowledge-refresh`, `knowledge-refresh-synthesis`, `knowledge-update`, `knowledge-index`, `knowledge-prefill`, `knowledge-lint`, `knowledge-health`, `knowledge-dashboard`, `knowledge-resume`
+
+**cogni-consult** (9) — `consult-setup`, `consult-scope`, `consult-action-fields`, `consult-design-thinking`, `consult-personas`, `consult-project-plan`, `consult-publish`, `consult-dashboard`, `consult-resume`
+
+**cogni-workspace** (11) — `manage-workspace`, `workspace-status`, `workspace-dashboard`, `manage-themes`, `manage-market-registry`, `install-mcp`, `claims`, `cogni-issues`, `text-to-narrative`, `copywriter`, `copy-reader`
+
+**cogni-trends** (9) — `trend-scout`, `value-modeler`, `trend-research`, `trend-synthesis`, `trend-booklet`, `verify-trend-report`, `trends-catalog`, `trends-dashboard`, `trends-resume`
+
+**cogni-portfolio** (21) — `portfolio-setup`, `portfolio-scan`, `portfolio-ingest`, `portfolio-taxonomy`, `products`, `features`, `markets`, `customers`, `propositions`, `solutions`, `packages`, `compete`, `portfolio-communicate`, `portfolio-consolidate`, `portfolio-architecture`, `portfolio-canvas`, `portfolio-verify`, `portfolio-lineage`, `portfolio-dashboard`, `portfolio-resume`, `trends-bridge`
+
+**cogni-marketing** (11) — `marketing-setup`, `content-strategy`, `content-calendar`, `campaign-builder`, `demand-generation`, `lead-generation`, `thought-leadership`, `sales-enablement`, `abm`, `marketing-dashboard`, `marketing-resume`
+
+**cogni-sales** (1) — `why-change`
+
+**cogni-website** (6) — `website-setup`, `website-plan`, `website-build`, `website-legal`, `website-preview`, `website-resume`
+
+## Recurring naming patterns
+
+Once the patterns are visible, most of the table above stops needing lookup.
+
+- **`*-setup`** bootstraps a project for that plugin. Always the first call.
+- **`*-resume`** is the re-entry point across sessions. It shows progress and recommends the next step, so it is the right thing to run when you do not remember where you left off.
+- **`*-dashboard`** renders a self-contained HTML view of current state.
+- **`*-verify`, `*-lint`, `*-health`** are quality gates over entities that already exist, not producers.
+- **`text-to-narrative`** is the one visual path: text in, an executive narrative plus one design brief for Claude Design out. There is no local renderer; Claude Design renders the brief.
+
+## Where to read more
+
+- [Plugin selection](plugin-selection.md) for which plugin owns a task
+- [Ecosystem overview](ecosystem-overview.md) for the plugin landscape and data flow
+- [Workflow guides](workflows/) for the cross-plugin pipelines

--- a/docs/ecosystem-overview.md
+++ b/docs/ecosystem-overview.md
@@ -332,6 +332,8 @@ Seven end-to-end workflow guides document the cross-plugin pipelines:
 ## See Also
 
 - [Install to Infographic](workflows/install-to-infographic.md) — install the marketplace, set up your workspace, and produce your first infographic
+- [Plugin selection](plugin-selection.md) — the routing table from task to plugin
+- [Command reference](command-reference.md) — slash commands and skills per plugin, one screen
 - [er-diagram.md](er-diagram.md) — cross-plugin entity relationship diagram
 - Plugin guides in [docs/plugin-guide/](plugin-guide/) — per-plugin tutorials with worked examples
 - Workflow guides in [docs/workflows/](workflows/) — end-to-end pipeline walkthroughs

--- a/docs/plugin-selection.md
+++ b/docs/plugin-selection.md
@@ -1,0 +1,56 @@
+# Plugin selection: which plugin handles my task
+
+Users usually know what they want to accomplish but not which of the eight plugins owns it. This page is the routing table from task to plugin. Match on what you are trying to *produce*, not on keywords: "I need to make slides" can mean cogni-workspace (a design brief from an existing narrative) or cogni-marketing (campaign materials), and picking wrong sends you down a pipeline that was never going to work. For the exact invocation once you know the plugin, see the [Command reference](command-reference.md).
+
+## Task to plugin
+
+| If the task is… | Start with | Then usually |
+|---|---|---|
+| Research a topic into a cited synthesis that compounds across runs | cogni-knowledge | `cogni-workspace:text-to-narrative` |
+| Fact-check a document against its cited sources | `cogni-workspace:claims` | — |
+| Identify industry trends and their strategic implications | cogni-trends | cogni-portfolio |
+| Define product or service propositions per market, size the opportunity, map competitors | cogni-portfolio | cogni-marketing or cogni-sales |
+| Turn structured content into an executive story with a design brief for slides, a document, an infographic or a web page | `cogni-workspace:text-to-narrative` | `cogni-workspace:copywriter` |
+| Polish a rough draft, or stress-test it against stakeholder personas | `cogni-workspace:copywriter` | `cogni-workspace:copy-reader` |
+| Produce B2B marketing content across channels | cogni-marketing | `cogni-workspace:copywriter` |
+| Build a customer-specific or segment sales pitch | cogni-sales | `cogni-workspace:text-to-narrative` |
+| Generate a deployable customer website from portfolio content | cogni-website | — |
+| Run a structured consulting engagement with a work-breakdown structure | cogni-consult | cogni-knowledge |
+| Set up the workspace, manage themes, install MCP servers, diagnose configuration | cogni-workspace | — |
+| Troubleshoot a plugin failure, or file an issue against a plugin | cogni-workspace (`/troubleshoot`, `cogni-issues`) | — |
+
+## What each plugin owns
+
+**cogni-knowledge** — Wiki-first research that compounds. Each project binds to a knowledge base and runs an inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification. Use it when the knowledge should persist and sharpen rather than die in a one-off report. Pairs with `cogni-workspace:claims` for an opt-in live-source resweep and with `cogni-workspace:text-to-narrative` for the executive story.
+
+**cogni-trends** — Trend scouting and TIPS reporting. Combines the Smarter Service Trendradar with the TIPS framework (Trends, Implications, Possibilities, Solutions) and researches bilingually in EN and DE against regional authorities across eight European and Anglo markets. Feeds cogni-portfolio (investment themes) and cogni-marketing (GTM themes).
+
+**cogni-portfolio** — Portfolio messaging on IS/DOES/MEANS. Market-independent features (IS), market-specific advantages (DOES) and benefits (MEANS), plus TAM/SAM/SOM sizing and competitor analysis across pluggable industry taxonomies. Standalone; pairs with cogni-trends for trend-backed features. Feeds cogni-marketing, cogni-sales and cogni-website.
+
+**cogni-marketing** — B2B content engine bridging cogni-trends themes and cogni-portfolio propositions into channel-ready content across sixteen formats. Needs both upstream plugins to have data. Bilingual DE/EN.
+
+**cogni-sales** — Pitch generation on the Corporate Visions Why Change methodology, for a named customer or a reusable market segment. Needs cogni-portfolio propositions; optionally enriched by cogni-trends.
+
+**cogni-website** — Assembles multi-page customer websites from the portfolio, marketing, trend and research content the other plugins produce, with shared navigation and theming.
+
+**cogni-consult** — Consulting engagement orchestrator. Scoping derives three to six action fields, the work-breakdown structure, from one SMART key question; each deliverable then runs its own design-thinking loop (empathize → define → ideate → prototype → test) with acting stakeholder personas challenging the work in their own voice. One cogni-knowledge base, bound at setup, is the research spine. It orchestrates; the content work is dispatched to the plugins that own it.
+
+**cogni-workspace** — The horizontal layer: it owns the shared workspace state the vertical plugins consume. Shared env vars and settings, theme management, the supported-markets registry, MCP server installation, workspace health and troubleshooting, issue filing. It also owns three cross-plugin capabilities. Claim verification (`cogni-workspace:claims`) checks a document's sourced assertions against the cited URLs and guides the resolution of deviations; use it before publishing research output. Narrative composition (`cogni-workspace:text-to-narrative`) turns structured content into an executive narrative on one of fifteen registered story arcs and cuts it into a single design brief that Claude Design renders as slides, a document, an infographic or a web page; nothing is rendered locally. Copywriting (`cogni-workspace:copywriter`) polishes with messaging frameworks (BLUF, Pyramid, SCQA, STAR, PSB, FAB, Inverted Pyramid), translates through an EN/DE pivot, and stress-tests a draft against stakeholder personas through `cogni-workspace:copy-reader`.
+
+## When nothing fits
+
+Say so plainly. Do not force-fit a plugin onto a task it was not designed for; a wrong recommendation costs more than an honest "the ecosystem does not cover this". Check whether a community plugin exists, or build one: [Plugin development](contributing/plugin-development.md) covers that path.
+
+## Where to read more
+
+| Resource | Path | When |
+|---|---|---|
+| Install to Infographic | [workflows/install-to-infographic.md](workflows/install-to-infographic.md) | New users, first-time setup |
+| Ecosystem overview | [ecosystem-overview.md](ecosystem-overview.md) | "What plugins are available?", "How do they connect?" |
+| Command reference | [command-reference.md](command-reference.md) | "What are the commands for cogni-X?" |
+| Plugin guides | [plugin-guide/](plugin-guide/) | "How does cogni-X work?", full capabilities |
+| Workflow guides | [workflows/](workflows/) | "How do I go from X to Y?" |
+| Architecture | [architecture/](architecture/) | Structure and design principles |
+| Contributing | [contributing/plugin-development.md](contributing/plugin-development.md) | Building a plugin |
+
+For a multi-plugin task, name the sequence rather than a single plugin, and check whether one of the seven workflow guides already covers it.


### PR DESCRIPTION
## Summary

Follow-up to #1936. The two cogni-help pages the doku wiki carried, the command cheatsheet and the plugin-selection guide, had no in-repo successor after the wiki retired. They return under `docs/`, rebuilt against the live tree rather than restored from history.

## New pages

- `docs/command-reference.md` — slash commands and skills per plugin, plus the recurring naming patterns. Skill and command lists were generated from `skills/*/SKILL.md` and `commands/*.md` and compared mechanically: zero mismatches across all eight plugins.
- `docs/plugin-selection.md` — the task-to-plugin routing table and what each plugin owns, rewritten for the current roster: `text-to-narrative` replaces the retired `narrative` skill, the retired render chain is gone (Claude Design renders the brief), the wiki self-references and the `ask` skill are gone, cogni-trends' market coverage matches its README.

## What changed from the wiki versions

- Retired surfaces removed: five render commands, `render-html-slides`, `enrich-report`, `cogni-workspace:narrative`, brief-based local rendering, the bundled wiki as a capability.
- Every `[[wikilink]]` became a relative `docs/` link; all 12 resolve.
- Stale claims corrected: cogni-workspace commands are five, skills eleven; story arcs are fifteen (counted from the arc contract files).

## Discoverability

- Root `README.md`: two lines added to the `docs/` tree inside the preserved "How it works" section, so a regeneration keeps them.
- `docs/ecosystem-overview.md`: two bullets added to "See Also". `doc-hub` updates an existing doc rather than rebuilding it, so hand-added bullets survive.

## Guards

Code-span nesting, README inventory-sync, external-dispatch, breadcrumb and attribution guards all pass; the layering suite is green over the new pages. No plugin files touched, so no version bump follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)